### PR TITLE
This issue affects section 9.6.4, Corporate Control Ontology, in the FIB...

### DIFF
--- a/be/OwnershipAndControl/CorporateControl.rdf
+++ b/be/OwnershipAndControl/CorporateControl.rdf
@@ -59,6 +59,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <sm:fileAbstract rdf:datatype="&xsd;string">This ontology defines concepts relating to corporation-specific control. These concepts are based on the general types of control (both de facto control and controlling interests), as defined in the ControlParties ontology, and are the specific examples of these concepts as they apply to companies incorporated by the issuance of shares.</sm:fileAbstract>
 
         <skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/EDMC-FIBO/BE/20131101/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
+        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/FND/</sm:dependsOn>
         <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/FormalBusinessOrganizations/</sm:dependsOn>
         <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/</sm:dependsOn>
         <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/</sm:dependsOn>
@@ -93,88 +94,88 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasAffiliate">
+       <rdfs:label>has affiliate</rdfs:label>
+       <skos:definition rdf:datatype="&xsd;string">has a party which directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with the company</skos:definition>
+       <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasControllingInterestParty"/>
+       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-oac-cctl;Affiliate"/>
+   </owl:ObjectProperty>
+
    <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasDomesticUltimateParent">
        <rdfs:label>has domestic ultimate parent</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">the organization recognized as the ultimate parent of the company within its country or jurisdiction of incorporation, if it has one</skos:definition>
-      <skos:editorialNote rdf:datatype="&xsd;string">In the case of companies that are subsidiaries of another company that itself has a parent, this identifies the organization at the top of the hierarchy of organizations in the country of registration. Adapted from consensus definition of Ultimate Parent, now that this is split into national and global parent.</skos:editorialNote>
-      <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">consensus definition of ultimate parent, with the split between domestic and global parent</fibo-fnd-utl-av:adaptedFrom>
-      <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasMajorityControllingParty"/>
-      <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-      <rdfs:range rdf:resource="&fibo-be-oac-cctl;DomesticUltimateParent"/>
+       <skos:definition rdf:datatype="&xsd;string">relates an organization to another recognized as its ultimate parent, within its country or jurisdiction of incorporation, if it has one</skos:definition>
+       <skos:editorialNote rdf:datatype="&xsd;string">In the case of companies that are subsidiaries of another company that itself has a parent, this identifies the organization at the top of the hierarchy of organizations in the country of registration. Adapted from consensus definition of Ultimate Parent, now that this is split into national and global parent.</skos:editorialNote>
+       <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">consensus definition of ultimate parent, with the split between domestic and global parent</fibo-fnd-utl-av:adaptedFrom>
+       <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasMajorityControllingParty"/>
+       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-oac-cctl;DomesticUltimateParent"/>
    </owl:ObjectProperty>
 
    <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasGlobalUltimateParent">
        <rdfs:label>has global ultimate parent</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">the organization recognized as the ultimate parent of the company, if it has one</skos:definition>
