### PR TITLE
BE-18, FBEF-20 - Testing with various reasoners and test data shows that...

### DIFF
--- a/be/LegalEntities/LegalPersons.rdf
+++ b/be/LegalEntities/LegalPersons.rdf
@@ -59,6 +59,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <sm:fileAbstract rdf:datatype="&xsd;string">This ontology defines legal personhood concepts. A legal person as defined here is any natural person or organization which is capable of accruing liability on its own part.</sm:fileAbstract>
 
         <skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/EDMC-FIBO/BE/20131101/LegalEntities/LegalPersons.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
+        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/FND/</sm:dependsOn>
 
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
@@ -108,14 +109,17 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <rdfs:label>chartered legal person</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">a legal person created by a royal charter or decree</skos:definition>
         <skos:editorialNote rdf:datatype="&xsd;string">In a monarchy or principality, the monarch typically vests the power to create such bodies, in an entity called (for example) the Privy Council.</skos:editorialNote>
-        <skos:example rdf:datatype="&xsd;string">Anything with &quot;Royal Institute&quot; in the name. Also universities are generally set up by royal charter in a monarchy or principality, (often pre-dating any Privy Council i.e. directly be the monarch in the case of older universities). The Bank of England and the British Broadcasting Council (BBC) are also incorporated through Royal Charter.</skos:example>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-lp;JudicialPerson"/>
+        <skos:example rdf:datatype="&xsd;string">Anything with 'Royal Institute' in the name. Also universities are generally set up by royal charter in a monarchy or principality, (often pre-dating any Privy Council i.e. directly be the monarch in the case of older universities). The Bank of England and the British Broadcasting Council (BBC) are also incorporated through Royal Charter.</skos:example>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
     </owl:Class>
 
-    <owl:Class rdf:about="&fibo-be-le-lp;JudicialPerson">
-        <rdfs:label>judicial person</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">Legal persons (lat. persona juris) are of two kinds: natural persons (people) and judicial persons (also called juristic or artificial or fictitious persons, lat. persona ficta), i.e., groups of people, such as corporations, which are treated by law as if they were persons.  While people acquire legal personhood when they are born, judicial persons do so when they are incorporated (registered) in accordance with law.</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://en.wikipedia.org/wiki/Legal_personality</fibo-fnd-utl-av:adaptedFrom>
+    <owl:Class rdf:about="&fibo-be-le-lp;JuridicalPerson">
+        <rdfs:label>juridical person</rdfs:label>
+        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">artificial person</fibo-fnd-utl-av:synonym>
+        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">juridical entity</fibo-fnd-utl-av:synonym>
+        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">juristic person</fibo-fnd-utl-av:synonym>
+        <skos:definition rdf:datatype="&xsd;string">an entity, as a firm, that is not a single natural person, as a human being, authorized by law with duties and rights, recognized as a legal authority having a distinct identity, a legal personality</skos:definition>
+        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Black's Law Dictionary Free Online, see http://thelawdictionary.org/juridical-person/</fibo-fnd-utl-av:definitionOrigin>
         <rdfs:subClassOf rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
         <rdfs:subClassOf rdf:resource="&fibo-be-le-lp;LegalPerson"/>
         <owl:disjointWith rdf:resource="&fibo-be-le-lp;NaturalPerson"/>
@@ -171,7 +175,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-pty-rl;hasRole"/>
+                <owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
                 <owl:someValuesFrom>              
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="&fibo-fnd-law-lcap;hasCapacity"/>
@@ -186,7 +190,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
     <owl:Class rdf:about="&fibo-be-le-lp;StatutoryBody">
         <rdfs:label>statutory body</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">A legal person which is created and given legal personhood by act of statute.</skos:definition>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-lp;JudicialPerson"/>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
     </owl:Class>
 
 </rdf:RDF>


### PR DESCRIPTION
... reasoning over the hasRole relationship in some circumstances returns incorrect results. Replacing the hasRole property with isPlayedBy corrects this issue.

In addition to correcting the hasRole issue, rename JudicialPerson to JuridicalPerson, which corresponds to the definition in question (rather than being about judges and courts).  This modification also aligns with the usage of the same concept in the OMG Records Management and GovDTF domain.
