### PR TITLE
FND-148 #comment - reverse erroneous move of the equivalence from Mon…

### DIFF
--- a/fnd/Accounting/CurrencyAmount.rdf
+++ b/fnd/Accounting/CurrencyAmount.rdf
@@ -92,7 +92,6 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>amount of money</rdfs:label>
-		<owl:equivalentClass rdf:resource="&fibo-fnd-acc-cur;MoneyAmount"/>
 		<skos:definition>a sum of money</skos:definition>
 		<skos:editorialNote>This is an actual sum of money, not the measure of a sum of money in monetary units, although it has the same basic properties (decimal number with a currenct unit).</skos:editorialNote>
 		<fibo-fnd-utl-av:synonym>cash</fibo-fnd-utl-av:synonym>
@@ -344,6 +343,7 @@ Where the currency is not associated with a single geographical entity as descri
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
 		<rdfs:label>money amount</rdfs:label>
 		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<owl:equivalentClass rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
 		<skos:definition>a sum of money</skos:definition>
 	</owl:Class>
 	


### PR DESCRIPTION
…eyAmount (deprecated) to AmountOfMoney (replacement) to AmountOfMoney pointing back at the deprecated class, which will cause errors when the deprecated class is removed for FIBO 2.0.