-      <skos:editorialNote rdf:datatype="&xsd;string">In the case of companies that are subsidiaries of another company that itself has a parent, this identifies the organization at the top of the hierarchy, world-wide. Adapted from consensus definition of Ultimate Parent, now that this is split into national and global parent.</skos:editorialNote>
-      <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">consensus definition of ultimate parent, with the split between domestic and global parent</fibo-fnd-utl-av:adaptedFrom>
-      <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasMajorityControllingParty"/>
-      <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-      <rdfs:range rdf:resource="&fibo-be-oac-cctl;GlobalUltimateParent"/>
-   </owl:ObjectProperty>
-
-   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsControllingInterestIn">
-       <rdfs:label>holds controlling interest in</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">a company in which the voting shareholder owns some voting equity stake.</skos:definition>
-      <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-opty;holdsAnInterestIn"/>
-      <rdfs:domain rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
-      <rdfs:range rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-   </owl:ObjectProperty>
-
-   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsSignificantControllingInterestIn">
-       <rdfs:label>holds significant controlling interest in</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">the incorporated company in which the voting shareholder holds a significant proportion (but not fifty percent or more) of the voting share equity.</skos:definition>
-      <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsControllingInterestIn"/>
-      <rdfs:domain rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
-      <rdfs:range rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-   </owl:ObjectProperty>
-
-   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsMajorityControllingInterestIn">
-       <rdfs:label>holds majority controlling interest in</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">the incorporated company in which the voting shareholder holds fifty percent or more of the voting share equity.</skos:definition>
-      <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsControllingInterestIn"/>
-      <rdfs:domain rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
-      <rdfs:range rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-   </owl:ObjectProperty>
-
-   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasSubsidiary">
-       <rdfs:label>has subsidiary</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">a subsidiary of the company, that is an affiliae controlled by the company directly, or indirectly through one or more intermediaries.</skos:definition>
-      <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-      <rdfs:range rdf:resource="&fibo-be-oac-cctl;Subsidiary"/>
-   </owl:ObjectProperty>
-
-   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasMajorityOwnedSubsidiary">
-       <rdfs:label>has majority owned subsidiary</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">a majority owned subsidiary of the company, in this case, where there is above 50 percent (50 percent plus one share) ownership of the shares.</skos:definition>
-      <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasSubsidiary"/>
-      <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-      <rdfs:range rdf:resource="&fibo-be-oac-cctl;WhollyOwnedSubsidiary"/>
-   </owl:ObjectProperty>
-
-   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasAffiliate">
-       <rdfs:label>has affiliate</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">has a party which directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with the company.</skos:definition>
-      <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasControllingInterestParty"/>
-      <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-      <rdfs:range rdf:resource="&fibo-be-oac-cctl;Affiliate"/>
-   </owl:ObjectProperty>
-
-   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;isWhollyOwnedBy">
-       <rdfs:label>is wholly owned by</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">the formally constituted organization that has 100 percent ownership and control over a given incorporated company</skos:definition>
-      <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasMajorityControllingInterestParty"/>
-      <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-      <rdfs:range rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
+       <skos:definition rdf:datatype="&xsd;string">relates an organization to another recognized as its ultimate parent, if it has one</skos:definition>
+       <skos:editorialNote rdf:datatype="&xsd;string">In the case of companies that are subsidiaries of another company that itself has a parent, this identifies the organization at the top of the hierarchy, world-wide. Adapted from consensus definition of Ultimate Parent, now that this is split into national and global parent.</skos:editorialNote>
+       <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">consensus definition of ultimate parent, with the split between domestic and global parent</fibo-fnd-utl-av:adaptedFrom>
+       <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasMajorityControllingParty"/>
+       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-oac-cctl;GlobalUltimateParent"/>
    </owl:ObjectProperty>
 
    <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasMajorityControllingInterestParty">
        <rdfs:label>has majority controlling interest party</rdfs:label>
