### PR TITLE
BE-13, FBEF-38 - Summary:

### DIFF
--- a/be/Corporations/Corporations.rdf
+++ b/be/Corporations/Corporations.rdf
@@ -172,10 +172,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         </rdfs:subClassOf>
     </owl:Class>
 
-    <owl:Class rdf:about="&fibo-be-corp-corp;IncorporatedCompany">
-        <rdfs:label>incorporated company</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">a company incorporated by the issuance of shares</skos:definition>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyIncorporatedWithEquity"/>
+    <owl:Class rdf:about="&fibo-be-le-cb;GeneralStockCorporation">
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
@@ -233,7 +230,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
 2. In the US, a corporation with unlimited liability for the shareholders. Investors in a US joint stock company receive stock (shares) which can be transferred, and can elect a board of directors, but are jointly-and-severally liable for companys debts and obligations. A US joint stock company cannot hold title to a real property.</skos:definition>
         <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/joint-stock-company.html</fibo-fnd-utl-av:definitionOrigin>
         <skos:editorialNote rdf:datatype="&xsd;string">There are two kinds of joint stock company. The private company kind and the open market. The shares are usually only held by the directors and Company Secretary.</skos:editorialNote>
-        <rdfs:subClassOf rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
     </owl:Class>
 
     <owl:Class rdf:about="&fibo-be-corp-corp;PrivatelyHeldCompany">
@@ -243,13 +240,13 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <skos:definition rdf:datatype="&xsd;string">A firm whose issued shares are all held by a family or a small group of investors and, therefore, cannot be bought by the public.</skos:definition>
         <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/closed-corporation.html</fibo-fnd-utl-av:definitionOrigin>
         <skos:editorialNote rdf:datatype="&xsd;string">Wikipedia: definition for British or Commonwealth version: A private company limited by shares is a type of company incorporated under the laws of England and Wales, Scotland, that of certain Commonwealth countries and the Republic of Ireland. It has shareholders with limited liability and its shares may not be offered to the general public, unlike those of public limited companies. Additional notes from Wikipedia: Limited by shares means that the company has shareholders, and that the liability of the shareholders to creditors of the company is limited to the capital originally invested, i.e. the nominal value of the shares and any premium paid in return for the issue of the shares by the company. A shareholders personal assets are thereby protected in the event of the companys insolvency, but money invested in the company will be lost. A limited company may be private or public. A private limited companys disclosure requirements are lighter, but for this reason its shares may not be offered to the general public (and therefore cannot be traded on a public stock exchange). This is the major distinguishing feature between a private limited company and a public limited company. Most companies, particularly small companies, are private. Private companies limited by shares are required to have the suffix Limited (often written Ltd or Ltd.) or Incorporated (Inc.) as part of their name, though the latter cannot be used in the UK or the Republic of Ireland. In the Republic of Ireland, Teoranta (Teo.) may be used instead, largely by Gaeltacht companies. Cyfyngedig (Cyf.) may be used by Welsh companies in a similar fashion.</skos:editorialNote>
-        <rdfs:subClassOf rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
     </owl:Class>
 
     <owl:Class rdf:about="&fibo-be-corp-corp;PubliclyHeldCompany">
         <rdfs:label>publicly held company</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">a company whose shares are traded and held publicly</skos:definition>
-        <rdfs:subClassOf rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
     </owl:Class>
 
 </rdf:RDF>

