### PR TITLE
DER-31 #comment - moved the definition of BasisSwap to the main Swaps…

### DIFF
--- a/der/DerivativesContracts/Swaps.rdf
+++ b/der/DerivativesContracts/Swaps.rdf
@@ -57,13 +57,13 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/">
 		<rdfs:label>Swaps Ontology</rdfs:label>
+		<dct:abstract>This ontology defines concepts specific to swap contracts, including relevant trading organizations, data repositories, and intermediaries.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:resource="http://www.omg.org/spec/ODM/"/>
 		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
 		<sm:copyright>Copyright (c) 2016-2017 EDM Council, Inc.
 Copyright (c) 2016-2017 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-drc-swp</sm:fileAbbreviation>
-		<sm:fileAbstract>This ontology defines concepts specific to swap contracts, including relevant trading organizations, data repositories, and intermediaries.</sm:fileAbstract>
 		<sm:filename>Swaps.rdf</sm:filename>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/"/>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/DER/AboutDER/"/>

--- a/der/RateDerivatives/IRSwaps.rdf
+++ b/der/RateDerivatives/IRSwaps.rdf
@@ -55,6 +55,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/">
 		<rdfs:label>Interest Rate Swaps Ontology</rdfs:label>
+		<dct:abstract>This ontology defines concepts specific to interest rate swap contracts, including but not limited to fixed and floating rate combinations, single and cross-currency contracts, etc.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:resource="http://www.omg.org/spec/ODM/"/>
 		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
@@ -68,7 +69,6 @@ Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/IND/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/SEC/"/>
 		<sm:fileAbbreviation>fibo-der-rtd-irswp</sm:fileAbbreviation>
-		<sm:fileAbstract>This ontology defines ...</sm:fileAbstract>
 		<sm:filename>IRSwaps.rdf</sm:filename>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/"/>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/AboutRateDerivatives/"/>
@@ -93,12 +93,6 @@ Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/20171201/RateDerivatives/IRSwaps/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-drc-swp;Swap">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-swp;SwapLeg">
-	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-rtd-irswp;CrossCurrencyInterestRateSwap">
 		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-irswp;InterestRateSwap"/>


### PR DESCRIPTION
… ontology and generalized the definition; made FloatFloatInterestRateSwap a child of BasisSwap; revised definitions per FCT discussion