-      <skos:definition rdf:datatype="&xsd;string">the parent organization of the company, if there is one.</skos:definition>
-      <skos:editorialNote rdf:datatype="&xsd;string">This is defined as company or other Formal Organization which owns a controlling stake of greater than 50 percent (50 percent plus one voting share or above) in this company.</skos:editorialNote>
-      <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasSignificantControllingInterestParty"/>
-      <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-      <rdfs:range rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestCompany"/>
+       <skos:definition rdf:datatype="&xsd;string">relates a company to an organization that has a majority ownership and control over it, i.e., its parent organization, if there is one</skos:definition>
+       <skos:editorialNote rdf:datatype="&xsd;string">This is defined as company or other Formal Organization which owns a controlling stake of greater than 50 percent (50 percent plus one voting share or above) in this company.</skos:editorialNote>
+       <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasSignificantControllingInterestParty"/>
+       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestCompany"/>
+   </owl:ObjectProperty>
+
+   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasMajorityOwnedSubsidiary">
+       <rdfs:label>has majority owned subsidiary</rdfs:label>
+       <skos:definition rdf:datatype="&xsd;string">relates a company to one of its majority-owned subsidiaries, i.e., a subsidiary of which it owns more than 50 percent (50 percent plus one share) of the outstanding shares</skos:definition>
+       <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasSubsidiary"/>
+       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-oac-cctl;WhollyOwnedSubsidiary"/>
+   </owl:ObjectProperty>
+
+   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasSubsidiary">
+       <rdfs:label>has subsidiary</rdfs:label>
+       <skos:definition rdf:datatype="&xsd;string">relates a company to one of its subsidiaries, that is an affiliae controlled by the company directly, or indirectly through one or more intermediaries</skos:definition>
+       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-oac-cctl;Subsidiary"/>
+   </owl:ObjectProperty>
+
+   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsControllingInterestIn">
+       <rdfs:label>holds controlling interest in</rdfs:label>
+       <skos:definition rdf:datatype="&xsd;string">relates a voting shareholder to a company in which that shareholder owns some voting equity stake</skos:definition>
+       <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-opty;holdsAnInterestIn"/>
+       <rdfs:domain rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
+       <rdfs:range rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+   </owl:ObjectProperty>
+
+   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsMajorityControllingInterestIn">
+       <rdfs:label>holds majority controlling interest in</rdfs:label>
+       <skos:definition rdf:datatype="&xsd;string">relates a voting shareholder to a company in which the voting shareholder holds fifty percent or more of the voting share equity</skos:definition>
+       <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsControllingInterestIn"/>
+       <rdfs:domain rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
+       <rdfs:range rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+   </owl:ObjectProperty>
+
+   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsSignificantControllingInterestIn">
+       <rdfs:label>holds significant controlling interest in</rdfs:label>
+       <skos:definition rdf:datatype="&xsd;string">relates a voting shareholder to a company in which the voting shareholder holds a significant proportion (but not fifty percent or more) of the voting share equity</skos:definition>
+       <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsControllingInterestIn"/>
+       <rdfs:domain rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
+       <rdfs:range rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+   </owl:ObjectProperty>
+
+   <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;isWhollyOwnedBy">
+       <rdfs:label>is wholly owned by</rdfs:label>
+       <skos:definition rdf:datatype="&xsd;string">relates a company to an organization that has 100 percent ownership and control over it</skos:definition>
+       <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasMajorityControllingInterestParty"/>
+       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
    </owl:ObjectProperty>
 
 
@@ -188,7 +189,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
 
     <owl:Class rdf:about="&fibo-be-oac-cctl;Affiliate">
         <rdfs:label>affiliate</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">an affiliate of, or a person affiliated with, a specific person is a person that directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with, the person specified.</skos:definition>
+        <skos:definition rdf:datatype="&xsd;string">an affiliate of, or a person affiliated with, a specific person is a person that directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with, the person specified</skos:definition>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:unionOf rdf:parseType="Collection">
@@ -201,7 +202,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
 
     <owl:Class rdf:about="&fibo-be-oac-cctl;ControlledCompany">
         <rdfs:label>controlled company</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">A company over which another incorporated company has some degree of control by way of ownership of voting shares</skos:definition>
+        <skos:definition rdf:datatype="&xsd;string">a company over which another organization has some degree of control by way of ownership of voting shares</skos:definition>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;ControlledParty"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -211,7 +212,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-pty-rl;hasRole"/>
+                <owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
                 <owl:someValuesFrom>              
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="&fibo-be-oac-cpty;isControlledToSomeDegreeBy"/>
@@ -224,13 +225,13 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
 
     <owl:Class rdf:about="&fibo-be-oac-cctl;DomesticUltimateParent">
         <rdfs:label>domestic ultimate parent</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">the organization which is recognized as the ultimate parent of the company within the country or jurisdiction of incorporation, this relationship may or may not be present, i.e. in the case of a company which has no parent.</skos:definition>