--- a/be/FunctionalEntities/FunctionalEntities.rdf
+++ b/be/FunctionalEntities/FunctionalEntities.rdf
@@ -102,21 +102,6 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <owl:Class rdf:about="&fibo-be-fct-fct;BenefitCorporation">
-        <rdfs:label>benefit corporation</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">Corporation set up under specific state legislation to provide some stated societal benefit, and with some corresponding relaxation of the obligation to maximize shareholder return.</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">This is a US-specific type of entity defined in new and emerging legislation in the US states of California, Hawaii, Virginia, Maryland, Vermont, New Jersey. Additional upcoming legislation (as at November 2011) in Colorado, New York, North Carolina, Pennsylvania, Michigan. Much of the description is framed in terms of the role of the entity rather than its nature, however the legislation specifically relaxes or otherwise changes the basic parameters of the Incorporated Company structure (for example relaxing the requirement to maximize shareholder return) It may therefore be more correct to define this as a type of Incorporated Company not a role that one sits in. Having said this, B Corporations are certified by a certifying body (B Lab), which impies that they already exist and are granted a status in a similar way to that granted to non profit enterprises. Therefore at present this is defined as a status which an Incorporated Company may attain.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:termOrigin rdf:datatype="&xsd;anyURI">www.bcorporation.net</fibo-fnd-utl-av:termOrigin>
-        <rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-                <owl:onClass rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-
     <owl:Class rdf:about="&fibo-be-fct-fct;Business">
         <rdfs:label>business</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">An organization or economic system where goods and services are exchanged for one another or for money. Every business requires some form of investment and enough customers to whom its output can be sold on a consistent basis in order to make a profit. Businesses can be privately owned, not-for-profit or state-owned. An example of a corporate business is PepsiCo, while a mom-and-pop catering business is a private enterprise.</skos:definition>
@@ -178,21 +163,6 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
                 <owl:onProperty rdf:resource="&fibo-be-fct-fct;isCharacterizedBy"/>
                 <owl:onClass rdf:resource="&fibo-be-fct-fct;Commerce"/>
                 <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-
-    <owl:Class rdf:about="&fibo-be-fct-fct;NonProfitOrganization">
-        <rdfs:label>non-profit organization</rdfs:label>
-        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">not-for-profit organization</fibo-fnd-utl-av:synonym>
-        <skos:definition rdf:datatype="&xsd;string">an organization that exists for some purpose other than to make a profit for its participants</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">A non-profit or charitable public or private foundation is a legal entity. Action: needs a relationship to Legal Entity. Which is not a human being. Need non human legal entity scope formally defined. Probably has a board of directors.</fibo-fnd-utl-av:explanatoryNote>
-        <rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-                <owl:onClass rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>

--- a/be/LegalEntities/CorporateBodies.rdf
+++ b/be/LegalEntities/CorporateBodies.rdf
@@ -98,25 +98,25 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <owl:ObjectProperty rdf:about="&fibo-be-le-cb;issuesEquity">
-        <rdfs:label>issues equity</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">A body incorporated by equity is incorporated through the issuance of some issued equity, which is a form of stockholders equity.</skos:definition>
-        <rdfs:domain rdf:resource="&fibo-be-le-cb;BodyIncorporatedWithEquity"/>
-        <rdfs:range rdf:resource="&fibo-fnd-acc-aeq;IssuedEquity"/>
-   </owl:ObjectProperty>
-
     <owl:ObjectProperty rdf:about="&fibo-be-le-cb;isConstitutedBy">
         <rdfs:label>is constituted by</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the instrument by which an entity is incorporated</skos:definition>
-        <rdfs:domain rdf:resource="&fibo-be-le-cb;BodyCorporate"/>
+        <rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
         <rdfs:range rdf:resource="&fibo-fnd-law-cor;Constitution"/>
     </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="&fibo-be-le-cb;issuesEquity">
+        <rdfs:label>issues equity</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">A body incorporated by equity is incorporated through the issuance of some issued equity, which is a form of stockholders equity.</skos:definition>
+        <rdfs:domain rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
+        <rdfs:range rdf:resource="&fibo-fnd-acc-aeq;IssuedEquity"/>
+   </owl:ObjectProperty>
 
     <owl:ObjectProperty rdf:about="&fibo-be-le-cb;isIncorporatedIn">
         <rdfs:label>is incorporated in</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">the legal jurisdiction under which the legal entity is incorporated</skos:definition>
         <skos:editorialNote rdf:datatype="&xsd;string">It is the laws of this jurisdiction that cause and allow the legal entity to exist and to incur debt and be sued at law as a legal entity.</skos:editorialNote>
