### PR TITLE
Addition of About files for FIBO BE and each of the FIBO BE Modules.

### DIFF
--- a/be/AboutBE-1.0.rdf
+++ b/be/AboutBE-1.0.rdf
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY dct "http://purl.org/dc/terms/" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
+    <!ENTITY fibo-be "http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/" >
+    <!ENTITY fibo-be-1.0 "http://www.omg.org/spec/EDMC-FIBO/BE/1.0/AboutBE-1.0/" >
+    <!ENTITY fibo-fnd-utl-av "http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/" >
+    <!ENTITY fibo-fnd-utl-bt "http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/BusinessFacingTypes/" >
+    <!ENTITY fibo-fnd-utl-alx "http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/Analytics/" >
+    <!ENTITY fibo-fnd-rel-rel "http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/" >
+    <!ENTITY fibo-fnd-arr-arr "http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/Arrangements/" >
+    <!ENTITY fibo-fnd-arr-cd "http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/Codes/" >
+    <!ENTITY fibo-fnd-arr-doc "http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/Documents/" >
+    <!ENTITY fibo-fnd-arr-id "http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/IdentifiersAndIndices/" >
+    <!ENTITY fibo-fnd-dt-fd "http://www.omg.org/spec/EDMC-FIBO/FND/DatesAndTimes/FinancialDates/" >
+    <!ENTITY fibo-fnd-dt-oc "http://www.omg.org/spec/EDMC-FIBO/FND/DatesAndTimes/Occurrences/" >
+    <!ENTITY fibo-fnd-dt-bd "http://www.omg.org/spec/EDMC-FIBO/FND/DatesAndTimes/BusinessDates/" >
+    <!ENTITY fibo-fnd-aap-agt "http://www.omg.org/spec/EDMC-FIBO/FND/AgentsAndPeople/Agents/" >
+    <!ENTITY fibo-fnd-aap-ppl "http://www.omg.org/spec/EDMC-FIBO/FND/AgentsAndPeople/People/" >
+    <!ENTITY fibo-fnd-plc-loc "http://www.omg.org/spec/EDMC-FIBO/FND/Places/Locations/" >
+    <!ENTITY fibo-fnd-plc-cty "http://www.omg.org/spec/EDMC-FIBO/FND/Places/Countries/" >
+    <!ENTITY fibo-fnd-plc-adr "http://www.omg.org/spec/EDMC-FIBO/FND/Places/Addresses/" >
+    <!ENTITY fibo-fnd-plc-fac "http://www.omg.org/spec/EDMC-FIBO/FND/Places/Facilities/" >
+    <!ENTITY fibo-fnd-plc-vrt "http://www.omg.org/spec/EDMC-FIBO/FND/Places/VirtualPlaces/" >
+    <!ENTITY fibo-fnd-gao-gl "http://www.omg.org/spec/EDMC-FIBO/FND/GoalsAndObjectives/Goals/" >
+    <!ENTITY fibo-fnd-gao-obj "http://www.omg.org/spec/EDMC-FIBO/FND/GoalsAndObjectives/Objectives/" >
+    <!ENTITY fibo-fnd-org-org "http://www.omg.org/spec/EDMC-FIBO/FND/Organizations/Organizations/" >
+    <!ENTITY fibo-fnd-org-fm "http://www.omg.org/spec/EDMC-FIBO/FND/Organizations/FormalOrganizations/" >
+    <!ENTITY fibo-fnd-org-lg "http://www.omg.org/spec/EDMC-FIBO/FND/Organizations/LegitimateOrganizations/" >
+    <!ENTITY fibo-fnd-pty-rl "http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Roles/" >
+    <!ENTITY fibo-fnd-pty-pty "http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Parties/" >
+    <!ENTITY fibo-fnd-agr-agr "http://www.omg.org/spec/EDMC-FIBO/FND/Agreements/Agreements/" >
+    <!ENTITY fibo-fnd-agr-ctr "http://www.omg.org/spec/EDMC-FIBO/FND/Agreements/Contracts/" >
+    <!ENTITY fibo-fnd-law-cor "http://www.omg.org/spec/EDMC-FIBO/FND/Law/LegalCore/" >
+    <!ENTITY fibo-fnd-law-jur "http://www.omg.org/spec/EDMC-FIBO/FND/Law/Jurisdiction/" >
+    <!ENTITY fibo-fnd-law-lcap "http://www.omg.org/spec/EDMC-FIBO/FND/Law/LegalCapacity/" >
+    <!ENTITY fibo-fnd-oac-ctl "http://www.omg.org/spec/EDMC-FIBO/FND/OwnershipAndControl/Control/" >
+    <!ENTITY fibo-fnd-oac-own "http://www.omg.org/spec/EDMC-FIBO/FND/OwnershipAndControl/Ownership/" >
+    <!ENTITY fibo-fnd-oac-oac "http://www.omg.org/spec/EDMC-FIBO/FND/OwnershipAndControl/OwnershipAndControl/" >
+    <!ENTITY fibo-fnd-acc-cur "http://www.omg.org/spec/EDMC-FIBO/FND/Accounting/CurrencyAmount/" >
+    <!ENTITY fibo-fnd-acc-aeq "http://www.omg.org/spec/EDMC-FIBO/FND/Accounting/AccountingEquity/" >
+
+    <!ENTITY fibo-be-le-lp "http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/LegalPersons/" >
+    <!ENTITY fibo-be-le-fbo "http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/FormalBusinessOrganizations/" >
+    <!ENTITY fibo-be-le-cb "http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/CorporateBodies/" >
+    <!ENTITY fibo-be-le-lei "http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/LEIEntities/" >
+    <!ENTITY fibo-be-corp-corp "http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/" >
+    <!ENTITY fibo-be-fct-fct "http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/FunctionalEntities/" >
+    <!ENTITY fibo-be-fct-pub "http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/Publishers/" >
+    <!ENTITY fibo-be-oac-opty "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/" >
+    <!ENTITY fibo-be-oac-cpty "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/ControlParties/" >
+    <!ENTITY fibo-be-oac-cown "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/CorporateOwnership/" >
+    <!ENTITY fibo-be-oac-cctl "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/CorporateControl/" >
+    <!ENTITY fibo-be-oac-exec "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/Executives/" >
+    <!ENTITY fibo-be-ptr-ptr "http://www.omg.org/spec/EDMC-FIBO/BE/Partnerships/Partnerships/" >
+    <!ENTITY fibo-be-tr-tr "http://www.omg.org/spec/EDMC-FIBO/BE/Trusts/Trusts/" >
+]>
+
+<rdf:RDF 
+xml:base="http://www.omg.org/spec/EDMC-FIBO/BE/1.0/AboutBE-1.0/"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+     xmlns:fibo-fnd="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"
+     xmlns:fibo-be-1.0="http://www.omg.org/spec/EDMC-FIBO/BE/1.0/AboutBE-1.0/"
+     xmlns:fibo-fnd-utl-av="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"
+     xmlns:fibo-fnd-utl-bt="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/BusinessFacingTypes/"
+     xmlns:fibo-fnd-utl-alx="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/Analytics/"
+     xmlns:fibo-fnd-rel-rel="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"
+     xmlns:fibo-fnd-arr-arr="http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/Arrangements/"
+     xmlns:fibo-fnd-arr-cd="http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/Codes/"
+     xmlns:fibo-fnd-arr-doc="http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/Documents/"
+     xmlns:fibo-fnd-arr-id="http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/IdentifiersAndIndices/"
+     xmlns:fibo-fnd-dt-fd="http://www.omg.org/spec/EDMC-FIBO/FND/DatesAndTimes/FinancialDates/"
+     xmlns:fibo-fnd-dt-oc="http://www.omg.org/spec/EDMC-FIBO/FND/DatesAndTimes/Occurrences/"
+     xmlns:fibo-fnd-dt-bd="http://www.omg.org/spec/EDMC-FIBO/FND/DatesAndTimes/BusinessDates/"
+     xmlns:fibo-fnd-aap-agt="http://www.omg.org/spec/EDMC-FIBO/FND/AgentsAndPeople/Agents/"
+     xmlns:fibo-fnd-aap-ppl="http://www.omg.org/spec/EDMC-FIBO/FND/AgentsAndPeople/People/"
+     xmlns:fibo-fnd-plc-loc="http://www.omg.org/spec/EDMC-FIBO/FND/Places/Locations/"
+     xmlns:fibo-fnd-plc-cty="http://www.omg.org/spec/EDMC-FIBO/FND/Places/Countries/"
+     xmlns:fibo-fnd-plc-adr="http://www.omg.org/spec/EDMC-FIBO/FND/Places/Addresses/"
+     xmlns:fibo-fnd-plc-fac="http://www.omg.org/spec/EDMC-FIBO/FND/Places/Facilities/"
+     xmlns:fibo-fnd-plc-vrt="http://www.omg.org/spec/EDMC-FIBO/FND/Places/VirtualPlaces/"
+     xmlns:fibo-fnd-gao-gl="http://www.omg.org/spec/EDMC-FIBO/FND/GoalsAndObjectives/Goals/"
+     xmlns:fibo-fnd-gao-obj="http://www.omg.org/spec/EDMC-FIBO/FND/GoalsAndObjectives/Objectives/"
+     xmlns:fibo-fnd-org-org="http://www.omg.org/spec/EDMC-FIBO/FND/Organizations/Organizations/"
+     xmlns:fibo-fnd-org-fm="http://www.omg.org/spec/EDMC-FIBO/FND/Organizations/FormalOrganizations/"
+     xmlns:fibo-fnd-org-lg="http://www.omg.org/spec/EDMC-FIBO/FND/Organizations/LegitimateOrganizations/"
+     xmlns:fibo-fnd-pty-rl="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Roles/"
+     xmlns:fibo-fnd-pty-pty="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Parties/"
+     xmlns:fibo-fnd-agr-agr="http://www.omg.org/spec/EDMC-FIBO/FND/Agreements/Agreements/"
+     xmlns:fibo-fnd-agr-ctr="http://www.omg.org/spec/EDMC-FIBO/FND/Agreements/Contracts/"
+     xmlns:fibo-fnd-law-cor="http://www.omg.org/spec/EDMC-FIBO/FND/Law/LegalCore/"
+     xmlns:fibo-fnd-law-jur="http://www.omg.org/spec/EDMC-FIBO/FND/Law/Jurisdiction/"
+     xmlns:fibo-fnd-law-lcap="http://www.omg.org/spec/EDMC-FIBO/FND/Law/LegalCapacity/"
+     xmlns:fibo-fnd-oac-ctl="http://www.omg.org/spec/EDMC-FIBO/FND/OwnershipAndControl/Control/"
+     xmlns:fibo-fnd-oac-own="http://www.omg.org/spec/EDMC-FIBO/FND/OwnershipAndControl/Ownership/"
+     xmlns:fibo-fnd-oac-oac="http://www.omg.org/spec/EDMC-FIBO/FND/OwnershipAndControl/OwnershipAndControl/"
+     xmlns:fibo-fnd-acc-cur="http://www.omg.org/spec/EDMC-FIBO/FND/Accounting/CurrencyAmount/"     
+     xmlns:fibo-fnd-acc-aeq="http://www.omg.org/spec/EDMC-FIBO/FND/Accounting/AccountingEquity/"
+
+     xmlns:fibo-be-le-lp="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/LegalPersons/"
+     xmlns:fibo-be-le-fbo="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/FormalBusinessOrganizations/"
+     xmlns:fibo-be-le-cb="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/CorporateBodies/"
+     xmlns:fibo-be-le-lei="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/LEIEntities/"
+     xmlns:fibo-be-corp-corp="http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/"
+     xmlns:fibo-be-fct-fct="http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/FunctionalEntities/"
+     xmlns:fibo-be-fct-pub="http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/Publishers/"
+     xmlns:fibo-be-oac-opty="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/"
+     xmlns:fibo-be-oac-cown="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/CorporateOwnership/"
+     xmlns:fibo-be-oac-cpty="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/ControlParties/"
+     xmlns:fibo-be-oac-cctl="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/CorporateControl/"
+     xmlns:fibo-be-oac-exec="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/Executives/"
+     xmlns:fibo-be-ptr-ptr="http://www.omg.org/spec/EDMC-FIBO/BE/Partnerships/Partnerships/"
+     xmlns:fibo-be-tr-tr="http://www.omg.org/spec/EDMC-FIBO/BE/Trusts/Trusts/">
+
+
+    <owl:Ontology rdf:about="http://www.omg.org/spec/EDMC-FIBO/BE/1.0/AboutBE-1.0/">
+        <rdfs:label>About the EDMC-FIBO Business Entities (BE) Specification Version 1.0</rdfs:label>
+
+
+    <!-- Curation and Rights Metadata for About the EDMC-FIBO Business Entities (BE) Specification Version 1.0 -->
+
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015 EDM Council, Inc.
+Copyright (c) 2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:resource="&sm;MITLicense"/>
+
+
+    <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Business Entities (BE) Specification Version 1.0 -->
+
+        <sm:filename rdf:datatype="&xsd;string">AboutBE-1.0.rdf</sm:filename>
+        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-be-1.0</sm:fileAbbreviation>
+        <owl:versionIRI rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/20150201/AboutBE-1.0/"/>
+
+        <sm:publicationDate rdf:datatype="&xsd;dateTime">2015-02-23T18:00:00</sm:publicationDate>
+
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/BusinessFacingTypes/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/Analytics/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/AgentsAndPeople/Agents/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/AgentsAndPeople/People/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/Arrangements/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/Codes/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/Documents/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Arrangements/IdentifiersAndIndices/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/DatesAndTimes/FinancialDates/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/DatesAndTimes/Occurrences/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/DatesAndTimes/BusinessDates/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Places/Locations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Places/Countries/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Places/Addresses/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Places/Facilities/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Places/VirtualPlaces/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/GoalsAndObjectives/Goals/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/GoalsAndObjectives/Objectives/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Organizations/Organizations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Organizations/FormalOrganizations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Organizations/LegitimateOrganizations/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Roles/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Parties/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Agreements/Agreements/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Agreements/Contracts/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Law/LegalCore/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Law/Jurisdiction/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Law/LegalCapacity/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/OwnershipAndControl/Control/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/OwnershipAndControl/Ownership/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/OwnershipAndControl/OwnershipAndControl/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Accounting/AccountingEquity/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Accounting/CurrencyAmount/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/LegalPersons/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/FormalBusinessOrganizations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/CorporateBodies/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/LEIEntities/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/FunctionalEntities/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/Publishers/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/ControlParties/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/CorporateOwnership/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/CorporateControl/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/Executives/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/Partnerships/Partnerships/"/>
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/Trusts/Trusts/"/>
+
+    </owl:Ontology>
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:NamedIndividual rdf:about="&fibo-be-1.0;BusinessEntities-1.0">
+        <rdf:type rdf:resource="&sm;SpecificationVersion"/>
+        <rdfs:label>EDMC Financial Industry Business Ontology (FIBO) Business Entities (BE) Specification Version 1.0</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">individual representing metadata about the FIBO Business Entities (BE) Version 1.0 Specification</skos:definition>
+        <sm:publicationDate rdf:datatype="&xsd;dateTime">2015-02-23T18:00:00</sm:publicationDate>
+        <sm:specificationVersionURL rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/1.0/</sm:specificationVersionURL>
+        <sm:specificationVersionStatus rdf:datatype="&xsd;string">Formal Specification</sm:specificationVersionStatus>
+        <sm:isVersionOf rdf:resource="&fibo-be;BESpecification"/>
+        <fibo-fnd-utl-av:usageNote rdf:datatype="&xsd;string">Users should be aware that the BE ontologies depend on the ontologies specified in the EDMC-FIBO Foundations (FND) specification, and as such, this ontology imports all of FND in addition to all of BE.  It is useful for importing the entire set of ontologies as the basis for other development, in other words. Individual ontologies within BE only import those on which they directly depend.</fibo-fnd-utl-av:usageNote>
+        <skos:historyNote rdf:datatype="&xsd;string">Revisions to the FIBO Business Entities (BE) Specification and related ontologies are managed per the process outlined in the Policies and Procedures for OMG standards, with the intent to maintain backwards compatibility in the ontologies to the degree possible.
+  
+The RDF/XML serialized OWL for the Foundations ODM/OWL ontologies have been checked for syntactic errors and logical consistency with Protege 4 (http://protege.stanford.edu/), HermiT 1.3.8 (http://www.hermit-reasoner.com/) and Pellet 2.2 (http://clarkparsia.com/pellet/).</skos:historyNote>
+        <sm:addressForComments rdf:datatype="&xsd;anyURI">http://www.omg.org/issues/</sm:addressForComments>
+    </owl:NamedIndividual>
+
+</rdf:RDF>

--- a/be/AboutBE.rdf
+++ b/be/AboutBE.rdf
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY dct "http://purl.org/dc/terms/" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
+    <!ENTITY fibo-be "http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/" >
+]>
+
+<rdf:RDF 
+xml:base="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+     xmlns:fibo-fnd="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/">
+
+
+    <owl:Ontology rdf:about="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/">
+        <rdfs:label>About the EDMC-FIBO Business Entities (BE) Specification</rdfs:label>
+
+
+    <!-- Curation and Rights Metadata for AboutBE -->
+
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015 EDM Council, Inc.
+Copyright (c) 2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:resource="&sm;MITLicense"/>
+
+
+    <!-- Ontology/File-Level Metadata for AboutBE -->
+
+        <sm:filename rdf:datatype="&xsd;string">AboutBE.rdf</sm:filename>
+        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-be</sm:fileAbbreviation>
+        <owl:versionIRI rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/20150201/AboutBE/"/>
+
+        <sm:publicationDate rdf:datatype="&xsd;dateTime">2015-02-23T18:00:00</sm:publicationDate>
+
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+
+
+        <owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+    </owl:Ontology>
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:NamedIndividual rdf:about="&fibo-be;BESpecification">
+        <rdf:type rdf:resource="&sm;Specification"/>
+        <rdfs:label>FIBO Business Entities (BE) Specification</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">individual representing metadata about the FIBO Business Entities specification</skos:definition>
+        <sm:specificationTitle rdf:datatype="&xsd;string">EDMC Financial Industry Business Ontology (FIBO) Business Entities (BE) Specification</sm:specificationTitle>
+        <sm:specificationAbbreviation rdf:datatype="&xsd;string">FIBO-BE</sm:specificationAbbreviation>
+        <sm:specificationURL rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/</sm:specificationURL>
+        <sm:specificationAbstract rdf:datatype="&xsd;string">The FIBO Business Entities specification provides a model of business concepts that are represented by finance industry terms as used in official regulatory and financial organization documents on the subject of Business Entities.
+
+This specification describes a set of ontologies of and relating to business entities, including legal entities and specific forms of entity, within the overall framework and heading of the Financial Industry Business Ontology (FIBO). 
+
+The business scope of this specification is all terms relating to and descriptive and/or definitive of a range of business entities and legal entities that are considered by financial industry firms, regulators and other industry participants to be of relevance in the financial services domain.  The contents cover concepts and terminology common to
+ - Legal entities, including the concepts specific to ISO 17442 and related respositories,
+ - Formal organizations, including concepts related to their corporate structure, ownership and control, primary executive roles for businesses,
+ - Functional entities related to the financial services industry according to their role or function, including but not limited to financial intermediaries, governments, non-governmental organizations, international organizations, exchange-related, and publishing entities, 
+ - Concepts specific to corporations, partnerships and trusts
+ - Concepts specific to the kinds of things that businesses provide, including financial intermediaries, such as products and services, as well as the consumers and providers of such products and services.</sm:specificationAbstract>
+
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2013-2015 EDM Council, Inc.
+Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
+        <sm:submitter rdf:datatype="&xsd;string">EDM Council, Inc.</sm:submitter>
+        <sm:contributor rdf:datatype="&xsd;string">Adaptive, Inc.</sm:contributor>
+        <sm:contributor rdf:datatype="&xsd;string">Thematix Partners LLC</sm:contributor>
+        <dct:license rdf:resource="&sm;MITLicense"/>
+        <sm:responsibleTaskForce rdf:datatype="&xsd;anyURI">http://fdtf.omg.org/</sm:responsibleTaskForce>
+
+        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
+        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/FND/</sm:dependsOn>
+
+        <sm:keyword rdf:datatype="&xsd;string">business entities</sm:keyword>
+        <sm:keyword rdf:datatype="&xsd;string">legal entities</sm:keyword>
+        <sm:keyword rdf:datatype="&xsd;string">LEI</sm:keyword>
+
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.edmcouncil.org/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+    </owl:NamedIndividual>
+
+</rdf:RDF>

