### PR TITLE
FIBOBE-4, BE-39 publisher should be a kind of party, which is not reflected in the model

### DIFF
--- a/be/FunctionalEntities/Publishers.rdf
+++ b/be/FunctionalEntities/Publishers.rdf
@@ -52,10 +52,10 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
 
         <sm:filename rdf:datatype="&xsd;string">Publishers.rdf</sm:filename>
         <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-be-fct-pub</sm:fileAbbreviation>
-        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/BE/20150201/FunctionalEntities/Publishers/"/>
+        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/BE/20150801/FunctionalEntities/Publishers/"/>
         <sm:fileAbstract rdf:datatype="&xsd;string">This ontology defines the fundamental concepts for publishers of information, including entities whose primary function is to publish, and entities (whether or not they are publishers in that sense) which are in the role of the publisher of some information. This ontology also includes the published information itself, i.e. the publication.</sm:fileAbstract>
 
-        <skos:changeNote rdf:datatype="&xsd;string">The http://www.omg.org/spec/EDMC-FIBO/BE/20140501/FunctionalEntities/Publishers.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
+        <skos:changeNote rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/BE/20140501/FunctionalEntities/Publishers.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
         <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/</sm:dependsOn>
         <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/</sm:dependsOn>
 
@@ -126,7 +126,7 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
 
     <owl:Class rdf:about="&fibo-be-fct-pub;Publisher">
         <rdfs:label>publisher</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fnd-pty-rl;AgentInRole"/>
+        <rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
@@ -134,9 +134,9 @@ Copyright (c) 2013-2015 Object Management Group, Inc.</sm:copyright>
                 <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <skos:definition rdf:datatype="&xsd;string">a party that makes some information available to the world at large</skos:definition>
-        <skos:scopeNote rdf:datatype="&xsd;string">This concept defines some business entity in its role as the publisher of some information.</skos:scopeNote>
+        <skos:definition rdf:datatype="&xsd;string">a party responsible for the printing or distribution of digital or printed information</skos:definition>
         <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Typically this role is filled by some entity whose function is that of a publishing house (sometimes also referred to as a publisher, in that different sense). Publishers may also include banks, government agencies and the like.</fibo-fnd-utl-av:explanatoryNote>
+        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/publisher.html</fibo-fnd-utl-av:adaptedFrom>
     </owl:Class>
     
     <owl:Class rdf:about="&fibo-be-fct-pub;PublishingHouse">


### PR DESCRIPTION
Revised the definition of publisher, added a new adapted from annotation (Business Dictionary), removed redundant scope note, changed parent from AgentInRole to PartyInRole
