### PR TITLE
Create individuals instead of classes for reuters and london stock ex…

### DIFF
--- a/sec/Securities/SecuritiesIdentification.rdf
+++ b/sec/Securities/SecuritiesIdentification.rdf
@@ -657,10 +657,19 @@ Copyright (c) 2016-2017 Object Management Group, Inc.</sm:copyright>
 		<skos:definition>a security identifier issued in the public domain and referred to in listings and other relevant publications</skos:definition>
 	</owl:Class>
 	
-	<owl:Class
+	<rdf:Description
 		rdf:about="&fibo-sec-sec-id;LondonStockExchange">
-		<rdfs:label>london stock exchange</rdfs:label>
-	</owl:Class>
+		<rdf:type
+			rdf:resource="&owl;NamedIndividual"/>
+		<rdf:type
+			rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdf:type
+			rdf:resource="&fibo-ind-ind-ind;FinancialInformationPublisher"/>
+		<rdfs:label>London Stock Exchange</rdfs:label>
+		<rdfs:seeAlso
+			rdf:resource="http://www.cusip.com/"/>
+		<skos:definition>individual representing the London Stock Exchange financial services provider</skos:definition>
+	</rdf:Description>
 	
 	<owl:Class
 		rdf:about="&fibo-sec-sec-id;NationalNumberingAgency">
@@ -909,7 +918,7 @@ Copyright (c) 2016-2017 Object Management Group, Inc.</sm:copyright>
 				<owl:hasValue
 					rdf:resource="&fibo-sec-sec-id;ThomsonReuters"/>
 				<owl:onProperty
-					rdf:resource="&fibo-fbc-fct-rga;isIssuedBy"/>
+					rdf:resource="&fibo-fbc-fct-rga;isRegisteredBy"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>Reuters instrument code</rdfs:label>
@@ -1056,10 +1065,23 @@ Copyright (c) 2016-2017 Object Management Group, Inc.</sm:copyright>
 			rdf:resource="&owl;NamedIndividual"/>
 	</fibo-sec-sec-id:ProprietarySecurityIdentificationScheme>
 	
-	<owl:Class
+	<rdf:Description
 		rdf:about="&fibo-sec-sec-id;ThomsonReuters">
+		<rdf:type
+			rdf:resource="&owl;NamedIndividual"/>
+		<rdf:type
+			rdf:resource="&fibo-fbc-pas-fpas;FinancialServiceProvider"/>
+		<rdf:type
+			rdf:resource="&fibo-ind-ind-ind;FinancialInformationPublisher"/>
 		<rdfs:label>thomson reuters</rdfs:label>
-	</owl:Class>
+		<rdfs:seeAlso
+			rdf:resource="http://www.cusip.com/"/>
+		<skos:definition>individual representing the Thomson Reuters financial services provider</skos:definition>
+		<fibo-fbc-fct-ra:registers
+			rdf:resource="&fibo-sec-sec-id;ReutersInstrumentCode"/>
+		<fibo-fnd-rel-rel:hasIdentity
+			rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/CommonInterestRates/ThomsonReuters"/>
+	</rdf:Description>
 	
 	<owl:ObjectProperty
 		rdf:about="&fibo-sec-sec-id;hasNationalIdentifier">


### PR DESCRIPTION
…change. Reuters links to the Corporation in CommonInterestRates (without an ontology import) and the london stock exchange does not link to anything, pending policy for separating out such entities as per FLT-86.

This is a tactical fix to at least make the current SEC ontology technically correct.