-        <rdfs:domain rdf:resource="&fibo-be-le-cb;BodyCorporate"/>
+        <rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
         <rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
     </owl:ObjectProperty>
 
@@ -129,10 +129,65 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <owl:Class rdf:about="&fibo-be-le-cb;BodyCorporate">
-        <rdfs:label>body corporate</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">A body corporate has a legal name and has certain rights, protections, privileges, responsibilities, and liabilities under law, similar to those of a natural person. The concept is pertinent to the philosophy of law, as it is essential to laws affecting a corporation (corporations law) (the law of business associations).</skos:definition>
-        <skos:editorialNote rdf:datatype="&xsd;string">This is an artificial legal person, that is something with legal personhood but which has been created artificially. It is also a formal organization (unlike for example artificial legal persons created by statute or by royal charter). Bodies Corporate, and all non-natural legal persons, are generally created by some legal act and supported by some instrument such as the issuance of shares or guarantees. These are what give the entity a separate legal standing in the jurisdiction in which they are defined, and that jurisdiction will have created the laws which allow and cause this kind of entity to exist.</skos:editorialNote>
+    <owl:Class rdf:about="&fibo-be-le-cb;BenefitCorporation">
+        <rdfs:label>benefit corporation</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">non-profit corporation set up under specific state legislation to provide some stated societal benefit, and with some corresponding relaxation of the obligation to maximize shareholder return</skos:definition>
+        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">This is a US-specific type of non-profit corporation defined in recent legislation in a number of states. In California, for example, benefit corporations may be defined as public benefit or mutual benefit corporations, depending on their purpose.</fibo-fnd-utl-av:explanatoryNote>
+        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">www.bcorporation.net</fibo-fnd-utl-av:adaptedFrom>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.business.ca.gov/Portals/0/Home/Docs/AB%202641%20SOS.pdf</rdfs:seeAlso>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;NonProfitCorporation"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&fibo-be-le-cb;BodyIncorporatedThroughAgreement">
+        <rdfs:label>body incorporated through agreement</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">A body with legal personhood, incorporated through some agreement among the principals, and without equity or guarantee instruments which would isolate the principals from liability.</skos:definition>
+        <skos:editorialNote rdf:datatype="&xsd;string">An LLP (in the UK) is an example of this, and is also a partnership. There, the LLP Document is the legal document which effectively constitutes the Partnership.</skos:editorialNote>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;Corporation"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&fibo-be-le-cb;BodyIncorporatedWithGuarantee">
+        <rdfs:label>body incorporated with guarantee</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">Incorporated entity without share capital, and in which the liability of its members is limited to the amount each one of them undertakes to contribute at the time the firm is wound up.</skos:definition>
+        <skos:editorialNote rdf:datatype="&xsd;string">The profit motive is not the prime objective of the organization.</skos:editorialNote>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;Corporation"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
+                <owl:onClass rdf:resource="&fibo-be-le-cb;BodyLimitedByGuaranteePrincipalsAgreement"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+
+    <owl:Class rdf:about="&fibo-be-le-cb;BodyLimitedByGuaranteePrincipalsAgreement">
+        <rdfs:label>body limited by guarantee principals agreement</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">The formal agreement between the principals of a body limited by guarantee.</skos:definition>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;OrganizationCoveringAgreement"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&fibo-be-le-cb;CommonInterestDevelopmentCorporation">
+        <rdfs:label>common interest development corporation</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">non-profit corporation set up under specific state legislation as a business entity for homeowners' associations</skos:definition>
+        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">A common interest development is typically a type of housing, composed of individually owned units, such as condominiums, townhouses, or single-family homes, that share ownership of common areas, such as swimming pools, landscaping, and parking. Common interest developments (also known as community interest developments or CIDs) are managed by homeowners' associations.</fibo-fnd-utl-av:explanatoryNote>
+        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.nolo.com/dictionary/common-interest-development-term.html</fibo-fnd-utl-av:adaptedFrom>
+        <skos:example rdf:datatype="&xsd;anyURI">http://www.dre.ca.gov/files/pdf/re39.pdf</skos:example>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;NonProfitCorporation"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&fibo-be-le-cb;CompanyIncorporatedByGuarantee">
+        <rdfs:label>company incorporated by guarantee</rdfs:label>
+        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">www.investorwords.com</fibo-fnd-utl-av:definitionOrigin>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyIncorporatedWithGuarantee"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="&fibo-be-le-cb;Corporation">
+        <rdfs:label>corporation</rdfs:label>
+        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">body corporate</fibo-fnd-utl-av:synonym>
+        <skos:definition rdf:datatype="&xsd;string">a formal organization treated as an entity - an artificial person or legal entity distinct from its owners - created by or under the authority of the laws of a state or nation</skos:definition>
+        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Banking Terms, Sixth Edition, 2012, definition of corporation</fibo-fnd-utl-av:adaptedFrom>
+        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://thelawdictionary.org/corporation/</fibo-fnd-utl-av:adaptedFrom>
+        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">A corporation has three distinguishing characteristics: (1) separation of ownership from management and general liability, i.e., its liability to creditors is limited to its resources, unlike some partnerships and sole proprietorships, (2) the ability to negotiate contracts and own property, and (3) transferable ownership, irrespective of changes in membership or the lifetimes of its stockholders.</fibo-fnd-utl-av:explanatoryNote>
+        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">A corporation is managed by or under the direction of a board of directors, which generally determines corporate policy. Officers manage the day-to-day affairs of the corporation.</fibo-fnd-utl-av:explanatoryNote>
         <rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
         <rdfs:subClassOf rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
         <rdfs:subClassOf>