--- a/be/Corporations/AboutCorporations.rdf
+++ b/be/Corporations/AboutCorporations.rdf
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY dct "http://purl.org/dc/terms/" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
+    <!ENTITY fibo-fnd-utl-av "http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/" >
+    <!ENTITY fibo-fnd-rel-rel "http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/" >
+    <!ENTITY fibo-be "http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/" >
+    <!ENTITY fibo-be-corp-mod "http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/AboutCorporations/" >
+]>
+
+<rdf:RDF xml:base="http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/AboutCorporations/"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+     xmlns:fibo-fnd-utl-av="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"
+     xmlns:fibo-fnd-rel-rel="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"
+     xmlns:fibo-be="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"
+     xmlns:fibo-be-corp-mod="http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/AboutCorporations/">
+
+
+    <owl:Ontology rdf:about="http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/AboutCorporations/">
+        <rdfs:label>About the EDMC-FIBO Business Entities (BE) Corporations Module</rdfs:label>
+
+
+    <!-- Curation and Rights Metadata for About the EDMC-FIBO BE Corporations Module -->
+
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015 EDM Council, Inc.
+Copyright (c) 2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:resource="&sm;MITLicense"/>
+
+
+    <!-- Ontology/File-Level Metadata for About the EDMC-FIBO BE Corporations Module -->
+
+        <sm:filename rdf:datatype="&xsd;string">AboutCorporations.rdf</sm:filename>
+        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-be-corp-mod</sm:fileAbbreviation>
+        <owl:versionIRI rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/20150201/Corporations/AboutCorporations/"/>
+
+        <sm:publicationDate rdf:datatype="&xsd;dateTime">2015-02-23T18:00:00</sm:publicationDate>
+
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"/>
+
+    </owl:Ontology>
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:NamedIndividual rdf:about="&fibo-be-corp-mod;CorporationsModule">
+        <rdf:type rdf:resource="&sm;Module"/>
+        <rdfs:label>FIBO BE Corporations Module</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">individual representing metadata about the FIBO BE corporations module</skos:definition>
+        <sm:moduleName rdf:datatype="&xsd;string">Corporations</sm:moduleName>
+        <sm:moduleAbbreviation rdf:datatype="&xsd;string">FIBO-BE-CORP</sm:moduleAbbreviation>
+        <sm:moduleVersion rdf:datatype="&xsd;string">1.0</sm:moduleVersion>
+        <sm:moduleAbstract rdf:datatype="&xsd;string">This module includes ontologies describing the essential features of companies incorporated by the issuance of shares. The terms in these ontologies build on terms about incorporated bodies more generally, and include terms about shareholding, which form the basis of relationships of ownership and control of or among these kinds of entities.</sm:moduleAbstract>
+
+        <fibo-fnd-rel-rel:isPartOf rdf:resource="&fibo-be;BESpecification"/>
+
+        <fibo-fnd-utl-av:usageNote rdf:datatype="&xsd;string">Users should be aware that the BE Corporations ontologies depend on a number of the ontologies specified in the EDMC-FIBO Foundations (FND) specification.  Individual ontologies in this module import only those FIBO FND ontologies they use directly, however.</fibo-fnd-utl-av:usageNote>
+
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.edmcouncil.org/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/</rdfs:seeAlso>
+    </owl:NamedIndividual>
+
+</rdf:RDF>

