### PR TITLE
IND-6, Revised InterestRates, EconomicIndicators, and ForeignExchange to...

### DIFF
--- a/ind/EconomicIndicators/EconomicIndicators.rdf
+++ b/ind/EconomicIndicators/EconomicIndicators.rdf
@@ -12,36 +12,14 @@
     <!ENTITY fibo-fnd-utl-bt "http://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/" >
     <!ENTITY fibo-fnd-rel-rel "http://spec.edmcouncil.org/fibo/FND/Relations/Relations/" >
     <!ENTITY fibo-fnd-utl-alx "http://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/" >
-    <!ENTITY fibo-fnd-aap-agt "http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/" >
     <!ENTITY fibo-fnd-plc-loc "http://spec.edmcouncil.org/fibo/FND/Places/Locations/" >
     <!ENTITY fibo-fnd-plc-cty "http://spec.edmcouncil.org/fibo/FND/Places/Countries/" >
-    <!ENTITY fibo-fnd-plc-adr "http://spec.edmcouncil.org/fibo/FND/Places/Addresses/" >
-    <!ENTITY fibo-fnd-gao-gl "http://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/" >
-    <!ENTITY fibo-fnd-org-org "http://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/" >
-    <!ENTITY fibo-fnd-org-fm "http://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/" >
-    <!ENTITY fibo-fnd-aap-ppl "http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/" >
-    <!ENTITY fibo-fnd-pty-rl "http://spec.edmcouncil.org/fibo/FND/Parties/Roles/" >
-    <!ENTITY fibo-fnd-pty-pty "http://spec.edmcouncil.org/fibo/FND/Parties/Parties/" >
-    <!ENTITY fibo-fnd-oac-own "http://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/" >
     <!ENTITY fibo-fnd-acc-cur "http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/" >
-    <!ENTITY fibo-fnd-acc-aeq "http://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/" >
-    <!ENTITY fibo-fnd-agr-agr "http://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/" >
-    <!ENTITY fibo-fnd-law-cor "http://spec.edmcouncil.org/fibo/FND/Law/LegalCore/" >
-    <!ENTITY fibo-fnd-law-jur "http://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/" >
-    <!ENTITY fibo-fnd-agr-ctr "http://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/" >
-    <!ENTITY fibo-fnd-law-lcap "http://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/" >
-    <!ENTITY fibo-be-le-lp "http://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/" >
-    <!ENTITY fibo-be-le-fbo "http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/" >
-    <!ENTITY fibo-be-le-cb "http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/" >
-    <!ENTITY fibo-be-corp-corp "http://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/" >
-    <!ENTITY fibo-be-fct-fct "http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/" >
     <!ENTITY fibo-be-fct-pub "http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/Publishers/" >
-    <!ENTITY fibo-ind-ind-ind "http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/" >
     <!ENTITY fibo-ind-ei-ei "http://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/" >
 ]>
 
-<rdf:RDF xmlns="http://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"
-     xml:base="http://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"
+<rdf:RDF xml:base="http://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -53,31 +31,10 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
      xmlns:fibo-fnd-utl-bt="http://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/"
      xmlns:fibo-fnd-rel-rel="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
      xmlns:fibo-fnd-utl-alx="http://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"
-     xmlns:fibo-fnd-aap-agt="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
      xmlns:fibo-fnd-plc-loc="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"
      xmlns:fibo-fnd-plc-cty="http://spec.edmcouncil.org/fibo/FND/Places/Countries/"
-     xmlns:fibo-fnd-plc-adr="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
-     xmlns:fibo-fnd-gao-gl="http://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
-     xmlns:fibo-fnd-org-org="http://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"
-     xmlns:fibo-fnd-org-fm="http://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"
-     xmlns:fibo-fnd-aap-ppl="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
-     xmlns:fibo-fnd-pty-rl="http://spec.edmcouncil.org/fibo/FND/Parties/Roles/"
-     xmlns:fibo-fnd-pty-pty="http://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-     xmlns:fibo-fnd-oac-own="http://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
      xmlns:fibo-fnd-acc-cur="http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-     xmlns:fibo-fnd-acc-aeq="http://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
-     xmlns:fibo-fnd-agr-agr="http://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
-     xmlns:fibo-fnd-law-cor="http://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
-     xmlns:fibo-fnd-law-jur="http://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-     xmlns:fibo-fnd-agr-ctr="http://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-     xmlns:fibo-fnd-law-lcap="http://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
-     xmlns:fibo-be-le-lp="http://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-     xmlns:fibo-be-le-fbo="http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-     xmlns:fibo-be-le-cb="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-     xmlns:fibo-be-corp-corp="http://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"
-     xmlns:fibo-be-fct-fct="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
      xmlns:fibo-be-fct-pub="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/Publishers/"
-     xmlns:fibo-ind-ind-ind="http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"
      xmlns:fibo-ind-ei-ei="http://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/">
 
 
@@ -85,120 +42,41 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
         <rdfs:label>Economic Indicators Ontology</rdfs:label>
 
 