@@ -165,17 +220,13 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         </rdfs:subClassOf>
     </owl:Class>
 
-    <owl:Class rdf:about="&fibo-be-le-cb;BodyIncorporatedThroughAgreement">
-        <rdfs:label>body incorporated through agreement</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">A body with legal personhood, incorporated through some agreement among the principals, and without equity or guarantee instruments which would isolate the principals from liability.</skos:definition>
-        <skos:editorialNote rdf:datatype="&xsd;string">An LLP (in the UK) is an example of this, and is also a partnership. There, the LLP Document is the legal document which effectively constitutes the Partnership.</skos:editorialNote>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyCorporate"/>
-    </owl:Class>
-
-    <owl:Class rdf:about="&fibo-be-le-cb;BodyIncorporatedWithEquity">
-        <rdfs:label>body incorporated with equity</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">A body corporate which is incorporated by means of the issuance of equity.</skos:definition>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyCorporate"/>
+    <owl:Class rdf:about="&fibo-be-le-cb;GeneralStockCorporation">
+        <rdfs:label>general stock corporation</rdfs:label>
+        <skos:definition rdf:datatype="&xsd;string">a for-profit corporation which has shareholders (stockholders), each of whom receives a portion of the ownership of the corporation through shares of stock</skos:definition>
+        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.oecd.org/daf/ca/CorporateGovernanceFactbook.pdf</fibo-fnd-utl-av:adaptedFrom>
+        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://biztaxlaw.about.com/od/glossarys/g/stockcorp.htm</fibo-fnd-utl-av:adaptedFrom>
+        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">The shares in a stock corporation may receive a return on their investment in the form of dividends. Shares are used for voting on matters of corporate policy or to elect directors, at the corporation's annual meeting and at other meetings of the corporation.</fibo-fnd-utl-av:explanatoryNote>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;Corporation"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&fibo-be-le-cb;issuesEquity"/>
@@ -183,32 +234,6 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
                 <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
