### PR TITLE
FND-79 #comment -- loosened the domain of hasDuration, as the propert…

### DIFF
--- a/fnd/DatesAndTimes/FinancialDates.rdf
+++ b/fnd/DatesAndTimes/FinancialDates.rdf
@@ -964,12 +964,10 @@ The payment schedule is a RegularSchedule, wiith these properties:
 		<rdfs:label>has duration</rdfs:label>
 		<fibo-fnd-utl-av:usageNote
 			rdf:datatype="&xsd;string">This duration may be omitted or unknown (hasSettledDuration missing) if either the start or end Date of the DatePeriod is a CalculatedDate or a DefinedDate.</fibo-fnd-utl-av:usageNote>
-		<rdfs:domain
-			rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
 		<rdfs:range
 			rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition
-			rdf:datatype="&xsd;string">the duration of a DatePeriod</skos:definition>
+			rdf:datatype="&xsd;string">the duration of a date period or similar concept, such as the tenor of a contract</skos:definition>
 	</rdf:Description>
 	
 	<owl:DatatypeProperty


### PR DESCRIPTION
…y may be used to specify the tenor of a rate or contract, not just the duration associated with a DatePeriod