--- a/be/FunctionalEntities/AboutFunctionalEntities.rdf
+++ b/be/FunctionalEntities/AboutFunctionalEntities.rdf
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY dct "http://purl.org/dc/terms/" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
+    <!ENTITY fibo-fnd-utl-av "http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/" >
+    <!ENTITY fibo-fnd-rel-rel "http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/" >
+    <!ENTITY fibo-be "http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/" >
+    <!ENTITY fibo-be-fct-mod "http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/AboutFunctionalEntities/" >
+]>
+
+<rdf:RDF xml:base="http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/AboutFunctionalEntities/"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+     xmlns:fibo-fnd-utl-av="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"
+     xmlns:fibo-fnd-rel-rel="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"
+     xmlns:fibo-be="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"
+     xmlns:fibo-be-fct-mod="http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/AboutFunctionalEntities/">
+
+
+    <owl:Ontology rdf:about="http://www.omg.org/spec/EDMC-FIBO/BE/FunctionalEntities/AboutFunctionalEntities/">
+        <rdfs:label>About the EDMC-FIBO Business Entities (BE) Functional Entities Module</rdfs:label>
+
+
+    <!-- Curation and Rights Metadata for About the EDMC-FIBO BE Functional Entities Module -->
+
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015 EDM Council, Inc.
+Copyright (c) 2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:resource="&sm;MITLicense"/>
+
+
+    <!-- Ontology/File-Level Metadata for About the EDMC-FIBO BE Functional Entities Module -->
+
+        <sm:filename rdf:datatype="&xsd;string">AboutFunctionalEntities.rdf</sm:filename>
+        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-be-fct-mod</sm:fileAbbreviation>
+        <owl:versionIRI rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/20150201/FunctionalEntities/AboutFunctionalEntities/"/>
+
+        <sm:publicationDate rdf:datatype="&xsd;dateTime">2015-02-23T18:00:00</sm:publicationDate>
+
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"/>
+
+    </owl:Ontology>
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:NamedIndividual rdf:about="&fibo-be-fct-mod;FunctionalEntitiesModule">
+        <rdf:type rdf:resource="&sm;Module"/>
+        <rdfs:label>FIBO BE Functional Entities Module</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">individual representing metadata about the FIBO BE functional entities module</skos:definition>
+        <sm:moduleName rdf:datatype="&xsd;string">Functional Entities</sm:moduleName>
+        <sm:moduleAbbreviation rdf:datatype="&xsd;string">FIBO-BE-FCT</sm:moduleAbbreviation>
+        <sm:moduleVersion rdf:datatype="&xsd;string">1.0</sm:moduleVersion>
+        <sm:moduleAbstract rdf:datatype="&xsd;string">This module includes ontologies describing entities that are defined according to their function, as opposed to their form. They include various forms of financial intermediaries including banks, government regulatory and registration agencies, special purpose vehicles, business versus non-profit etc., as well as entities described in terms of their function in some process, such as clearing houses, exchanges, markets, publishers, settlement entities and the like.</sm:moduleAbstract>
+
+        <fibo-fnd-rel-rel:isPartOf rdf:resource="&fibo-be;BESpecification"/>
+
+        <fibo-fnd-utl-av:usageNote rdf:datatype="&xsd;string">Users should be aware that the BE Functional Entities ontologies depend on a number of the ontologies specified in the EDMC-FIBO Foundations (FND) specification.  Individual ontologies in this module import only those FIBO FND ontologies they use directly, however.</fibo-fnd-utl-av:usageNote>
+
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.edmcouncil.org/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/</rdfs:seeAlso>
+    </owl:NamedIndividual>
+
+</rdf:RDF>