-    </owl:Class>
-
-    <owl:Class rdf:about="&fibo-be-le-cb;BodyIncorporatedWithGuarantee">
-        <rdfs:label>body incorporated with guarantee</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">Incorporated entity without share capital, and in which the liability of its members is limited to the amount each one of them undertakes to contribute at the time the firm is wound up.</skos:definition>
-        <skos:editorialNote rdf:datatype="&xsd;string">The profit motive is not the prime objective of the organization.</skos:editorialNote>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyCorporate"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
-                <owl:onClass rdf:resource="&fibo-be-le-cb;BodyLimitedByGuaranteePrincipalsAgreement"/>
-                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-    </owl:Class>
-
-    <owl:Class rdf:about="&fibo-be-le-cb;BodyLimitedByGuaranteePrincipalsAgreement">
-        <rdfs:label>body limited by guarantee principals agreement</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">The formal agreement between the principals of a body limited by guarantee.</skos:definition>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;OrganizationCoveringAgreement"/>
-    </owl:Class>
-
-    <owl:Class rdf:about="&fibo-be-le-cb;CompanyIncorporatedByGuarantee">
-        <rdfs:label>company incorporated by guarantee</rdfs:label>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">www.investorwords.com</fibo-fnd-utl-av:definitionOrigin>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyIncorporatedWithGuarantee"/>
     </owl:Class>
 
     <owl:Class rdf:about="&fibo-be-le-cb;IncorporationGuarantee">
@@ -242,6 +267,15 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
+    </owl:Class>
+
+    <owl:Class rdf:about="&fibo-be-le-cb;NonProfitCorporation">
+        <rdfs:label>non-profit corporation</rdfs:label>
+        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">not-for-profit corporation</fibo-fnd-utl-av:synonym>
+        <skos:definition rdf:datatype="&xsd;string">a corporation approved by its jurisdictional oversight and taxing authorities as operating for educational, charitable, social, religious, civic or humanitarian purposes</skos:definition>
+        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://legal-dictionary.thefreedictionary.com/nonprofit+corporation</fibo-fnd-utl-av:adaptedFrom>
+        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">A nonprofit corporation is formed by incorporators, and has a board of directors and officers, but no shareholders. These incorporators, directors and officers may not receive a distribution of (any money from) profits, but officers and management may be paid reasonable salaries for services to the corporation.</fibo-fnd-utl-av:explanatoryNote>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;Corporation"/>
     </owl:Class>
 
 </rdf:RDF>

--- a/be/OwnershipAndControl/CorporateControl.rdf
+++ b/be/OwnershipAndControl/CorporateControl.rdf
@@ -13,6 +13,7 @@
     <!ENTITY fibo-fnd-pty-rl "http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Roles/" >
     <!ENTITY fibo-fnd-pty-pty "http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Parties/" >
     <!ENTITY fibo-be-le-fbo "http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/FormalBusinessOrganizations/" >
+    <!ENTITY fibo-be-le-cb "http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/CorporateBodies/" >
     <!ENTITY fibo-be-corp-corp "http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/" >
     <!ENTITY fibo-be-oac-opty "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/" >
     <!ENTITY fibo-be-oac-cpty "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/ControlParties/" >
@@ -33,6 +34,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
      xmlns:fibo-fnd-pty-rl="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Roles/"
      xmlns:fibo-fnd-pty-pty="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Parties/"
      xmlns:fibo-be-le-fbo="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/FormalBusinessOrganizations/"
+     xmlns:fibo-be-le-cb="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/CorporateBodies/"
      xmlns:fibo-be-corp-corp="http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/"
      xmlns:fibo-be-oac-opty="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/"
      xmlns:fibo-be-oac-cpty="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/ControlParties/"
@@ -78,6 +80,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Roles/"/>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Parties/"/>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/FormalBusinessOrganizations/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/CorporateBodies/"/>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/"/>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/"/>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/ControlParties/"/>
@@ -98,7 +101,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
        <rdfs:label>has affiliate</rdfs:label>
        <skos:definition rdf:datatype="&xsd;string">has a party which directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with the company</skos:definition>
        <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasControllingInterestParty"/>
-       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:domain rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
        <rdfs:range rdf:resource="&fibo-be-oac-cctl;Affiliate"/>
    </owl:ObjectProperty>
 