-    <!-- Specification Family Level Metadata for the FIBO IND Economic Indicators Ontology -->
-
-        <sm:familyTitle rdf:datatype="&xsd;string">Financial Industry Business Ontology (FIBO)</sm:familyTitle>
-        <sm:familyAbbreviation rdf:datatype="&xsd;string">FIBO</sm:familyAbbreviation>
-        <sm:familyURL rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/</sm:familyURL>
-        <sm:familyAbstract rdf:datatype="&xsd;string">The content that comprises the Financial Industry Business Ontology (FIBO) is documentation, interpretable in formal logic, of the concepts represented by finance industry terms as used in official financial organization documents such as contracts, product/service specifications and governance and regulatory compliance documents.</sm:familyAbstract>
-
-        <sm:technologyArea rdf:datatype="&xsd;string">formal semantics</sm:technologyArea>
-
-        <sm:topicArea rdf:datatype="&xsd;string">finance</sm:topicArea>
-
-        <sm:keyword rdf:datatype="&xsd;string">Financial Industry Business Ontology</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">FIBO</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">ontology</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">vocabulary</sm:keyword>
-
-
-    <!-- Specification Level Metadata for the FIBO IND Economic Indicators Ontology -->
-
-        <sm:specificationTitle rdf:datatype="&xsd;string">Financial Industry Business Ontology (FIBO) Indices and Indicators Specification</sm:specificationTitle>
-        <sm:specificationAbbreviation rdf:datatype="&xsd;string">FIBO-IND</sm:specificationAbbreviation>
-        <sm:specificationURL rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/</sm:specificationURL>
-        <sm:specificationAbstract rdf:datatype="&xsd;string">FIBO Indices and Indicators is a set of business concepts representing the various forms of market indices, economic indicators and market interest rates.  
-
-The FIBO Indices and Indicators models covers quoted interest rates, economic measures such as employment rates, and quoted indices based on baskets of securities, including specific kinds of securities in share indices or bond indices, as well as credit indices. 
-
-The indices and indicators terms consist of numeric parameters which vary over time, and which therefore take a value which is temporal (having a present value, a number of past values based on the frequency with which that index or indicator is updated, and an indefinite number of future values based on various prediction criteria (unlike past values, a future vaue for a given date or date and time, need not be unique).</sm:specificationAbstract>
-
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/</sm:dependsOn>
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/BE/</sm:dependsOn>
-
-        <sm:keyword rdf:datatype="&xsd;string">economic index</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">economic rate</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">interest rate</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">market index</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">foreign exchange</sm:keyword>
-
-
-    <!-- Specification Version Metadata for the FIBO IND Economic Indicators Ontology -->
-
-        <sm:publicationDate rdf:datatype="&xsd;dateTime">2014-06-16T18:00:00</sm:publicationDate>
-        <sm:specificationVersionURL rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/RFC/</sm:specificationVersionURL>
-        <sm:specificationVersionStatus rdf:datatype="&xsd;string">Request For Comments (RFC)</sm:specificationVersionStatus>
-        <skos:historyNote rdf:datatype="&xsd;string">This version of the FIBO Indices and Indicators Specification covers the various index and indicator parameters, with reference to temporally sensitive representation of values. It does not include composite indices based on negotiable securities. 
-
-Revisions to FIBO Indices and Indicators are managed per the process outlined in the Policies and Procedures for OMG standards, with the intent to maintain backwards compatibility in the ontologies to the degree possible.
-  
-The RDF/XML serialized OWL for the Indices and Indicators ODM/OWL ontologies have been checked for syntactic errors and logical consistency with Protege 4 (http://protege.stanford.edu/), HermiT 1.3.8 (http://www.hermit-reasoner.com/) and Pellet 2.2 (http://clarkparsia.com/pellet/).</skos:historyNote>
-        <sm:addressForComments rdf:datatype="&xsd;anyURI">http://www.omg.org/issues/</sm:addressForComments>
-
-
-    <!-- Module Level Metadata for the FIBO IND Economic Indicators Ontology -->
-
-
-        <sm:moduleName rdf:datatype="&xsd;string">EconomicIndicators</sm:moduleName>
-        <sm:moduleAbbreviation rdf:datatype="&xsd;string">FIBO-IND-EI</sm:moduleAbbreviation>
-        <sm:moduleVersion rdf:datatype="&xsd;string">1.0</sm:moduleVersion>
-        <sm:moduleAbstract rdf:datatype="&xsd;string">This module includes ontologies defining concepts to do with published economic indicators. These give some indication of the state of some economy. Indicators of this type are usually published by governments or goernment agencies, or by international agencies or agencies of countries other than the ones reported on. Examples include Gross Domestic Product (GDP) and unemployment rates.</sm:moduleAbstract>
-
-
     <!-- Curation and Rights Metadata for the FIBO IND Economic Indicators Ontology -->
 
-        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2014 EDM Council, Inc.
-Copyright (c) 2014 Object Management Group, Inc.</sm:copyright>
-        <sm:submitter rdf:datatype="&xsd;string">EDM Council, Inc.</sm:submitter>
-        <sm:contributor rdf:datatype="&xsd;string">Adaptive, Inc.</sm:contributor>
-        <sm:contributor rdf:datatype="&xsd;string">Thematix Partners LLC</sm:contributor>
-        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/mit-license.php</dct:license>
-        <sm:responsibleTaskForce rdf:datatype="&xsd;anyURI">http://fdtf.omg.org/</sm:responsibleTaskForce>
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2014-2015 EDM Council, Inc.
+Copyright (c) 2014-2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for the FIBO IND Indicators Ontology -->
 
-        <sm:filename rdf:datatype="&xsd;string">EconomicIndicators</sm:filename>
+        <sm:filename rdf:datatype="&xsd;string">EconomicIndicators.rdf</sm:filename>
         <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-ind-ei-ei</sm:fileAbbreviation>
-        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/IND/20140601/EconomicIndicators/EconomicIndicators/"/>
+        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/IND/20150501/EconomicIndicators/EconomicIndicators/"/>
         <sm:fileAbstract rdf:datatype="&xsd;string">This ontology provides the parameters which make up the various types of market economic indicators, along with basic facts about these such as the economies or countries they apply to.</sm:fileAbstract>
 
+        <skos:changeNote rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/IND/20140601/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF report.</skos:changeNote>
+        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/</sm:dependsOn>
+        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/BE/</sm:dependsOn>
         <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/</sm:dependsOn>
 
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 
-        <owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/AboutIND/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/EconomicIndicators/AboutEconomicIndicators/</rdfs:seeAlso>
+
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/Publishers/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
 
     </owl:Ontology>
     
@@ -343,12 +221,7 @@ Copyright (c) 2014 Object Management Group, Inc.</sm:copyright>
     <owl:Class rdf:about="&fibo-ind-ei-ei;InflationRate">
         <rdfs:label>inflation rate</rdfs:label>
         <rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-utl-bt;hasPercentageValue"/>
-                <owl:allValuesFrom rdf:resource="&fibo-fnd-utl-bt;percentage"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&fibo-fnd-utl-bt;Percentage"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
@@ -378,12 +251,7 @@ Copyright (c) 2014 Object Management Group, Inc.</sm:copyright>
     <owl:Class rdf:about="&fibo-ind-ei-ei;PercentageUnemploymentRate">
         <rdfs:label>percentage unemployment rate</rdfs:label>
         <rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;UnemploymentRate"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-utl-bt;hasPercentageValue"/>
-                <owl:someValuesFrom rdf:resource="&fibo-fnd-utl-bt;percentage"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="&fibo-fnd-utl-bt;Percentage"/>
         <skos:definition rdf:datatype="&xsd;string">an economic indicator representing the ratio of unemployment to the labor force of a given economy for some specified period expressed in percentage terms</skos:definition>
     </owl:Class>
     

--- a/ind/ForeignExchange/ForeignExchange.rdf
+++ b/ind/ForeignExchange/ForeignExchange.rdf
@@ -12,36 +12,13 @@
     <!ENTITY fibo-fnd-utl-bt "http://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/" >
     <!ENTITY fibo-fnd-rel-rel "http://spec.edmcouncil.org/fibo/FND/Relations/Relations/" >
     <!ENTITY fibo-fnd-utl-alx "http://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/" >
-    <!ENTITY fibo-fnd-aap-agt "http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/" >
-    <!ENTITY fibo-fnd-plc-loc "http://spec.edmcouncil.org/fibo/FND/Places/Locations/" >
-    <!ENTITY fibo-fnd-plc-cty "http://spec.edmcouncil.org/fibo/FND/Places/Countries/" >
-    <!ENTITY fibo-fnd-plc-adr "http://spec.edmcouncil.org/fibo/FND/Places/Addresses/" >
-    <!ENTITY fibo-fnd-gao-gl "http://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/" >
-    <!ENTITY fibo-fnd-org-org "http://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/" >
-    <!ENTITY fibo-fnd-org-fm "http://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/" >
-    <!ENTITY fibo-fnd-aap-ppl "http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/" >
-    <!ENTITY fibo-fnd-pty-rl "http://spec.edmcouncil.org/fibo/FND/Parties/Roles/" >
-    <!ENTITY fibo-fnd-pty-pty "http://spec.edmcouncil.org/fibo/FND/Parties/Parties/" >
-    <!ENTITY fibo-fnd-oac-own "http://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/" >
+    <!ENTITY fibo-fnd-dt-fd "http://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/" >
     <!ENTITY fibo-fnd-acc-cur "http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/" >
-    <!ENTITY fibo-fnd-acc-aeq "http://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/" >
-    <!ENTITY fibo-fnd-agr-agr "http://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/" >
-    <!ENTITY fibo-fnd-law-cor "http://spec.edmcouncil.org/fibo/FND/Law/LegalCore/" >
-    <!ENTITY fibo-fnd-law-jur "http://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/" >
-    <!ENTITY fibo-fnd-agr-ctr "http://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/" >
-    <!ENTITY fibo-fnd-law-lcap "http://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/" >
-    <!ENTITY fibo-be-le-lp "http://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/" >
-    <!ENTITY fibo-be-le-fbo "http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/" >
-    <!ENTITY fibo-be-le-cb "http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/" >
-    <!ENTITY fibo-be-corp-corp "http://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/" >
-    <!ENTITY fibo-be-fct-fct "http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/" >
-    <!ENTITY fibo-be-fct-pub "http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/Publishers/" >
     <!ENTITY fibo-ind-ind-ind "http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/" >
     <!ENTITY fibo-ind-fx-fx "http://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/" >
 ]>
 
-<rdf:RDF xmlns="http://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/"
-     xml:base="http://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/"
+<rdf:RDF xml:base="http://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -53,30 +30,8 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
      xmlns:fibo-fnd-utl-bt="http://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/"
      xmlns:fibo-fnd-rel-rel="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
      xmlns:fibo-fnd-utl-alx="http://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"
-     xmlns:fibo-fnd-aap-agt="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
-     xmlns:fibo-fnd-plc-loc="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"
-     xmlns:fibo-fnd-plc-cty="http://spec.edmcouncil.org/fibo/FND/Places/Countries/"
-     xmlns:fibo-fnd-plc-adr="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
-     xmlns:fibo-fnd-gao-gl="http://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
-     xmlns:fibo-fnd-org-org="http://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"
-     xmlns:fibo-fnd-org-fm="http://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"
-     xmlns:fibo-fnd-aap-ppl="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
-     xmlns:fibo-fnd-pty-rl="http://spec.edmcouncil.org/fibo/FND/Parties/Roles/"
-     xmlns:fibo-fnd-pty-pty="http://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-     xmlns:fibo-fnd-oac-own="http://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+     xmlns:fibo-fnd-dt-fd="http://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
      xmlns:fibo-fnd-acc-cur="http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-     xmlns:fibo-fnd-acc-aeq="http://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
-     xmlns:fibo-fnd-agr-agr="http://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
-     xmlns:fibo-fnd-law-cor="http://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
-     xmlns:fibo-fnd-law-jur="http://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-     xmlns:fibo-fnd-agr-ctr="http://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-     xmlns:fibo-fnd-law-lcap="http://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
-     xmlns:fibo-be-le-lp="http://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-     xmlns:fibo-be-le-fbo="http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-     xmlns:fibo-be-le-cb="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-     xmlns:fibo-be-corp-corp="http://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"
-     xmlns:fibo-be-fct-fct="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
-     xmlns:fibo-be-fct-pub="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/Publishers/"
      xmlns:fibo-ind-ind-ind="http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"
      xmlns:fibo-ind-fx-fx="http://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/">
 
@@ -85,118 +40,38 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
         <rdfs:label>Foreign Exchange Ontology</rdfs:label>
 
 
-    <!-- Specification Family Level Metadata for the FIBO IND Foreign Exchange Ontology -->
-
-        <sm:familyTitle rdf:datatype="&xsd;string">Financial Industry Business Ontology (FIBO)</sm:familyTitle>
-        <sm:familyAbbreviation rdf:datatype="&xsd;string">FIBO</sm:familyAbbreviation>
-        <sm:familyURL rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/</sm:familyURL>
-        <sm:familyAbstract rdf:datatype="&xsd;string">The content that comprises the Financial Industry Business Ontology (FIBO) is documentation, interpretable in formal logic, of the concepts represented by finance industry terms as used in official financial organization documents such as contracts, product/service specifications and governance and regulatory compliance documents.</sm:familyAbstract>
-
-        <sm:technologyArea rdf:datatype="&xsd;string">formal semantics</sm:technologyArea>
-
-        <sm:topicArea rdf:datatype="&xsd;string">finance</sm:topicArea>
-
-        <sm:keyword rdf:datatype="&xsd;string">Financial Industry Business Ontology</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">FIBO</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">ontology</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">vocabulary</sm:keyword>
-
-
-    <!-- Specification Level Metadata for the FIBO IND Foreign Exchange Ontology -->
-
-        <sm:specificationTitle rdf:datatype="&xsd;string">Financial Industry Business Ontology (FIBO) Indices and Indicators Specification</sm:specificationTitle>
-        <sm:specificationAbbreviation rdf:datatype="&xsd;string">FIBO-IND</sm:specificationAbbreviation>
-        <sm:specificationURL rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/</sm:specificationURL>
-        <sm:specificationAbstract rdf:datatype="&xsd;string">FIBO Indices and Indicators is a set of business concepts representing the various forms of market indices, economic indicators and market interest rates.  
-
-The FIBO Indices and Indicators models covers quoted interest rates, economic measures such as employment rates, and quoted indices based on baskets of securities, including specific kinds of securities in share indices or bond indices, as well as credit indices. 
-
-The indices and indicators terms consist of numeric parameters which vary over time, and which therefore take a value which is temporal (having a present value, a number of past values based on the frequency with which that index or indicator is updated, and an indefinite number of future values based on various prediction criteria (unlike past values, a future vaue for a given date or date and time, need not be unique).</sm:specificationAbstract>
-
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/</sm:dependsOn>
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/BE/</sm:dependsOn>
-
-        <sm:keyword rdf:datatype="&xsd;string">economic index</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">economic rate</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">interest rate</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">market index</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">foreign exchange</sm:keyword>
-
-
-    <!-- Specification Version Metadata for the FIBO IND Foreign Exchange Ontology -->
-
-        <sm:publicationDate rdf:datatype="&xsd;dateTime">2014-06-16T18:00:00</sm:publicationDate>
-        <sm:specificationVersionURL rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/RFC/</sm:specificationVersionURL>
-        <sm:specificationVersionStatus rdf:datatype="&xsd;string">Request For Comments (RFC)</sm:specificationVersionStatus>
-        <skos:historyNote rdf:datatype="&xsd;string">This version of the FIBO Indices and Indicators Specification covers the various index and indicator parameters, with reference to temporally sensitive representation of values. It does not include composite indices based on negotiable securities. 
-
-Revisions to FIBO Indices and Indicators are managed per the process outlined in the Policies and Procedures for OMG standards, with the intent to maintain backwards compatibility in the ontologies to the degree possible.
-  
-The RDF/XML serialized OWL for the Indices and Indicators ODM/OWL ontologies have been checked for syntactic errors and logical consistency with Protege 4 (http://protege.stanford.edu/), HermiT 1.3.8 (http://www.hermit-reasoner.com/) and Pellet 2.2 (http://clarkparsia.com/pellet/).</skos:historyNote>
-        <sm:addressForComments rdf:datatype="&xsd;anyURI">http://www.omg.org/issues/</sm:addressForComments>
-
-
-    <!-- Module Level Metadata for the FIBO IND Foreign Exchange Ontology -->
-
-        <sm:moduleName rdf:datatype="&xsd;string">ForeignExchange</sm:moduleName>
-        <sm:moduleAbbreviation rdf:datatype="&xsd;string">FIBO-IND-FX</sm:moduleAbbreviation>
-        <sm:moduleVersion rdf:datatype="&xsd;string">1.0</sm:moduleVersion>
-        <sm:moduleAbstract rdf:datatype="&xsd;string">This module includes ontologies defining concepts to do with foreign exchange.</sm:moduleAbstract>
-
-
     <!-- Curation and Rights Metadata for the FIBO IND Foreign Exchange Ontology -->
 
-        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2014 EDM Council, Inc.
-Copyright (c) 2014 Object Management Group, Inc.</sm:copyright>
-        <sm:submitter rdf:datatype="&xsd;string">EDM Council, Inc.</sm:submitter>
-        <sm:contributor rdf:datatype="&xsd;string">Adaptive, Inc.</sm:contributor>
-        <sm:contributor rdf:datatype="&xsd;string">Thematix Partners LLC</sm:contributor>
-        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/mit-license.php</dct:license>
-        <sm:responsibleTaskForce rdf:datatype="&xsd;anyURI">http://fdtf.omg.org/</sm:responsibleTaskForce>
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2014-2015 EDM Council, Inc.
+Copyright (c) 2014-2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for the FIBO IND Foreign Exchange Ontology -->
 
-        <sm:filename rdf:datatype="&xsd;string">ForeignExchange</sm:filename>
+        <sm:filename rdf:datatype="&xsd;string">ForeignExchange.rdf</sm:filename>
         <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-ind-fx-fx</sm:fileAbbreviation>
-        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/IND/20140601/ForeignExchange/ForeignExchange/"/>
+        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/IND/20150501/ForeignExchange/ForeignExchange/"/>
         <sm:fileAbstract rdf:datatype="&xsd;string">This ontology provides the parameters for foreign exchange rates, covering spot and forward rates, as well as Fx spot rate volatilities.</sm:fileAbstract>
 
+        <skos:changeNote rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/IND/20140601/ForeignExchange/ForeignExchange.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF report.</skos:changeNote>
+        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/</sm:dependsOn>
         <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/</sm:dependsOn>
 
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 
-        <owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/AboutIND/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/ForeignExchange/AboutForeignExchange/</rdfs:seeAlso>
+
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/Publishers/"/>
+
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
 
     </owl:Ontology>
@@ -230,6 +105,13 @@ Copyright (c) 2014 Object Management Group, Inc.</sm:copyright>
         <rdfs:domain rdf:resource="&fibo-ind-fx-fx;ExchangeRate"/>
     </owl:ObjectProperty>
     
+    <owl:ObjectProperty rdf:about="&fibo-ind-fx-fx;hasSettlementDate">
+        <rdfs:label>has settlement date</rdfs:label>
+        <rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+        <rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+        <skos:definition rdf:datatype="&xsd;string">a predicate indicating the settlement date of a given transaction</skos:definition>
+    </owl:ObjectProperty>
+
     <owl:ObjectProperty rdf:about="&fibo-ind-fx-fx;isPremiumOn">
         <rdfs:label>is premium on</rdfs:label>
         <skos:definition rdf:datatype="&xsd;string">The currency forward rate is expressed as a premium on the spot rate for the currency pair</skos:definition>
@@ -253,19 +135,6 @@ Copyright (c) 2014 Object Management Group, Inc.</sm:copyright>
         <rdfs:domain rdf:resource="&fibo-ind-fx-fx;ExchangeRate"/>
     </owl:DatatypeProperty>
     
-    <owl:DatatypeProperty rdf:about="&fibo-ind-fx-fx;hasSettlementDate">
-        <rdfs:label>has settlement date</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">a predicate indicating the settlement date of a given transaction</skos:definition>
-        <rdfs:range rdf:resource="&xsd;dateTime"/>
-    </owl:DatatypeProperty>
-    
-    <owl:DatatypeProperty rdf:about="&fibo-ind-fx-fx;isQuotedAs">
-        <rdfs:label>is quoted as</rdfs:label>
-        <skos:definition rdf:datatype="&xsd;string">the forward rate expressed as a percentage of the corresponding spot rate</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">the forward rate, being quoted as a premium on the spot rate, is quoted as a percentage figure</fibo-fnd-utl-av:explanatoryNote>
-        <rdfs:range rdf:resource="&fibo-fnd-utl-bt;percentage"/>
-    </owl:DatatypeProperty>
-    
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -277,17 +146,12 @@ Copyright (c) 2014 Object Management Group, Inc.</sm:copyright>
     
     <owl:Class rdf:about="&fibo-ind-fx-fx;CurrencyForwardRate">
         <rdfs:label>currency forward rate</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Measure"/>
+        <rdfs:subClassOf rdf:resource="&fibo-ind-fx-fx;ExchangeRate"/>
+        <rdfs:subClassOf rdf:resource="&fibo-fnd-utl-bt;Percentage"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&fibo-ind-fx-fx;hasSettlementDate"/>
-                <owl:allValuesFrom rdf:resource="&xsd;dateTime"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-ind-fx-fx;isQuotedAs"/>
-                <owl:someValuesFrom rdf:resource="&fibo-fnd-utl-bt;percentage"/>
+                <owl:allValuesFrom rdf:resource="&fibo-fnd-dt-fd;Date"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <skos:definition rdf:datatype="&xsd;string">The rate of exchange between two currencies for settlement at some future point in time, expressed as a premium on the spot rate. </skos:definition>

--- a/ind/InterestRates/InterestRates.rdf
+++ b/ind/InterestRates/InterestRates.rdf
@@ -10,38 +10,15 @@
     <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
     <!ENTITY fibo-fnd-utl-av "http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/" >
     <!ENTITY fibo-fnd-utl-bt "http://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/" >
-    <!ENTITY fibo-fnd-rel-rel "http://spec.edmcouncil.org/fibo/FND/Relations/Relations/" >
-    <!ENTITY fibo-fnd-utl-alx "http://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/" >
     <!ENTITY fibo-fnd-aap-agt "http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/" >
-    <!ENTITY fibo-fnd-plc-loc "http://spec.edmcouncil.org/fibo/FND/Places/Locations/" >
-    <!ENTITY fibo-fnd-plc-cty "http://spec.edmcouncil.org/fibo/FND/Places/Countries/" >
-    <!ENTITY fibo-fnd-plc-adr "http://spec.edmcouncil.org/fibo/FND/Places/Addresses/" >
-    <!ENTITY fibo-fnd-gao-gl "http://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/" >
-    <!ENTITY fibo-fnd-org-org "http://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/" >
-    <!ENTITY fibo-fnd-org-fm "http://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/" >
-    <!ENTITY fibo-fnd-aap-ppl "http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/" >
-    <!ENTITY fibo-fnd-pty-rl "http://spec.edmcouncil.org/fibo/FND/Parties/Roles/" >
-    <!ENTITY fibo-fnd-pty-pty "http://spec.edmcouncil.org/fibo/FND/Parties/Parties/" >
-    <!ENTITY fibo-fnd-oac-own "http://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/" >
+    <!ENTITY fibo-fnd-rel-rel "http://spec.edmcouncil.org/fibo/FND/Relations/Relations/" >
+    <!ENTITY fibo-fnd-dt-fd "http://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/" >
     <!ENTITY fibo-fnd-acc-cur "http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/" >
-    <!ENTITY fibo-fnd-acc-aeq "http://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/" >
-    <!ENTITY fibo-fnd-agr-agr "http://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/" >
-    <!ENTITY fibo-fnd-law-cor "http://spec.edmcouncil.org/fibo/FND/Law/LegalCore/" >
-    <!ENTITY fibo-fnd-law-jur "http://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/" >
-    <!ENTITY fibo-fnd-agr-ctr "http://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/" >
-    <!ENTITY fibo-fnd-law-lcap "http://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/" >
-    <!ENTITY fibo-be-le-lp "http://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/" >
-    <!ENTITY fibo-be-le-fbo "http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/" >
-    <!ENTITY fibo-be-le-cb "http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/" >
-    <!ENTITY fibo-be-corp-corp "http://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/" >
-    <!ENTITY fibo-be-fct-fct "http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/" >
-    <!ENTITY fibo-be-fct-pub "http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/Publishers/" >
     <!ENTITY fibo-ind-ind-ind "http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/" >
     <!ENTITY fibo-ind-ir-ir "http://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/" >
 ]>
 
-<rdf:RDF xmlns="http://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"
-     xml:base="http://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"
+<rdf:RDF xml:base="http://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -51,32 +28,10 @@
 xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
      xmlns:fibo-fnd-utl-av="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
      xmlns:fibo-fnd-utl-bt="http://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/"
-     xmlns:fibo-fnd-rel-rel="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-     xmlns:fibo-fnd-utl-alx="http://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"
      xmlns:fibo-fnd-aap-agt="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
-     xmlns:fibo-fnd-plc-loc="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"
-     xmlns:fibo-fnd-plc-cty="http://spec.edmcouncil.org/fibo/FND/Places/Countries/"
-     xmlns:fibo-fnd-plc-adr="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
-     xmlns:fibo-fnd-gao-gl="http://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
-     xmlns:fibo-fnd-org-org="http://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"
-     xmlns:fibo-fnd-org-fm="http://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"
-     xmlns:fibo-fnd-aap-ppl="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
-     xmlns:fibo-fnd-pty-rl="http://spec.edmcouncil.org/fibo/FND/Parties/Roles/"
-     xmlns:fibo-fnd-pty-pty="http://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-     xmlns:fibo-fnd-oac-own="http://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+     xmlns:fibo-fnd-rel-rel="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+     xmlns:fibo-fnd-dt-fd="http://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
      xmlns:fibo-fnd-acc-cur="http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-     xmlns:fibo-fnd-acc-aeq="http://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
-     xmlns:fibo-fnd-agr-agr="http://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
-     xmlns:fibo-fnd-law-cor="http://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
-     xmlns:fibo-fnd-law-jur="http://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-     xmlns:fibo-fnd-agr-ctr="http://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-     xmlns:fibo-fnd-law-lcap="http://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
-     xmlns:fibo-be-le-lp="http://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-     xmlns:fibo-be-le-fbo="http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-     xmlns:fibo-be-le-cb="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-     xmlns:fibo-be-corp-corp="http://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"
-     xmlns:fibo-be-fct-fct="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
-     xmlns:fibo-be-fct-pub="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/Publishers/"
      xmlns:fibo-ind-ind-ind="http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"
      xmlns:fibo-ind-ir-ir="http://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/">
 
@@ -85,122 +40,68 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
         <rdfs:label>Interest Rates Ontology</rdfs:label>
 
 
-    <!-- Specification Family Level Metadata for the FIBO IND Interest Rates Ontology -->
-
-        <sm:familyTitle rdf:datatype="&xsd;string">Financial Industry Business Ontology (FIBO)</sm:familyTitle>
-        <sm:familyAbbreviation rdf:datatype="&xsd;string">FIBO</sm:familyAbbreviation>
-        <sm:familyURL rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/</sm:familyURL>
-        <sm:familyAbstract rdf:datatype="&xsd;string">The content that comprises the Financial Industry Business Ontology (FIBO) is documentation, interpretable in formal logic, of the concepts represented by finance industry terms as used in official financial organization documents such as contracts, product/service specifications and governance and regulatory compliance documents.</sm:familyAbstract>
-
-        <sm:technologyArea rdf:datatype="&xsd;string">formal semantics</sm:technologyArea>
-
-        <sm:topicArea rdf:datatype="&xsd;string">finance</sm:topicArea>
-
-        <sm:keyword rdf:datatype="&xsd;string">Financial Industry Business Ontology</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">FIBO</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">ontology</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">vocabulary</sm:keyword>
-
-
-    <!-- Specification Level Metadata for the FIBO IND Interest Rates Ontology -->
-
-        <sm:specificationTitle rdf:datatype="&xsd;string">Financial Industry Business Ontology (FIBO) Indices and Indicators Specification</sm:specificationTitle>
-        <sm:specificationAbbreviation rdf:datatype="&xsd;string">FIBO-IND</sm:specificationAbbreviation>
-        <sm:specificationURL rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/</sm:specificationURL>
-        <sm:specificationAbstract rdf:datatype="&xsd;string">FIBO Indices and Indicators is a set of business concepts representing the various forms of market indices, economic indicators and market interest rates.  
-
-The FIBO Indices and Indicators models covers quoted interest rates, economic measures such as employment rates, and quoted indices based on baskets of securities, including specific kinds of securities in share indices or bond indices, as well as credit indices. 
-
-The indices and indicators terms consist of numeric parameters which vary over time, and which therefore take a value which is temporal (having a present value, a number of past values based on the frequency with which that index or indicator is updated, and an indefinite number of future values based on various prediction criteria (unlike past values, a future vaue for a given date or date and time, need not be unique).</sm:specificationAbstract>
-
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/</sm:dependsOn>
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/BE/</sm:dependsOn>
-
-        <sm:keyword rdf:datatype="&xsd;string">economic index</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">economic rate</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">interest rate</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">market index</sm:keyword>
-        <sm:keyword rdf:datatype="&xsd;string">foreign exchange</sm:keyword>
-
-
-    <!-- Specification Version Metadata for the FIBO IND Interest Rates Ontology -->
-
-        <sm:publicationDate rdf:datatype="&xsd;dateTime">2014-06-16T18:00:00</sm:publicationDate>
-        <sm:specificationVersionURL rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/RFC/</sm:specificationVersionURL>
-        <sm:specificationVersionStatus rdf:datatype="&xsd;string">Request For Comments (RFC)</sm:specificationVersionStatus>
-        <skos:historyNote rdf:datatype="&xsd;string">This version of the FIBO Indices and Indicators Specification covers the various index and indicator parameters, with reference to temporally sensitive representation of values. It does not include composite indices based on negotiable securities. 
-
-Revisions to FIBO Indices and Indicators are managed per the process outlined in the Policies and Procedures for OMG standards, with the intent to maintain backwards compatibility in the ontologies to the degree possible.
-  
-The RDF/XML serialized OWL for the Indices and Indicators ODM/OWL ontologies have been checked for syntactic errors and logical consistency with Protege 4 (http://protege.stanford.edu/), HermiT 1.3.8 (http://www.hermit-reasoner.com/) and Pellet 2.2 (http://clarkparsia.com/pellet/).</skos:historyNote>
-        <sm:addressForComments rdf:datatype="&xsd;anyURI">http://www.omg.org/issues/</sm:addressForComments>
-
-
-    <!-- Module Level Metadata for the FIBO IND Interest Rates Ontology -->
-
-        <sm:moduleName rdf:datatype="&xsd;string">InterestRates</sm:moduleName>
-        <sm:moduleAbbreviation rdf:datatype="&xsd;string">FIBO-IND-IR</sm:moduleAbbreviation>
-        <sm:moduleVersion rdf:datatype="&xsd;string">1.0</sm:moduleVersion>
-        <sm:moduleAbstract rdf:datatype="&xsd;string">This module includes ontologies defining concepts to do with interest rates, that is rates of interest paid on capital by banks and other lenders, including inter-bank lending rates and rates of certain representative debt instruments.</sm:moduleAbstract>
-
-
     <!-- Curation and Rights Metadata for the FIBO IND Interest Rates Ontology -->
 
-        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2014 EDM Council, Inc.
-Copyright (c) 2014 Object Management Group, Inc.</sm:copyright>
-        <sm:submitter rdf:datatype="&xsd;string">EDM Council, Inc.</sm:submitter>
-        <sm:contributor rdf:datatype="&xsd;string">Adaptive, Inc.</sm:contributor>
-        <sm:contributor rdf:datatype="&xsd;string">Thematix Partners LLC</sm:contributor>
-        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/mit-license.php</dct:license>
-        <sm:responsibleTaskForce rdf:datatype="&xsd;anyURI">http://fdtf.omg.org/</sm:responsibleTaskForce>
+        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2014-2015 EDM Council, Inc.
+Copyright (c) 2014-2015 Object Management Group, Inc.</sm:copyright>
+        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for the FIBO IND Interest Rates Ontology -->
 
-        <sm:filename rdf:datatype="&xsd;string">InterestRates</sm:filename>
+        <sm:filename rdf:datatype="&xsd;string">InterestRates.rdf</sm:filename>
         <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-ind-ir-ir</sm:fileAbbreviation>
-        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/IND/20140601/InterestRates/InterestRates/"/>
+        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/IND/20150501/InterestRates/InterestRates/"/>
         <sm:fileAbstract rdf:datatype="&xsd;string">This ontology provides the basic types of interest rate which are recognized in the financial markets, and the relationships between these where applicable. THese include bank base rates, inter-bank offer rates, overnight rates of interest and the US Federal Funds rate which is widely used as a rate of reference. It also includes the concept of a market rate spread between two interest rates.</sm:fileAbstract>
 
+        <skos:changeNote rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/IND/20140601/InterestRates/InterestRates.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF report.</skos:changeNote>
+        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/</sm:dependsOn>
         <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/</sm:dependsOn>
 
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
         <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 
-        <owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/AboutIND/</rdfs:seeAlso>
+        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/IND/InterestRates/AboutInterestRates/</rdfs:seeAlso>
+
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/Publishers/"/>
+
         <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
 
     </owl:Ontology>
     
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:ObjectProperty rdf:about="&fibo-ind-ir-ir;hasQuotationDate">
+        <rdfs:label>has quotation date</rdfs:label>
+        <rdfs:domain rdf:resource="&fibo-ind-ir-ir;ReferenceRate"/>
+        <rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+        <rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+        <skos:definition rdf:datatype="&xsd;string">relates a reference rate to the date it was quoted on</skos:definition>
+    </owl:ObjectProperty>
+    
+    <owl:ObjectProperty rdf:about="&fibo-ind-ir-ir;hasReferenceCurrency">
+        <rdfs:label>has reference currency</rdfs:label>
+        <rdfs:domain rdf:resource="&fibo-ind-ir-ir;ReferenceRate"/>
+        <rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+        <rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;has"/>
+        <skos:definition rdf:datatype="&xsd;string">relates a reference rate to the currency it is based on</skos:definition>
+        <skos:editorialNote rdf:datatype="&xsd;string">This was not modeled as a subproperty of hasCurrency due to the domain for hasCurrency of MonetaryAmount.</skos:editorialNote>
+    </owl:ObjectProperty>
+
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -302,28 +203,23 @@ Copyright (c) 2014 Object Management Group, Inc.</sm:copyright>
     <owl:Class rdf:about="&fibo-ind-ir-ir;ReferenceRate">
         <rdfs:label>reference rate</rdfs:label>
         <rdfs:subClassOf rdf:resource="&fibo-ind-ind-ind;MarketRate"/>
+        <rdfs:subClassOf rdf:resource="&fibo-fnd-utl-bt;Percentage"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasEffectiveDate"/>
+                <owl:onProperty rdf:resource="&fibo-ind-ir-ir;hasQuotationDate"/>
+                <owl:onClass rdf:resource="&fibo-fnd-dt-fd;Date"/>
                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onDataRange rdf:resource="&xsd;dateTime"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-utl-bt;hasPercentageValue"/>
-                <owl:allValuesFrom rdf:resource="&fibo-fnd-utl-bt;percentage"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasCurrency"/>
+                <owl:onProperty rdf:resource="&fibo-ind-ir-ir;hasReferenceCurrency"/>
                 <owl:allValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasName"/>
+                <owl:onProperty rdf:resource="&fibo-fnd-aap-agt;hasName"/>
                 <owl:allValuesFrom rdf:resource="&fibo-fnd-utl-bt;text"/>
             </owl:Restriction>
         </rdfs:subClassOf>


### PR DESCRIPTION
... (1) use FinancialDates rather than xsd:dateTime where appropriate, (2) revise the approach to percentages, since Percentage is now a class per recent changes to FND rather than a datatype, and (3) updated reference for hasName to Agents (was Relations), all of which were needed to fix several reasoning errors.