--- a/be/LegalEntities/AboutLegalEntities.rdf
+++ b/be/LegalEntities/AboutLegalEntities.rdf
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY dct "http://purl.org/dc/terms/" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
+    <!ENTITY fibo-fnd-utl-av "http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/" >
+    <!ENTITY fibo-fnd-rel-rel "http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/" >
+    <!ENTITY fibo-be "http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/" >
+    <!ENTITY fibo-be-le-mod "http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/AboutLegalEntities/" >
+]>
+
+<rdf:RDF xml:base="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/AboutLegalEntities/"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+     xmlns:fibo-fnd-utl-av="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"
+     xmlns:fibo-fnd-rel-rel="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"
+     xmlns:fibo-be="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"
+     xmlns:fibo-be-le-mod="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/AboutLegalEntities/">
+
+
+    <owl:Ontology rdf:about="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/AboutLegalEntities/">
+        <rdfs:label>About the EDMC-FIBO Business Entities (BE) Legal Entities Module</rdfs:label>
+
+
+    <!-- Curation and Rights Metadata for About the EDMC-FIBO BE Legal Entities Module -->
+
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015 EDM Council, Inc.
+Copyright (c) 2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:resource="&sm;MITLicense"/>
+
+
+    <!-- Ontology/File-Level Metadata for About the EDMC-FIBO BE Legal Entities Module -->
+
+        <sm:filename rdf:datatype="&xsd;string">AboutLegalEntities.rdf</sm:filename>
+        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-be-le-mod</sm:fileAbbreviation>
+        <owl:versionIRI rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/20150201/LegalEntities/AboutLegalEntities/"/>
+
+        <sm:publicationDate rdf:datatype="&xsd;dateTime">2015-02-23T18:00:00</sm:publicationDate>
+
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"/>
+
+    </owl:Ontology>
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:NamedIndividual rdf:about="&fibo-be-le-mod;LegalEntitiesModule">
+        <rdf:type rdf:resource="&sm;Module"/>
+        <rdfs:label>FIBO BE Legal Entities Module</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">individual representing metadata about the FIBO BE legal entities module</skos:definition>
+        <sm:moduleName rdf:datatype="&xsd;string">Legal Entities</sm:moduleName>
+        <sm:moduleAbbreviation rdf:datatype="&xsd;string">FIBO-BE-LE</sm:moduleAbbreviation>
+        <sm:moduleVersion rdf:datatype="&xsd;string">1.0</sm:moduleVersion>
+        <sm:moduleAbstract rdf:datatype="&xsd;string">This module contains ontologies which define the basis for legal personhood and business entities generally. This includes (1) definitions that distinguish between judicial and natural person, (2) definitions of formally constituted organizations, their members and high-level subdivisions, and identification and classification schemes, (3) definitions of corporate entities and the ways in which they may be incorporated, and (4) definitions required for implementation and use of the ISO 17442 Legal Entity Identifier (LEI) standard, including concepts for contractually capable and legal entities that reuse properties defined elsewhere in FIBO FND and BE.</sm:moduleAbstract>
+
+        <fibo-fnd-rel-rel:isPartOf rdf:resource="&fibo-be;BESpecification"/>
+
+        <fibo-fnd-utl-av:usageNote rdf:datatype="&xsd;string">Users should be aware that the BE Legal Entities ontologies depend on a number of the ontologies specified in the EDMC-FIBO Foundations (FND) specification.  Individual ontologies in this module import only those FIBO FND ontologies they use directly, however.</fibo-fnd-utl-av:usageNote>
+
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.edmcouncil.org/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/</rdfs:seeAlso>
+    </owl:NamedIndividual>
+
+</rdf:RDF>