@@ -108,7 +111,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
        <skos:editorialNote rdf:datatype="&xsd;string">In the case of companies that are subsidiaries of another company that itself has a parent, this identifies the organization at the top of the hierarchy of organizations in the country of registration. Adapted from consensus definition of Ultimate Parent, now that this is split into national and global parent.</skos:editorialNote>
        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">consensus definition of ultimate parent, with the split between domestic and global parent</fibo-fnd-utl-av:adaptedFrom>
        <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasMajorityControllingParty"/>
-       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:domain rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
        <rdfs:range rdf:resource="&fibo-be-oac-cctl;DomesticUltimateParent"/>
    </owl:ObjectProperty>
 
@@ -118,7 +121,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
        <skos:editorialNote rdf:datatype="&xsd;string">In the case of companies that are subsidiaries of another company that itself has a parent, this identifies the organization at the top of the hierarchy, world-wide. Adapted from consensus definition of Ultimate Parent, now that this is split into national and global parent.</skos:editorialNote>
        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">consensus definition of ultimate parent, with the split between domestic and global parent</fibo-fnd-utl-av:adaptedFrom>
        <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasMajorityControllingParty"/>
-       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:domain rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
        <rdfs:range rdf:resource="&fibo-be-oac-cctl;GlobalUltimateParent"/>
    </owl:ObjectProperty>
 
@@ -127,7 +130,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
        <skos:definition rdf:datatype="&xsd;string">relates a company to an organization that has a majority ownership and control over it, i.e., its parent organization, if there is one</skos:definition>
        <skos:editorialNote rdf:datatype="&xsd;string">This is defined as company or other Formal Organization which owns a controlling stake of greater than 50 percent (50 percent plus one voting share or above) in this company.</skos:editorialNote>
        <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasSignificantControllingInterestParty"/>
-       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:domain rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
        <rdfs:range rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestCompany"/>
    </owl:ObjectProperty>
 
@@ -135,14 +138,14 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
        <rdfs:label>has majority owned subsidiary</rdfs:label>
        <skos:definition rdf:datatype="&xsd;string">relates a company to one of its majority-owned subsidiaries, i.e., a subsidiary of which it owns more than 50 percent (50 percent plus one share) of the outstanding shares</skos:definition>
        <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasSubsidiary"/>
-       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:domain rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
        <rdfs:range rdf:resource="&fibo-be-oac-cctl;WhollyOwnedSubsidiary"/>
    </owl:ObjectProperty>
 
    <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasSubsidiary">
        <rdfs:label>has subsidiary</rdfs:label>
        <skos:definition rdf:datatype="&xsd;string">relates a company to one of its subsidiaries, that is an affiliae controlled by the company directly, or indirectly through one or more intermediaries</skos:definition>
-       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:domain rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
        <rdfs:range rdf:resource="&fibo-be-oac-cctl;Subsidiary"/>
    </owl:ObjectProperty>
 
@@ -151,7 +154,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
        <skos:definition rdf:datatype="&xsd;string">relates a voting shareholder to a company in which that shareholder owns some voting equity stake</skos:definition>
        <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-opty;holdsAnInterestIn"/>
        <rdfs:domain rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
-       <rdfs:range rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
    </owl:ObjectProperty>
 
    <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsMajorityControllingInterestIn">
@@ -159,7 +162,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
        <skos:definition rdf:datatype="&xsd;string">relates a voting shareholder to a company in which the voting shareholder holds fifty percent or more of the voting share equity</skos:definition>
        <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsControllingInterestIn"/>
        <rdfs:domain rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
-       <rdfs:range rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
    </owl:ObjectProperty>
 
    <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsSignificantControllingInterestIn">
@@ -167,14 +170,14 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
        <skos:definition rdf:datatype="&xsd;string">relates a voting shareholder to a company in which the voting shareholder holds a significant proportion (but not fifty percent or more) of the voting share equity</skos:definition>
        <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsControllingInterestIn"/>
        <rdfs:domain rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
-       <rdfs:range rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:range rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
    </owl:ObjectProperty>
 
    <owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;isWhollyOwnedBy">
        <rdfs:label>is wholly owned by</rdfs:label>
        <skos:definition rdf:datatype="&xsd;string">relates a company to an organization that has 100 percent ownership and control over it</skos:definition>
        <rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasMajorityControllingInterestParty"/>
-       <rdfs:domain rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+       <rdfs:domain rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
        <rdfs:range rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
    </owl:ObjectProperty>
 
@@ -235,7 +238,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
     </owl:Class>
 
-    <owl:Class rdf:about="&fibo-be-corp-corp;IncorporatedCompany">
+    <owl:Class rdf:about="&fibo-be-le-cb;GeneralStockCorporation">
         <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">The restrictions defined herein extend the definition of incorporated company to link it to external entities that hold shares in it.</fibo-fnd-utl-av:explanatoryNote>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -335,7 +338,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
                             </owl:Restriction>
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="&fibo-be-oac-opty;holdsAnInterestIn"/>
-                                <owl:allValuesFrom rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+                                <owl:allValuesFrom rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
                             </owl:Restriction>
                         </owl:unionOf>
                     </owl:Class>

--- a/be/OwnershipAndControl/CorporateOwnership.rdf
+++ b/be/OwnershipAndControl/CorporateOwnership.rdf
@@ -14,6 +14,7 @@
     <!ENTITY fibo-fnd-pty-rl "http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Roles/" >
     <!ENTITY fibo-fnd-acc-aeq "http://www.omg.org/spec/EDMC-FIBO/FND/Accounting/AccountingEquity/" >
     <!ENTITY fibo-fnd-agr-ctr "http://www.omg.org/spec/EDMC-FIBO/FND/Agreements/Contracts/" >
+    <!ENTITY fibo-be-le-cb "http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/CorporateBodies/" >
     <!ENTITY fibo-be-corp-corp "http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/" >
     <!ENTITY fibo-be-oac-opty "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/" >
     <!ENTITY fibo-be-oac-cown "http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/CorporateOwnership/" >
@@ -33,6 +34,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
      xmlns:fibo-fnd-pty-rl="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Roles/"
      xmlns:fibo-fnd-acc-aeq="http://www.omg.org/spec/EDMC-FIBO/FND/Accounting/AccountingEquity/"
      xmlns:fibo-fnd-agr-ctr="http://www.omg.org/spec/EDMC-FIBO/FND/Agreements/Contracts/"
+     xmlns:fibo-be-le-cb="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/CorporateBodies/"
      xmlns:fibo-be-corp-corp="http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/"
      xmlns:fibo-be-oac-opty="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/"
      xmlns:fibo-be-oac-cown="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/CorporateOwnership/">
@@ -74,6 +76,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Parties/Roles/"/>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Accounting/AccountingEquity/"/>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/FND/Agreements/Contracts/"/>
+        <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/LegalEntities/CorporateBodies/"/>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/Corporations/Corporations/"/>
         <owl:imports rdf:resource="http://www.omg.org/spec/EDMC-FIBO/BE/OwnershipAndControl/OwnershipParties/"/>
 
@@ -127,7 +130,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
                             </owl:Restriction>
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="&fibo-be-oac-opty;holdsAnInterestIn"/>
-                                <owl:allValuesFrom rdf:resource="&fibo-be-corp-corp;IncorporatedCompany"/>
+                                <owl:allValuesFrom rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
                             </owl:Restriction>
                         </owl:unionOf>
                     </owl:Class>

