### PR TITLE
BE-12, FBEF-21 - Pellet hangs when reasoning over the Corporate Bodies o...

### DIFF
--- a/be/LegalEntities/CorporateBodies.rdf
+++ b/be/LegalEntities/CorporateBodies.rdf
@@ -134,14 +134,14 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <skos:definition rdf:datatype="&xsd;string">A body corporate has a legal name and has certain rights, protections, privileges, responsibilities, and liabilities under law, similar to those of a natural person. The concept is pertinent to the philosophy of law, as it is essential to laws affecting a corporation (corporations law) (the law of business associations).</skos:definition>
         <skos:editorialNote rdf:datatype="&xsd;string">This is an artificial legal person, that is something with legal personhood but which has been created artificially. It is also a formal organization (unlike for example artificial legal persons created by statute or by royal charter). Bodies Corporate, and all non-natural legal persons, are generally created by some legal act and supported by some instrument such as the issuance of shares or guarantees. These are what give the entity a separate legal standing in the jurisdiction in which they are defined, and that jurisdiction will have created the laws which allow and cause this kind of entity to exist.</skos:editorialNote>
         <rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-lp;JudicialPerson"/>
-        <owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
+        <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&fibo-be-le-cb;isConstitutedBy"/>
                 <owl:onClass rdf:resource="&fibo-be-le-cb;InstrumentOfIncorporation"/>
                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
-        </owl:equivalentClass>
+        </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasLegalName"/>


### PR DESCRIPTION
...ntology, which appears to be caused by the equivalence in the definition of BodyCorporate to being constituted by an instrument of incorporation. The issue corresponds to a "lint" error produced by Pellet in testing. Relaxing this to a subclass relationship (i.e., changing it from a necessary and sufficient condition to just a necessary condition) eliminates the issue.

In addition to correcting ”lint” issue, this resolution addresses the renaming of JudicialPerson in LegalPersons, as a part of issue resolution to FBEF-20, to JuridicalPerson.