--- a/be/OwnershipAndControl/AboutBEOwnershipAndControl.rdf
+++ b/be/OwnershipAndControl/AboutBEOwnershipAndControl.rdf
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY dct "http://purl.org/dc/terms/" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
+    <!ENTITY fibo-fnd-utl-av "http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/" >
+    <!ENTITY fibo-fnd-rel-rel "http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/" >
+    <!ENTITY fibo-be "http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/" >
+    <!ENTITY fibo-be-oac-mod "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/AboutBEOwnershipAndControl/" >
+]>
+
+<rdf:RDF xml:base="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/AboutBEOwnershipAndControl/"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+     xmlns:fibo-fnd-utl-av="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"
+     xmlns:fibo-fnd-rel-rel="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"
+     xmlns:fibo-be="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"
+     xmlns:fibo-be-oac-mod="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/AboutBEOwnershipAndControl/">
+
+
+    <owl:Ontology rdf:about="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/AboutBEOwnershipAndControl/">
+        <rdfs:label>About the EDMC-FIBO Business Entities (BE) Ownership and Control Module</rdfs:label>
+
+
+    <!-- Curation and Rights Metadata for About the EDMC-FIBO BE Ownership and Control Module -->
+
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015 EDM Council, Inc.
+Copyright (c) 2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:resource="&sm;MITLicense"/>
+
+
+    <!-- Ontology/File-Level Metadata for About the EDMC-FIBO BE Ownership and Control Module -->
+
+        <sm:filename rdf:datatype="&xsd;string">AboutBEOwnershipAndControl.rdf</sm:filename>
+        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-be-oac-mod</sm:fileAbbreviation>
+        <owl:versionIRI rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/20150201/OwnershipAndControl/AboutBEOwnershipAndControl/"/>
+
+        <sm:publicationDate rdf:datatype="&xsd;dateTime">2015-02-23T18:00:00</sm:publicationDate>
+
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"/>
+
+    </owl:Ontology>
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:NamedIndividual rdf:about="&fibo-be-oac-mod;OwnershipAndControlModule">
+        <rdf:type rdf:resource="&sm;Module"/>
+        <rdfs:label>FIBO BE Ownership and Control Module</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">individual representing metadata about the FIBO BE ownership and control module</skos:definition>
+        <sm:moduleName rdf:datatype="&xsd;string">Ownership and Control</sm:moduleName>
+        <sm:moduleAbbreviation rdf:datatype="&xsd;string">FIBO-BE-OAC</sm:moduleAbbreviation>
+        <sm:moduleVersion rdf:datatype="&xsd;string">1.0</sm:moduleVersion>
+        <sm:moduleAbstract rdf:datatype="&xsd;string">This module contains ontologies that define various types and aspects of ownership and control as they apply among and between business entities.  The ontologies in this module include the definition of types of party as defined in the roles of ownership and control along with the capacities which define those parties, and separately the relationships of ownership and control directly between organizations, which arise from the existence of those roles. Specific types of ownership and control relationships that are unique to incorporated companies are defined in addition to the more general terms to which these relate. Also included is an ontology of the types of control relationships that exist by virtue of the powers conferred upon corporate officers, board members and other executive roles.</sm:moduleAbstract>
+
+        <fibo-fnd-rel-rel:isPartOf rdf:resource="&fibo-be;BESpecification"/>
+
+        <fibo-fnd-utl-av:usageNote rdf:datatype="&xsd;string">Users should be aware that the BE Ownership and Control ontologies depend on a number of the ontologies specified in the EDMC-FIBO Foundations (FND) specification.  Individual ontologies in this module import only those FIBO FND ontologies they use directly, however.</fibo-fnd-utl-av:usageNote>
+
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.edmcouncil.org/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/</rdfs:seeAlso>
+    </owl:NamedIndividual>
+
+</rdf:RDF>