--- a/be/Partnerships/Partnerships.rdf
+++ b/be/Partnerships/Partnerships.rdf
@@ -163,7 +163,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-                <owl:onClass rdf:resource="&fibo-be-le-cb;BodyCorporate"/>
+                <owl:onClass rdf:resource="&fibo-be-le-cb;Corporation"/>
                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -229,7 +229,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <rdfs:label>legally incorporated partnership</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">Any partnership which is defined as a legal person within a given jurisdiction, for example a limited liability partnership (if that is a legal person).</skos:definition>
         <skos:editorialNote rdf:datatype="&xsd;string">The precise details and definition of these may vary from one jurisdiction to another. This type of entity is defined by being a legal person in its own right, as distinct from the usual type of partnership where the partners remain jointly and severally liable for debts.</skos:editorialNote>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyCorporate"/>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;Corporation"/>
         <rdfs:subClassOf rdf:resource="&fibo-be-ptr-ptr;Partnership"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -399,7 +399,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <rdfs:label>partnership incorporated by equity</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">a partnership incorporated via the issuance of equity, with limited partners (i.e., partners whose liability is limited) that are necessarily not natural persons (i.e., cannot be individuals)</skos:definition>
         <rdfs:subClassOf rdf:resource="&fibo-be-ptr-ptr;PartnershipWithLimitedPartners"/>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyIncorporatedWithEquity"/>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;GeneralStockCorporation"/>
     </owl:Class>
 
     <owl:Class rdf:about="&fibo-be-ptr-ptr;PartnershipIncorporatedThroughAgreement">
@@ -485,7 +485,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
        <rdfs:label>partnership with only limited partners</rdfs:label>
        <skos:definition rdf:datatype="&xsd;string">a partnership having limited partners but no general partners</skos:definition>
         <rdfs:subClassOf rdf:resource="&fibo-be-ptr-ptr;PartnershipWithLimitedPartners"/>
-        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyCorporate"/>
+        <rdfs:subClassOf rdf:resource="&fibo-be-le-cb;Corporation"/>
    </owl:Class>
 
 </rdf:RDF>


### PR DESCRIPTION
Review of any state web site for defining a business call this "Corporation". Not all corporations are companies, however. The actual restrictions on this class are exactly those appropriate for Corporation, but the text definition should be something like:

"A corporation is a separate legal entity owned by shareholders who enjoy protection from personal liability. Corporations are taxed annually on their earnings; corporate shareholders pay individual income tax on these earnings when they are distributed as dividends.
A corporation is managed by or under the direction of a board of directors, which generally determines corporate policy. Officers manage the day-to-day affairs of the corporation. Shareholders do not participate in day-to-day management activities. Management structure can be altered by committees of board members and shareholder agreements. Shareholders generally are not personally liable for obligations of the corporation."

Definition origin: http://www.business.ca.gov/StartaBusiness/DefiningaBusiness/Corporation.aspx

The Corporation class should have the following subclasses:
General Stock Corporation
Non-Profit Corporation
Benefit Corporation (which we have already in Functional Entities)
Common Interest Development Corporation

Non-Profit / benefit corporations have a corporate structure that can be defined using restrictions, and are not functional entities. They should be defined as kinds of corporations.

Discussion:
This issue affects section 9.2.3, Corporate Bodies, section 9.3.1, Corporations Ontology, in the FIBO BE 1.0 Alpha specification, with downstream impact on section 9.7.1, Functional Entities, section 9.6.3, Corporate Ownership, section 9.6.4, Corporate Control, and section 9.4.1, Partnerships.

Further review of the current set of concepts and related definitions has led to the consensus that the BodyCorporate concept in the Corporate Bodies ontology and the concept of a Corporation, at the highest level of abstraction, are synonymous.  Thus, the consensus is to rename BodyCorporate to Corporation, and integrate a source-able definition for it from a respected legal source, as long as that definition is essentially the same as what we currently have and is not jurisdiction-specific.  Links to jurisdiction-specific definitions may be provided, however.

Additionally, a better name for the current IncorporatedCompany concept is GeneralStockCorporation, which corresponds to the broader meaning of the semantics in the current ontology for incorporated company.  Again a better terminological definition should be sourced from an appropriate reference, as long as it is in keeping with the current text definition.

**\* The resolution of this issue assumes that the resolution to issues FBEF-3, resolving mechanical syntax issues, issues FBEF-4, FBEF-6, FBEF-7, and FBEF-9 through FBEF-12, which resolve issues related to modifications in FIBO FND by the 1.0 finalization process, as well as issues FBEF-20 through FBEF-24, FBEF-30, FBEF-31, FBEF-34, and FBEF-35, which resolve lint errors, reasoning issues due to the hasRole property, and miscellaneous annotation issues have already been applied.