+        <skos:definition rdf:datatype="&xsd;string">an organization that is recognized as the ultimate parent of a given company within the country or jurisdiction of incorporation; this relationship may or may not be present, i.e. in the case of a company that has no parent</skos:definition>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
     </owl:Class>
 
     <owl:Class rdf:about="&fibo-be-oac-cctl;GlobalUltimateParent">
         <rdfs:label>global ultimate parent</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">The organization which is recognized as the ultimate parent of the company. This relationship may or may not be present, i.e. in the case of a company which has no parent.</skos:definition>
+        <skos:definition rdf:datatype="&xsd;string">an organization that is recognized as the ultimate parent of the company; this relationship may or may not be present, i.e. in the case of a company that has no parent</skos:definition>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
     </owl:Class>
 
@@ -268,14 +269,14 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
 
     <owl:Class rdf:about="&fibo-be-oac-cctl;JointVenturePartner">
         <rdfs:label>joint venture partner</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">a party which has the role of joint venture partner to some venture</skos:definition>
+        <skos:definition rdf:datatype="&xsd;string">a party in the role of joint venture partner to some venture</skos:definition>
         <skos:editorialNote rdf:datatype="&xsd;string">This is part of ongoing work - legal definitions sought.</skos:editorialNote>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;EntityControllingParty"/>
     </owl:Class>
 
     <owl:Class rdf:about="&fibo-be-oac-cctl;NonWhollyOwnedSubsidiary">
         <rdfs:label>non-wholly owned subsidiary</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">A subsidiary which is not a wholly owned subsidiary.</skos:definition>
+        <skos:definition rdf:datatype="&xsd;string">a subsidiary which is not a wholly owned subsidiary</skos:definition>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;Subsidiary"/>
     </owl:Class>
 
@@ -286,7 +287,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
 
     <owl:Class rdf:about="&fibo-be-oac-cctl;SignificantShareholdingCompany">
         <rdfs:label>significant shareholding company</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">a company that owns a significant voting stake in an incorporated company</skos:definition>
+        <skos:definition rdf:datatype="&xsd;string">a company that owns a significant voting stake in another company</skos:definition>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;SignificantControllingInterestParty"/>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;VotingShareholdingCompany"/>
     </owl:Class>
@@ -299,7 +300,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
     <owl:Class rdf:about="&fibo-be-oac-cctl;TotalControllingInterestCompany">
        <rdfs:label>total controlling interest company</rdfs:label>
        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">parent company</fibo-fnd-utl-av:synonym>
-       <skos:definition rdf:datatype="&xsd;string">formal organization having 100 percent ownership in the incorporated company it holds voting shares in.</skos:definition>
+       <skos:definition rdf:datatype="&xsd;string">an organization having 100 percent ownership one or more organizations it holds voting shares in</skos:definition>
        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">By virtue of holding 100 percent of the share ownership, the total controlling interest company also holds 100 percent of the controlling equity, if there is a difference.  Therefore, it is both a total owner and a total controlling party.</fibo-fnd-utl-av:explanatoryNote>
        <rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;TotalOwner"/>
        <rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestCompany"/>
@@ -319,12 +320,12 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
 
     <owl:Class rdf:about="&fibo-be-oac-cctl;VotingShareholder">
         <rdfs:label>voting shareholder</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">A party owning voting shares in some company limited by the issue of shares</skos:definition>
+        <skos:definition rdf:datatype="&xsd;string">a party owning voting shares in some company limited by the issue of shares</skos:definition>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;DeJureControllingInterestParty"/>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cown;Shareholder"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-pty-rl;hasRole"/>
+                <owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
                 <owl:someValuesFrom>              
                     <owl:Class>
                         <owl:unionOf rdf:parseType="Collection">


### PR DESCRIPTION
...O BE 1.0 Alpha specification.

Two occurrences of hasRole have been replaced with isPlayedBy, one in the definition of ControlledCompany and the other in the extended definition of VotingShareholder.

In addition, labels have been added to most of the properties and a few classes in the ontology, and several literals were revised to add the appropriate datatypes, primarily xsd:string and xsd:anyURI, depending on the annotation value.

Finally, the VOM ancillary model, from which the RDF/XML serialized OWL and UML XMI are generated, was revised to correct the duplicate proxy class for IncorporatedCompany.
