### PR TITLE
Trivial one word change to use onClass instead of allValuesFrom.

### DIFF
--- a/be/OwnershipAndControl/Executives.rdf
+++ b/be/OwnershipAndControl/Executives.rdf
@@ -466,7 +466,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
-                <owl:allValuesFrom rdf:resource="&fibo-be-oac-exec;CompanyLaw"/>
+                <owl:onClass rdf:resource="&fibo-be-oac-exec;CompanyLaw"/>
                 <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>


### PR DESCRIPTION
This is a problem I hit as I was importing into Adaptive to generate the ODM XMI for the BE deliverables to OMG. 
Assuming this is indeed a bug we should re-submit this fixed file; and the UML and spec document probably also need updating.