--- a/be/Partnerships/AboutPartnerships.rdf
+++ b/be/Partnerships/AboutPartnerships.rdf
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY dct "http://purl.org/dc/terms/" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
+    <!ENTITY fibo-fnd-utl-av "http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/" >
+    <!ENTITY fibo-fnd-rel-rel "http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/" >
+    <!ENTITY fibo-be "http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/" >
+    <!ENTITY fibo-be-ptr-mod "http://www.omg.org/spec/EDMC-FIBO/BE/Partnerships/AboutPartnerships/" >
+]>
+
+<rdf:RDF xml:base="http://www.omg.org/spec/EDMC-FIBO/BE/Partnerships/AboutPartnerships/"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+     xmlns:fibo-fnd-utl-av="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"
+     xmlns:fibo-fnd-rel-rel="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"
+     xmlns:fibo-be="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"
+     xmlns:fibo-be-ptr-mod="http://www.omg.org/spec/EDMC-FIBO/BE/Partnerships/AboutPartnerships/">
+
+
+    <owl:Ontology rdf:about="http://www.omg.org/spec/EDMC-FIBO/BE/Partnerships/AboutPartnerships/">
+        <rdfs:label>About the EDMC-FIBO Business Entities (BE) Partnerships Module</rdfs:label>
+
+
+    <!-- Curation and Rights Metadata for About the EDMC-FIBO BE Partnerships Module -->
+
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015 EDM Council, Inc.
+Copyright (c) 2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:resource="&sm;MITLicense"/>
+
+
+    <!-- Ontology/File-Level Metadata for About the EDMC-FIBO BE Partnerships Module -->
+
+        <sm:filename rdf:datatype="&xsd;string">AboutPartnerships.rdf</sm:filename>
+        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-be-ptr-mod</sm:fileAbbreviation>
+        <owl:versionIRI rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/20150201/Partnerships/AboutPartnerships/"/>
+
+        <sm:publicationDate rdf:datatype="&xsd;dateTime">2015-02-23T18:00:00</sm:publicationDate>
+
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"/>
+
+    </owl:Ontology>
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:NamedIndividual rdf:about="&fibo-be-ptr-mod;PartnershipsModule">
+        <rdf:type rdf:resource="&sm;Module"/>
+        <rdfs:label>FIBO BE Partnerships Module</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">individual representing metadata about the FIBO BE partnerships module</skos:definition>
+        <sm:moduleName rdf:datatype="&xsd;string">Partnerships</sm:moduleName>
+        <sm:moduleAbbreviation rdf:datatype="&xsd;string">FIBO-BE-PTR</sm:moduleAbbreviation>
+        <sm:moduleVersion rdf:datatype="&xsd;string">1.0</sm:moduleVersion>
+        <sm:moduleAbstract rdf:datatype="&xsd;string">This module contains ontologies that define concepts relating to types of partnerships, including incorporated and non-incorporated organizations. Partnerships are defined without reference to jurisdiction-specific legal forms. The abstractions distinguish between types of partnerships and related formation characteristics, as well as kinds of partners and types of partnership equity.</sm:moduleAbstract>
+
+        <fibo-fnd-rel-rel:isPartOf rdf:resource="&fibo-be;BESpecification"/>
+
+        <fibo-fnd-utl-av:usageNote rdf:datatype="&xsd;string">Users should be aware that the BE Partnerships ontologies depend on a number of the ontologies specified in the EDMC-FIBO Foundations (FND) specification.  Individual ontologies in this module import only those FIBO FND ontologies they use directly, however.</fibo-fnd-utl-av:usageNote>
+
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.edmcouncil.org/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/</rdfs:seeAlso>
+    </owl:NamedIndividual>
+
+</rdf:RDF>

