### PR TITLE
FBC-60 -- (1) revise the terminology in the definition of CentralBank…

### DIFF
--- a/fbc/FunctionalEntities/FinancialServicesEntities.rdf
+++ b/fbc/FunctionalEntities/FinancialServicesEntities.rdf
@@ -1,367 +1,648 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!DOCTYPE rdf:RDF [
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY dct "http://purl.org/dc/terms/" >
-    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
-    <!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/" >
-    <!ENTITY fibo-fnd-utl-av "http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/" >
-    <!ENTITY fibo-fnd-rel-rel "http://spec.edmcouncil.org/fibo/FND/Relations/Relations/" >
-
-    <!ENTITY fibo-be-le-cb "http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/" >
-
-    <!ENTITY fibo-fbc-pas-fpas "http://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/" >
-    <!ENTITY fibo-fbc-fct-rga "http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/" >
-    <!ENTITY fibo-fbc-fct-fse "http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/" >
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-fct-fct "http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
+	<!ENTITY fibo-be-ge-ge "http://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/">
+	<!ENTITY fibo-be-le-cb "http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+	<!ENTITY fibo-be-le-fbo "http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+	<!ENTITY fibo-fbc-fct-fse "http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/">
+	<!ENTITY fibo-fbc-fct-rga "http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/">
+	<!ENTITY fibo-fbc-pas-fpas "http://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/">
+	<!ENTITY fibo-fnd-acc-cur "http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-plc-cty "http://spec.edmcouncil.org/fibo/FND/Places/Countries/">
+	<!ENTITY fibo-fnd-rel-rel "http://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-
-<rdf:RDF xml:base="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:xml="http://www.w3.org/XML/1998/namespace"
-     xmlns:dct="http://purl.org/dc/terms/"
-     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-     xmlns:fibo-fnd-utl-av="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-     xmlns:fibo-fnd-rel-rel="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-
-     xmlns:fibo-be-le-cb="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-
-     xmlns:fibo-fbc-pas-fpas="http://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"
-     xmlns:fibo-fbc-fct-rga="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/"
-     xmlns:fibo-fbc-fct-fse="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/">
-
-
-    <owl:Ontology rdf:about="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/">
-        <rdfs:label>Financial Services Entities Ontology</rdfs:label>
-
-
-    <!-- Curation and Rights Metadata for the FIBO FBC Financial Services Entities Ontology -->
-
-        <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015 EDM Council, Inc.
-Copyright (c) 2015 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
-
-
-    <!-- Ontology/File-Level Metadata for the FIBO FBC Financial Services Entities Ontology -->
-
-        <sm:filename rdf:datatype="&xsd;string">FinancialServicesEntities.rdf</sm:filename>
-        <sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-fbc-fct-fse</sm:fileAbbreviation>
-        <owl:versionIRI rdf:resource="http://spec.edmcouncil.org/fibo/FBC/20150801/FunctionalEntities/FinancialServicesEntities/"/>
-        <sm:fileAbstract rdf:datatype="&xsd;string">This ontology defines basic financial service providers, such as holding companies, financial institutions (both depository and non-depository institutions), and clearing houses at a relatively general level. Nuances specific to the institutions located in a specific country are defined in jurisdiction specific dependent ontologies.</sm:fileAbstract>
-
-        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
-        <sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FBC/AboutFBC/</rdfs:seeAlso>
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/AboutFBCFunctionalEntities/</rdfs:seeAlso>
-
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-        <owl:imports rdf:resource="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/"/>
-
-    </owl:Ontology>
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Classes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;Bank">
-        <rdfs:label>bank</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">an organization, usually a corporation, that accepts deposits, makes loans, pays checks, and performs related services, for individual members of the public and/or businesses and other organizations</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">The Bank Holding Company Act of 1956 defines a bank as any depository financial intermediary that accepts checking accounts (checks) or makes commercial loans, and its deposits are insured by a federal deposit insurance agency.  A bank acts as a middleman between suppliers of funds and users of funds, substituting its own credit judgement for that of the ultimate suppliers of funds, collecting those funds from three sources: checking accounts, savings and time deposits; short-term borrowings from other banks; and equity capital. A bank earns money by reinvesting these funds in longer-term assets.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">A bank, as specified in the Investment Company Act of 1940, is a financial intermediary that is (a) a depository institution (as defined in section 3 of the Federal Deposit Insurance Act) or a branch or agency of a foreign bank (as such terms are defined in section 1(b) of the International Banking Act of 1978), (b) a member bank of the Federal Reserve System, (c) any other banking institution or trust company, whether incorporated or not, doing business under the laws of any State or of the United States, a substantial portion of the business of which consists of receiving deposits or exercising fiduciary powers similar to those permitted to national banks under the authority of the Comptroller of the Currency, and which is supervised and examined by State or Federal authority having supervision over banks, and which is not operated for the purpose of evading the provisions of this title, and (d) a receiver, conservator, or other liquidating agent of any institution or firm included in clause (a), (b), or (c) of this paragraph.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">A state bank is defined as any bank, banking association, trust company, savings bank, industrial bank (or similar depository institution operating substantially in the same manner as an industrial bank), or other banking institution which is engaged in the business of receiving deposits other than trust funds, and in the US, is incorporated under the laws of any State or which is operating under the Code of Law for the District of Columbia, including any cooperative bank or other unincorporated bank the deposits of which were insured by the Federal Deposit Insurance Corporation on the day before the date of the enactment of the Financial Institutions Reform, Recovery, and Enforcement Act of 1989.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">As defined in the Federal Deposit Insurance Act, https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:adaptedFrom>
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://www.sec.gov/about/laws/ica40.pdf</rdfs:seeAlso>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;BankForInternationalSettlements">
-        <rdfs:label>bank for international settlements</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">an international financial organization that serves central banks in their pursuit of monetary and financial stability, helping to foster international cooperation in those areas and acting as a bank for central banks</skos:definition>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:definitionOrigin>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;BankHoldingCompany">
-        <rdfs:label>bank holding company</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
-        <skos:definition rdf:datatype="&xsd;string">any company that has direct or indirect control of one or more banks and is regulated and supervised by (1) the Federal Reserve in accordance with the Bank Holding Company Act of 1956, or (2) the equivalent international or central banking authority in the country that has jurisdiction over said company; BHCs may also own nonbanking subsidiaries such as broker-dealers and asset managers.</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">According to the FFIEC, a bank holding company is a company that owns and/or controls one or more U.S. banks or one that owns, or has controlling interest in, one or more banks. A bank holding company may also own another bank holding company, which in turn owns or controls a bank; the company at the top of the ownership chain is called the top holder. The Board of Governors is responsible for regulating and supervising bank holding companies, even if the bank owned by the holding company is under the primary supervision of a different federal agency (OCC or FDIC).</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;BrokerageFirm">
-        <rdfs:label>brokerage firm</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">a firm in the business of buying and selling securities, operating as both a broker and a dealer, depending on the transaction</skos:definition>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:definitionOrigin>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">The term broker-dealer is used in U.S. securities regulation parlance to describe stock brokerages, because most of them act as both agents and principals. A brokerage acts as a broker (or agent) when it executes orders on behalf of clients, whereas it acts as a dealer (or principal) when it trades for its own account.</fibo-fnd-utl-av:explanatoryNote>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;CentralBank">
-        <rdfs:label>central bank</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">a financial institution that is the monetary authority and major regulatory bank in a nation (or group of nations)</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Its functions include issuing and managing the country's currency, controlling monetary policy and supervising money market operations, managing exchange and gold reserves, acting as lender of last resort to commercial banks, and providing banking services to the government. Central banks are state-controlled but are increasingly being given an independent status to insulate them from partisan politics.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/centralbank.asp</fibo-fnd-utl-av:adaptedFrom>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://lexicon.ft.com/Term?term=central-bank</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;CentralCounterpartyClearingHouse">
-        <rdfs:label>central counterparty clearing house</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;ClearingHouse"/>
-        <fibo-fnd-utl-av:abbreviation rdf:datatype="&xsd;string">CCP</fibo-fnd-utl-av:abbreviation>
-        <skos:definition rdf:datatype="&xsd;string">a clearing house that helps facilitate trading in derivatives and equities markets</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">These clearing houses are often operated by the major banks in the country. The house's prime responsibility is to provide efficiency and stability to the financial markets that they operate in.
+<rdf:RDF
+	xml:base="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-fct-fct="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
+	xmlns:fibo-be-ge-ge="http://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"
+	xmlns:fibo-be-le-cb="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+	xmlns:fibo-be-le-fbo="http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+	xmlns:fibo-fbc-fct-fse="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/"
+	xmlns:fibo-fbc-fct-rga="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/"
+	xmlns:fibo-fbc-pas-fpas="http://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"
+	xmlns:fibo-fnd-acc-cur="http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-plc-cty="http://spec.edmcouncil.org/fibo/FND/Places/Countries/"
+	xmlns:fibo-fnd-rel-rel="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology
+		rdf:about="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/">
+		<rdfs:label>Financial Services Entities Ontology</rdfs:label>
+		<dct:license
+			rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<sm:contentLanguage
+			rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
+		<sm:contentLanguage
+			rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:copyright
+			rdf:datatype="&xsd;string">Copyright (c) 2015-2016 EDM Council, Inc.
+Copyright (c) 2015-2016 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/BE/</sm:dependsOn>
+		<sm:dependsOn
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FND/</sm:dependsOn>
+		<sm:fileAbbreviation
+			rdf:datatype="&xsd;string">fibo-fbc-fct-fse</sm:fileAbbreviation>
+		<sm:fileAbstract
+			rdf:datatype="&xsd;string">This ontology defines basic financial service providers, such as holding companies, financial institutions (both depository and non-depository institutions), and clearing houses at a relatively general level. Nuances specific to the institutions located in a specific country are defined in jurisdiction specific dependent ontologies.</sm:fileAbstract>
+		<sm:filename
+			rdf:datatype="&xsd;string">FinancialServicesEntities.rdf</sm:filename>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/</rdfs:seeAlso>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FBC/AboutFBC/</rdfs:seeAlso>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/AboutFBCFunctionalEntities/</rdfs:seeAlso>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+		<owl:imports
+			rdf:resource="http://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI
+			rdf:resource="http://spec.edmcouncil.org/fibo/FBC/20160801/FunctionalEntities/FinancialServicesEntities/"/>
+		<skos:changeNote
+			rdf:datatype="&xsd;string">The http://spec.edmcouncil.org/fibo/FBC/20150801/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
+	</owl:Ontology>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;Bank">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
+		<rdfs:label>bank</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">As defined in the Federal Deposit Insurance Act, https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">A bank, as specified in the Investment Company Act of 1940, is a financial intermediary that is (a) a depository institution (as defined in section 3 of the Federal Deposit Insurance Act) or a branch or agency of a foreign bank (as such terms are defined in section 1(b) of the International Banking Act of 1978), (b) a member bank of the Federal Reserve System, (c) any other banking institution or trust company, whether incorporated or not, doing business under the laws of any State or of the United States, a substantial portion of the business of which consists of receiving deposits or exercising fiduciary powers similar to those permitted to national banks under the authority of the Comptroller of the Currency, and which is supervised and examined by State or Federal authority having supervision over banks, and which is not operated for the purpose of evading the provisions of this title, and (d) a receiver, conservator, or other liquidating agent of any institution or firm included in clause (a), (b), or (c) of this paragraph.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">A state bank is defined as any bank, banking association, trust company, savings bank, industrial bank (or similar depository institution operating substantially in the same manner as an industrial bank), or other banking institution which is engaged in the business of receiving deposits other than trust funds, and in the US, is incorporated under the laws of any State or which is operating under the Code of Law for the District of Columbia, including any cooperative bank or other unincorporated bank the deposits of which were insured by the Federal Deposit Insurance Corporation on the day before the date of the enactment of the Financial Institutions Reform, Recovery, and Enforcement Act of 1989.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">The Bank Holding Company Act of 1956 defines a bank as any depository financial intermediary that accepts checking accounts (checks) or makes commercial loans, and its deposits are insured by a federal deposit insurance agency.  A bank acts as a middleman between suppliers of funds and users of funds, substituting its own credit judgement for that of the ultimate suppliers of funds, collecting those funds from three sources: checking accounts, savings and time deposits; short-term borrowings from other banks; and equity capital. A bank earns money by reinvesting these funds in longer-term assets.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">https://www.sec.gov/about/laws/ica40.pdf</rdfs:seeAlso>
+		<skos:definition
+			rdf:datatype="&xsd;string">an organization, usually a corporation, that accepts deposits, makes loans, pays checks, and performs related services, for individual members of the public and/or businesses and other organizations</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;BankForInternationalSettlements">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;Bank"/>
+		<rdfs:label>bank for international settlements</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;string">Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition
+			rdf:datatype="&xsd;string">an international financial organization that serves central banks in their pursuit of monetary and financial stability, helping to foster international cooperation in those areas and acting as a bank for central banks</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;BankHoldingCompany">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-be-fct-fct;Business"/>
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onClass
+					rdf:resource="&fibo-be-le-cb;Corporation"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+				<owl:qualifiedCardinality
+					rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>bank holding company</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">According to the FFIEC, a bank holding company is a company that owns and/or controls one or more U.S. banks or one that owns, or has controlling interest in, one or more banks. A bank holding company may also own another bank holding company, which in turn owns or controls a bank; the company at the top of the ownership chain is called the top holder. The Board of Governors is responsible for regulating and supervising bank holding companies, even if the bank owned by the holding company is under the primary supervision of a different federal agency (OCC or FDIC).</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition
+			rdf:datatype="&xsd;string">any company that has direct or indirect control of one or more banks and is regulated and supervised by (1) the Federal Reserve in accordance with the Bank Holding Company Act of 1956, or (2) the equivalent international or central banking authority in the country that has jurisdiction over said company; BHCs may also own nonbanking subsidiaries such as broker-dealers and asset managers</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;BrokerageFirm">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
+		<rdfs:label>brokerage firm</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;string">Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:definitionOrigin>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">The term broker-dealer is used in U.S. securities regulation parlance to describe stock brokerages, because most of them act as both agents and principals. A brokerage acts as a broker (or agent) when it executes orders on behalf of clients, whereas it acts as a dealer (or principal) when it trades for its own account.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition
+			rdf:datatype="&xsd;string">a firm in the business of buying and selling securities, operating as both a broker and a dealer, depending on the transaction</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;CentralBank">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;Bank"/>
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;MonetaryAuthority"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:allValuesFrom
+					rdf:resource="&fibo-be-ge-ge;Instrumentality"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>central bank</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;anyURI">http://lexicon.ft.com/Term?term=central-bank</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/centralbank.asp</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">Its functions include issuing and managing the country&apos;s currency, controlling monetary policy and supervising money market operations, managing exchange and gold reserves, acting as lender of last resort to commercial banks, and providing banking services to the government. Central banks are state-controlled but are increasingly being given an independent status to insulate them from partisan politics.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition
+			rdf:datatype="&xsd;string">a financial institution that is the monetary authority and major regulatory bank for a country (or group of countries)</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;CentralCounterpartyClearingHouse">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;ClearingHouse"/>
+		<rdfs:label>central counterparty clearing house</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation
+			rdf:datatype="&xsd;string">CCP</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/ccph.asp</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">These clearing houses are often operated by the major banks in the country. The house&apos;s prime responsibility is to provide efficiency and stability to the financial markets that they operate in.
 
 There are two main processes that are carried out by CCPs: clearing and settlement of market transactions. Clearing relates to identifying the obligations of both parties on either side of a transaction. Settlement occurs when the final transfer of securities and funds occur.
 
 CCPs benefit both parties in a transaction because they bear most of the credit risk. If two individuals deal with one another, the buyer bears the credit risk of the seller, and vice versa. When a CCP is used the credit risk that is held against both buyer and seller is coming from the CCP, which in all likelihood is much less than in the previous situation.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/ccph.asp</fibo-fnd-utl-av:adaptedFrom>
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.esma.europa.eu/system/files/EACH2.pdf</rdfs:seeAlso>
-    </owl:Class>
-
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;ClearingBank">
-        <rdfs:label>clearing bank</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;CommercialBank"/>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;ClearingHouse"/>
-        <skos:definition rdf:datatype="&xsd;string">a commercial bank that facilitates payment and settlement of financial transactions, such as check clearing or facilitating trades between the sellers and buyers of securities or other financial instruments or contracts</skos:definition>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:definitionOrigin>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;ClearingCorporation">
-        <rdfs:label>clearing corporation</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;ClearingHouse"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-                <owl:onClass rdf:resource="&fibo-be-le-cb;Corporation"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <skos:definition rdf:datatype="&xsd;string">a clearing house that is organized as a corporation</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;ClearingHouse">
-        <rdfs:label>clearing house</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-                <owl:onClass rdf:resource="&fibo-fbc-fct-fse;ClearingService"/>
-                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <skos:definition rdf:datatype="&xsd;string">a financial service provider that is exchange affiliated and provides clearing services, including the validation, delivery, and settlement of financial transactions, for financial intermediaries</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;ClearingService">
-        <rdfs:label>clearing service</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
-        <skos:definition rdf:datatype="&xsd;string">a service provided to financial institutions including the validation, delivery, and settlement of financial transactions</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;CommercialBank">
-        <rdfs:label>commercial bank</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;Bank"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-                <owl:onClass rdf:resource="&fibo-be-le-cb;Corporation"/>
-                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <skos:definition rdf:datatype="&xsd;string">a bank that provides services, such as accepting deposits, giving business loans and auto loans, mortgage lending, and basic investment products like savings accounts and certificates of deposit</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">A commercial bank is a financial institution that is owned by stockholders, operates for a profit, and engages in various lending activities.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">The traditional commercial bank is a brick and mortar institution with tellers, safe deposit boxes, vaults and ATMs. However, some commercial banks do not have any physical branches and require consumers to complete all transactions by phone or Internet. In exchange, they generally pay higher interest rates on investments and deposits, and charge lower fees.</fibo-fnd-utl-av:explanatoryNote>
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</rdfs:seeAlso>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/commercialbank.asp</fibo-fnd-utl-av:definitionOrigin>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;CommercialFinanceCompany">
-        <rdfs:label>commercial finance company</rdfs:label>
-        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">commercial credit company</fibo-fnd-utl-av:synonym>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinanceCompany"/>
-        <skos:definition rdf:datatype="&xsd;string">a finance company that makes loans to manufacturers and wholesalers, secured by accounts receivable, inventories, and equipment</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;CommodityTradingAdvisor">
-        <rdfs:label>commodity trading advisor</rdfs:label>
-        <fibo-fnd-utl-av:abbreviation rdf:datatype="&xsd;string">CTA</fibo-fnd-utl-av:abbreviation>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">an individual or organization that directly or indirectly advises others as to the value or advisability of buying or selling futures contracts or options</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Indirect advice includes exercising trading authority over a customer's account. In the U.S., registered CTAs are registered with the Commodities Futures Trading Commission (CFTC) and are generally required to be members of the National Futures Association (NFA).</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;ConsumerFinanceCompany">
-        <rdfs:label>consumer finance company</rdfs:label>
-        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">direct loan company</fibo-fnd-utl-av:synonym>
-        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">small loan company</fibo-fnd-utl-av:synonym>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinanceCompany"/>
-        <skos:definition rdf:datatype="&xsd;string">a finance company that lends to individuals under the small loans laws of the jurisdiction in which they operate</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;DepositoryInstitution">
-        <rdfs:label>depository institution</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">any financial institution engaged in the business of receiving deposits from the public or other institutions, other than trust funds</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">12 U.S. Code Section 1813 - Definitions, see, for example, http://www.law.cornell.edu/uscode/text/12/1813</fibo-fnd-utl-av:adaptedFrom>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-     
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;FaceAmountCertificateCompany">
-        <rdfs:label>face amount certificate company</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;InvestmentCompany"/>
-        <owl:disjointWith rdf:resource="&fibo-fbc-fct-fse;ManagementCompany"/>
-        <skos:definition rdf:datatype="&xsd;string">an investment company which is engaged or proposes to engage in the business of issuing face-amount certificates of the installment type, or which has been engaged in such business and has any such certificate outstanding</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">An investor may enter into a contract with an issuer of a face amount certificate to contract to receive a stated or fixed amount of money (the face amount) at a stated date in the future. In exchange for this future sum, the investor must deposit an agreed lump sum or make scheduled installment payments over time. Face amount certificates are rarely issued these days, as most of the tax advantages that the investment once offered have been lost through changes in the tax laws.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.investopedia.com/study-guide/series-99/chapters-46/chapter-5-investment-companies/introduction-investment-companies/</rdfs:seeAlso>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;FinancialInstitution">
-        <rdfs:label>financial institution</rdfs:label>
-        <skos:prefLabel rdf:datatype="&xsd;string">financial institution</skos:prefLabel>
-        <skos:altLabel rdf:datatype="&xsd;string">financial intermediary</skos:altLabel>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-                <owl:onClass rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
-                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="&fibo-fbc-fct-rga;isRegulatedBy"/>
-                <owl:someValuesFrom rdf:resource="&fibo-fbc-fct-rga;RegulatoryAgency"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <skos:definition rdf:datatype="&xsd;string">a financial service provider identified as either a government agency or privately owned entity that collects funds from the public and from other institutions, and invests those funds in financial assets, such as loans, securities, bank deposits, and income-generating property</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Financial institutions are differentiated by the way they obtain and invest funds. Depository institutions accept public deposits, which are insured by the government against loss, and channel those deposits into lending activities.  Non-depository institutions, such as brokerage firms, life insurance companies, pension funds, and investment companies, fund their investment activities directly from financial markets by selling securities to the public or by selling insurance policies, in the case of insurance companies.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;FinanceCompany">
-        <rdfs:label>finance company</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">a financial intermediary in the business of making loans to individuals or businesses that obtains its financing from banks, institutions, and other money market sources rather than from deposits</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;InsuranceCompany">
-        <rdfs:label>insurance company</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">a non-depository institution whose primary and predominant business activity is the writing of insurance or the reinsuring of risks underwritten by insurance companies, and that provides compensation based on the happening of one or more contingencies</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">In the US, insurance companies are subject to supervision by the insurance commissioner or a similar official or agency of a State; or any receiver or similar official or any liquidating agent for such a company, in his capacity as such. Common forms of insurance include life, property and casualty, and health insurance. In addition to insuring against hazards, many insurance companies also sell investments or investment-like products. The most prevalent investment products offered by insurers are annuities and life insurance policies that also feature investment elements.
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://www.esma.europa.eu/system/files/EACH2.pdf</rdfs:seeAlso>
+		<skos:definition
+			rdf:datatype="&xsd;string">a clearing house that helps facilitate trading in derivatives and equities markets</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;ClearingBank">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;ClearingHouse"/>
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;CommercialBank"/>
+		<rdfs:label>clearing bank</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;string">Office of Financial Research (OFR) Annual Report, 2012, Glossary</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition
+			rdf:datatype="&xsd;string">a commercial bank that facilitates payment and settlement of financial transactions, such as check clearing or facilitating trades between the sellers and buyers of securities or other financial instruments or contracts</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;ClearingCorporation">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;ClearingHouse"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onClass
+					rdf:resource="&fibo-be-le-cb;Corporation"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+				<owl:qualifiedCardinality
+					rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>clearing corporation</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition
+			rdf:datatype="&xsd;string">a clearing house that is organized as a corporation</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;ClearingHouse">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:minQualifiedCardinality
+					rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+				<owl:onClass
+					rdf:resource="&fibo-fbc-fct-fse;ClearingService"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;provides"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>clearing house</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition
+			rdf:datatype="&xsd;string">a financial service provider that is exchange affiliated and provides clearing services, including the validation, delivery, and settlement of financial transactions, for financial intermediaries</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;ClearingService">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
+		<rdfs:label>clearing service</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition
+			rdf:datatype="&xsd;string">a service provided to financial institutions including the validation, delivery, and settlement of financial transactions</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;CommercialBank">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;Bank"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onClass
+					rdf:resource="&fibo-be-le-cb;Corporation"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+				<owl:qualifiedCardinality
+					rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>commercial bank</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/c/commercialbank.asp</fibo-fnd-utl-av:definitionOrigin>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">A commercial bank is a financial institution that is owned by stockholders, operates for a profit, and engages in various lending activities.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">The traditional commercial bank is a brick and mortar institution with tellers, safe deposit boxes, vaults and ATMs. However, some commercial banks do not have any physical branches and require consumers to complete all transactions by phone or Internet. In exchange, they generally pay higher interest rates on investments and deposits, and charge lower fees.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</rdfs:seeAlso>
+		<skos:definition
+			rdf:datatype="&xsd;string">a bank that provides services, such as accepting deposits, giving business loans and auto loans, mortgage lending, and basic investment products like savings accounts and certificates of deposit</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;CommercialFinanceCompany">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;FinanceCompany"/>
+		<rdfs:label>commercial finance company</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:synonym
+			rdf:datatype="&xsd;string">commercial credit company</fibo-fnd-utl-av:synonym>
+		<skos:definition
+			rdf:datatype="&xsd;string">a finance company that makes loans to manufacturers and wholesalers, secured by accounts receivable, inventories, and equipment</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;CommodityTradingAdvisor">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
+		<rdfs:label>commodity trading advisor</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation
+			rdf:datatype="&xsd;string">CTA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">Indirect advice includes exercising trading authority over a customer&apos;s account. In the U.S., registered CTAs are registered with the Commodities Futures Trading Commission (CFTC) and are generally required to be members of the National Futures Association (NFA).</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition
+			rdf:datatype="&xsd;string">an individual or organization that directly or indirectly advises others as to the value or advisability of buying or selling futures contracts or options</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;ConsumerFinanceCompany">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;FinanceCompany"/>
+		<rdfs:label>consumer finance company</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:synonym
+			rdf:datatype="&xsd;string">direct loan company</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym
+			rdf:datatype="&xsd;string">small loan company</fibo-fnd-utl-av:synonym>
+		<skos:definition
+			rdf:datatype="&xsd;string">a finance company that lends to individuals under the small loans laws of the jurisdiction in which they operate</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;DepositoryInstitution">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
+		<rdfs:label>depository institution</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">12 U.S. Code Section 1813 - Definitions, see, for example, http://www.law.cornell.edu/uscode/text/12/1813</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition
+			rdf:datatype="&xsd;string">any financial institution engaged in the business of receiving deposits from the public or other institutions, other than trust funds</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;FaceAmountCertificateCompany">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;InvestmentCompany"/>
+		<rdfs:label>face amount certificate company</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;string">Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">An investor may enter into a contract with an issuer of a face amount certificate to contract to receive a stated or fixed amount of money (the face amount) at a stated date in the future. In exchange for this future sum, the investor must deposit an agreed lump sum or make scheduled installment payments over time. Face amount certificates are rarely issued these days, as most of the tax advantages that the investment once offered have been lost through changes in the tax laws.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://www.investopedia.com/study-guide/series-99/chapters-46/chapter-5-investment-companies/introduction-investment-companies/</rdfs:seeAlso>
+		<owl:disjointWith
+			rdf:resource="&fibo-fbc-fct-fse;ManagementCompany"/>
+		<skos:definition
+			rdf:datatype="&xsd;string">an investment company which is engaged or proposes to engage in the business of issuing face-amount certificates of the installment type, or which has been engaged in such business and has any such certificate outstanding</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;FinanceCompany">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
+		<rdfs:label>finance company</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition
+			rdf:datatype="&xsd;string">a financial intermediary in the business of making loans to individuals or businesses that obtains its financing from banks, institutions, and other money market sources rather than from deposits</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;FinancialInstitution">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:minQualifiedCardinality
+					rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+				<owl:onClass
+					rdf:resource="&fibo-fbc-pas-fpas;FinancialService"/>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;provides"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty
+					rdf:resource="&fibo-fbc-fct-rga;isRegulatedBy"/>
+				<owl:someValuesFrom
+					rdf:resource="&fibo-fbc-fct-rga;RegulatoryAgency"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>financial institution</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">Financial institutions are differentiated by the way they obtain and invest funds. Depository institutions accept public deposits, which are insured by the government against loss, and channel those deposits into lending activities.  Non-depository institutions, such as brokerage firms, life insurance companies, pension funds, and investment companies, fund their investment activities directly from financial markets by selling securities to the public or by selling insurance policies, in the case of insurance companies.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:altLabel
+			rdf:datatype="&xsd;string">financial intermediary</skos:altLabel>
+		<skos:definition
+			rdf:datatype="&xsd;string">a financial service provider identified as either a government agency or privately owned entity that collects funds from the public and from other institutions, and invests those funds in financial assets, such as loans, securities, bank deposits, and income-generating property</skos:definition>
+		<skos:prefLabel
+			rdf:datatype="&xsd;string">financial institution</skos:prefLabel>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;InsuranceCompany">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
+		<rdfs:label>insurance company</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;anyURI">https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">In the US, insurance companies are subject to supervision by the insurance commissioner or a similar official or agency of a State; or any receiver or similar official or any liquidating agent for such a company, in his capacity as such. Common forms of insurance include life, property and casualty, and health insurance. In addition to insuring against hazards, many insurance companies also sell investments or investment-like products. The most prevalent investment products offered by insurers are annuities and life insurance policies that also feature investment elements.
 
 A number of insurance companies operate brokerage arms that trade securities on behalf of clients.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.ffiec.gov/nicpubweb/Content/HELP/Institution%20Type%20Description.htm</fibo-fnd-utl-av:adaptedFrom>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;InvestmentBank">
-        <rdfs:label>investment bank</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
-        <rdfs:subClassOf>
-            <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="&fibo-fbc-fct-fse;Bank"/>
-                    <rdf:Description rdf:about="&fibo-fbc-fct-fse;BrokerageFirm"/>
-                </owl:unionOf>
-            </owl:Class>
-        </rdfs:subClassOf>
-        <skos:definition rdf:datatype="&xsd;string">a financial service provider that performs a variety of services. Investment banks specialize in large and complex financial transactions such as underwriting, acting as an intermediary between a securities issuer and the investing public, facilitating mergers and other corporate reorganizations, and acting as a broker and/or financial adviser for institutional clients.</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Major investment banks include Barclays, BofA Merrill Lynch, Warburgs, Goldman Sachs, Deutsche Bank, JP Morgan, Morgan Stanley, Salomon Brothers, UBS, Credit Suisse, Citibank and Lazard. Some investment banks specialize in particular industry sectors. Many investment banks also have retail operations that serve small, individual customers.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/i/investmentbank.asp</fibo-fnd-utl-av:definitionOrigin>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;InvestmentCompany">
-        <rdfs:label>investment company</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">Any issuer which: (a) is or holds itself out as being engaged primarily, or proposes to engage primarily, in the business of investing, reinvesting, or trading in securities; (b) is engaged or proposes to engage in the business of issuing face-amount certificates of the installment type, or has been engaged in such business and has any such certificate outstanding; or (c) is engaged or proposes to engage in the business of investing, reinvesting, owning, holding, or trading in securities, and owns or proposes to acquire investment securities having a value exceeding 40 per centum of the value of such issuer&amp;apos;s total assets (exclusive of Government securities and cash items) on an unconsolidated basis</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">An investment company is organized as either a corporation or as a trust. Individual investors&apos; money is then pooled together in a single account and used to purchase securities that will have the greatest chance of helping the investment company reach its objectives. All investors jointly own the portfolio that is created through these pooled funds, and each investor has an undivided interest in the securities.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">In the US, all investment company offerings are subject to the Securities Act of 1933, which requires the investment company to register with the Securities Exchange Commission (SEC) and to give all purchasers a prospectus. Investment companies are also subject to the Investment Company Act of 1940, which sets forth guidelines on how investment companies must operate.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-        <rdfs:seeAlso rdf:datatype="&xsd;anyURI">http://www.investopedia.com/study-guide/series-99/chapters-46/chapter-5-investment-companies/introduction-investment-companies/</rdfs:seeAlso>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;ManagementCompany">
-        <rdfs:label>management company</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;InvestmentCompany"/>
-        <owl:disjointWith rdf:resource="&fibo-fbc-fct-fse;UnitInvestmentTrust"/>
-        <skos:definition rdf:datatype="&xsd;string">Any investment company that sells and manages a portfolio of securities other than a face-amount certificate company or unit investment fund.</skos:definition>
-        <fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Management companies allow investors to pool their capital with that of other investors in order to purchase professionally-managed groups of diversified securities.</fibo-fnd-utl-av:explanatoryNote>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;NonDepositoryInstitution">
-        <rdfs:label>non-depository institution</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">any financial institution that acts as the middleman between two parties in a financial transaction, and that does not provide traditional depository services, such as brokerage firms, insurance companies, investment companies, etc.</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;PrincipalUnderwriter">
-        <rdfs:label>principal underwriter</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;Underwriter"/>
-        <skos:definition rdf:datatype="&xsd;string">Principal underwriter of or for any investment company other than a closed-end company, or of any security issued by such a company, means any underwriter who as principal purchases from such company, or pursuant to contract has the right (whether absolute or conditional) from time to time to purchase from such company, any such security for distribution, or who as agent for such company sells or has the right to sell any such security to a dealer or to the public or both, but does not include a dealer who purchases from such company through a principal underwriter acting as agent for such company. Principal underwriter of or for a closed-end company or any issuer which is not an investment company, or of any security issued by such a company or issuer, means any underwriter who, in connection with a primary distribution of securities, (a) is in privity of contract with the issuer or an affiliated person of the issuer; (b) acting alone or in concert with one or more other persons, initiates or directs the formation of an underwriting syndicate; or (c) is allowed a rate of gross commission, spread, or other profit greater than the rate allowed another underwriter participating in the distribution.</skos:definition>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;SalesFinanceCompany">
-        <rdfs:label>sales finance company</rdfs:label>
-        <fibo-fnd-utl-av:synonym rdf:datatype="&xsd;string">acceptance company</fibo-fnd-utl-av:synonym>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinanceCompany"/>
-        <skos:definition rdf:datatype="&xsd;string">a finance company that purchases retail and wholesale paper from automobile and other consumer and commercial goods dealers</skos:definition>
-        <fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;string">Barron's Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;SavingsAssociation">
-        <rdfs:label>savings association</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
-        <skos:definition rdf:datatype="&xsd;string">A savings association is defined as: (a) any Federal savings association, where a Federal savings association means any Federal savings association or Federal savings bank which is chartered under section 1464 of the Federal Deposit Insurance Act; (b) any State savings association, where a State savings association means any building and loan association, savings and loan association, or homestead association; or any cooperative bank (other than a cooperative bank which is a State bank as defined in subsection (a)(2)) of the Federal Deposit Insurance Act, which is organized and operating according to the laws of the State (as defined in subsection (a)(3)) in which it is chartered or organized; and (c) any corporation (other than a bank) that the Board of Directors and the Comptroller of the Currency jointly determine to be operating in substantially the same manner as a savings association.</skos:definition>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:definitionOrigin>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;Underwriter">
-        <rdfs:label>underwriter</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
-        <skos:definition rdf:datatype="&xsd;string">any person who has purchased from an issuer with a view to, or sells for an issuer in connection with, the distribution of any security, or participates or has a direct or indirect participation in any such undertaking, or participates or has a participation in the direct or indirect underwriting of any such undertaking; but such term shall not include a person whose interest is limited to a commission from an underwriter or dealer not in excess of the usual and customary distributor's or seller's commission</skos:definition>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-    </owl:Class>
-    
-    <owl:Class rdf:about="&fibo-fbc-fct-fse;UnitInvestmentTrust">
-        <rdfs:label>unit investment trust</rdfs:label>
-        <skos:prefLabel rdf:datatype="&xsd;string">unit investment trust</skos:prefLabel>
-        <skos:altLabel rdf:datatype="&xsd;string">unit investment company</skos:altLabel>
-        <rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;InvestmentCompany"/>
-        <skos:definition rdf:datatype="&xsd;string">an investment company which (a) is organized under a trust indenture, contract of custodianship or agency, or similar instrument, (b) does not have a board of directors, and (c) issues only redeemable securities, each of which represents an undivided interest in a unit of specified securities; but does not include a voting trust</skos:definition>
-        <fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
-    </owl:Class>
-    
+		<skos:definition
+			rdf:datatype="&xsd;string">a non-depository institution whose primary and predominant business activity is the writing of insurance or the reinsuring of risks underwritten by insurance companies, and that provides compensation based on the happening of one or more contingencies</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;InvestmentBank">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-be-fct-fct;Business"/>
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf>
+					<rdf:Description>
+						<rdf:first
+							rdf:resource="&fibo-fbc-fct-fse;Bank"/>
+						<rdf:rest>
+							<rdf:Description>
+								<rdf:first
+									rdf:resource="&fibo-fbc-fct-fse;BrokerageFirm"/>
+								<rdf:rest
+									rdf:resource="&rdf;nil"/>
+							</rdf:Description>
+						</rdf:rest>
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label>investment bank</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/i/investmentbank.asp</fibo-fnd-utl-av:definitionOrigin>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">Major investment banks include Barclays, BofA Merrill Lynch, Warburgs, Goldman Sachs, Deutsche Bank, JP Morgan, Morgan Stanley, Salomon Brothers, UBS, Credit Suisse, Citibank and Lazard. Some investment banks specialize in particular industry sectors. Many investment banks also have retail operations that serve small, individual customers.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition
+			rdf:datatype="&xsd;string">a financial service provider that performs a variety of services. Investment banks specialize in large and complex financial transactions such as underwriting, acting as an intermediary between a securities issuer and the investing public, facilitating mergers and other corporate reorganizations, and acting as a broker and/or financial adviser for institutional clients.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;InvestmentCompany">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;NonDepositoryInstitution"/>
+		<rdfs:label>investment company</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;string">Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">An investment company is organized as either a corporation or as a trust. Individual investors&apos; money is then pooled together in a single account and used to purchase securities that will have the greatest chance of helping the investment company reach its objectives. All investors jointly own the portfolio that is created through these pooled funds, and each investor has an undivided interest in the securities.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">In the US, all investment company offerings are subject to the Securities Act of 1933, which requires the investment company to register with the Securities Exchange Commission (SEC) and to give all purchasers a prospectus. Investment companies are also subject to the Investment Company Act of 1940, which sets forth guidelines on how investment companies must operate.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:seeAlso
+			rdf:datatype="&xsd;anyURI">http://www.investopedia.com/study-guide/series-99/chapters-46/chapter-5-investment-companies/introduction-investment-companies/</rdfs:seeAlso>
+		<skos:definition
+			rdf:datatype="&xsd;string">Any issuer which: (a) is or holds itself out as being engaged primarily, or proposes to engage primarily, in the business of investing, reinvesting, or trading in securities; (b) is engaged or proposes to engage in the business of issuing face-amount certificates of the installment type, or has been engaged in such business and has any such certificate outstanding; or (c) is engaged or proposes to engage in the business of investing, reinvesting, owning, holding, or trading in securities, and owns or proposes to acquire investment securities having a value exceeding 40 per centum of the value of such issuer&amp;apos;s total assets (exclusive of Government securities and cash items) on an unconsolidated basis</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;ManagementCompany">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;InvestmentCompany"/>
+		<rdfs:label>management company</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;string">Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
+		<fibo-fnd-utl-av:explanatoryNote
+			rdf:datatype="&xsd;string">Management companies allow investors to pool their capital with that of other investors in order to purchase professionally-managed groups of diversified securities.</fibo-fnd-utl-av:explanatoryNote>
+		<owl:disjointWith
+			rdf:resource="&fibo-fbc-fct-fse;UnitInvestmentTrust"/>
+		<skos:definition
+			rdf:datatype="&xsd;string">Any investment company that sells and manages a portfolio of securities other than a face-amount certificate company or unit investment fund.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;MonetaryAuthority">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-rga;RegulatoryAgency"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty
+					rdf:resource="&fibo-be-ge-ge;hasJurisdiction"/>
+				<owl:someValuesFrom
+					rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty
+					rdf:resource="&fibo-fbc-fct-fse;regulatesSupplyOf"/>
+				<owl:someValuesFrom
+					rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>monetary authority</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;anyURI">http://lexicon.ft.com/Term?term=monetary-authority</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;anyURI">http://www.investordictionary.com/definition/monetary-authority</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition
+			rdf:datatype="&xsd;string">a regulatory agency that controls the monetary policy, regulation and supply of money in some country or group of countries</skos:definition>
+		<skos:example
+			rdf:datatype="&xsd;string">a central bank, the executive branch of a government, a central bank for several nations, a currency board</skos:example>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;NonDepositoryInstitution">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-be-fct-fct;Business"/>
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
+		<rdfs:label>non-depository institution</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition
+			rdf:datatype="&xsd;string">any financial institution that acts as the middleman between two parties in a financial transaction, and that does not provide traditional depository services, such as brokerage firms, insurance companies, investment companies, etc.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;PrincipalUnderwriter">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;Underwriter"/>
+		<rdfs:label>principal underwriter</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;string">Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition
+			rdf:datatype="&xsd;string">Principal underwriter of or for any investment company other than a closed-end company, or of any security issued by such a company, means any underwriter who as principal purchases from such company, or pursuant to contract has the right (whether absolute or conditional) from time to time to purchase from such company, any such security for distribution, or who as agent for such company sells or has the right to sell any such security to a dealer or to the public or both, but does not include a dealer who purchases from such company through a principal underwriter acting as agent for such company. Principal underwriter of or for a closed-end company or any issuer which is not an investment company, or of any security issued by such a company or issuer, means any underwriter who, in connection with a primary distribution of securities, (a) is in privity of contract with the issuer or an affiliated person of the issuer; (b) acting alone or in concert with one or more other persons, initiates or directs the formation of an underwriting syndicate; or (c) is allowed a rate of gross commission, spread, or other profit greater than the rate allowed another underwriter participating in the distribution.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;SalesFinanceCompany">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;FinanceCompany"/>
+		<rdfs:label>sales finance company</rdfs:label>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:datatype="&xsd;string">Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:synonym
+			rdf:datatype="&xsd;string">acceptance company</fibo-fnd-utl-av:synonym>
+		<skos:definition
+			rdf:datatype="&xsd;string">a finance company that purchases retail and wholesale paper from automobile and other consumer and commercial goods dealers</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;SavingsAssociation">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
+		<rdfs:label>savings association</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;anyURI">https://www.fdic.gov/regulations/laws/rules/1000-400.html#fdic1000sec.3a</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition
+			rdf:datatype="&xsd;string">A savings association is defined as: (a) any Federal savings association, where a Federal savings association means any Federal savings association or Federal savings bank which is chartered under section 1464 of the Federal Deposit Insurance Act; (b) any State savings association, where a State savings association means any building and loan association, savings and loan association, or homestead association; or any cooperative bank (other than a cooperative bank which is a State bank as defined in subsection (a)(2)) of the Federal Deposit Insurance Act, which is organized and operating according to the laws of the State (as defined in subsection (a)(3)) in which it is chartered or organized; and (c) any corporation (other than a bank) that the Board of Directors and the Comptroller of the Currency jointly determine to be operating in substantially the same manner as a savings association.</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;SelfRegulatingOrganization">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-rga;RegulatoryAgency"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty
+					rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+				<owl:someValuesFrom
+					rdf:resource="&fibo-be-le-fbo;NonGovernmentalOrganization"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>self-regulating organization</rdfs:label>
+		<fibo-fnd-utl-av:abbreviation
+			rdf:datatype="&xsd;string">SRO</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom
+			rdf:resource="http://www.investopedia.com/terms/s/sro.asp"/>
+		<rdfs:seeAlso
+			rdf:resource="https://en.wikipedia.org/wiki/Self-regulatory_organization"/>
+		<skos:definition
+			rdf:datatype="&xsd;string">a non-governmental organization that has the power to create and exercise some degree of regulatory authority over an industry or profession in some country or group of countries</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;Underwriter">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdfs:label>underwriter</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;string">Section 3a of the Investment Company Act of 1940 as amended in January, 2012, https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition
+			rdf:datatype="&xsd;string">any person who has purchased from an issuer with a view to, or sells for an issuer in connection with, the distribution of any security, or participates or has a direct or indirect participation in any such undertaking, or participates or has a participation in the direct or indirect underwriting of any such undertaking; but such term shall not include a person whose interest is limited to a commission from an underwriter or dealer not in excess of the usual and customary distributor&apos;s or seller&apos;s commission</skos:definition>
+	</owl:Class>
+	
+	<owl:Class
+		rdf:about="&fibo-fbc-fct-fse;UnitInvestmentTrust">
+		<rdfs:subClassOf
+			rdf:resource="&fibo-fbc-fct-fse;InvestmentCompany"/>
+		<rdfs:label>unit investment trust</rdfs:label>
+		<fibo-fnd-utl-av:definitionOrigin
+			rdf:datatype="&xsd;string">Section 4, definition of investment companies, Investment Company Act of 1940 as amended and approved as of 3 January 2012, see https://www.sec.gov/about/laws/ica40.pdf</fibo-fnd-utl-av:definitionOrigin>
+		<skos:altLabel
+			rdf:datatype="&xsd;string">unit investment company</skos:altLabel>
+		<skos:definition
+			rdf:datatype="&xsd;string">an investment company which (a) is organized under a trust indenture, contract of custodianship or agency, or similar instrument, (b) does not have a board of directors, and (c) issues only redeemable securities, each of which represents an undivided interest in a unit of specified securities; but does not include a voting trust</skos:definition>
+		<skos:prefLabel
+			rdf:datatype="&xsd;string">unit investment trust</skos:prefLabel>
+	</owl:Class>
+	
+	<owl:ObjectProperty
+		rdf:about="&fibo-fbc-fct-fse;regulatesSupplyOf">
+		<rdfs:subPropertyOf
+			rdf:resource="&fibo-fnd-rel-rel;governs"/>
+		<rdfs:label>regulates supply of</rdfs:label>
+		<rdfs:domain
+			rdf:resource="&fibo-fbc-fct-rga;RegulatoryAgency"/>
+		<skos:definition
+			rdf:datatype="&xsd;string">a predicate indicating that a regulatory agency controls or supervises the amount of something available in some market by means of rules and regulations</skos:definition>
+		<skos:example
+			rdf:datatype="&xsd;string">The Federal Reserve System, whose banks together comprise the central bank of the United States, supervises banking system and regulates the money supply in the US.</skos:example>
+	</owl:ObjectProperty>
+
 </rdf:RDF>


### PR DESCRIPTION
… to use "country" instead of "nation" and (2) incorporate definition of monetary authority and update the definition of central bank based on the concepts that were originally in FIBO IND Interest Rate Publishers

This is the first half of the resolution to correct IND to eliminate redundant classes that cause incorrect reasoning in IND.
