### PR TITLE
FIBOFND11-62 Update Postal Address

### DIFF
--- a/fnd/Places/Addresses.rdf
+++ b/fnd/Places/Addresses.rdf
@@ -1,166 +1,198 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!DOCTYPE rdf:RDF [
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY dct "http://purl.org/dc/terms/" >
-    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
-    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
-    <!ENTITY fibo-fnd-utl-av "http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/" >
-    <!ENTITY fibo-fnd-rel-rel "http://spec.edmcouncil.org/fibo/FND/Relations/Relations/" >
-    <!ENTITY fibo-fnd-arr-id "http://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/" >
-    <!ENTITY fibo-fnd-plc-loc "http://spec.edmcouncil.org/fibo/FND/Places/Locations/" >
-    <!ENTITY fibo-fnd-plc-adr "http://spec.edmcouncil.org/fibo/FND/Places/Addresses/" >
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-arr-id "http://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/">
+	<!ENTITY fibo-fnd-plc-adr "http://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
+	<!ENTITY fibo-fnd-plc-loc "http://spec.edmcouncil.org/fibo/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-rel-rel "http://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-
-<rdf:RDF xml:base="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:dct="http://purl.org/dc/terms/"
-     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-     xmlns:fibo-fnd-utl-av="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-     xmlns:fibo-fnd-rel-rel="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-     xmlns:fibo-fnd-arr-id="http://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/"
-     xmlns:fibo-fnd-plc-loc="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"
-     xmlns:fibo-fnd-plc-adr="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
-
-
-    <owl:Ontology rdf:about="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
-        <rdfs:label>Addresses Ontology</rdfs:label>
-
-
-    <!-- Curation and Rights Metadata for the FIBO FND Addresses Ontology -->
-
-        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2013-2016 EDM Council, Inc.
+<rdf:RDF
+	xml:base="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-arr-id="http://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/"
+	xmlns:fibo-fnd-plc-adr="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
+	xmlns:fibo-fnd-plc-loc="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"
+	xmlns:fibo-fnd-rel-rel="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology
+		rdf:about="http://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
+		<rdfs:label>Addresses Ontology</rdfs:label>
+		<dct:license
+			rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<sm:contentLanguage
+			rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+		<sm:contentLanguage
+			rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:copyright
+			rdf:datatype="&xsd;string">Copyright (c) 2013-2016 EDM Council, Inc.
 Copyright (c) 2013-2016 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
-
-
-    <!-- Ontology/File-Level Metadata for the FIBO FND Addresses Ontology -->
-
-        <sm:filename rdf:datatype="&xsd;string">Addresses.rdf</sm:filename>
-        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-fnd-plc-adr</sm:fileAbbreviation>
-        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/FND/20160201/Places/Addresses/"/>
-        <sm:fileAbstract rdf:datatype="&xsd;string">This ontology provides a very high level definition of address, essentially a placeholder for use in mapping addresses to the appropriate regional standards or to some as yet undefined global address ontology, for use in other FIBO ontology elements. A minimal set of address related terms are included as required for financial risk management and other application use cases, and these are all to be considered as placeholders for suitable global address standards as these become available.</sm:fileAbstract>
-
-        <skos:changeNote rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/FND/20141101/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 RTF report. Differences from the 1.0 version include the addition of a hasAddress property, and renaming PostalAddress to PhysicalAddress.</skos:changeNote>
-        <skos:changeNote rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/FND/20130801/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://spec.edmcouncil.org/fibo/FND/1.0/AboutFND-1.0/. Primary differences include elimination of data properties in favor of a simple class model,the addition of virtual address, and the addition of addressing scheme.</skos:changeNote>
-        <skos:changeNote rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/Foundations/20130601/Organizations/Addresses.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
+		<sm:dependsOn
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/</sm:dependsOn>
+		<sm:dependsOn
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Places/Locations/</sm:dependsOn>
+		<sm:dependsOn
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Relations/Relations/</sm:dependsOn>
+		<sm:dependsOn
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
+		<sm:fileAbbreviation
+			rdf:datatype="&xsd;string">fibo-fnd-plc-adr</sm:fileAbbreviation>
+		<sm:fileAbstract
+			rdf:datatype="&xsd;string">This ontology provides a very high level definition of address, essentially a placeholder for use in mapping addresses to the appropriate regional standards or to some as yet undefined global address ontology, for use in other FIBO ontology elements. A minimal set of address related terms are included as required for financial risk management and other application use cases, and these are all to be considered as placeholders for suitable global address standards as these become available.</sm:fileAbstract>
+		<sm:filename
+			rdf:datatype="&xsd;string">Addresses.rdf</sm:filename>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/AboutFND/</rdfs:seeAlso>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Places/AboutPlaces/</rdfs:seeAlso>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI
+			rdf:resource="http://spec.edmcouncil.org/fibo/FND/20160201/Places/Addresses/"/>
+		<skos:changeNote
+			rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/FND/20130801/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://spec.edmcouncil.org/fibo/FND/1.0/AboutFND-1.0/. Primary differences include elimination of data properties in favor of a simple class model,the addition of virtual address, and the addition of addressing scheme.</skos:changeNote>
+		<skos:changeNote
+			rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/Foundations/20130601/Organizations/Addresses.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
    (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
    (3) to change the file suffix from .owl to .rdf to increase usability in RDF tools
    (4) to use 4-level abbreviations and corresponding namespace prefixes for all FIBO ontologies, reflecting a family/specification/module/ontology structure
    (5) to incorporate changes to the specification metadata to support documentation at the family, specification, module, and ontology level, similar to the abbreviations
    (6) to move this ontology from Organizations to Places and eliminate unnecessary properties and related imports dependencies.</skos:changeNote>
+		<skos:changeNote
+			rdf:datatype="&xsd;string">The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Places/Addresses.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report. Differences from the 1.0 version include the addition of a hasAddress property and PhysicalAddress class as a parent of PostalAddress.</skos:changeNote>
+	</owl:Ontology>
+	
+	<owl:Class
+		rdf:about="&fibo-fnd-plc-adr;Address">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fnd-arr-id;Index"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onClass
+					rdf:resource="&fibo-fnd-plc-adr;AddressingScheme"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;hasDefinition"/>
+				<owl:qualifiedCardinality
+					rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onClass
+					rdf:resource="&fibo-fnd-plc-loc;Location"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:qualifiedCardinality
+					rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>address</rdfs:label>
+		<skos:definition
+			rdf:datatype="&xsd;string">an index to a location to which communications may be delivered</skos:definition>
+		<skos:editorialNote
+			rdf:datatype="&xsd;string">This came from FDTF Address Reviews Aug/Sept 2011. It represents a place holder for mapping to other standards, such as those for email, network, and other electronic addresses as well as physical and mailing addresses.</skos:editorialNote>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fnd-plc-adr;AddressingScheme">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fnd-arr-id;IndexingScheme"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:allValuesFrom
+					rdf:resource="&fibo-fnd-plc-adr;Address"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;defines"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>addressing scheme</rdfs:label>
+		<skos:definition
+			rdf:datatype="&xsd;string">a system for allocating addresses to objects</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fnd-plc-adr;PhysicalAddress">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fnd-plc-adr;Address"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onClass
+					rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:qualifiedCardinality
+					rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>physical address</rdfs:label>
+		<skos:definition
+			rdf:datatype="&xsd;string">a physical address where communications can be addressed, papers served or representatives located for any kind of organization or person</skos:definition>
+		<skos:editorialNote
+			rdf:datatype="&xsd;string">There are existing international and regional standards for defining postal addresses.  This is a place holder for mapping to regional standards for postal address representation</skos:editorialNote>
+		<skos:scopeNote
+			rdf:datatype="&xsd;string">An address is a collection of information, presented in a mostly fixed format, used for describing the location of a building, apartment, or other structure or a plot of land, generally using political boundaries and street names as references, along with other identifiers such as house or apartment numbers.  Some addresses also contain special codes to aid routing of mail and packages, such as a ZIP code or post code. (Wikipedia)</skos:scopeNote>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fnd-plc-adr;PostCodeArea">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
+		<rdfs:label>post code area</rdfs:label>
+		<skos:definition
+			rdf:datatype="&xsd;string">a physical area uniquely identified by some postal code</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fnd-plc-adr;PostalAddress">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<rdfs:label>postal address</rdfs:label>
+		<skos:definition
+			rdf:datatype="&xsd;string">a physical address where postal communications can be addressed, for any kind of organization or person</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fnd-plc-adr;VirtualAddress">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fnd-plc-adr;Address"/>
+		<rdfs:label>virtual address</rdfs:label>
+		<owl:disjointWith
+			rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<skos:definition
+			rdf:datatype="&xsd;string">an address identifying a virtual, i.e. non-physical location</skos:definition>
+	</owl:Class>
+	
+	<owl:ObjectProperty
+		rdf:about="&fibo-fnd-plc-adr;hasAddress">
+		<rdfs:subPropertyOf
+			rdf:resource="&fibo-fnd-rel-rel;has"/>
+		<rdfs:label>has address</rdfs:label>
+		<rdfs:range
+			rdf:resource="&fibo-fnd-plc-adr;Address"/>
+		<skos:definition
+			rdf:datatype="&xsd;string">has a means by which the entity may be located or contacted or may receive correspondence</skos:definition>
+	</owl:ObjectProperty>
 
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Relations/Relations/</sm:dependsOn>
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/</sm:dependsOn>
-        <sm:dependsOn rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Places/Locations/</sm:dependsOn>
-
-        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
-        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/AboutFND/</rdfs:seeAlso>
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/Places/AboutPlaces/</rdfs:seeAlso>
-
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
-
-    </owl:Ontology>
-    
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Object Properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->    
-
-    <owl:ObjectProperty rdf:about="&fibo-fnd-plc-adr;hasAddress">
-        <rdfs:label>has address</rdfs:label>
-        <rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;has"/>
-        <rdfs:range rdf:resource="&fibo-fnd-plc-adr;Address"/>
-        <skos:definition rdf:datatype="&xsd;string">has a means by which the entity may be located or contacted or may receive correspondence</skos:definition>
-    </owl:ObjectProperty>
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Classes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->    
-
-    <owl:Class rdf:about="&fibo-fnd-plc-adr;Address">
-        <rdfs:label>address</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fnd-arr-id;Index"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-                <owl:onClass rdf:resource="&fibo-fnd-plc-loc;Location"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasDefinition"/>
-                <owl:onClass rdf:resource="&fibo-fnd-plc-adr;AddressingScheme"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <skos:definition rdf:datatype="&xsd;string">an index to a location to which communications may be delivered</skos:definition>
-        <skos:editorialNote rdf:datatype="&xsd;string">This came from FDTF Address Reviews Aug/Sept 2011. It represents a place holder for mapping to other standards, such as those for email, network, and other electronic addresses as well as physical and mailing addresses.</skos:editorialNote>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fnd-plc-adr;AddressingScheme">
-        <rdfs:label>addressing scheme</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fnd-arr-id;IndexingScheme"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;defines"/>
-                <owl:allValuesFrom rdf:resource="&fibo-fnd-plc-adr;Address"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <skos:definition rdf:datatype="&xsd;string">a system for allocating addresses to objects</skos:definition>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fnd-plc-adr;PostCodeArea">
-        <rdfs:label>post code area</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
-        <skos:definition rdf:datatype="&xsd;string">a physical area uniquely identified by some postal code</skos:definition>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fnd-plc-adr;PhysicalAddress">
-        <rdfs:label>physical address</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-                <owl:onClass rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <skos:definition rdf:datatype="&xsd;string">a physical address where communications can be addressed, papers served or representatives located for any kind of organization or person</skos:definition>
-        <skos:scopeNote rdf:datatype="&xsd;string">An address is a collection of information, presented in a mostly fixed format, used for describing the location of a building, apartment, or other structure or a plot of land, generally using political boundaries and street names as references, along with other identifiers such as house or apartment numbers.  Some addresses also contain special codes to aid routing of mail and packages, such as a ZIP code or post code. (Wikipedia)</skos:scopeNote>
-        <skos:editorialNote rdf:datatype="&xsd;string">There are existing international and regional standards for defining postal addresses.  This is a place holder for mapping to regional standards for postal address representation</skos:editorialNote>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fnd-plc-adr;VirtualAddress">
-        <rdfs:label>virtual address</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>
-        <owl:disjointWith rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
-        <skos:definition rdf:datatype="&xsd;string">an address identifying a virtual, i.e. non-physical location</skos:definition>
-    </owl:Class>
-    
 </rdf:RDF>


### PR DESCRIPTION
There was a change made at the last minute to FND in yellow having to do with Postal Address. 

Added PostalAddress as a subclass of Physical Address, with definition "a physical address where postal communications can be addressed, for any kind of organization or person", and updated the change note to match. 