--- a/be/Trusts/AboutTrusts.rdf
+++ b/be/Trusts/AboutTrusts.rdf
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY dct "http://purl.org/dc/terms/" >
+    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
+    <!ENTITY fibo-fnd-utl-av "http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/" >
+    <!ENTITY fibo-fnd-rel-rel "http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/" >
+    <!ENTITY fibo-be "http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/" >
+    <!ENTITY fibo-be-tr-mod "http://www.omg.org/spec/EDMC-FIBO/BE/Trusts/AboutTrusts/" >
+]>
+
+<rdf:RDF xml:base="http://www.omg.org/spec/EDMC-FIBO/BE/Trusts/AboutTrusts/"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:dct="http://purl.org/dc/terms/"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+     xmlns:fibo-fnd-utl-av="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"
+     xmlns:fibo-fnd-rel-rel="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"
+     xmlns:fibo-be="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"
+     xmlns:fibo-be-tr-mod="http://www.omg.org/spec/EDMC-FIBO/BE/Trusts/AboutTrusts/">
+
+
+    <owl:Ontology rdf:about="http://www.omg.org/spec/EDMC-FIBO/BE/Trusts/AboutTrusts/">
+        <rdfs:label>About the EDMC-FIBO Business Entities (BE) Trusts Module</rdfs:label>
+
+
+    <!-- Curation and Rights Metadata for About the EDMC-FIBO BE Trusts Module -->
+
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015 EDM Council, Inc.
+Copyright (c) 2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:resource="&sm;MITLicense"/>
+
+
+    <!-- Ontology/File-Level Metadata for About the EDMC-FIBO BE Trusts Module -->
+
+        <sm:filename rdf:datatype="&xsd;string">AboutTrusts.rdf</sm:filename>
+        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-be-tr-mod</sm:fileAbbreviation>
+        <owl:versionIRI rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/20150201/Trusts/AboutTrusts/"/>
+
+        <sm:publicationDate rdf:datatype="&xsd;dateTime">2015-02-23T18:00:00</sm:publicationDate>
+
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+
+
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Utilities/AnnotationVocabulary/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Relations/Relations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/"/>
+
+    </owl:Ontology>
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:NamedIndividual rdf:about="&fibo-be-tr-mod;TrustsModule">
+        <rdf:type rdf:resource="&sm;Module"/>
+        <rdfs:label>FIBO BE Trusts Module</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">individual representing metadata about the FIBO BE trusts module</skos:definition>
+        <sm:moduleName rdf:datatype="&xsd;string">Trusts</sm:moduleName>
+        <sm:moduleAbbreviation rdf:datatype="&xsd;string">FIBO-BE-TR</sm:moduleAbbreviation>
+        <sm:moduleVersion rdf:datatype="&xsd;string">1.0</sm:moduleVersion>
+        <sm:moduleAbstract rdf:datatype="&xsd;string">This module contains ontologies which define types of trust and the facts about them. Trusts are defined as a kind of formally constituted organization with specific parties as set down in law for trusts (trustor, trustee and beneficiary), each of these being signatories to a trust agreement.</sm:moduleAbstract>
+
+        <fibo-fnd-rel-rel:isPartOf rdf:resource="&fibo-be;BESpecification"/>
+
+        <fibo-fnd-utl-av:usageNote rdf:datatype="&xsd;string">Users should be aware that the BE Trusts ontologies depend on a number of the ontologies specified in the EDMC-FIBO Foundations (FND) specification.  Individual ontologies in this module import only those FIBO FND ontologies they use directly, however.</fibo-fnd-utl-av:usageNote>
+
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.edmcouncil.org/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/AboutBE/</rdfs:seeAlso>
+    </owl:NamedIndividual>
+
+</rdf:RDF>


### PR DESCRIPTION
Addition of the About files for FIBO BE. 

Have also checked the status of all the BE RDF/OWL files against the most recent OMG submission: 

These are all in the version URI 20131101 except for FunctionalEntities/Publishers which is URI 20140501, having been submitted as additional changes, with the FIBO IND submission. 

GitHub is therefore up to date as to FIBO Business Entities. 
