### PR TITLE
Fnd 174 - Needs remerge

### DIFF
--- a/be/CorporationsExt/CorporationEquity.rdf
+++ b/be/CorporationsExt/CorporationEquity.rdf
@@ -1,91 +1,94 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-corx-ceq "https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/">
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-corx-ceq "https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/"
-	xmlns:fibo-be-corx-ceq="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/">
-		<rdfs:label xml:lang="en">CorporationEquity</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;governedBy">
-		<rdfs:label xml:lang="en">governed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
-		<skos:definition xml:lang="en">The Company constitution or Articles of Inforporation, Articles of Association etc. which defines the terms for equity instruments issued by that company.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;hasCapital">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-le-cb;issuesEquity"/>
-		<rdfs:label xml:lang="en">has capital</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<skos:definition xml:lang="en">The capital issued by the company at its formation or subsequently.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review comment: Participation is not necessarily a share. Ownership of the capital.</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;hasHoldingOfAnotherCompanys">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-corx-ceq;hasCapital"/>
-		<rdfs:label xml:lang="en">has holding of another companys</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
-		<skos:definition xml:lang="en">Equity held by the company, in another company. This is assumed to be publicly issued equity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;hasMajorityHoldingOfAnotherCompanys">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-corx-ceq;hasHoldingOfAnotherCompanys"/>
-		<rdfs:label xml:lang="en">has majority holding of another companys</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
-		<skos:definition xml:lang="en">Majority Equity held by the company, in another company. This is assumed to be publicly issued equity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;mayHaveCapitalAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-corx-ceq;hasCapital"/>
-		<rdfs:label xml:lang="en">may have capital as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PrivateEquity"/>
-		<skos:definition xml:lang="en">Additional privately held equity in the company, which is not held as publicly issued shares.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-corx-ceq;hasCapital"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-corx-ceq="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CorporationEquity</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology describes equity held in corporations by other corporations. These are mainly relationships.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;governedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:range rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Company constitution or Articles of Inforporation, Articles of Association etc. which defines the terms for equity instruments issued by that company.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;hasCapital">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-le-cb;issuesEquity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has capital</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The capital issued by the company at its formation or subsequently.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review comment: Participation is not necessarily a share. Ownership of the capital.</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;hasHoldingOfAnotherCompanys">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-corx-ceq;hasCapital"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has holding of another companys</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Equity held by the company, in another company. This is assumed to be publicly issued equity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;hasMajorityHoldingOfAnotherCompanys">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-corx-ceq;hasHoldingOfAnotherCompanys"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has majority holding of another companys</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Majority Equity held by the company, in another company. This is assumed to be publicly issued equity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;mayHaveCapitalAs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-corx-ceq;hasCapital"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may have capital as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;PrivateEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Additional privately held equity in the company, which is not held as publicly issued shares.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-corx-ceq;hasCapital"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/be/CorporationsExt/CorporationsExtras.rdf
+++ b/be/CorporationsExt/CorporationsExtras.rdf
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY core "http://www.w3.org/2004/02/skos/core/">
-	<!ENTITY fibo-be-corx-corx "https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationsExtras/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY core "http://www.w3.org/2004/02/skos/core/">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-corx-corx "https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationsExtras/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationsExtras/"
-	xmlns:core="http://www.w3.org/2004/02/skos/core/"
-	xmlns:fibo-be-corx-corx="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationsExtras/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationsExtras/">
-		<rdfs:label xml:lang="en">CorporationsExtras</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationsExtras/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-corx-corx;IncorporatedCompanyLegalFormAbbreviation">
-		<rdfs:label>IncorporatedCompanyLegalFormAbbreviation</rdfs:label>
-		<skos:definition>The textual styling of the legal form of a legally incorporated company, as referred to in the jurisdiction in which it is incorporated and the language of that jurisdiction.</skos:definition>
-	</owl:Class>
+<rdf:RDF
+buxmlns:core="http://www.w3.org/2004/02/skos/core/"
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-corx-corx="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationsExtras/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationsExtras/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CorporationsExtras</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Defines the notion of corporate legal form as a class of thing. To be deprecated once this concept has been added in Release BE.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationsExtras/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-corx-corx;IncorporatedCompanyLegalFormAbbreviation">
+bubu<rdfs:label>IncorporatedCompanyLegalFormAbbreviation</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">The textual styling of the legal form of a legally incorporated company, as referred to in the jurisdiction in which it is incorporated and the language of that jurisdiction.</skos:definition>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/be/CorporationsExt/DeemedParents.rdf
+++ b/be/CorporationsExt/DeemedParents.rdf
@@ -1,92 +1,95 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-corx-dmp "https://spec.edmcouncil.org/fibo/BE/CorporationsExt/DeemedParents/">
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-oac-cctl "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-corx-dmp "https://spec.edmcouncil.org/fibo/BE/CorporationsExt/DeemedParents/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-oac-cctl "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/DeemedParents/"
-	xmlns:fibo-be-corx-dmp="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/DeemedParents/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-oac-cctl="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/DeemedParents/">
-		<rdfs:label xml:lang="en">DeemedParents</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/DeemedParents/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-corx-dmp;DeemedParent">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;VotingShareholdingCompany"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-corx-dmp;definingOwnershipThreshold"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">deemed parent</rdfs:label>
-		<skos:definition xml:lang="en">A party which is deemed to be a &quot;Parent&quot; for some purpose, as defined by some specific ownership threshold other than that defined for Parent i.e. other than 50% + 1 voting share.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may for example be where some regulatory or reporting regime requires that parties are reported as being a &quot;Parent&quot; for some threshold other than that defined for the normal working definition of Parent, such as over 25%. The threshold is defined as a property of this class of thing.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-corx-dmp;DeemedSubsidiary">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;ControlledCompany"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-corx-dmp;definingOwnershipThreshold"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">deemed subsidiary</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-corx-dmp;ThresholdBasedRelatedCompany">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">threshold based related company</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-dmp;deemedToHaveParent">
-		<rdfs:label xml:lang="en">deemed to have parent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-corx-dmp;DeemedParent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-dmp;deemedToHaveSubsidiary">
-		<rdfs:label xml:lang="en">deemed to have subsidiary</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-corx-dmp;DeemedSubsidiary"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-dmp;definingOwnershipThreshold">
-		<rdfs:label xml:lang="en">defining ownership threshold</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-corx-dmp;ThresholdBasedRelatedCompany"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The percentage of ownership of one party by another party, for which it is deemed that the owning Party is to be defined as a Parent and that the other Party is to be defined as a Subsidiary, for the purposes in question.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
-		<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-corx-dmp="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/DeemedParents/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-oac-cctl="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/DeemedParents/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DeemedParents</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Ontology for the concepts whereby a given entity is deemed to be a parent or subsidiary in some specific e.g. regulatory context, based on the definition of something being a parent or subsidiary for the purposes of some regulation or internal reporting matter based on a defined percentage threshold of ownership.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/DeemedParents/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-corx-dmp;DeemedParent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;VotingShareholdingCompany"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-corx-dmp;definingOwnershipThreshold"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deemed parent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which is deemed to be a &quot;Parent&quot; for some purpose, as defined by some specific ownership threshold other than that defined for Parent i.e. other than 50% + 1 voting share.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may for example be where some regulatory or reporting regime requires that parties are reported as being a &quot;Parent&quot; for some threshold other than that defined for the normal working definition of Parent, such as over 25%. The threshold is defined as a property of this class of thing.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-corx-dmp;DeemedSubsidiary">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;ControlledCompany"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-corx-dmp;definingOwnershipThreshold"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deemed subsidiary</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-corx-dmp;ThresholdBasedRelatedCompany">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">threshold based related company</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-corx-dmp;deemedToHaveParent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deemed to have parent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-corx-dmp;DeemedParent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-corx-dmp;deemedToHaveSubsidiary">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deemed to have subsidiary</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-corx-dmp;DeemedSubsidiary"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-corx-dmp;definingOwnershipThreshold">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defining ownership threshold</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-corx-dmp;ThresholdBasedRelatedCompany"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage of ownership of one party by another party, for which it is deemed that the owning Party is to be defined as a Parent and that the other Party is to be defined as a Subsidiary, for the purposes in question.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+bubu<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/be/EntitiesTypesExt/LegalFoundations.rdf
+++ b/be/EntitiesTypesExt/LegalFoundations.rdf
@@ -1,90 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-etx-fnd "https://spec.edmcouncil.org/fibo/BE/EntitiesTypesExt/LegalFoundations/">
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-etx-fnd "https://spec.edmcouncil.org/fibo/BE/EntitiesTypesExt/LegalFoundations/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/EntitiesTypesExt/LegalFoundations/"
-	xmlns:fibo-be-etx-fnd="https://spec.edmcouncil.org/fibo/BE/EntitiesTypesExt/LegalFoundations/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/EntitiesTypesExt/LegalFoundations/">
-		<rdfs:label xml:lang="en">LegalFoundations</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/EntitiesTypesExt/LegalFoundations/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-etx-fnd;Anstalt">
-		<rdfs:subClassOf rdf:resource="&fibo-be-etx-fnd;Foundation"/>
-		<rdfs:label xml:lang="en">anstalt</rdfs:label>
-		<skos:definition xml:lang="en">Form of Foundation registered in Leichtenstein.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-etx-fnd;Foundation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-etx-fnd;governedByFoundationAgreement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-etx-fnd;FoundationAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">foundation</rdfs:label>
-		<skos:definition xml:lang="en">A formal foundation. Further Notes Formal definition sought.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-etx-fnd;FoundationAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;OrganizationCoveringAgreement"/>
-		<rdfs:label xml:lang="en">foundation agreement</rdfs:label>
-		<skos:definition xml:lang="en">The formal agreement by which the Foundation is governed</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the or any agreement among the principals, as distinct from the or any founding charter.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-etx-fnd;LegallyIncorporatedFoundation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-etx-fnd;Foundation"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-cb;Corporation"/>
-		<rdfs:label xml:lang="en">legally incorporated foundation</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-be-etx-fnd;UnincorporatedFoundation"/>
-		<skos:definition xml:lang="en">A foundation with independent legal personhood.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The mechanism for this to be possible is typical in Civil Law (e.g. mainland European) jurisdictions. In Common Law jurisdictions the term Foundation is more typically descriptive of the activity and tax status of an entity not of its legal personhood or lack of it.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-etx-fnd;PrivateInterestFoundation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-etx-fnd;Foundation"/>
-		<rdfs:label xml:lang="en">private interest foundation</rdfs:label>
-		<skos:definition xml:lang="en">A form of foundation registered in Panama.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-etx-fnd;UnincorporatedFoundation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-etx-fnd;Foundation"/>
-		<rdfs:label xml:lang="en">unincorporated foundation</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-etx-fnd;governedByFoundationAgreement">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
-		<rdfs:label xml:lang="en">governed by foundation agreement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-etx-fnd;Foundation"/>
-		<rdfs:range rdf:resource="&fibo-be-etx-fnd;FoundationAgreement"/>
-		<skos:definition xml:lang="en">The agreement which governs the Foundation. This is the document which governs the activities of the Foundation and the contractual relations among the principals.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-etx-fnd="https://spec.edmcouncil.org/fibo/BE/EntitiesTypesExt/LegalFoundations/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/EntitiesTypesExt/LegalFoundations/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LegalFoundations</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Formal basis for the legal person type &quot;Foundation&quot; along with basic facts about these.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/EntitiesTypesExt/LegalFoundations/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-etx-fnd;Anstalt">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-etx-fnd;Foundation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">anstalt</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Form of Foundation registered in Leichtenstein.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-etx-fnd;Foundation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-etx-fnd;governedByFoundationAgreement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-etx-fnd;FoundationAgreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">foundation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal foundation. Further Notes Formal definition sought.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-etx-fnd;FoundationAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;OrganizationCoveringAgreement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">foundation agreement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formal agreement by which the Foundation is governed</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the or any agreement among the principals, as distinct from the or any founding charter.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-etx-fnd;LegallyIncorporatedFoundation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-etx-fnd;Foundation"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-cb;Corporation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legally incorporated foundation</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-be-etx-fnd;UnincorporatedFoundation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A foundation with independent legal personhood.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The mechanism for this to be possible is typical in Civil Law (e.g. mainland European) jurisdictions. In Common Law jurisdictions the term Foundation is more typically descriptive of the activity and tax status of an entity not of its legal personhood or lack of it.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-etx-fnd;PrivateInterestFoundation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-etx-fnd;Foundation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">private interest foundation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A form of foundation registered in Panama.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-etx-fnd;UnincorporatedFoundation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-etx-fnd;Foundation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unincorporated foundation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-etx-fnd;governedByFoundationAgreement">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governed by foundation agreement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-etx-fnd;Foundation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-etx-fnd;FoundationAgreement"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The agreement which governs the Foundation. This is the document which governs the activities of the Foundation and the contractual relations among the principals.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/FunctionalEntitiesExt/Branding.rdf
+++ b/be/FunctionalEntitiesExt/Branding.rdf
@@ -1,63 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
-	<!ENTITY fibo-be-fctx-brn "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/Branding/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
+bu<!ENTITY fibo-be-fctx-brn "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/Branding/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/Branding/"
-	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
-	xmlns:fibo-be-fctx-brn="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/Branding/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/Branding/">
-		<rdfs:label xml:lang="en">Branding</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/Branding/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-fct-fct;Business">
-		<owl:equivalentClass rdf:resource="&fibo-be-fctx-brn;Business"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-brn;BrandName">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Name"/>
-		<rdfs:label xml:lang="en">brand name</rdfs:label>
-		<skos:definition xml:lang="en">A name with or without some strong image (usually legally defined), which identifies an organization or some part of product or service thereof.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-brn;Business">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-brn;hasCommercialIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fctx-brn;BrandName"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">business</rdfs:label>
-		<skos:definition xml:lang="en">Some entity set up for the purposes of carrying out some commercial activities for profit.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-brn;hasCommercialIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;hasName"/>
-		<rdfs:label xml:lang="en">has commercial identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-brn;Business"/>
-		<rdfs:range rdf:resource="&fibo-be-fctx-brn;BrandName"/>
-		<skos:definition xml:lang="en">A name or identity by which a business organization is known for marketing and communication purposes. This may or may not be the same as the name of the organization.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
+buxmlns:fibo-be-fctx-brn="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/Branding/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/Branding/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Branding</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Ontology for the basic concept of a brand and its usage in relation to a business. Note: contains a duplicate of the concept of business.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/Branding/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-fct-fct;Business">
+bubu<owl:equivalentClass rdf:resource="&fibo-be-fctx-brn;Business"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-brn;BrandName">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Name"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">brand name</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A name with or without some strong image (usually legally defined), which identifies an organization or some part of product or service thereof.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-brn;Business">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-brn;hasCommercialIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-fctx-brn;BrandName"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some entity set up for the purposes of carrying out some commercial activities for profit.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-brn;hasCommercialIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;hasName"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has commercial identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-brn;Business"/>
+bubu<rdfs:range rdf:resource="&fibo-be-fctx-brn;BrandName"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A name or identity by which a business organization is known for marketing and communication purposes. This may or may not be the same as the name of the organization.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/FunctionalEntitiesExt/FundEntities.rdf
+++ b/be/FunctionalEntitiesExt/FundEntities.rdf
@@ -1,96 +1,99 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
-	<!ENTITY fibo-be-fctx-fne "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/">
-	<!ENTITY fibo-be-fctx-spv "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
-	<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
+bu<!ENTITY fibo-be-fctx-fne "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/">
+bu<!ENTITY fibo-be-fctx-spv "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
+bu<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/"
-	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
-	xmlns:fibo-be-fctx-fne="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/"
-	xmlns:fibo-be-fctx-spv="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"
-	xmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/">
-		<rdfs:label xml:lang="en">FundEntities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-fne;FCP">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-		<rdfs:label xml:lang="en">f c p</rdfs:label>
-		<skos:definition xml:lang="en">A French fund vehicle type. Designation and definition needed.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-fne;FundsCreation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SPVPurpose"/>
-		<rdfs:label xml:lang="en">funds creation</rdfs:label>
-		<skos:definition xml:lang="en">SPV set up for fund management Conesnsus:Review</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-fne;FundsSPV">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-fne;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-spv;isSetUpFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fctx-fne;FundsCreation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">funds s p v</rdfs:label>
-		<skos:definition xml:lang="en">A Special Purpose Vehicle (SPV) set up specifically to create an investment fund. It is set up by a company or a group of companies for this purpose. The SPV is formed for a specific reason and exists for a specific period of time and is then disbanded.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-fne;SICAF">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-		<rdfs:label xml:lang="en">s i c a f</rdfs:label>
-		<skos:definition xml:lang="en">A French fund vehicle type. Designation and definition needed.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-fne;SICAV">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-		<rdfs:label xml:lang="en">s i c a v</rdfs:label>
-		<skos:definition xml:lang="en">Societe Collective a Capital Variable</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-fne;holds">
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-fne;FundsSPV"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<skos:definition xml:lang="en">The Funds Special Purpose Vehicle holds this Fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-fne;intendedLiquidationDate">
-		<rdfs:label xml:lang="en">intended liquidation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-fne;FundsSPV"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Intended or scheduled fund closing date - date of final NAV.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
+buxmlns:fibo-be-fctx-fne="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/"
+buxmlns:fibo-be-fctx-spv="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"
+buxmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FundEntities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Functional Entities relevant to collective investment vehicles. These are mainly kinds of fund vehicle as defined in a small selection of jurisdictions.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-fne;FCP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">f c p</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A French fund vehicle type. Designation and definition needed.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-fne;FundsCreation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SPVPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funds creation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">SPV set up for fund management Conesnsus:Review</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-fne;FundsSPV">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-fne;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-spv;isSetUpFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-fctx-fne;FundsCreation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funds s p v</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Special Purpose Vehicle (SPV) set up specifically to create an investment fund. It is set up by a company or a group of companies for this purpose. The SPV is formed for a specific reason and exists for a specific period of time and is then disbanded.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-fne;SICAF">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">s i c a f</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A French fund vehicle type. Designation and definition needed.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-fne;SICAV">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">s i c a v</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Societe Collective a Capital Variable</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-fne;holds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-fne;FundsSPV"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Funds Special Purpose Vehicle holds this Fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-fne;intendedLiquidationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">intended liquidation date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-fne;FundsSPV"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Intended or scheduled fund closing date - date of final NAV.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/FunctionalEntitiesExt/ProcessEntities.rdf
+++ b/be/FunctionalEntitiesExt/ProcessEntities.rdf
@@ -1,98 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fctx-prc "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/">
-	<!ENTITY fibo-bp-prc-fcp "https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-bus-agc "https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fctx-prc "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/">
+bu<!ENTITY fibo-bp-prc-fcp "https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-bus-agc "https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/"
-	xmlns:fibo-be-fctx-prc="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/"
-	xmlns:fibo-bp-prc-fcp="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-bus-agc="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/">
-		<rdfs:label xml:lang="en">ProcessEntities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-prc;FinancialCommitmentCounterparty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-prc;isSeenAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial commitment counterparty</rdfs:label>
-		<skos:definition xml:lang="en">Some party with which the company has entered into some formal financial commitments.</skos:definition>
-		<skos:editorialNote xml:lang="en">1. Initial notes Jan 2011 Stems from contracts entered into Later notes: Note that facts relating to correlation in marketplace have been defined as another kind of party.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-prc;MarketCorrelationRiskParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">market correlation risk party</rdfs:label>
-		<skos:definition xml:lang="en">A party which is party to some undue dependency in their market of operation, such as undue reliance of a particular market sector for their economic survival.</skos:definition>
-		<skos:editorialNote xml:lang="en">No facts are modeled about this at present, and it may not be realistic to model this semantically other than to define the entity in words and refer to it. Words may need review and refinement. Earlier review session notes: One party depends on the existence of another party for their business survival. Networks of economic relationships. Why this matters: This impacts portfolio. Correlation. e.g. if I supply windscreens to 1 manufacturer what happens if that goes bust? Logically, contagion risk is about correlation.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-prc;ProcessRoleBusinessEntity">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-prc;definedInContextOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">process role business entity</rdfs:label>
-		<skos:definition xml:lang="en">Some business entity that stands in some role.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is distinct from Party, and refers to the entity as a kind of entity defined by its role, such as Settlement Entity. This covers specific process areas rather than the overall nature of the business, for example a reporting entity, settlement entity and so on in the context of securities transactions workflow.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-prc;SettlementEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-prc;ProcessRoleBusinessEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-prc;definedInContextOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-prc-fcp;Settlement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">settlement entity</rdfs:label>
-		<skos:definition xml:lang="en">A entity as seen for transaction settlement purposes.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review notes (Q2 2011) This is a Role. Change accordingly. This is the role an entity may be playing in a transaction. This will be in the Transactions model when done. Example agent in tri party RePo, may not be involved in the contract but is effecting the settlement between the two separate entities. Example we started with was when dealing with a specific copany but needing to know the location you are dealing with, e.g. settling with a different branch i.e. have to send to a different bank account. Decision: Hold till we do Transactions - there&apos;s brokers, traders, settlement clearing institutions and so on. Binds to the concept of location. Additional notes for the next update: Definition and notes captured against &quot;Legal Entity has Settlement Entity&quot;: The entity with which settlement of transactions with the entity is to be settled, if this is not the entire entity. See March 30, 2011 notes for origin of this concept</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-prc;definedInContextOf">
-		<rdfs:label xml:lang="en">defined in context of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-prc;ProcessRoleBusinessEntity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
-		<skos:definition xml:lang="en">The business context in which the entity has its definition.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-prc;isSeenAs">
-		<rdfs:label xml:lang="en">is seen as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-prc;FinancialCommitmentCounterparty"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fctx-prc="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/"
+buxmlns:fibo-bp-prc-fcp="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-bus-agc="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ProcessEntities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Entities described in terms of their participation in a business process workflow. This is a high level abstract concept from which the participants in various kids of industry process and workflow may be described. Includes a small selection of such entities for some specific contexts such as risk, settlement.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-prc;FinancialCommitmentCounterparty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-prc;isSeenAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial commitment counterparty</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some party with which the company has entered into some formal financial commitments.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">1. Initial notes Jan 2011 Stems from contracts entered into Later notes: Note that facts relating to correlation in marketplace have been defined as another kind of party.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-prc;MarketCorrelationRiskParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market correlation risk party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which is party to some undue dependency in their market of operation, such as undue reliance of a particular market sector for their economic survival.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">No facts are modeled about this at present, and it may not be realistic to model this semantically other than to define the entity in words and refer to it. Words may need review and refinement. Earlier review session notes: One party depends on the existence of another party for their business survival. Networks of economic relationships. Why this matters: This impacts portfolio. Correlation. e.g. if I supply windscreens to 1 manufacturer what happens if that goes bust? Logically, contagion risk is about correlation.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-prc;ProcessRoleBusinessEntity">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-prc;definedInContextOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">process role business entity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some business entity that stands in some role.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is distinct from Party, and refers to the entity as a kind of entity defined by its role, such as Settlement Entity. This covers specific process areas rather than the overall nature of the business, for example a reporting entity, settlement entity and so on in the context of securities transactions workflow.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-prc;SettlementEntity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-prc;ProcessRoleBusinessEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-prc;definedInContextOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-prc-fcp;Settlement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement entity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A entity as seen for transaction settlement purposes.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review notes (Q2 2011) This is a Role. Change accordingly. This is the role an entity may be playing in a transaction. This will be in the Transactions model when done. Example agent in tri party RePo, may not be involved in the contract but is effecting the settlement between the two separate entities. Example we started with was when dealing with a specific copany but needing to know the location you are dealing with, e.g. settling with a different branch i.e. have to send to a different bank account. Decision: Hold till we do Transactions - there&apos;s brokers, traders, settlement clearing institutions and so on. Binds to the concept of location. Additional notes for the next update: Definition and notes captured against &quot;Legal Entity has Settlement Entity&quot;: The entity with which settlement of transactions with the entity is to be settled, if this is not the entire entity. See March 30, 2011 notes for origin of this concept</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-prc;definedInContextOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined in context of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-prc;ProcessRoleBusinessEntity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The business context in which the entity has its definition.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-prc;isSeenAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is seen as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-prc;FinancialCommitmentCounterparty"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/FunctionalEntitiesExt/ReportingEntities.rdf
+++ b/be/FunctionalEntitiesExt/ReportingEntities.rdf
@@ -1,203 +1,206 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fctx-prc "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/">
-	<!ENTITY fibo-be-fctx-rep "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ReportingEntities/">
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fctx-prc "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/">
+bu<!ENTITY fibo-be-fctx-rep "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ReportingEntities/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
+bu<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ReportingEntities/"
-	xmlns:fibo-be-fctx-prc="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/"
-	xmlns:fibo-be-fctx-rep="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ReportingEntities/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ReportingEntities/">
-		<rdfs:label xml:lang="en">ReportingEntities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ReportingEntities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-rep;CorporateFilingObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;StatutoryReportingObligation"/>
-		<rdfs:label xml:lang="en">corporate filing obligation</rdfs:label>
-		<skos:definition xml:lang="en">The obligation to file reports on the Incorporated Company as defined by the jurisdiction under which it is constituted.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-rep;NonStatutoryReportingObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
-		<rdfs:label xml:lang="en">non statutory reporting obligation</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-be-fctx-rep;StatutoryReportingObligation"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-rep;RegulatoryEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;Organization"/>
-		<rdfs:label xml:lang="en">regulatory entity</rdfs:label>
-		<skos:definition xml:lang="en">Some entity which has some regulatory function.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be a statutory regulator, or this may be an entity such as an exchange. Note that the relative term for the role that this entity performs is &quot;Regulator&quot; or similar. This term itself defines a sort of entity which is specifically set up for this kind of function.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-rep;ReportingEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-prc;ProcessRoleBusinessEntity"/>
-		<rdfs:label xml:lang="en">reporting entity</rdfs:label>
-		<skos:definition xml:lang="en">Some part of some company which is treated as a distinct entity internally for reporting purposes, but which externally is not a distinct kind of entity in any way.</skos:definition>
-		<skos:editorialNote xml:lang="en">Has no legal standing. Not going to deal with this for now. Also: Line of Business Division. 
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fctx-prc="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/"
+buxmlns:fibo-be-fctx-rep="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ReportingEntities/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
+buxmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ReportingEntities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ReportingEntities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Types of entities involved in regulatory reporting including authorities, regulators, reporting entities. Includes concept that have subsequently been re-created in parts of FBC in different terms.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ProcessEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/ReportingEntities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-rep;CorporateFilingObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;StatutoryReportingObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate filing obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The obligation to file reports on the Incorporated Company as defined by the jurisdiction under which it is constituted.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-rep;NonStatutoryReportingObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non statutory reporting obligation</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-be-fctx-rep;StatutoryReportingObligation"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-rep;RegulatoryEntity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;Organization"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regulatory entity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some entity which has some regulatory function.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be a statutory regulator, or this may be an entity such as an exchange. Note that the relative term for the role that this entity performs is &quot;Regulator&quot; or similar. This term itself defines a sort of entity which is specifically set up for this kind of function.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-rep;ReportingEntity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-prc;ProcessRoleBusinessEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reporting entity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some part of some company which is treated as a distinct entity internally for reporting purposes, but which externally is not a distinct kind of entity in any way.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Has no legal standing. Not going to deal with this for now. Also: Line of Business Division. 
 Further Notes:April 06: Alternative term: Organizational Sub Unit separate from how classified for reporting. Sometimes there may be parts of a company which are separate legal entities - this is dealt with elsewhere. This term here is when the legal entity recognizes specific components of itself for internal reporting purposes, without reference to other entities, or to legal jurisdictions. Note that the requirement for one legal entity to report in more than one jurisdiction is dealt with elsewhere, by the Legal Entity having one or more reporting requirements. Coincidentally, this legal entity may have several entities internally which are reported separately for profit and loss. Review session: Definition of &quot;internal&quot; varies from one purpose to another. Accounting (where wholly owned subsidiaries consolidated into reports); Basel II - have specific capital requirements that range across business entities in certain circumstances.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-rep;ReportingObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;Duty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-rep;isAbout"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-le-cb;Corporation">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-le-fbo;OrganizationalSubUnit">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-rep;isTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fctx-rep;RegulatoryEntity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">reporting obligation</rdfs:label>
-		<skos:definition xml:lang="en">An obligation to report to some entity about some matter.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review session 30 March 2011: ADD: Relationship to statutory body e.g. FSA Other obligations: Listing obligations with an exchange may exceed or differ from statutory reporting obligations. These would to the exchange and not to the FSA. Common patter: All reporting obligations are &quot;to&quot; some body. These are on different frequencies. So reporting obligation on ASX may differ form statutory obligations. e.g. notify exchange of factors which may influence your profitability. For natural persons: Add tax reporting obligation.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-rep;StatutoryAuthority">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-rep;incorporatedUnder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">statutory authority</rdfs:label>
-		<skos:definition xml:lang="en">Some organization which is an authority created and mandated in statute law for some purpose e.g. reporting.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-rep;StatutoryRegulator">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;RegulatoryEntity"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;StatutoryAuthority"/>
-		<rdfs:label xml:lang="en">statutory regulator</rdfs:label>
-		<skos:definition xml:lang="en">Some regulatory body set up under some law, for the purposes of statutory regulation and reporting.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is the entity that companies and other formally constituted legal entities have obligations to report to. Examples include the FSA in the UK. REVIEW QUESTIONS: These also often refer to Jurisdiction (however, the UK is not one Jurisdiction but two or more e.g. England and Wales). This connection is implied by the fact that all Law governs some Jurisdiction. Do we need an explicit relationship here derived from this pair of relationships (&quot;Property chaining&quot; in technical terms)? for instance we refer to a regulator as being under some reporting jurisdiction.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-rep;StatutoryReportingEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;ReportingEntity"/>
-		<rdfs:label xml:lang="en">statutory reporting entity</rdfs:label>
-		<skos:definition xml:lang="en">An entity which is obliged to report for statutory purposes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-rep;StatutoryReportingObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;StatutoryResponsibility"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-rep;isTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fctx-rep;StatutoryRegulator"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">statutory reporting obligation</rdfs:label>
-		<skos:definition xml:lang="en">Some reporting obligation set out in some statute.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are 3 kinds of reporting obligation: 1. Statute 2. Exchange etc. (private / quasi govt entity) 3. Agency (on behalf of statute).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;hasCorporateFilingObligation">
-		<rdfs:label xml:lang="en">has corporate filing obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-fctx-rep;CorporateFilingObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;hasObligation">
-		<rdfs:label xml:lang="en">has obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
-		<rdfs:range rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;hasStatutoryReportingObligation">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-fctx-rep;hasObligation"/>
-		<rdfs:label xml:lang="en">has statutory reporting obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
-		<rdfs:range rdf:resource="&fibo-be-fctx-rep;StatutoryReportingObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;incorporatedUnder">
-		<rdfs:label xml:lang="en">incorporated under</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-rep;StatutoryAuthority"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;isAbout">
-		<rdfs:label xml:lang="en">is about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-be-le-cb;Corporation">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-be-le-fbo;OrganizationalSubUnit">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;isTo">
-		<rdfs:label xml:lang="en">is to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
-		<rdfs:range rdf:resource="&fibo-be-fctx-rep;RegulatoryEntity"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;Corporation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-rep;hasObligation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
-		<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-le-fbo;OrganizationalSubUnit">
-	</owl:Class>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-rep;ReportingObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;Duty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-rep;isAbout"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-be-le-cb;Corporation">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-be-le-fbo;OrganizationalSubUnit">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-rep;isTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-fctx-rep;RegulatoryEntity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reporting obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An obligation to report to some entity about some matter.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review session 30 March 2011: ADD: Relationship to statutory body e.g. FSA Other obligations: Listing obligations with an exchange may exceed or differ from statutory reporting obligations. These would to the exchange and not to the FSA. Common patter: All reporting obligations are &quot;to&quot; some body. These are on different frequencies. So reporting obligation on ASX may differ form statutory obligations. e.g. notify exchange of factors which may influence your profitability. For natural persons: Add tax reporting obligation.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-rep;StatutoryAuthority">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-rep;incorporatedUnder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">statutory authority</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some organization which is an authority created and mandated in statute law for some purpose e.g. reporting.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-rep;StatutoryRegulator">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;RegulatoryEntity"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;StatutoryAuthority"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">statutory regulator</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some regulatory body set up under some law, for the purposes of statutory regulation and reporting.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is the entity that companies and other formally constituted legal entities have obligations to report to. Examples include the FSA in the UK. REVIEW QUESTIONS: These also often refer to Jurisdiction (however, the UK is not one Jurisdiction but two or more e.g. England and Wales). This connection is implied by the fact that all Law governs some Jurisdiction. Do we need an explicit relationship here derived from this pair of relationships (&quot;Property chaining&quot; in technical terms)? for instance we refer to a regulator as being under some reporting jurisdiction.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-rep;StatutoryReportingEntity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;ReportingEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">statutory reporting entity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An entity which is obliged to report for statutory purposes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-rep;StatutoryReportingObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;StatutoryResponsibility"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-rep;isTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-fctx-rep;StatutoryRegulator"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">statutory reporting obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some reporting obligation set out in some statute.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There are 3 kinds of reporting obligation: 1. Statute 2. Exchange etc. (private / quasi govt entity) 3. Agency (on behalf of statute).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;hasCorporateFilingObligation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has corporate filing obligation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-fctx-rep;CorporateFilingObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;hasObligation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has obligation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;hasStatutoryReportingObligation">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-fctx-rep;hasObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has statutory reporting obligation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-fctx-rep;StatutoryReportingObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;incorporatedUnder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incorporated under</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-rep;StatutoryAuthority"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;isAbout">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-be-le-cb;Corporation">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-be-le-fbo;OrganizationalSubUnit">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-rep;isTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-fctx-rep;RegulatoryEntity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;Corporation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-rep;hasObligation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-fctx-rep;ReportingObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+bubu<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-fbo;OrganizationalSubUnit">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/be/FunctionalEntitiesExt/SPVs.rdf
+++ b/be/FunctionalEntitiesExt/SPVs.rdf
@@ -1,116 +1,119 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
-	<!ENTITY fibo-be-fctx-spv "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
+bu<!ENTITY fibo-be-fctx-spv "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"
-	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
-	xmlns:fibo-be-fctx-spv="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
-		<rdfs:label xml:lang="en">SPVs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-spv;SPVPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
-		<rdfs:label xml:lang="en">s p v purpose</rdfs:label>
-		<skos:definition xml:lang="en">The reason for the creation of a Special Purpose Vehicle.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is used to identify different kinds of SPV which may have different detailed facts about them; however in general all SPVs are much the same.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-spv;SpecialPurposeVehicle">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-spv;constitutedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-spv;isSetUpFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fctx-spv;SPVPurpose"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-spv;sPVHoldsPool"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/Pool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-spv;sponsoredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">special purpose vehicle</rdfs:label>
-		<skos:definition xml:lang="en">A Special Purpose Vehicle (SPV) set up specifically to issue a security or securities. It is set up by a company or a group of companies for some purpose such as to create instruments that are off the company&apos;s balance sheet or to issue Participation Notes for investors in another jurisdiction. The SPV is formed for a specific reason and exists for a specific period of time and is then disbanded. Further notes: Special Purpose Vehicles are also referred to as bankruptcy remote entities, as they isolate financial risk. For Participation Notes: slightly different purpose but the same kind of vehicle. The only investment made by the SPV is that they buy in the stock. These are the same kind of entity in all of the contexts in which they exist.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;constitutedAs">
-		<rdfs:label xml:lang="en">constituted as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">The Special Purpose Vehicle is constituted as some kind of Formal Organization.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be a company incorporated by shares, a limited liability company or some other form of legal entity, including legal person and non incorporated formal organization. These are usually limited in their articles as to what they can do. It is as this entity that the SPV is able to be party to contracts and incur debts. Note that it cannot be an individual human being.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;intendedLiquidationDate">
-		<rdfs:label xml:lang="en">intended liquidation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date on which the SPV is scheduled to be disbanded and wound up.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;isSetUpFor">
-		<rdfs:label xml:lang="en">is set up for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
-		<rdfs:range rdf:resource="&fibo-be-fctx-spv;SPVPurpose"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;sPVHoldsPool">
-		<rdfs:label xml:lang="en">s p v holds pool</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/Pool"/>
-		<skos:definition xml:lang="en">A Special Purpose Vehicle always holds some kind of pool. This may be a debt pool, an asset pool (fund) or some pool of securities from which it issues Participation Notes.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;sponsoredBy">
-		<rdfs:label xml:lang="en">sponsored by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-		<skos:definition xml:lang="en">The entity which is the creator and servicer of the SPV. Notes: To protect investors from possible bankruptcy of the corporation, there are three legal safeguards: - Transfer of assets from the corporation is a non-recourse, true sale. - Investors receive a perfected interest in the assets&apos; cash flows. - A non-consolidation legal opinion is obtained certifying that assets of the trust or special purpose vehicle cannot be consolidated with the corporation&apos;s assets in the event of bankruptcy.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
+buxmlns:fibo-be-fctx-spv="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SPVs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Special Purpose Vehicles – these are business entities set up as part of the issuance of certain kinds of debt instrument. The physical form of such entities may be one of several legal forms, whereas in this ontology the notion of the special purpose vehicle itself is described in terms of its function as such. This ontology defines the basic SPV concept which is extended in other ontologies for specific kinds of these.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-spv;SPVPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">s p v purpose</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The reason for the creation of a Special Purpose Vehicle.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is used to identify different kinds of SPV which may have different detailed facts about them; however in general all SPVs are much the same.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-spv;SpecialPurposeVehicle">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-spv;constitutedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-spv;isSetUpFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-fctx-spv;SPVPurpose"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-spv;sPVHoldsPool"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/Pool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-spv;sponsoredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">special purpose vehicle</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Special Purpose Vehicle (SPV) set up specifically to issue a security or securities. It is set up by a company or a group of companies for some purpose such as to create instruments that are off the company&apos;s balance sheet or to issue Participation Notes for investors in another jurisdiction. The SPV is formed for a specific reason and exists for a specific period of time and is then disbanded. Further notes: Special Purpose Vehicles are also referred to as bankruptcy remote entities, as they isolate financial risk. For Participation Notes: slightly different purpose but the same kind of vehicle. The only investment made by the SPV is that they buy in the stock. These are the same kind of entity in all of the contexts in which they exist.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;constitutedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">constituted as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Special Purpose Vehicle is constituted as some kind of Formal Organization.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be a company incorporated by shares, a limited liability company or some other form of legal entity, including legal person and non incorporated formal organization. These are usually limited in their articles as to what they can do. It is as this entity that the SPV is able to be party to contracts and incur debts. Note that it cannot be an individual human being.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;intendedLiquidationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">intended liquidation date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date on which the SPV is scheduled to be disbanded and wound up.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;isSetUpFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is set up for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
+bubu<rdfs:range rdf:resource="&fibo-be-fctx-spv;SPVPurpose"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;sPVHoldsPool">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">s p v holds pool</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/Pool"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Special Purpose Vehicle always holds some kind of pool. This may be a debt pool, an asset pool (fund) or some pool of securities from which it issues Participation Notes.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-fctx-spv;sponsoredBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sponsored by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity which is the creator and servicer of the SPV. Notes: To protect investors from possible bankruptcy of the corporation, there are three legal safeguards: - Transfer of assets from the corporation is a non-recourse, true sale. - Investors receive a perfected interest in the assets&apos; cash flows. - A non-consolidation legal opinion is obtained certifying that assets of the trust or special purpose vehicle cannot be consolidated with the corporation&apos;s assets in the event of bankruptcy.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/FunctionalEntitiesExt/StateEntities.rdf
+++ b/be/FunctionalEntitiesExt/StateEntities.rdf
@@ -1,62 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
-	<!ENTITY fibo-be-fctx-sta "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
+bu<!ENTITY fibo-be-fctx-sta "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/"
-	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
-	xmlns:fibo-be-fctx-sta="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/">
-		<rdfs:label xml:lang="en">StateEntities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-sta;GovernmentMortgageAgency">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">government mortgage agency</rdfs:label>
-		<skos:definition xml:lang="en">An agency set up by a government for the purpose of issuing mortgages.</skos:definition>
-		<skos:editorialNote xml:lang="en">Note on the original property &apos;takes form of&apos;  (replaced by a restriction): The form which the Government Mortgage Agency takes. This is a Legal Entity and not a Natural Person, that is, it is an Artificial Person.</skos:editorialNote>
-		<skos:scopeNote xml:lang="en">These exist in the USA and may also exist now or in future in other countries. There are three such agencies in thr USA: FNMA, GNMA and FHLMC (Fannie Mae, Ginnie Mae and Freddie Mac respectively).</skos:scopeNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fctx-sta;SovereignWealthFund">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-		<rdfs:label xml:lang="en">sovereign wealth fund</rdfs:label>
-		<skos:definition xml:lang="en">Government investment fund funded by foreign currency reserves. Review: Also include things like International Monetary Fund. Are these a Legal Entity? See also Funds model. Move the question about Sovereign Wealth Funds to the Funds model. Looking at definitions (e.g. Wikipedia) it&apos;s a state owned investment fund. The legal entity owner is a government (or in fact a State, which is governed by a Government).</skos:definition>
-	</owl:Class>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-be-fctx-sta;legalName">
-		<rdfs:label xml:lang="en">legal name</rdfs:label>
-	</owl:DatatypeProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
+buxmlns:fibo-be-fctx-sta="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">StateEntities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Selected kinds of entity in the government space, described in functional terms regardless of the precise legal form that they may take. Most such entities are now described in Release ontologies, while this ontology retains two that have not yet been adopted – government mortgage agency and sovereign wealth fund.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-sta;GovernmentMortgageAgency">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">government mortgage agency</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An agency set up by a government for the purpose of issuing mortgages.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Note on the original property &apos;takes form of&apos;  (replaced by a restriction): The form which the Government Mortgage Agency takes. This is a Legal Entity and not a Natural Person, that is, it is an Artificial Person.</skos:editorialNote>
+bubu<skos:scopeNote rdf:datatype="&rdf;langString" xml:lang="en">These exist in the USA and may also exist now or in future in other countries. There are three such agencies in thr USA: FNMA, GNMA and FHLMC (Fannie Mae, Ginnie Mae and Freddie Mac respectively).</skos:scopeNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-fctx-sta;SovereignWealthFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sovereign wealth fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Government investment fund funded by foreign currency reserves. Review: Also include things like International Monetary Fund. Are these a Legal Entity? See also Funds model. Move the question about Sovereign Wealth Funds to the Funds model. Looking at definitions (e.g. Wikipedia) it&apos;s a state owned investment fund. The legal entity owner is a government (or in fact a State, which is governed by a Government).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-be-fctx-sta;legalName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal name</rdfs:label>
+bu</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/be/LegalEntitiesExt/CorporateBodiesGuarantees.rdf
+++ b/be/LegalEntitiesExt/CorporateBodiesGuarantees.rdf
@@ -1,36 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-lex-gty "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/CorporateBodiesGuarantees/">
-	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-lex-gty "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/CorporateBodiesGuarantees/">
+bu<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/CorporateBodiesGuarantees/"
-	xmlns:fibo-be-lex-gty="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/CorporateBodiesGuarantees/"
-	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/CorporateBodiesGuarantees/">
-		<rdfs:label xml:lang="en">CorporateBodiesGuarantees</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/CorporateBodiesGuarantees/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-lex-gty;CompanyOwner">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;GuaranteeProvidingMember"/>
-		<rdfs:label xml:lang="en">company owner</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-lex-gty="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/CorporateBodiesGuarantees/"
+buxmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/CorporateBodiesGuarantees/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CorporateBodiesGuarantees</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Ontology for additional material about guarantees in the context of entities that are incorporated by means of guarantee. Most of these are now in adopted ontologies; this ontology contains only the concept of a company owner in this context.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/CorporateBodiesGuarantees/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-lex-gty;CompanyOwner">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;GuaranteeProvidingMember"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">company owner</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/be/LegalEntitiesExt/EntityNames.rdf
+++ b/be/LegalEntitiesExt/EntityNames.rdf
@@ -1,80 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-lex-nam "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/EntityNames/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-lex-nam "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/EntityNames/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/EntityNames/"
-	xmlns:fibo-be-lex-nam="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/EntityNames/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/EntityNames/">
-		<rdfs:label xml:lang="en">EntityNames</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/EntityNames/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-lex-nam;LegalName">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Name"/>
-		<rdfs:label xml:lang="en">legal name</rdfs:label>
-		<skos:definition xml:lang="en">The full legal name of an entity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-lex-nam;PersonalName">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Name"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-lex-nam;additionalName"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">personal name</rdfs:label>
-		<skos:definition xml:lang="en">The name of an individual person.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-lex-nam;additionalName">
-		<rdfs:label xml:lang="en">additional name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-lex-nam;PersonalName"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Additional or &quot;middle&quot; names given to the person by his or her parents or derived through tradition based on other family names.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-lex-nam;familyName">
-		<rdfs:label xml:lang="en">family name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-lex-nam;PersonalName"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The name the person derives from his or her family</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-lex-nam;fullLegalName">
-		<rdfs:label xml:lang="en">full legal name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-lex-nam;LegalName"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The text which represents the full legal name of an entity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-lex-nam;givenName">
-		<rdfs:label xml:lang="en">given name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-lex-nam;PersonalName"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The name given to the person by his or her parents and unique within their immediate family.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-lex-nam="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/EntityNames/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/EntityNames/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">EntityNames</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This extension ontology defines entity names as a concept, as opposed to simply having datatypes whose type is a string. This extends the foundations extensions notion of name as a category of thing that can be described and reasoned about. Covers personal names as well as business names.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/EntityNames/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-lex-nam;LegalName">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Name"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal name</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The full legal name of an entity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-lex-nam;PersonalName">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Name"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-lex-nam;additionalName"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">personal name</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The name of an individual person.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-lex-nam;additionalName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">additional name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-lex-nam;PersonalName"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Additional or &quot;middle&quot; names given to the person by his or her parents or derived through tradition based on other family names.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-lex-nam;familyName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">family name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-lex-nam;PersonalName"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The name the person derives from his or her family</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-lex-nam;fullLegalName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">full legal name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-lex-nam;LegalName"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The text which represents the full legal name of an entity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-lex-nam;givenName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">given name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-lex-nam;PersonalName"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The name given to the person by his or her parents and unique within their immediate family.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/LegalEntitiesExt/FormalOrganizationsExtended.rdf
+++ b/be/LegalEntitiesExt/FormalOrganizationsExtended.rdf
@@ -1,52 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-lex-fox "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/FormalOrganizationsExtended/">
-	<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-be-lex-fox "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/FormalOrganizationsExtended/">
+bu<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/FormalOrganizationsExtended/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-lex-fox="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/FormalOrganizationsExtended/"
-	xmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/FormalOrganizationsExtended/">
-		<rdfs:label xml:lang="en">FormalOrganizationsExtended</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/FormalOrganizationsExtended/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-lex-fox;hasFormalOrganizationMember"/>
-				<owl:allValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganizationMember"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<owl:equivalentClass rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-lex-fox;hasFormalOrganizationMember">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-ptyx;hasOrganizationMember"/>
-		<rdfs:label xml:lang="en">has formal organization member</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganizationMember"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-be-lex-fox="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/FormalOrganizationsExtended/"
+buxmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/FormalOrganizationsExtended/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FormalOrganizationsExtended</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional material about formal organizations. This defines the relationship of formal organizations to their membership.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/FormalOrganizationsExtended/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-lex-fox;hasFormalOrganizationMember"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganizationMember"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<owl:equivalentClass rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-lex-fox;hasFormalOrganizationMember">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-ptyx;hasOrganizationMember"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has formal organization member</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganizationMember"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/LegalEntitiesExt/LEICapacity.rdf
+++ b/be/LegalEntitiesExt/LEICapacity.rdf
@@ -1,72 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/">
-	<!ENTITY fibo-be-lex-lec "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LEICapacity/">
-	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/">
+bu<!ENTITY fibo-be-lex-lec "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LEICapacity/">
+bu<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LEICapacity/"
-	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"
-	xmlns:fibo-be-lex-lec="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LEICapacity/"
-	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LEICapacity/">
-		<rdfs:label xml:lang="en">LEICapacity</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LEICapacity/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-lei;ContractuallyCapableEntity">
-		<owl:equivalentClass rdf:resource="&fibo-be-lex-lec;ContractuallyCapableEntity"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-lex-lec;ContractuallyCapableEntity">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-lex-lec;hasContractualCapability"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-lcap;ContractualCapability"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractually capable entity</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-lex-lec;hasContractualCapability">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-lcap;hasCapacity"/>
-		<rdfs:label xml:lang="en">has contractual capability</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-lex-lec;ContractuallyCapableEntity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-lcap;ContractualCapability"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-lex-lec;isContractualCapabilityOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-lcap;isCapacityOf"/>
-		<rdfs:label xml:lang="en">is contractual capability of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-law-lcap;ContractualCapability"/>
-		<rdfs:range rdf:resource="&fibo-be-lex-lec;ContractuallyCapableEntity"/>
-		<skos:definition xml:lang="en">An entity which has this Contractual Capability.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a context-specific or relative entity, defined in terms of its being an entity and having this capacity.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-lcap;ContractualCapability">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"
+buxmlns:fibo-be-lex-lec="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LEICapacity/"
+buxmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LEICapacity/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LEICapacity</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extension of the concepts around Legal Entity Identifier, whereby LEIs are allocated to more kinds of entity than simply those that are legal persons, and are recognized as even being legal entities in the LEI sense in a jurisdiction-specific context. These entities are labeled as contractually capable entities. These are the conceptual nuances that underpin the Release model for LEI Entities. The concept of contractually capable entity may also exist in the Release ontologies and is to be de-duplicated.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LEICapacity/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-lei;ContractuallyCapableEntity">
+bubu<owl:equivalentClass rdf:resource="&fibo-be-lex-lec;ContractuallyCapableEntity"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-lex-lec;ContractuallyCapableEntity">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-lex-lec;hasContractualCapability"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-lcap;ContractualCapability"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractually capable entity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-lex-lec;hasContractualCapability">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-lcap;hasCapacity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has contractual capability</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-lex-lec;ContractuallyCapableEntity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-lcap;ContractualCapability"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-lex-lec;isContractualCapabilityOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-lcap;isCapacityOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is contractual capability of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-law-lcap;ContractualCapability"/>
+bubu<rdfs:range rdf:resource="&fibo-be-lex-lec;ContractuallyCapableEntity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An entity which has this Contractual Capability.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a context-specific or relative entity, defined in terms of its being an entity and having this capacity.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-law-lcap;ContractualCapability">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/be/LegalEntitiesExt/LegalPersonsExtended.rdf
+++ b/be/LegalEntitiesExt/LegalPersonsExtended.rdf
@@ -1,51 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-be-lex-lpx "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LegalPersonsExtended/">
-	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-be-lex-lpx "https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LegalPersonsExtended/">
+bu<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LegalPersonsExtended/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-be-lex-lpx="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LegalPersonsExtended/"
-	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LegalPersonsExtended/">
-		<rdfs:label xml:lang="en">LegalPersonsExtended</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LegalPersonsExtended/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-lex-lpx;liabilityAccruesTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-lcap;isCapacityOf"/>
-		<rdfs:label xml:lang="en">liability accrues to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-law-lcap;LiabilityCapacity"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-		<skos:definition xml:lang="en">That to which the liability ultimately unwinds, or to which it accrues.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is by definition a Legal Entity in the sense used here, that is to say a legal entity is defined by the fact that it is the entity to which any and all liability ultimately unwinds, regardless of whether agreements have been entered into by some other entity or on behalf of some other person.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-lcap;LiabilityCapacity">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-be-lex-lpx="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LegalPersonsExtended/"
+buxmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LegalPersonsExtended/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LegalPersonsExtended</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional material about the concept of legal person. This ontology defines the property whereby liability accrues to a legal person, ths being the defining feature of legal personhood in the legal sense.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntitiesExt/LegalPersonsExtended/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-lex-lpx;liabilityAccruesTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-lcap;isCapacityOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">liability accrues to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-law-lcap;LiabilityCapacity"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That to which the liability ultimately unwinds, or to which it accrues.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is by definition a Legal Entity in the sense used here, that is to say a legal entity is defined by the fact that it is the entity to which any and all liability ultimately unwinds, regardless of whether agreements have been entered into by some other entity or on behalf of some other person.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-law-lcap;LiabilityCapacity">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/be/OwnershipAndControlExt/BERelations.rdf
+++ b/be/OwnershipAndControlExt/BERelations.rdf
@@ -1,173 +1,176 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-oacx-ber "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/BERelations/">
-	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-be-oacx-ber "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/BERelations/">
+bu<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/BERelations/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-oacx-ber="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/BERelations/"
-	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/BERelations/">
-		<rdfs:label xml:lang="en">BERelations</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/BERelations/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oacx-ber;majorityControllingOwnershipBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;controlledBy">
-		<rdfs:label xml:lang="en">controlled by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<skos:definition xml:lang="en">Some entity which controls the Formal Organization, this being some kind of autonomous agent.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This relationship corresponds to the party relation &quot;Entity controlled by&quot; and the scope of that party, by inheritance from &quot;Party&quot; itself, as being any Autonomous Agent. That is, any type of autonomous agent may be found in the role of the controlling party of some Formal Organization (this is the most general level of any type of control; types of de jure control may only be exerted by narrower ranges of types of entity).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;hasLegalControlOf">
-		<rdfs:label xml:lang="en">has legal control of</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">The entity has legal control over this organization.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;hasShareholder">
-		<rdfs:label xml:lang="en">has shareholder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition xml:lang="en">Some entity which part owns the Incorporated Company by means of shares.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;hasShareholderFormalOrganization">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;hasShareholder"/>
-		<rdfs:label xml:lang="en">has organizational shareholder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">Some Formal Organization which part owns the Incorporated Company by means of shares.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;majorityControllingInterestBy">
-		<rdfs:label xml:lang="en">majority controlling interest by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition xml:lang="en">Entity having controlling ownership of the Formal Organization.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is defined as being anything above fifty percent of the controlling ownership, for example voting shares or contractually defined control percentages.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;majorityControllingOwnershipBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someControllingInterestByCompany"/>
-		<rdfs:label xml:lang="en">majority controlling ownership by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<skos:definition xml:lang="en">Incorporated Company holding over fifty percent of the voting shares in this Incorporated Company.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;majorityVotingShareholdingBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someVotingShareholdingBy"/>
-		<rdfs:label xml:lang="en">majority voting shareholding by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">Formal Organization holding over fifty percent of the voting shares in this Incorporated Company.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;partOwnedBy">
-		<rdfs:label xml:lang="en">part owned by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition xml:lang="en">The entity is owned in some part by this kind of entity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This relationship corresponds to the party &quot;Entity Owning Party&quot;, which is defined as owning any Formal Organization, and being itself some potential owning party, that is the union of Formal Organization, Legal Person and legitimate organization.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;significantControllingInterestBy">
-		<rdfs:label xml:lang="en">significant controlling interest by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition xml:lang="en">Entity which has significant control of the Formal Organization.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is defined as anything above a minimum threshold which is considered significant, but up to or below 50%.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;significantControllingInterestByCompany">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someControllingInterestByCompany"/>
-		<rdfs:label xml:lang="en">significant controlling interest by company</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<skos:definition xml:lang="en">Incorporated Company having a significant voting ownership in the Incorporated Company.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;significantVotingShareholdingBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someVotingShareholdingBy"/>
-		<rdfs:label xml:lang="en">significant voting shareholding by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">Formal Organization having significant voting ownership in the Incorporated Company.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;someControllingInterestByCompany">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someVotingShareholdingBy"/>
-		<rdfs:label xml:lang="en">some controlling interest by company</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<skos:definition xml:lang="en">Company having some degree of voting ownership in the company.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;someVotingShareholdingBy">
-		<rdfs:label xml:lang="en">some voting shareholding by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">Formal Organization having some degree of voting ownership in the company.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;totalVotingShareholdingBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;majorityVotingShareholdingBy"/>
-		<rdfs:label xml:lang="en">total voting shareholding by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">Formal Organization holding all of the voting shares in the Incorporated Company.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;whollyControlledBy">
-		<rdfs:label xml:lang="en">wholly controlled by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition xml:lang="en">Entity having controlling ownership of the Formal Organization.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is defined as having 100% ownership (and therefore control ownership) of the formal Organization by whatever means is in place for ownership in that organization.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;whollyOwnedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;majorityControllingOwnershipBy"/>
-		<rdfs:label xml:lang="en">wholly owned by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<skos:definition xml:lang="en">Incorporated Company holding all of the voting shares in the Incorporated Company.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-be-oacx-ber="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/BERelations/"
+buxmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/BERelations/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BERelations</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional relationships of ownership and of control between organizations, such as part and whole control or ownership.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/BERelations/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-oacx-ber;majorityControllingOwnershipBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;controlledBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">controlled by</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some entity which controls the Formal Organization, this being some kind of autonomous agent.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This relationship corresponds to the party relation &quot;Entity controlled by&quot; and the scope of that party, by inheritance from &quot;Party&quot; itself, as being any Autonomous Agent. That is, any type of autonomous agent may be found in the role of the controlling party of some Formal Organization (this is the most general level of any type of control; types of de jure control may only be exerted by narrower ranges of types of entity).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;hasLegalControlOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has legal control of</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity has legal control over this organization.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;hasShareholder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has shareholder</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some entity which part owns the Incorporated Company by means of shares.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;hasShareholderFormalOrganization">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;hasShareholder"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has organizational shareholder</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some Formal Organization which part owns the Incorporated Company by means of shares.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;majorityControllingInterestBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">majority controlling interest by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Entity having controlling ownership of the Formal Organization.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is defined as being anything above fifty percent of the controlling ownership, for example voting shares or contractually defined control percentages.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;majorityControllingOwnershipBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someControllingInterestByCompany"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">majority controlling ownership by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Incorporated Company holding over fifty percent of the voting shares in this Incorporated Company.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;majorityVotingShareholdingBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someVotingShareholdingBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">majority voting shareholding by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal Organization holding over fifty percent of the voting shares in this Incorporated Company.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;partOwnedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">part owned by</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity is owned in some part by this kind of entity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This relationship corresponds to the party &quot;Entity Owning Party&quot;, which is defined as owning any Formal Organization, and being itself some potential owning party, that is the union of Formal Organization, Legal Person and legitimate organization.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;significantControllingInterestBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">significant controlling interest by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Entity which has significant control of the Formal Organization.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is defined as anything above a minimum threshold which is considered significant, but up to or below 50%.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;significantControllingInterestByCompany">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someControllingInterestByCompany"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">significant controlling interest by company</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Incorporated Company having a significant voting ownership in the Incorporated Company.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;significantVotingShareholdingBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someVotingShareholdingBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">significant voting shareholding by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal Organization having significant voting ownership in the Incorporated Company.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;someControllingInterestByCompany">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;someVotingShareholdingBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">some controlling interest by company</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Company having some degree of voting ownership in the company.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;someVotingShareholdingBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">some voting shareholding by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal Organization having some degree of voting ownership in the company.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;totalVotingShareholdingBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;majorityVotingShareholdingBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">total voting shareholding by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal Organization holding all of the voting shares in the Incorporated Company.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;whollyControlledBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">wholly controlled by</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Entity having controlling ownership of the Formal Organization.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is defined as having 100% ownership (and therefore control ownership) of the formal Organization by whatever means is in place for ownership in that organization.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ber;whollyOwnedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-ber;majorityControllingOwnershipBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">wholly owned by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Incorporated Company holding all of the voting shares in the Incorporated Company.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/OwnershipAndControlExt/ControlPartiesExtras.rdf
+++ b/be/OwnershipAndControlExt/ControlPartiesExtras.rdf
@@ -1,128 +1,131 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/ControlParties/">
-	<!ENTITY fibo-be-oacx-cpx "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/ControlPartiesExtras/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-be-oac-cpty "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/ControlParties/">
+bu<!ENTITY fibo-be-oacx-cpx "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/ControlPartiesExtras/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/ControlPartiesExtras/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/ControlParties/"
-	xmlns:fibo-be-oacx-cpx="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/ControlPartiesExtras/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/ControlPartiesExtras/">
-		<rdfs:label xml:lang="en">ControlPartiesExtras</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/ControlParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/ControlPartiesExtras/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-oac-cpty;ContractualControl">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oacx-cpx;contractualDeJureControlConferredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-oacx-cpx;ControlRelatedContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-oac-cpty;LimitedDeFactoControl">
-		<terms:description xml:lang="en">The ability to direct the affairs of some entity within prescribed limits. Those limits are described in terms of activities which the entity holding such control may cause the controlled entity to carry out.</terms:description>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-oacx-cpx;ControlRelatedContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<rdfs:label xml:lang="en">control related contract</rdfs:label>
-		<skos:definition xml:lang="en">A contract in which one party agrees to confer some degree and type of control upon the other party to that contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;contractualDeJureControlConferredBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
-		<rdfs:label xml:lang="en">contractual de jure control conferred by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ContractualControl"/>
-		<rdfs:range rdf:resource="&fibo-be-oacx-cpx;ControlRelatedContract"/>
-		<skos:definition xml:lang="en">Contractual Control is conferred by some contract in which one party agrees to confer some degree and type of control upon the other party to that contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;controlIsInRespectTo">
-		<rdfs:label xml:lang="en">control is in respect to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-oac-cpty;LimitedDeFactoControl"/>
-		<skos:scopeNote xml:lang="en">Defines a kind of control which may be described in percentage terms or otherwise, as being control other than absolute, and therefore needing to be defined in terms of what are the activities on the part of the controlled entity, which the entity holding this control is able to direct the entity to do or not do. Scope Note: This is the basic relationship to &quot;any&quot; kind of activity; to define specific kinds of control one needs to define specific kinds of activity such as the ability to hire or replace executives, the ability to alter the capital structure of the entity, and so on. Types of control defined in terms of activities which regulators or (via statute), sovereigns may compel or prevent an entity doing, would also be framed in terms of extensions to the &quot;Activity&quot; and refinements of this relationship (either as sub-properties of or as restrictions on this relationship).</skos:scopeNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;deJureControllingInterestPartyHasIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">de jure controlling interest party has identity</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition xml:lang="en">That which performs the role of De Jure Controlling Party.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be any form of potential owning party, that is a person, legal person, legitimate organization or formal organization (anything which is able to hold and own formal ownership instruments of some sort).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;effectivelyExercises">
-		<rdfs:label xml:lang="en">effectively exercises</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-oac-cpty;InvestmentBasedDeFactoControl"/>
-		<skos:definition xml:lang="en">The Investment Owning Party effectively exercises some degree of de facto control as a result of their interest in the entity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;entityControllingPartyIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">entity controlling party identity</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition xml:lang="en">That which is able to be the Entity Controlling Party. Scope Note: It is assumed that since control follows from some form of ownership or contractual instrument, that the range of entities which may fulfil this party role is the same as that for entity ownership, namely &quot;Involved Party&quot;; that is, a logical union of natural persons, legal persons and formal organizations.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;exercisesMajorityOf">
-		<rdfs:label xml:lang="en">exercises majority of</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-oac-cpty;DegreeOfControl"/>
-		<skos:definition xml:lang="en">Exercises, either alone or in equal degree with other such parties, majority De Facto Control over the entity in respect of which this party is defined.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;exercisesSomeDegreeOfControlOver">
-		<rdfs:label xml:lang="en">exercises some degree of control over</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;generalPartnerExercises">
-		<rdfs:label xml:lang="en">general partner exercises</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-oac-cpty;ConstitutionalDeJureControl"/>
-		<skos:definition xml:lang="en">The General Partner exercises control as a result of holding General Partner equity, which is therefore a form of constitutional control of the entity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;hasDeFactoControllingInterestParty">
-		<rdfs:label xml:lang="en">has de facto controlling interest party</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-oac-cpty;DeFactoControllingInterestParty"/>
-		<skos:definition xml:lang="en">Some party which exercises some de facto control over the Formal Organization.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;hasDeJureControllingInterestParty">
-		<rdfs:label xml:lang="en">has de jure controlling interest party</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-oac-cpty;DeJureControllingInterestParty"/>
-		<skos:definition xml:lang="en">The Formal Organization is legally controlled in some way by some de jure controlling party, that is some entity which exercises legally based control.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-be-oac-cpty="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/ControlParties/"
+buxmlns:fibo-be-oacx-cpx="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/ControlPartiesExtras/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/ControlPartiesExtras/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ControlPartiesExtras</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">Additional concepts relating to control of one party by another, such as control by means of contract. Includes deep hierarchy of kinds of control relationship. Relates to any kind of entity.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/ControlParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/ControlPartiesExtras/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-oac-cpty;ContractualControl">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-oacx-cpx;contractualDeJureControlConferredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-oacx-cpx;ControlRelatedContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-oac-cpty;LimitedDeFactoControl">
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">The ability to direct the affairs of some entity within prescribed limits. Those limits are described in terms of activities which the entity holding such control may cause the controlled entity to carry out.</terms:description>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-oacx-cpx;ControlRelatedContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">control related contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A contract in which one party agrees to confer some degree and type of control upon the other party to that contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;contractualDeJureControlConferredBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual de jure control conferred by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-oac-cpty;ContractualControl"/>
+bubu<rdfs:range rdf:resource="&fibo-be-oacx-cpx;ControlRelatedContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual Control is conferred by some contract in which one party agrees to confer some degree and type of control upon the other party to that contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;controlIsInRespectTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">control is in respect to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-oac-cpty;LimitedDeFactoControl"/>
+bubu<skos:scopeNote rdf:datatype="&rdf;langString" xml:lang="en">Defines a kind of control which may be described in percentage terms or otherwise, as being control other than absolute, and therefore needing to be defined in terms of what are the activities on the part of the controlled entity, which the entity holding this control is able to direct the entity to do or not do. Scope Note: This is the basic relationship to &quot;any&quot; kind of activity; to define specific kinds of control one needs to define specific kinds of activity such as the ability to hire or replace executives, the ability to alter the capital structure of the entity, and so on. Types of control defined in terms of activities which regulators or (via statute), sovereigns may compel or prevent an entity doing, would also be framed in terms of extensions to the &quot;Activity&quot; and refinements of this relationship (either as sub-properties of or as restrictions on this relationship).</skos:scopeNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;deJureControllingInterestPartyHasIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">de jure controlling interest party has identity</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That which performs the role of De Jure Controlling Party.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be any form of potential owning party, that is a person, legal person, legitimate organization or formal organization (anything which is able to hold and own formal ownership instruments of some sort).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;effectivelyExercises">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effectively exercises</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-oac-cpty;InvestmentBasedDeFactoControl"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Investment Owning Party effectively exercises some degree of de facto control as a result of their interest in the entity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;entityControllingPartyIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">entity controlling party identity</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That which is able to be the Entity Controlling Party. Scope Note: It is assumed that since control follows from some form of ownership or contractual instrument, that the range of entities which may fulfil this party role is the same as that for entity ownership, namely &quot;Involved Party&quot;; that is, a logical union of natural persons, legal persons and formal organizations.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;exercisesMajorityOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercises majority of</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-oac-cpty;DegreeOfControl"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Exercises, either alone or in equal degree with other such parties, majority De Facto Control over the entity in respect of which this party is defined.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;exercisesSomeDegreeOfControlOver">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercises some degree of control over</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;generalPartnerExercises">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">general partner exercises</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-oac-cpty;ConstitutionalDeJureControl"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The General Partner exercises control as a result of holding General Partner equity, which is therefore a form of constitutional control of the entity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;hasDeFactoControllingInterestParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has de facto controlling interest party</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-oac-cpty;DeFactoControllingInterestParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some party which exercises some de facto control over the Formal Organization.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cpx;hasDeJureControllingInterestParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has de jure controlling interest party</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-oac-cpty;DeJureControllingInterestParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Formal Organization is legally controlled in some way by some de jure controlling party, that is some entity which exercises legally based control.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/OwnershipAndControlExt/CorporateControlExtras.rdf
+++ b/be/OwnershipAndControlExt/CorporateControlExtras.rdf
@@ -1,37 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-oac-cctl "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/">
-	<!ENTITY fibo-be-oacx-ccx "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateControlExtras/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-oac-cctl "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/">
+bu<!ENTITY fibo-be-oacx-ccx "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateControlExtras/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateControlExtras/"
-	xmlns:fibo-be-oac-cctl="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/"
-	xmlns:fibo-be-oacx-ccx="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateControlExtras/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateControlExtras/">
-		<rdfs:label xml:lang="en">CorporateControlExtras</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateControlExtras/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ccx;isJointVentureOf">
-		<rdfs:label xml:lang="en">is joint venture of</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-oac-cctl;JointVenturePartner"/>
-		<skos:definition xml:lang="en">Formal definition needed. This is something which is a company which is not wholly or majority owned by any one other company but is instead a joint venture i.e. 50/50 holdings or 33/33/33 etc.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-oac-cctl="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/"
+buxmlns:fibo-be-oacx-ccx="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateControlExtras/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateControlExtras/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CorporateControlExtras</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Corporation-specific control relationships extending the ones in Control Parties Extras. Contains only the relationship describing joint ventures.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateControlExtras/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ccx;isJointVentureOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is joint venture of</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-oac-cctl;JointVenturePartner"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal definition needed. This is something which is a company which is not wholly or majority owned by any one other company but is instead a joint venture i.e. 50/50 holdings or 33/33/33 etc.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/OwnershipAndControlExt/CorporateOwnershipExtras.rdf
+++ b/be/OwnershipAndControlExt/CorporateOwnershipExtras.rdf
@@ -1,51 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/">
-	<!ENTITY fibo-be-oacx-cox "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/">
+bu<!ENTITY fibo-be-oacx-cox "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"
-	xmlns:fibo-be-oacx-cox="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/">
-		<rdfs:label xml:lang="en">CorporateOwnershipExtras</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oacx-cox;partHeldByShareholder"/>
-				<owl:onClass rdf:resource="&fibo-be-oac-cown;Shareholder"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-cox;partHeldByShareholder">
-		<rdfs:label xml:lang="en">part held by shareholder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-cown;Shareholder"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"
+buxmlns:fibo-be-oacx-cox="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CorporateOwnershipExtras</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional terms relating to ownership of corporations specifically. This covers part ownership of a corporation by a shareholder.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-oacx-cox;partHeldByShareholder"/>
+bubububu<owl:onClass rdf:resource="&fibo-be-oac-cown;Shareholder"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-cox;partHeldByShareholder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">part held by shareholder</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-oac-cown;Shareholder"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/OwnershipAndControlExt/OwnershipPartiesExtras.rdf
+++ b/be/OwnershipAndControlExt/OwnershipPartiesExtras.rdf
@@ -1,42 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-oacx-opx "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-oacx-opx "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/"
-	xmlns:fibo-be-oacx-opx="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/">
-		<rdfs:label xml:lang="en">OwnershipPartiesExtras</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-opx;entityOwningPartyIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">entity owning party identity</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
-		<skos:definition xml:lang="en">That which may perform the role of Owner of some business entity or formal organization.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be any entity which is capable of holding and owning any type of ownership instrument, whether or not that is a Legal Person in its own right, but not including informal illicit organizations which have no means for owning things in their own right.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-oacx-opx="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">OwnershipPartiesExtras</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Contains only the relationship defining the party identity for the owner of a corporation, as a sub property of hasIdentity rather than as a restriction, so this can be used for more detailed descriptions of kinds of owner.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-opx;entityOwningPartyIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">entity owning party identity</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;IndependentParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That which may perform the role of Owner of some business entity or formal organization.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be any entity which is capable of holding and owning any type of ownership instrument, whether or not that is a Legal Person in its own right, but not including informal illicit organizations which have no means for owning things in their own right.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/OwnershipAndControlExt/UltimateBeneficialOwners.rdf
+++ b/be/OwnershipAndControlExt/UltimateBeneficialOwners.rdf
@@ -1,89 +1,92 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/">
-	<!ENTITY fibo-be-oacx-opx "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/">
-	<!ENTITY fibo-be-oacx-ubo "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/UltimateBeneficialOwners/">
-	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/">
+bu<!ENTITY fibo-be-oacx-opx "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/">
+bu<!ENTITY fibo-be-oacx-ubo "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/UltimateBeneficialOwners/">
+bu<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/UltimateBeneficialOwners/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"
-	xmlns:fibo-be-oacx-opx="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/"
-	xmlns:fibo-be-oacx-ubo="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/UltimateBeneficialOwners/"
-	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/UltimateBeneficialOwners/">
-		<rdfs:label xml:lang="en">UltimateBeneficialOwners</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/UltimateBeneficialOwners/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-oacx-ubo;UltimateBeneficialOwner">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cown;BeneficialOwner"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oacx-ubo;UltimateBeneficialOwnerWillBe"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-ppl;Person"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oacx-ubo;isUltimateBeneficialOwnerOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">ultimate beneficial owner</rdfs:label>
-		<skos:definition xml:lang="en">The ultimate holders of the assets of a hierarchy of companies. These may be people or other legal entities.</skos:definition>
-		<skos:editorialNote xml:lang="en">There may be other relationships that lead to this. Family Office: Another kind of entity that may be used ot get around vertain tax provisions. Also relates to control versus ownership. Defined by law as the owning or controlling of more than (a threshold e.g. 25% or 10% of the entity, as defined in the individual AML laws in the applicable jurisdiction). Review: Determine whether this is any human being or an adult human being; else OK. Need to differentiate betwen: BO as a company BO as a natural person. There are different rules around how we treat that data, e.g. if MGB is 50% owner of Aardvary Ltd, there are requirements for what information we need. Review question: Is UBO always a human being? Yes Could be government. It has to not be a company.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ubo;UltimateBeneficialOwnerWillBe">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-opx;entityOwningPartyIdentity"/>
-		<rdfs:label xml:lang="en">ultimate beneficial owner will be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-oacx-ubo;UltimateBeneficialOwner"/>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-ppl;Person"/>
-		<skos:definition xml:lang="en">ultimate Beneficial Owner is any kind of Human Being.</skos:definition>
-		<skos:editorialNote xml:lang="en">Questions around minor versus adult human being. Assume so far that ...</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ubo;hasUltimateBeneficialOwner">
-		<rdfs:label xml:lang="en">has ultimate beneficial owner</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<rdfs:range rdf:resource="&fibo-be-oacx-ubo;UltimateBeneficialOwner"/>
-		<skos:definition xml:lang="en">The ultimate holders of the assets of a hierarchy of companies. These may be people or other legal entities.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Defined by law as the owning or controlling of more than (a threshold e.g. 25% or 10% of the entity, as defined in the individual AML laws in the applicable jurisdiction). Review: Determine whether this is any human being or an adult human being; else OK.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oacx-ubo;isUltimateBeneficialOwnerOf">
-		<rdfs:label xml:lang="en">is ultimate beneficial owner of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-oacx-ubo;UltimateBeneficialOwner"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-		<owl:inverseOf rdf:resource="&fibo-be-oacx-ubo;hasUltimateBeneficialOwner"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"
+buxmlns:fibo-be-oacx-opx="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/"
+buxmlns:fibo-be-oacx-ubo="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/UltimateBeneficialOwners/"
+buxmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/UltimateBeneficialOwners/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">UltimateBeneficialOwners</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">The ultimate beneficial owner of a corporation or other owned organization. This is always a human being and is found by navigating the ownership hierarchies of a set of organizations. This is defined in terms only of ownership (benefit) not of control.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/CorporateOwnershipExtras/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/OwnershipPartiesExtras/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControlExt/UltimateBeneficialOwners/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-oacx-ubo;UltimateBeneficialOwner">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-oac-cown;BeneficialOwner"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-oacx-ubo;UltimateBeneficialOwnerWillBe"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-ppl;Person"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-oacx-ubo;isUltimateBeneficialOwnerOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ultimate beneficial owner</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The ultimate holders of the assets of a hierarchy of companies. These may be people or other legal entities.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">There may be other relationships that lead to this. Family Office: Another kind of entity that may be used ot get around vertain tax provisions. Also relates to control versus ownership. Defined by law as the owning or controlling of more than (a threshold e.g. 25% or 10% of the entity, as defined in the individual AML laws in the applicable jurisdiction). Review: Determine whether this is any human being or an adult human being; else OK. Need to differentiate betwen: BO as a company BO as a natural person. There are different rules around how we treat that data, e.g. if MGB is 50% owner of Aardvary Ltd, there are requirements for what information we need. Review question: Is UBO always a human being? Yes Could be government. It has to not be a company.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ubo;UltimateBeneficialOwnerWillBe">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-oacx-opx;entityOwningPartyIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ultimate beneficial owner will be</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-oacx-ubo;UltimateBeneficialOwner"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-aap-ppl;Person"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">ultimate Beneficial Owner is any kind of Human Being.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Questions around minor versus adult human being. Assume so far that ...</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ubo;hasUltimateBeneficialOwner">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has ultimate beneficial owner</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-oacx-ubo;UltimateBeneficialOwner"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The ultimate holders of the assets of a hierarchy of companies. These may be people or other legal entities.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Defined by law as the owning or controlling of more than (a threshold e.g. 25% or 10% of the entity, as defined in the individual AML laws in the applicable jurisdiction). Review: Determine whether this is any human being or an adult human being; else OK.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-oacx-ubo;isUltimateBeneficialOwnerOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is ultimate beneficial owner of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-oacx-ubo;UltimateBeneficialOwner"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bubu<owl:inverseOf rdf:resource="&fibo-be-oacx-ubo;hasUltimateBeneficialOwner"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/PartnershipsExt/PartnershipsExtras.rdf
+++ b/be/PartnershipsExt/PartnershipsExtras.rdf
@@ -1,70 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/">
-	<!ENTITY fibo-be-ptrx-ptrx "https://spec.edmcouncil.org/fibo/BE/PartnershipsExt/PartnershipsExtras/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/">
+bu<!ENTITY fibo-be-ptrx-ptrx "https://spec.edmcouncil.org/fibo/BE/PartnershipsExt/PartnershipsExtras/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/PartnershipsExt/PartnershipsExtras/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"
-	xmlns:fibo-be-ptrx-ptrx="https://spec.edmcouncil.org/fibo/BE/PartnershipsExt/PartnershipsExtras/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/PartnershipsExt/PartnershipsExtras/">
-		<rdfs:label xml:lang="en">PartnershipsExtras</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/PartnershipsExt/PartnershipsExtras/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;CompanyIncorporatedByGuarantee">
-		<owl:disjointWith rdf:resource="&fibo-be-ptrx-ptrx;PartnershipIncorporatedByGuarantee"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-ptrx-ptrx;PartnershipIncorporatedByGuarantee">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyIncorporatedWithGuarantee"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-ptr-ptr;PartnershipWithLimitedPartners"/>
-		<rdfs:label xml:lang="en">partnership incorporated by guarantee</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-ptrx-ptrx;hasPartnershipEquity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-le-fbo;hasEquity"/>
-		<rdfs:label xml:lang="en">has partnership equity</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-ptr-ptr;PartnershipEquity"/>
-		<skos:definition xml:lang="en">The Partnership has some Partnership Equity in it.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may take one or both of two forms: General Partner Equity and Limited Partner Equity.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-ptrx-ptrx;incorportatedPartnershipMemberIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">incorportated partnership member has identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-ptr-ptr;LegallyIncorporatedPartnershipMember"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-		<skos:definition xml:lang="en">The legal entity which is the Legally Incorporated Partnership Member.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"
+buxmlns:fibo-be-ptrx-ptrx="https://spec.edmcouncil.org/fibo/BE/PartnershipsExt/PartnershipsExtras/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/PartnershipsExt/PartnershipsExtras/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">PartnershipsExtras</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional concepts relating to partnerships, including additional partnership types. Contains the logically possibly but unattested concept of a partnership incorporate by guarantee (as a kind of incorporated entity that is also a kind of partnership), and also the notion of partnership equity for partnerships in general.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/PartnershipsExt/PartnershipsExtras/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;CompanyIncorporatedByGuarantee">
+bubu<owl:disjointWith rdf:resource="&fibo-be-ptrx-ptrx;PartnershipIncorporatedByGuarantee"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-ptrx-ptrx;PartnershipIncorporatedByGuarantee">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-cb;BodyIncorporatedWithGuarantee"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-ptr-ptr;PartnershipWithLimitedPartners"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partnership incorporated by guarantee</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-ptrx-ptrx;hasPartnershipEquity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-be-le-fbo;hasEquity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has partnership equity</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-ptr-ptr;PartnershipEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Partnership has some Partnership Equity in it.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may take one or both of two forms: General Partner Equity and Limited Partner Equity.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-ptrx-ptrx;incorportatedPartnershipMemberIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incorportated partnership member has identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-ptr-ptr;LegallyIncorporatedPartnershipMember"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The legal entity which is the Legally Incorporated Partnership Member.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/be/TrustsExt/TrustFundDirectRelations.rdf
+++ b/be/TrustsExt/TrustFundDirectRelations.rdf
@@ -1,42 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-be-trx-tfdr "https://spec.edmcouncil.org/fibo/BE/TrustsExt/TrustFundDirectRelations/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-be-trx-tfdr "https://spec.edmcouncil.org/fibo/BE/TrustsExt/TrustFundDirectRelations/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/TrustsExt/TrustFundDirectRelations/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-be-trx-tfdr="https://spec.edmcouncil.org/fibo/BE/TrustsExt/TrustFundDirectRelations/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/TrustsExt/TrustFundDirectRelations/">
-		<rdfs:label xml:lang="en">TrustFundDirectRelations</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/TrustsExt/TrustFundDirectRelations/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-trx-tfdr;unitHolder">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasMember"/>
-		<rdfs:label xml:lang="en">unit holder</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-		<skos:definition xml:lang="en">The holder of units in a trust.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is a legal entity. REVIEW: This term was added during some early discussions of Funds (pre 2012). Need to determine whether this is something that exists for all Trusts (probably not), or if it is a fact about specific kinds of trusts that are used in funds / CIV, in which case there would be a sub-class of Trust with this property.</skos:editorialNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-be-trx-tfdr="https://spec.edmcouncil.org/fibo/BE/TrustsExt/TrustFundDirectRelations/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/TrustsExt/TrustFundDirectRelations/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">TrustFundDirectRelations</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Contains one direct relationship that was not included in release ontologies, describing the unit holder relationship for trusts in the context of trust funds. This ontology would also contain other information specific to trust fund trusts that would not apply to trusts more generally.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/TrustsExt/TrustFundDirectRelations/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-be-trx-tfdr;unitHolder">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasMember"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unit holder</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The holder of units in a trust.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is a legal entity. REVIEW: This term was added during some early discussions of Funds (pre 2012). Need to determine whether this is something that exists for all Trusts (probably not), or if it is a fact about specific kinds of trusts that are used in funds / CIV, in which case there would be a sub-class of Trust with this property.</skos:editorialNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/Process/FinancialContextAndProcess.rdf
+++ b/bp/Process/FinancialContextAndProcess.rdf
@@ -1,216 +1,219 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-prc-fcp "https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
-	<!ENTITY fibo-fnd-bus-agc "https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-prc-fcp "https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
+bu<!ENTITY fibo-fnd-bus-agc "https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"
-	xmlns:fibo-bp-prc-fcp="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"
-	xmlns:fibo-fnd-bus-agc="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
-		<rdfs:label xml:lang="en">FinancialContextAndProcess</rdfs:label>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;Clearing">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;ClearingAndSettlement"/>
-		<rdfs:label xml:lang="en">clearing</rdfs:label>
-		<skos:definition xml:lang="en">The process by which securities trades are cleared.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;ClearingAndSettlement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
-		<rdfs:label xml:lang="en">clearing and settlement</rdfs:label>
-		<skos:definition xml:lang="en">The business process or service area of securities clearing and settlement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;FinancialIndustryContext">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
-		<rdfs:label xml:lang="en">financial industry context</rdfs:label>
-		<skos:definition xml:lang="en">The context in which business activites take place within the financial industry, i.e. investment management, wholesale financial markets trading and so on.</skos:definition>
-		<skos:editorialNote xml:lang="en">REVIEW: Ther precise definition above defines the Scope of this model.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;FinancialMarketsRegulation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
-		<rdfs:label xml:lang="en">financial markets regulation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;InvestmentManagement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
-		<rdfs:label xml:lang="en">investment management</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;MarketDataProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
-		<rdfs:label xml:lang="en">market data provision</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;PortfolioManagement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;InvestmentManagement"/>
-		<rdfs:label xml:lang="en">portfolio management</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;PreTrade">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;InvestmentManagement"/>
-		<rdfs:label xml:lang="en">pre trade</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;PretradeQuotes">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
-		<rdfs:label xml:lang="en">pretrade quotes</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;PretradeReferenceDataProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
-		<rdfs:label xml:lang="en">pretrade reference data provision</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;PrimaryMarket">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
-		<rdfs:label xml:lang="en">primary market</rdfs:label>
-		<skos:definition xml:lang="en">Issuance and primary market trading of new Traded Financial Instruments</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;PrimaryMarketClosing">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PrimaryMarket"/>
-		<rdfs:label xml:lang="en">primary market closing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;PrimaryMarketIndicationsOfInterest">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
-		<rdfs:label xml:lang="en">primary market indications of interest</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecondaryMarketTradingContext">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
-		<rdfs:label xml:lang="en">secondary market trading context</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesCustody">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
-		<rdfs:label xml:lang="en">securities custody</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesPostTrade">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
-		<rdfs:label xml:lang="en">securities post trade</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesPostTradePositionManagement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
-		<rdfs:label xml:lang="en">securities post trade position management</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTrade">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
-		<rdfs:label xml:lang="en">securities trade</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeAllocation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
-		<rdfs:label xml:lang="en">securities trade allocation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeCaptureAndValidation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
-		<rdfs:label xml:lang="en">securities trade capture and validation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeConfirmationAffirmation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
-		<rdfs:label xml:lang="en">securities trade confirmation affirmation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeDatePositionReporting">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesTrade"/>
-		<rdfs:label xml:lang="en">securities trade date position reporting</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeExecution">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesTrade"/>
-		<rdfs:label xml:lang="en">securities trade execution</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeOrderRouting">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesTrade"/>
-		<rdfs:label xml:lang="en">securities trade order routing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradesMatching">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
-		<rdfs:label xml:lang="en">securities trades matching</rdfs:label>
-		<skos:definition xml:lang="en">Matching of trade allegations to identify confirmed trades, on an Over the Counter market in Traded Securities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradesReporting">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
-		<rdfs:label xml:lang="en">securities trades reporting</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;SecurityRetirement">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-prc-fcp;isRetirementOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security retirement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;Settlement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;ClearingAndSettlement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PrimaryMarketClosing"/>
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;WhenIssuedTrading"/>
-		<rdfs:label xml:lang="en">settlement</rdfs:label>
-		<skos:definition xml:lang="en">The process by which securities trades are settled.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;ShortSaleLocate">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
-		<rdfs:label xml:lang="en">short sale locate</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;TradeAdvertisements">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
-		<rdfs:label xml:lang="en">trade advertisements</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;TradedSecurityLifecycle">
-		<rdfs:label xml:lang="en">traded security lifecycle</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;TradesReferenceDataProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesTrade"/>
-		<rdfs:label xml:lang="en">trades reference data provision</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-prc-fcp;WhenIssuedTrading">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PrimaryMarket"/>
-		<rdfs:label xml:lang="en">when issued trading</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-prc-fcp;context">
-		<rdfs:label xml:lang="en">context</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-prc-fcp;isRetirementOf">
-		<rdfs:label xml:lang="en">is retirement of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-prc-fcp;SecurityRetirement"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-prc-fcp="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"
+buxmlns:fibo-fnd-bus-agc="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FinancialContextAndProcess</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Core ontology defining process concepts in general for refinement and re-use elsewhere in this domain.</dct:abstract>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;Clearing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;ClearingAndSettlement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">clearing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process by which securities trades are cleared.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;ClearingAndSettlement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">clearing and settlement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The business process or service area of securities clearing and settlement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;FinancialIndustryContext">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial industry context</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The context in which business activites take place within the financial industry, i.e. investment management, wholesale financial markets trading and so on.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">REVIEW: Ther precise definition above defines the Scope of this model.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;FinancialMarketsRegulation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial markets regulation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;InvestmentManagement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment management</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;MarketDataProvision">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market data provision</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;PortfolioManagement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;InvestmentManagement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">portfolio management</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;PreTrade">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;InvestmentManagement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pre trade</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;PretradeQuotes">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pretrade quotes</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;PretradeReferenceDataProvision">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pretrade reference data provision</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;PrimaryMarket">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Issuance and primary market trading of new Traded Financial Instruments</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;PrimaryMarketClosing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PrimaryMarket"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary market closing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;PrimaryMarketIndicationsOfInterest">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary market indications of interest</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecondaryMarketTradingContext">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secondary market trading context</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesCustody">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities custody</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesPostTrade">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities post trade</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesPostTradePositionManagement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities post trade position management</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTrade">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;FinancialIndustryContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trade</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeAllocation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trade allocation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeCaptureAndValidation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trade capture and validation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeConfirmationAffirmation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trade confirmation affirmation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeDatePositionReporting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trade date position reporting</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeExecution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trade execution</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradeOrderRouting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trade order routing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradesMatching">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trades matching</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Matching of trade allegations to identify confirmed trades, on an Over the Counter market in Traded Securities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecuritiesTradesReporting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesPostTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trades reporting</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;SecurityRetirement">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-prc-fcp;isRetirementOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security retirement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;Settlement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;ClearingAndSettlement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PrimaryMarketClosing"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;WhenIssuedTrading"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process by which securities trades are settled.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;ShortSaleLocate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">short sale locate</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;TradeAdvertisements">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PreTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trade advertisements</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;TradedSecurityLifecycle">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded security lifecycle</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;TradesReferenceDataProvision">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecuritiesTrade"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trades reference data provision</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-prc-fcp;WhenIssuedTrading">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PrimaryMarket"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">when issued trading</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-prc-fcp;context">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">context</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-prc-fcp;isRetirementOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is retirement of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-prc-fcp;SecurityRetirement"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/Regulatory/RegulatoryRequirements.rdf
+++ b/bp/Regulatory/RegulatoryRequirements.rdf
@@ -1,150 +1,153 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-reg-req "https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-reg-req "https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"
-	xmlns:fibo-bp-reg-req="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
-		<rdfs:label xml:lang="en">RegulatoryRequirements</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;BusinessRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;Requirement"/>
-		<rdfs:label xml:lang="en">business requirement</rdfs:label>
-		<skos:definition xml:lang="en">A requirement driven by business imperatives.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;BusinessRule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
-		<rdfs:label xml:lang="en">business rule</rdfs:label>
-		<skos:definition xml:lang="en">A rule which applies in some business context. Includes operations rules, regulatory rules and so on.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;LegalRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;Requirement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-reg-req;mandatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">legal requirement</rdfs:label>
-		<skos:definition xml:lang="en">A requirement driven by legal instruments, that is a requirement which is defined in and mandated by some body of statute law.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;OperationalRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRequirement"/>
-		<rdfs:label xml:lang="en">operational requirement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;OperationalRule">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRule"/>
-		<rdfs:label xml:lang="en">operational rule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;ProductRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRequirement"/>
-		<rdfs:label xml:lang="en">product requirement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;RegulatoryOperationalRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
-		<rdfs:label xml:lang="en">regulatory operational requirement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;RegulatoryRegistrationRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
-		<rdfs:label xml:lang="en">regulatory registration requirement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;RegulatoryReportingRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
-		<rdfs:label xml:lang="en">regulatory reporting requirement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;RegulatoryRule">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-reg-req;formalizes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-reg-req;mayDrive"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-reg-req;OperationalRule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">regulatory rule</rdfs:label>
-		<skos:definition xml:lang="en">A rule which has compliance mandates backed by some Government, with associated lenalties.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;Requirement">
-		<rdfs:label xml:lang="en">requirement</rdfs:label>
-		<skos:definition xml:lang="en">Something that must be done or refrained from</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;RiskMitigationRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRequirement"/>
-		<rdfs:label xml:lang="en">risk mitigation requirement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-reg-req;SystemRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;ProductRequirement"/>
-		<rdfs:label xml:lang="en">system requirement</rdfs:label>
-		<skos:definition xml:lang="en">A requirement to be met in some System.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-reg-req;formalizes">
-		<rdfs:label xml:lang="en">formalizes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-reg-req;RegulatoryRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-reg-req;mandatedBy">
-		<rdfs:label xml:lang="en">mandated by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-reg-req;LegalRequirement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-reg-req;mandates">
-		<rdfs:label xml:lang="en">mandates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-		<rdfs:range rdf:resource="&fibo-bp-reg-req;LegalRequirement"/>
-		<owl:inverseOf rdf:resource="&fibo-bp-reg-req;mandatedBy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-reg-req;mayDrive">
-		<rdfs:label xml:lang="en">may drive</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-reg-req;RegulatoryRule"/>
-		<rdfs:range rdf:resource="&fibo-bp-reg-req;OperationalRule"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-reg-req="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">RegulatoryRequirements</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Regulatory requirements process concepts in general. These are the basic concepts to be built out for specific regulatory compliance and reporting processes as needed in different jurisdictions, or specifically with a financial institution that would extend these terms to derive their own reporting process ontologies.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;BusinessRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;Requirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business requirement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A requirement driven by business imperatives.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;BusinessRule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business rule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A rule which applies in some business context. Includes operations rules, regulatory rules and so on.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;LegalRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;Requirement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-reg-req;mandatedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal requirement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A requirement driven by legal instruments, that is a requirement which is defined in and mandated by some body of statute law.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;OperationalRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">operational requirement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;OperationalRule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">operational rule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;ProductRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">product requirement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;RegulatoryOperationalRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regulatory operational requirement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;RegulatoryRegistrationRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regulatory registration requirement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;RegulatoryReportingRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regulatory reporting requirement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;RegulatoryRule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-reg-req;formalizes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-reg-req;mayDrive"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-reg-req;OperationalRule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regulatory rule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A rule which has compliance mandates backed by some Government, with associated lenalties.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;Requirement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requirement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something that must be done or refrained from</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;RiskMitigationRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;BusinessRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">risk mitigation requirement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-reg-req;SystemRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;ProductRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">system requirement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A requirement to be met in some System.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-reg-req;formalizes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formalizes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-reg-req;RegulatoryRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-reg-req;mandatedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandated by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-reg-req;LegalRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-reg-req;mandates">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandates</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-reg-req;LegalRequirement"/>
+bubu<owl:inverseOf rdf:resource="&fibo-bp-reg-req;mandatedBy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-reg-req;mayDrive">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may drive</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-reg-req;RegulatoryRule"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-reg-req;OperationalRule"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/SecuritiesIssuance/AgencyMBSIssuance.rdf
+++ b/bp/SecuritiesIssuance/AgencyMBSIssuance.rdf
@@ -1,553 +1,556 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-ambs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/">
-	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
-	<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-	<!ENTITY fibo-bp-iss-mbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/">
-	<!ENTITY fibo-bp-iss-pmbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/">
-	<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
-	<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
-	<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-ambs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/">
+bu<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
+bu<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bu<!ENTITY fibo-bp-iss-mbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/">
+bu<!ENTITY fibo-bp-iss-pmbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/">
+bu<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
+bu<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
+bu<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/"
-	xmlns:fibo-bp-iss-ambs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/"
-	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-mbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"
-	xmlns:fibo-bp-iss-pmbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"
-	xmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
-	xmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
-	xmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/">
-		<rdfs:label xml:lang="en">AgencyMBSIssuance</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;AcquireMortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;purchase"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">acquire mortgage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;AddMortgageToPool">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;addsToPool"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">add mortgage to pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationEnd">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;flow"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceStart"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">agency mortgage pool creation end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasEnd"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationEnd"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasStart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationStart"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">agency mortgage pool creation process</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-bp-iss-pmbs;NonAgencyPoolCreationProcess"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationStart">
-		<rdfs:label xml:lang="en">agency mortgage pool creation start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;AllocatePrimaryIdentifier">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">allocate primary identifier</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;AssessPoolSuitablilityForIssuance">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">assess pool suitablility for issuance</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;ClassifyMortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;isAssessmentOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">classify mortgage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;DefineMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;isDefiningOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">define mortgage pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;DraftPassThroughTermsheet">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
-		<rdfs:label xml:lang="en">draft pass through termsheet</rdfs:label>
-		<skos:definition xml:lang="en">Draft of set of information defining the pass thorugh security terms. These will eventually become the contractual terms of the instrument. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;DrawUpOfferingMemorandum">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">draw up offering memorandum</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;DrawUpTermsheet">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">draw up termsheet</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;FinalizePoolContent">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">finalize pool content</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;FinalizeProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">finalize prospectus</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;IdentifyConformingMortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;refersTo.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">identify conforming mortgage</rdfs:label>
-		<skos:definition xml:lang="en">Identify mortgage conforming to overall requirements for this issuer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This does not relate to the criteria for belonging to an individual, defined mortgage pool but conforms to the requirements of the issuing organization overall. This is for Agency pools. For non-agency, the equivalent of this step is carried out at pool level with a clause to reject the mortgage.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;IdentifyUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;resultsInAppointmentOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PotentialPassThroughIssuanceUnderwriter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">identify underwriter</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;InAssemblyAgencyMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InAssembly"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">in assembly agency mortgage pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;InIssuanceAgencyMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InIssuance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">in issuance agency mortgage pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;MakeSecuritiesAvailabeInMarket">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">make securities availabe in market</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;MarketIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasResource"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSDraftProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">market issue</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;NotYetIssued"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">not yet issued agency mortgage pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughIssuanceEnd">
-		<rdfs:label xml:lang="en">pass through issuance end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughIssuanceStart">
-		<rdfs:label xml:lang="en">pass through issuance start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughIssueProspectusPart">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-mbs;ProspectusPart"/>
-		<rdfs:label xml:lang="en">pass through issue prospectus part</rdfs:label>
-		<skos:definition xml:lang="en">A part or section of a prospectus for a pass through MBS issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughMBSDraftProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesFinal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSFinalProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pass through m b s draft prospectus</rdfs:label>
-		<skos:definition xml:lang="en">The draft prospectus for a pass through Mortgage Backed Securities issue, as determined by the issuing agency prior to marketing the issue. Certain terms in the draft prospectus will be finalized later in the issuance process to become the actual Prospectus. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughMBSFinalProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDealProspectus"/>
-		<rdfs:label xml:lang="en">pass through m b s final prospectus</rdfs:label>
-		<skos:definition xml:lang="en">Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughMBSFinalTermsheet">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-ambs;PassThroughIssueProspectusPart"/>
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;definesTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;definesTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pass through m b s final termsheet</rdfs:label>
-		<skos:definition xml:lang="en">The final termsheet for the pass through MBS issue. This defines the terms for the MBS contract itself. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughMBSSecuritizationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-mbs;MBSSecuritizationProcess"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasEnd.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceEnd"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasStart.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceStart"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pass through m b s securitization process</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSSecuritizationProcess"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughOfferingMemorandum">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-mbs;includesDetailsAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSFinalTermsheet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pass through offering memorandum</rdfs:label>
-		<skos:definition xml:lang="en">The offering memorandum for a pass through MBS issue, setting out basic information about a future issue, for the information of prospective investors and their agents. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PoolConformanceCriteria">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;definesCriteriaFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool conformance criteria</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;adds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AddMortgageToPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;finalizes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;FinalizePoolContent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;identifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;IdentifyConformingMortgage"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;purchases"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AcquireMortgage"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;validates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;ValidateConformance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AssessPoolSuitablilityForIssuance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;ClassifyMortgage"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">potential agency m b s issuer</rdfs:label>
-		<skos:definition xml:lang="en">The entity which will become the issuing party for the pass through MBS Issue. This entity is the principal actor in most of the activities involved in the issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;PotentialPassThroughIssuanceUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialUnderwriter"/>
-		<rdfs:label xml:lang="en">potential pass through issuance underwriter</rdfs:label>
-		<skos:definition xml:lang="en">The entity which will become the underwriter for the pass through MBS issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;RegisterSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">register security</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;SuitableForIssue">
-		<rdfs:label xml:lang="en">suitable for issue</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ambs;ValidateConformance">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">validate conformance</rdfs:label>
-		<skos:definition xml:lang="en">The mortgage is automatically validated for conformance to the requirements of the pool in which it is to be included.</skos:definition>
-		<skos:editorialNote xml:lang="en">From review comment 6 Oct: box called validate conformance automatic eg max loan balance</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;adds">
-		<rdfs:label xml:lang="en">adds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;AddMortgageToPool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;addsToPool">
-		<rdfs:label xml:lang="en">adds to pool</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AddMortgageToPool"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;allocatesIdentifier">
-		<rdfs:label>allocates identifier</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;definesCriteriaFor">
-		<rdfs:label xml:lang="en">defines criteria for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;finalizes">
-		<rdfs:label xml:lang="en">finalizes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;FinalizePoolContent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;flow">
-		<rdfs:label xml:lang="en">flow</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationEnd"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceStart"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasEnd">
-		<rdfs:label xml:lang="en">has end</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationEnd"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasEnd.1">
-		<rdfs:label xml:lang="en">has end</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSSecuritizationProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceEnd"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasResource">
-		<rdfs:label xml:lang="en">has resource</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;MarketIssue"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSDraftProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasStart">
-		<rdfs:label xml:lang="en">has start</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationStart"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasStart.1">
-		<rdfs:label xml:lang="en">has start</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSSecuritizationProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceStart"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;identifies">
-		<rdfs:label xml:lang="en">identifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;IdentifyConformingMortgage"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;isAssessmentOf">
-		<rdfs:label xml:lang="en">is assessment of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;ClassifyMortgage"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;isDefiningOf">
-		<rdfs:label xml:lang="en">is defining of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;DefineMortgagePool"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-bp-iss-ambs;lifecycleState.2">
-		<rdfs:label xml:lang="en">lifecycle state</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;maximumLoanBalance">
-		<rdfs:label xml:lang="en">maximum loan balance</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;minimumRating">
-		<rdfs:label xml:lang="en">minimum rating</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;purchase">
-		<rdfs:label xml:lang="en">purchase</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AcquireMortgage"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;purchases">
-		<rdfs:label xml:lang="en">purchases</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;AcquireMortgage"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;refersTo">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;ValidateConformance"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;refersTo.1">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;IdentifyConformingMortgage"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;resultsInAppointmentOf">
-		<rdfs:label xml:lang="en">results in appointment of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;IdentifyUnderwriter"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PotentialPassThroughIssuanceUnderwriter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;validates">
-		<rdfs:label xml:lang="en">validates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ambs;ValidateConformance"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-ambs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/"
+buxmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
+buxmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
+buxmlns:fibo-bp-iss-mbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"
+buxmlns:fibo-bp-iss-pmbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"
+buxmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
+buxmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
+buxmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AgencyMBSIssuance</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Process ontology for the process of issuance (securitization) of mortgage backed securities by government agencies. Based on US government agency MBS issuance process.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;AcquireMortgage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;purchase"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">acquire mortgage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;AddMortgageToPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;addsToPool"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">add mortgage to pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationEnd">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;flow"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceStart"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency mortgage pool creation end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasEnd"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationEnd"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasStart"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationStart"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency mortgage pool creation process</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-bp-iss-pmbs;NonAgencyPoolCreationProcess"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency mortgage pool creation start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;AllocatePrimaryIdentifier">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocate primary identifier</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;AssessPoolSuitablilityForIssuance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assess pool suitablility for issuance</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;ClassifyMortgage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;isAssessmentOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">classify mortgage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;DefineMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;isDefiningOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">define mortgage pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;DraftPassThroughTermsheet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draft pass through termsheet</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Draft of set of information defining the pass thorugh security terms. These will eventually become the contractual terms of the instrument. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;DrawUpOfferingMemorandum">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draw up offering memorandum</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;DrawUpTermsheet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draw up termsheet</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;FinalizePoolContent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">finalize pool content</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;FinalizeProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">finalize prospectus</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;IdentifyConformingMortgage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;refersTo.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identify conforming mortgage</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Identify mortgage conforming to overall requirements for this issuer.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This does not relate to the criteria for belonging to an individual, defined mortgage pool but conforms to the requirements of the issuing organization overall. This is for Agency pools. For non-agency, the equivalent of this step is carried out at pool level with a clause to reject the mortgage.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;IdentifyUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;resultsInAppointmentOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PotentialPassThroughIssuanceUnderwriter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identify underwriter</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;InAssemblyAgencyMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InAssembly"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in assembly agency mortgage pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;InIssuanceAgencyMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InIssuance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in issuance agency mortgage pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;MakeSecuritiesAvailabeInMarket">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">make securities availabe in market</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;MarketIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasResource"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSDraftProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market issue</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;NotYetIssued"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">not yet issued agency mortgage pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughIssuanceEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through issuance end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughIssuanceStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through issuance start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughIssueProspectusPart">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-mbs;ProspectusPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through issue prospectus part</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A part or section of a prospectus for a pass through MBS issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughMBSDraftProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesFinal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSFinalProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through m b s draft prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The draft prospectus for a pass through Mortgage Backed Securities issue, as determined by the issuing agency prior to marketing the issue. Certain terms in the draft prospectus will be finalized later in the issuance process to become the actual Prospectus. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughMBSFinalProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDealProspectus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through m b s final prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughMBSFinalTermsheet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-ambs;PassThroughIssueProspectusPart"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;definesTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;definesTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through m b s final termsheet</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The final termsheet for the pass through MBS issue. This defines the terms for the MBS contract itself. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughMBSSecuritizationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-mbs;MBSSecuritizationProcess"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasEnd.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceEnd"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;hasStart.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceStart"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through m b s securitization process</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSSecuritizationProcess"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PassThroughOfferingMemorandum">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-mbs;includesDetailsAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSFinalTermsheet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through offering memorandum</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The offering memorandum for a pass through MBS issue, setting out basic information about a future issue, for the information of prospective investors and their agents. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PoolConformanceCriteria">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;definesCriteriaFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool conformance criteria</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;adds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AddMortgageToPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;finalizes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;FinalizePoolContent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;identifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;IdentifyConformingMortgage"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;purchases"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AcquireMortgage"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;validates"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;ValidateConformance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AssessPoolSuitablilityForIssuance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;ClassifyMortgage"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential agency m b s issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity which will become the issuing party for the pass through MBS Issue. This entity is the principal actor in most of the activities involved in the issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;PotentialPassThroughIssuanceUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialUnderwriter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential pass through issuance underwriter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity which will become the underwriter for the pass through MBS issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;RegisterSecurity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">register security</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;SuitableForIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">suitable for issue</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ambs;ValidateConformance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">validate conformance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The mortgage is automatically validated for conformance to the requirements of the pool in which it is to be included.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From review comment 6 Oct: box called validate conformance automatic eg max loan balance</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;adds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">adds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;AddMortgageToPool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;addsToPool">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">adds to pool</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AddMortgageToPool"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;allocatesIdentifier">
+bubu<rdfs:label>allocates identifier</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;definesCriteriaFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines criteria for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;finalizes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">finalizes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;FinalizePoolContent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;flow">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">flow</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationEnd"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceStart"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has end</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationEnd"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasEnd.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has end</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSSecuritizationProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceEnd"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasResource">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has resource</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;MarketIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSDraftProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has start</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;AgencyMortgagePoolCreationStart"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;hasStart.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has start</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PassThroughMBSSecuritizationProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PassThroughIssuanceStart"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;identifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;IdentifyConformingMortgage"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;isAssessmentOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is assessment of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;ClassifyMortgage"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;isDefiningOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is defining of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;DefineMortgagePool"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;NotYetIssuedAgencyMortgagePool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-bp-iss-ambs;lifecycleState.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lifecycle state</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;maximumLoanBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum loan balance</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;minimumRating">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum rating</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;purchase">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;AcquireMortgage"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;purchases">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchases</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;AcquireMortgage"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;refersTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;ValidateConformance"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PoolConformanceCriteria"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;refersTo.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;IdentifyConformingMortgage"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;resultsInAppointmentOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in appointment of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;IdentifyUnderwriter"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;PotentialPassThroughIssuanceUnderwriter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ambs;validates">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">validates</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ambs;PotentialAgencyMBSIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ambs;ValidateConformance"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/SecuritiesIssuance/DebtIssuance.rdf
+++ b/bp/SecuritiesIssuance/DebtIssuance.rdf
@@ -1,279 +1,282 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
-	<!ENTITY fibo-bp-iss-muni "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
-	<!ENTITY fibo-bp-iss-pmbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/">
-	<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
+bu<!ENTITY fibo-bp-iss-muni "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
+bu<!ENTITY fibo-bp-iss-pmbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/">
+bu<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-bp-iss-muni="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"
-	xmlns:fibo-bp-iss-pmbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"
-	xmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
-		<rdfs:label xml:lang="en">DebtIssuance</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;ABSSecuritizationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcess"/>
-		<rdfs:label xml:lang="en">a b s securitization process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;AssetPoolCreationProcess">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;followedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;isCreationOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">asset pool creation process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;CDOSecuritizationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
-		<rdfs:label xml:lang="en">c d o securitization process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;CompletedDebtsPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;developsInto"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedPoolOfIndividualDebts"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InIssuance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">completed debts pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;CreditCardPoolCreationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
-		<rdfs:label xml:lang="en">credit card pool creation process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;DebtInstrumentPoolCreationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
-		<rdfs:label xml:lang="en">debt instrument pool creation process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;DebtSecuritizationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-		<rdfs:label xml:lang="en">debt securitization process</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-bp-iss-muni;DebtAuctionProcess"/>
-		<owl:disjointWith rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;HomeEquityLineOfCreditPoolCreationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
-		<rdfs:label xml:lang="en">home equity line of credit pool creation process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;InAssembly">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection"/>
-		<rdfs:label xml:lang="en">in assembly</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;InAssemblyDebtsPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;developsInto"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;CompletedDebtsPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InAssembly"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">in assembly debts pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;InIssuance">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection"/>
-		<rdfs:label xml:lang="en">in issuance</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;IssuanceProcessActivity">
-		<rdfs:label xml:lang="en">issuance process activity</rdfs:label>
-		<skos:definition xml:lang="en">An activity within the process of securities issuance.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;Issued">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection"/>
-		<rdfs:label xml:lang="en">issued</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;LoanPoolCreationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
-		<rdfs:label xml:lang="en">loan pool creation process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;MTNRegistration">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;Registration"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;MTNOfferProgram"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">m t n registration</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;MuniIssueUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter"/>
-		<rdfs:label xml:lang="en">muni issue underwriter</rdfs:label>
-		<skos:definition xml:lang="en">The party which agrees to buy any certificates that are not bought by investors Term origin:DTCC</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;NotYetIssued">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection"/>
-		<rdfs:label xml:lang="en">not yet issued</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;NotYetIssuedDebtsPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;developsInto"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InAssemblyDebtsPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;NotYetIssued"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">not yet issued debts pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
-		<rdfs:label xml:lang="en">pool backed security securitization process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;SecuritizationProcessActor"/>
-		<rdfs:label xml:lang="en">pool backed security securitization process actor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;followedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;isCreationOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">retail asset pool creation process</rdfs:label>
-		<skos:definition xml:lang="en">The process by which pools of assets are created. These may then be used in the issue of securities based on those asset pools as underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-dbti;SecuritizationProcessActor">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
-		<rdfs:label xml:lang="en">securitization process actor</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;announces">
-		<rdfs:label xml:lang="en">announces</rdfs:label>
-		<skos:definition xml:lang="en">The issue of one or more securities that the announcement pertains to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;assesses">
-		<rdfs:label xml:lang="en">assesses</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;describes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">describes</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;followedBy">
-		<rdfs:label xml:lang="en">followed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;isAbout">
-		<rdfs:label xml:lang="en">is about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;MTNRegistration"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;MTNOfferProgram"/>
-		<skos:definition xml:lang="en">The registration process for a MTN registers the program ahead of the issue of individual MTN securities.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;isCreationOf">
-		<rdfs:label xml:lang="en">is creation of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-bp-iss-dbti;lifecycleState">
-		<rdfs:label xml:lang="en">lifecycle state</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;resultsIn">
-		<rdfs:label xml:lang="en">results in</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;PotentialTranchedIssueUnderwriter"/>
-	</owl:ObjectProperty>
-	
-	<rdf:Description rdf:about="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Phase"/>
-	</rdf:Description>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
+buxmlns:fibo-bp-iss-muni="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"
+buxmlns:fibo-bp-iss-pmbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"
+buxmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtIssuance</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">General issuance process for issuance of debt instruments. Forms the basis for more detailed issuance processes such as MBS issuance and municipal bonds issue.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;ABSSecuritizationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">a b s securitization process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;AssetPoolCreationProcess">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;followedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;isCreationOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset pool creation process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;CDOSecuritizationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o securitization process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;CompletedDebtsPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;developsInto"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedPoolOfIndividualDebts"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InIssuance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">completed debts pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;CreditCardPoolCreationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit card pool creation process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;DebtInstrumentPoolCreationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt instrument pool creation process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;DebtSecuritizationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt securitization process</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-bp-iss-muni;DebtAuctionProcess"/>
+bubu<owl:disjointWith rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;HomeEquityLineOfCreditPoolCreationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">home equity line of credit pool creation process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;InAssembly">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in assembly</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;InAssemblyDebtsPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;developsInto"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;CompletedDebtsPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InAssembly"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in assembly debts pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;InIssuance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in issuance</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;IssuanceProcessActivity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance process activity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An activity within the process of securities issuance.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;Issued">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;LoanPoolCreationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan pool creation process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;MTNRegistration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;Registration"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;isAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;MTNOfferProgram"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m t n registration</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;MuniIssueUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">muni issue underwriter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which agrees to buy any certificates that are not bought by investors Term origin:DTCC</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;NotYetIssued">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">not yet issued</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;NotYetIssuedDebtsPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;developsInto"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InAssemblyDebtsPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;NotYetIssued"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">not yet issued debts pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool backed security securitization process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;SecuritizationProcessActor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool backed security securitization process actor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;followedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;isCreationOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">retail asset pool creation process</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process by which pools of assets are created. These may then be used in the issue of securities based on those asset pools as underlying.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-dbti;SecuritizationProcessActor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securitization process actor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;announces">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announces</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issue of one or more securities that the announcement pertains to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;assesses">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assesses</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;describes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">describes</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;followedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">followed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-dbti;DebtSecuritizationProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;isAbout">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;MTNRegistration"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;MTNOfferProgram"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The registration process for a MTN registers the program ahead of the issue of individual MTN securities.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;isCreationOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is creation of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-dbti;AssetPoolCreationProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-bp-iss-dbti;lifecycleState">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lifecycle state</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-dbti;resultsIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;PotentialTranchedIssueUnderwriter"/>
+bu</owl:ObjectProperty>
+bu
+bu<rdf:Description rdf:about="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Phase"/>
+bu</rdf:Description>
 
 </rdf:RDF>

--- a/bp/SecuritiesIssuance/EquitiesIPOIssuance.rdf
+++ b/bp/SecuritiesIssuance/EquitiesIPOIssuance.rdf
@@ -1,442 +1,445 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-	<!ENTITY fibo-bp-iss-ipo "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/EquitiesIPOIssuance/">
-	<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bu<!ENTITY fibo-bp-iss-ipo "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/EquitiesIPOIssuance/">
+bu<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/EquitiesIPOIssuance/"
-	xmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-ipo="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/EquitiesIPOIssuance/"
-	xmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/EquitiesIPOIssuance/">
-		<rdfs:label xml:lang="en">EquitiesIPOIssuance</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/EquitiesIPOIssuance/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;AgreeBasisForAllocation">
-		<rdfs:label xml:lang="en">agree basis for allocation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;Allocation">
-		<rdfs:label xml:lang="en">allocation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;AllocationBasisDetails">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">allocation basis details</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;AllocationDetails">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">allocation details</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;AnnounceEquityIssue">
-		<rdfs:label xml:lang="en">announce equity issue</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;ApplicationForShares">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">application for shares</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;AppointAdvisors">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;broker"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;CorporateBroker"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Issuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;lead"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;reportingAccountant"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;ReportingAccountant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">appoint advisors</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;AppointRegistrar">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;registrar"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Registrar"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">appoint registrar</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;AppointSponsor">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;issuer.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Issuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;lead.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">appoint sponsor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;ApproveForFlotation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;listingAuthority.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">approve for flotation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;CorporateBroker">
-		<rdfs:label xml:lang="en">corporate broker</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;EquityAnnouncement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">equity announcement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;Exchange">
-		<rdfs:label xml:lang="en">exchange</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;FilingDetails">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">filing details</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;FormalApprovalForListingAndTrading">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;listingAuthority"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">formal approval for listing and trading</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOFullProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
-		<rdfs:label xml:lang="en">i p o full prospectus</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOPreliminaryProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesFinal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;IPOFullProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">i p o preliminary prospectus</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOProcess">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;hasEnd"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;IPOProcessEnd"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;hasStart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;IPOProcessStart"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">i p o process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOProcessEnd">
-		<rdfs:label xml:lang="en">i p o process end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOProcessStart">
-		<rdfs:label xml:lang="en">i p o process start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOSettlementDetails">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">i p o settlement details</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;IndicationOfInterest">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">indication of interest</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;Issuer">
-		<rdfs:label xml:lang="en">issuer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;Listing">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;listedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Exchange"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">listing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;ListingAuthority">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;mayBe"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Exchange"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">listing authority</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;ListingDetails">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">listing details</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;Marketing">
-		<rdfs:label xml:lang="en">marketing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;MarketingOfShareIssue">
-		<rdfs:label xml:lang="en">marketing of share issue</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;NoticeOfAllocation">
-		<rdfs:label xml:lang="en">notice of allocation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;OverOrUndersubscirbed">
-		<rdfs:label xml:lang="en">over or undersubscirbed</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;PotentialShareUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialUnderwriter"/>
-		<rdfs:label xml:lang="en">potential share underwriter</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;PublishInitialProspectus">
-		<rdfs:label xml:lang="en">publish initial prospectus</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;PurchasePrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">purchase price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;PurchaseUnallocatedStock">
-		<rdfs:label xml:lang="en">purchase unallocated stock</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;ReceiveApplications">
-		<rdfs:label xml:lang="en">receive applications</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;RegisterWithRegulatoryAuthority">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;listingAuthority.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">register with regulatory authority</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;Registrar">
-		<rdfs:label xml:lang="en">registrar</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;RegistrationStatementDocument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">registration statement document</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;ReportingAccountant">
-		<rdfs:label xml:lang="en">reporting accountant</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;SetPrice">
-		<rdfs:label xml:lang="en">set price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;SettlementOfAllocatedShares">
-		<rdfs:label xml:lang="en">settlement of allocated shares</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;ShareRegister">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">share register</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;Sponsor">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;mayBe.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;CorporateBroker"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">sponsor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;SyndicateMember">
-		<rdfs:label xml:lang="en">syndicate member</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-ipo;Underwriting">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;shareUnderwriter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;PotentialShareUnderwriter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;syndicateMember"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;SyndicateMember"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">underwriting</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;broker">
-		<rdfs:label xml:lang="en">broker</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointAdvisors"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;CorporateBroker"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;hasEnd">
-		<rdfs:label xml:lang="en">has end</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;IPOProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;IPOProcessEnd"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;hasStart">
-		<rdfs:label xml:lang="en">has start</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;IPOProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;IPOProcessStart"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;issuer">
-		<rdfs:label xml:lang="en">issuer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointAdvisors"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Issuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;issuer.1">
-		<rdfs:label xml:lang="en">issuer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointSponsor"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Issuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;lead">
-		<rdfs:label xml:lang="en">lead</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointAdvisors"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;lead.1">
-		<rdfs:label xml:lang="en">lead</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointSponsor"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;listedBy">
-		<rdfs:label xml:lang="en">listed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;Listing"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Exchange"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;listingAuthority">
-		<rdfs:label xml:lang="en">listing authority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;FormalApprovalForListingAndTrading"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;listingAuthority.1">
-		<rdfs:label xml:lang="en">listing authority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;RegisterWithRegulatoryAuthority"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;listingAuthority.2">
-		<rdfs:label xml:lang="en">listing authority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;ApproveForFlotation"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;mayBe">
-		<rdfs:label xml:lang="en">may be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Exchange"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;mayBe.1">
-		<rdfs:label xml:lang="en">may be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;CorporateBroker"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;registrar">
-		<rdfs:label xml:lang="en">registrar</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointRegistrar"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Registrar"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;reportingAccountant">
-		<rdfs:label xml:lang="en">reporting accountant</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointAdvisors"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;ReportingAccountant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;shareUnderwriter">
-		<rdfs:label xml:lang="en">share underwriter</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;Underwriting"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;PotentialShareUnderwriter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;syndicateMember">
-		<rdfs:label xml:lang="en">syndicate member</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;Underwriting"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-ipo;SyndicateMember"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
+buxmlns:fibo-bp-iss-ipo="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/EquitiesIPOIssuance/"
+buxmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/EquitiesIPOIssuance/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">EquitiesIPOIssuance</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Issuance process for equity instruments that are issued via an Initial Public Offering (IPO).</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/EquitiesIPOIssuance/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;AgreeBasisForAllocation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agree basis for allocation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;Allocation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;AllocationBasisDetails">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocation basis details</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;AllocationDetails">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocation details</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;AnnounceEquityIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announce equity issue</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;ApplicationForShares">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">application for shares</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;AppointAdvisors">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;broker"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;CorporateBroker"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Issuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;lead"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;reportingAccountant"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;ReportingAccountant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">appoint advisors</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;AppointRegistrar">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;registrar"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Registrar"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">appoint registrar</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;AppointSponsor">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;issuer.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Issuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;lead.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">appoint sponsor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;ApproveForFlotation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;listingAuthority.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">approve for flotation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;CorporateBroker">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate broker</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;EquityAnnouncement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity announcement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;Exchange">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;FilingDetails">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">filing details</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;FormalApprovalForListingAndTrading">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;listingAuthority"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formal approval for listing and trading</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOFullProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i p o full prospectus</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOPreliminaryProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesFinal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;IPOFullProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i p o preliminary prospectus</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOProcess">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;hasEnd"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;IPOProcessEnd"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;hasStart"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;IPOProcessStart"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i p o process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOProcessEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i p o process end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOProcessStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i p o process start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;IPOSettlementDetails">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i p o settlement details</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;IndicationOfInterest">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">indication of interest</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;Issuer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;Listing">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;listedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Exchange"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;ListingAuthority">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;mayBe"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;Exchange"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listing authority</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;ListingDetails">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listing details</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;Marketing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">marketing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;MarketingOfShareIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">marketing of share issue</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;NoticeOfAllocation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notice of allocation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;OverOrUndersubscirbed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">over or undersubscirbed</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;PotentialShareUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialUnderwriter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential share underwriter</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;PublishInitialProspectus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">publish initial prospectus</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;PurchasePrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;PurchaseUnallocatedStock">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase unallocated stock</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;ReceiveApplications">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">receive applications</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;RegisterWithRegulatoryAuthority">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;listingAuthority.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">register with regulatory authority</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;Registrar">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registrar</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;RegistrationStatementDocument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registration statement document</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;ReportingAccountant">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reporting accountant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;SetPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">set price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;SettlementOfAllocatedShares">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement of allocated shares</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;ShareRegister">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share register</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;Sponsor">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;mayBe.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;CorporateBroker"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sponsor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;SyndicateMember">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">syndicate member</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-ipo;Underwriting">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;shareUnderwriter"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;PotentialShareUnderwriter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ipo;syndicateMember"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ipo;SyndicateMember"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriting</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;broker">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">broker</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointAdvisors"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;CorporateBroker"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;hasEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has end</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;IPOProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;IPOProcessEnd"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;hasStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has start</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;IPOProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;IPOProcessStart"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;issuer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointAdvisors"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Issuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;issuer.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointSponsor"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Issuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;lead">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lead</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointAdvisors"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;lead.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lead</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointSponsor"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;listedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;Listing"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Exchange"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;listingAuthority">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listing authority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;FormalApprovalForListingAndTrading"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;listingAuthority.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listing authority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;RegisterWithRegulatoryAuthority"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;listingAuthority.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listing authority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;ApproveForFlotation"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;mayBe">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;ListingAuthority"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Exchange"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;mayBe.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;Sponsor"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;CorporateBroker"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;registrar">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registrar</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointRegistrar"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;Registrar"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;reportingAccountant">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reporting accountant</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;AppointAdvisors"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;ReportingAccountant"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;shareUnderwriter">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share underwriter</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;Underwriting"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;PotentialShareUnderwriter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-ipo;syndicateMember">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">syndicate member</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-ipo;Underwriting"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-ipo;SyndicateMember"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/SecuritiesIssuance/IssuanceDocuments.rdf
+++ b/bp/SecuritiesIssuance/IssuanceDocuments.rdf
@@ -1,362 +1,365 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-		<rdfs:label xml:lang="en">IssuanceDocuments</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;Indenture">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:label xml:lang="en">indenture</rdfs:label>
-		<skos:definition xml:lang="en">A written contract, also known as a &quot;Deed of Trust&quot;, under which bonds and debentures are issued, setting forth maturity date, interest rate, redemption rights, call privileges and other terms. Under the rules of the Trust Indenture Act of 1939, the contract is executed by the issuer and a trustee who acts on behalf of the bondholders.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;IssuanceTrustAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:label xml:lang="en">issuance trust agreement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;OfferingDocument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;ControlDocument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;identifiedAs"/>
-				<owl:allValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityDraftProspectus">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityFinalProspectus">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityIssuanceCertificate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityIssueOrdinance">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityTermSheet">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:allValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;identifiedAs"/>
-				<owl:onClass>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityDraftProspectus">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityFinalProspectus">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityIssuanceCertificate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityIssueOrdinance">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityTermSheet">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:onClass>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;containsTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;OfferingDocumentTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;hasDocumentDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">offering document</rdfs:label>
-		<skos:definition xml:lang="en">The type of document that is required to be sent in an Offering to make the securities in the Offering eligible at (for example) DTC.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;OfferingDocumentTerms">
-		<rdfs:label xml:lang="en">offering document terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms which are contained in the identified IOffering Document and are considered legally binding within the Issuance and Offering process, if they exist.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;OfferingMemorandum">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssueMemorandum"/>
-		<rdfs:label xml:lang="en">offering memorandum</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;PlacementAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:label xml:lang="en">placement agreement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;PrivatePlacementMemorandum">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssueMemorandum"/>
-		<rdfs:label xml:lang="en">private placement memorandum</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;ProspectusTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;ProvisionalTermsDescription"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesOnIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityContractTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">prospectus terms set</rdfs:label>
-		<skos:definition xml:lang="en">A set of terms in a Prospectus which on issue will become the binding Contractual Terms of the Security. For example, Call Terms, Interest Payment Terms.</skos:definition>
-		<skos:editorialNote xml:lang="en">becomes: The terms in the Prospectus become legally binding contractual terms of the Security, at issue. (former property, now a restriction)</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;ProvisionalTermsDescription">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:label xml:lang="en">provisional terms description</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:label xml:lang="en">securities issuance agreement</rdfs:label>
-		<skos:definition xml:lang="en">A formal agreement, deed or contract in respect of some intended securities issuance.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
-		<rdfs:label xml:lang="en">securities issuance communication</rdfs:label>
-		<skos:definition xml:lang="en">A formal memorandum in respect of some securities issuance.</skos:definition>
-		<skos:definition xml:lang="en">A notice, statement, declaration, memorandum or other formal written communication in respect of some securities issue, sent out by or on behalf of the issuers of some intended securities issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceNoticeOfSale">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Notice"/>
-		<rdfs:label xml:lang="en">securities issuance notice of sale</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceOfficialStatement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;FormalStatement"/>
-		<rdfs:label xml:lang="en">securities issuance official statement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssueMemorandum">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
-		<rdfs:label xml:lang="en">securities issue memorandum</rdfs:label>
-		<skos:definition xml:lang="en">A formal memorandum in respect of some securities issuance.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityDraftProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DraftContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesFinal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;hasDraftTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;ProspectusTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;comesIntoEffectAs"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security draft prospectus</rdfs:label>
-		<skos:definition xml:lang="en">The draft prospectus for the issue, as determined prior to marketing the issue. Certain terms in the draft prospectus will be finalized later in the issuance process to become the actual Prospectus. Term origin:DTCC issuance Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityFinalProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Prospectus"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;hasProspectiveTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;ProspectusTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security final prospectus</rdfs:label>
-		<skos:definition xml:lang="en">The final Prospectus for an issue describes the Offer Issue, including facts about the issue itself such as closing dates, and known facts about the securities that will form part of that issue.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Anticipated facts might include expected issue price, yields, pool parameters as appropriate for the type of instrument being issued. Term origin:SMER</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityIssuanceCertificate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Certificate"/>
-		<rdfs:label xml:lang="en">security issuance certificate</rdfs:label>
-		<skos:definition xml:lang="en">A formal agreement, deed or contract in respect of some intended securities issuance.</skos:definition>
-		<skos:definition xml:lang="en">A formal memorandum in respect of some securities issuance.</skos:definition>
-		<skos:definition xml:lang="en">A notice, statement, declaration, memorandum or other formal written communication in respect of some securities issue, sent out by or on behalf of the issuers of some intended securities issue.</skos:definition>
-		<skos:definition xml:lang="en">Certificate as defined in DTCC terms for type of Offering Document. REVIEW: It is not known whether this is the security certificate itself, or a certificate relating to the Offering of a new Security or issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityIssueOrdinance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-cor;Ordinance"/>
-		<rdfs:label xml:lang="en">security issue ordinance</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityTermSheet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;TermsSheet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;hasProvisionalTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;TermsSheetTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security term sheet</rdfs:label>
-		<skos:definition xml:lang="en">A set of written terms for a future financial security setting out legal or contractual rights, obligations and the like, but not (or not yet) forming part of a set of Contractual Terms of the security contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A typical case would be a termsheet in a prospectus, informing potential investors in something, what terms they will expect when the prospectus becomes a formal contract. Note that Termsheet as defined here, being part of the terms of a future contract, refers to the termsheet for the or each individual tranche (i.e. individual contract). In issues with more than one tranche there may well be one document referred to as &quot;the termsheet&quot; but this would legally be several termsheets in the sense used here. Therefore more than one Termsheet may be included in one physical document. Term origin:MBS PoC Reviews</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;SeriesDeclaration">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Declaration"/>
-		<rdfs:label xml:lang="en">series declaration</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;ShareUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityUnderwriter"/>
-		<rdfs:label xml:lang="en">share underwriter</rdfs:label>
-		<skos:definition xml:lang="en">The party which agrees to buy any certificates that are not bought by investors Term origin:SR Modeling</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-doc;TermsSheetTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;ProvisionalTermsDescription"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesOnIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityContractTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">terms sheet terms set</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;becomesFinal">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;becomesFormalizedAs"/>
-		<rdfs:label xml:lang="en">becomes final</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;becomesOnIssue">
-		<rdfs:label xml:lang="en">becomes on issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;ProvisionalTermsDescription"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityContractTerms"/>
-		<skos:definition xml:lang="en">An individual set of terms in a Terms Sheet may become a corresponding set of Terms in an Security. This would happen as part of the Issuance process.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;containsTerms">
-		<rdfs:label xml:lang="en">contains terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-doc;OfferingDocumentTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;definesTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">defines terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityContractTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;documentType">
-		<rdfs:label xml:lang="en">document type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The type of document that is required to be sent in an Offering to make the securities in the Offering eligible at DTC.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;hasDocumentDate">
-		<rdfs:label xml:lang="en">has document date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The date stated in the document, from which the document is considered &apos;Official&apos; or Released.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;hasDraftTerms">
-		<rdfs:label xml:lang="en">has draft terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-doc;ProspectusTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;hasProspectiveTerms">
-		<rdfs:label xml:lang="en">has prospective terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-doc;ProspectusTermsSet"/>
-		<skos:definition xml:lang="en">The final Security Prospectus contains all the Terms which upon issue will become the binding contractual Terms of the Security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;hasProvisionalTerms">
-		<rdfs:label xml:lang="en">has provisional terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-doc;TermsSheetTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;isFinalVersion">
-		<rdfs:label xml:lang="en">is final version</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The version of the document, i.e. whether it is a Draft or a Final version. Note: This is not the revision number, if that exists.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">IssuanceDocuments</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Ontology containing concepts about types of documentation that are used, referred to or generated by aspects of securities issuance processes.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;Indenture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">indenture</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A written contract, also known as a &quot;Deed of Trust&quot;, under which bonds and debentures are issued, setting forth maturity date, interest rate, redemption rights, call privileges and other terms. Under the rules of the Trust Indenture Act of 1939, the contract is executed by the issuer and a trustee who acts on behalf of the bondholders.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;IssuanceTrustAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance trust agreement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;OfferingDocument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;ControlDocument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;identifiedAs"/>
+bubububu<owl:allValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityDraftProspectus">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityFinalProspectus">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityIssuanceCertificate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityIssueOrdinance">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityTermSheet">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:allValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;identifiedAs"/>
+bubububu<owl:onClass>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityDraftProspectus">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityFinalProspectus">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityIssuanceCertificate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityIssueOrdinance">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-doc;SecurityTermSheet">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:onClass>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;containsTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;OfferingDocumentTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;hasDocumentDate"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offering document</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of document that is required to be sent in an Offering to make the securities in the Offering eligible at (for example) DTC.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;OfferingDocumentTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offering document terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms which are contained in the identified IOffering Document and are considered legally binding within the Issuance and Offering process, if they exist.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;OfferingMemorandum">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssueMemorandum"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offering memorandum</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;PlacementAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">placement agreement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;PrivatePlacementMemorandum">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssueMemorandum"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">private placement memorandum</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;ProspectusTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;ProvisionalTermsDescription"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesOnIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityContractTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prospectus terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of terms in a Prospectus which on issue will become the binding Contractual Terms of the Security. For example, Call Terms, Interest Payment Terms.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">becomes: The terms in the Prospectus become legally binding contractual terms of the Security, at issue. (former property, now a restriction)</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;ProvisionalTermsDescription">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">provisional terms description</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issuance agreement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal agreement, deed or contract in respect of some intended securities issuance.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issuance communication</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal memorandum in respect of some securities issuance.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A notice, statement, declaration, memorandum or other formal written communication in respect of some securities issue, sent out by or on behalf of the issuers of some intended securities issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceNoticeOfSale">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Notice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issuance notice of sale</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssuanceOfficialStatement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;FormalStatement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issuance official statement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecuritiesIssueMemorandum">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issue memorandum</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal memorandum in respect of some securities issuance.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityDraftProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DraftContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesFinal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;hasDraftTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;ProspectusTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;comesIntoEffectAs"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security draft prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The draft prospectus for the issue, as determined prior to marketing the issue. Certain terms in the draft prospectus will be finalized later in the issuance process to become the actual Prospectus. Term origin:DTCC issuance Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityFinalProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Prospectus"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;hasProspectiveTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;ProspectusTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security final prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The final Prospectus for an issue describes the Offer Issue, including facts about the issue itself such as closing dates, and known facts about the securities that will form part of that issue.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Anticipated facts might include expected issue price, yields, pool parameters as appropriate for the type of instrument being issued. Term origin:SMER</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityIssuanceCertificate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Certificate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security issuance certificate</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal agreement, deed or contract in respect of some intended securities issuance.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal memorandum in respect of some securities issuance.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A notice, statement, declaration, memorandum or other formal written communication in respect of some securities issue, sent out by or on behalf of the issuers of some intended securities issue.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Certificate as defined in DTCC terms for type of Offering Document. REVIEW: It is not known whether this is the security certificate itself, or a certificate relating to the Offering of a new Security or issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityIssueOrdinance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-cor;Ordinance"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security issue ordinance</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SecurityTermSheet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;TermsSheet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;hasProvisionalTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;TermsSheetTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security term sheet</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of written terms for a future financial security setting out legal or contractual rights, obligations and the like, but not (or not yet) forming part of a set of Contractual Terms of the security contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A typical case would be a termsheet in a prospectus, informing potential investors in something, what terms they will expect when the prospectus becomes a formal contract. Note that Termsheet as defined here, being part of the terms of a future contract, refers to the termsheet for the or each individual tranche (i.e. individual contract). In issues with more than one tranche there may well be one document referred to as &quot;the termsheet&quot; but this would legally be several termsheets in the sense used here. Therefore more than one Termsheet may be included in one physical document. Term origin:MBS PoC Reviews</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;SeriesDeclaration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecuritiesIssuanceCommunication"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Declaration"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">series declaration</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;ShareUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityUnderwriter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share underwriter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which agrees to buy any certificates that are not bought by investors Term origin:SR Modeling</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-doc;TermsSheetTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;ProvisionalTermsDescription"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesOnIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityContractTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">terms sheet terms set</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;becomesFinal">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;becomesFormalizedAs"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes final</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;becomesOnIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes on issue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;ProvisionalTermsDescription"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityContractTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An individual set of terms in a Terms Sheet may become a corresponding set of Terms in an Security. This would happen as part of the Issuance process.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;containsTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contains terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-doc;OfferingDocumentTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;definesTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityContractTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;documentType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">document type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of document that is required to be sent in an Offering to make the securities in the Offering eligible at DTC.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;hasDocumentDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has document date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date stated in the document, from which the document is considered &apos;Official&apos; or Released.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;hasDraftTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has draft terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-doc;ProspectusTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;hasProspectiveTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has prospective terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-doc;ProspectusTermsSet"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The final Security Prospectus contains all the Terms which upon issue will become the binding contractual Terms of the Security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;hasProvisionalTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has provisional terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-doc;TermsSheetTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;isFinalVersion">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is final version</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The version of the document, i.e. whether it is a Draft or a Final version. Note: This is not the revision number, if that exists.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/SecuritiesIssuance/IssuanceProcess.rdf
+++ b/bp/SecuritiesIssuance/IssuanceProcess.rdf
@@ -1,328 +1,331 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
-	<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-	<!ENTITY fibo-bp-iss-muni "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
-	<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
+bu<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bu<!ENTITY fibo-bp-iss-muni "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
+bu<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
-	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-muni="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"
-	xmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
-		<rdfs:label xml:lang="en">IssuanceProcess</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;Announcement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;offeringRequestor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;PotentialIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">announcement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;CompetitiveSaleMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecurityOfferingSaleMethod"/>
-		<rdfs:label xml:lang="en">competitive sale method</rdfs:label>
-		<skos:definition xml:lang="en">No definition</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;IssuanceProcessActivity">
-		<rdfs:label xml:lang="en">issuance process activity</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;NegotiatedSaleMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecurityOfferingSaleMethod"/>
-		<rdfs:label xml:lang="en">negotiated sale method</rdfs:label>
-		<skos:definition xml:lang="en">No definition</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;Offering">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;hasSaleMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecurityOfferingSaleMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;requiredToMakeEligible"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasDistributionType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecurityOfferingDistributionMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;givesRiseTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">offering</rdfs:label>
-		<skos:definition xml:lang="en">The process step of offering a security for issue. This is the making available of a new securities issue through an underwriting.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It is assumed that this exists for all security types as the precise issuance process is defined among the Offering terms. Terms which only exist for specific types of instrument are given as specialized variants of this class of Thing.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;OfferingDocumentInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DocumentInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;pertainsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">offering document information</rdfs:label>
-		<skos:definition xml:lang="en">Information pertaining to the Offering Document but not forming part of it.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;PotentialIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;isPotentialIssuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">potential issuer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;PotentialUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
-		<rdfs:label xml:lang="en">potential underwriter</rdfs:label>
-		<skos:definition xml:lang="en">The entity which will become the underwriter for an issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;PrimaryIdentifierIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
-		<rdfs:label xml:lang="en">primary identifier issuer</rdfs:label>
-		<skos:definition xml:lang="en">The party which formally issues the primary security identifier to the security. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;PrimarySecurityOfferingDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecurityOfferingDistributionMethod"/>
-		<rdfs:label xml:lang="en">primary security offering distribution</rdfs:label>
-		<skos:definition xml:lang="en">The original sale of a company&apos;s securities, in which the proceeds from the sale are received directly by the company.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;SecondarySecurityOfferingDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecurityOfferingDistributionMethod"/>
-		<rdfs:label xml:lang="en">secondary security offering distribution</rdfs:label>
-		<skos:definition xml:lang="en">An Offering of a security which has been previously issued.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;SecuritiesIssuanceProcess">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;produces"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasIssuanceGuarantor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecurityIssuanceGuarantor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasPotentialIssuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;PotentialIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;subscriber.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities issuance process</rdfs:label>
-		<skos:definition xml:lang="en">The process by which a financial security is issued.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor">
-		<rdfs:label xml:lang="en">securities issuance process actor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;SecurityIssuanceGuarantor">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;isIssuanceGuarantor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security issuance guarantor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;SecurityOfferingDistributionMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DistributionMethod"/>
-		<rdfs:label xml:lang="en">security offering distribution method</rdfs:label>
-		<skos:definition xml:lang="en">The distribution type of a securities Offering.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;SecurityOfferingSaleMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;SaleMethod"/>
-		<rdfs:label xml:lang="en">security offering sale method</rdfs:label>
-		<skos:definition xml:lang="en">Method for sale of a new security offering.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-prc;SecurityOfferingType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">security offering type</rdfs:label>
-		<skos:definition xml:lang="en">The way in which a Securities Issue is offered.</skos:definition>
-	</owl:Class>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-bp-iss-prc;documentType">
-		<rdfs:label xml:lang="en">document type</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;expectedClosingDate">
-		<rdfs:label xml:lang="en">expected closing date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Announcement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date on which the transfer of positions to underwriters is expected to take place. This date is provided by underwriters as part of an announcement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;expectedClosingDate.1">
-		<rdfs:label xml:lang="en">expected closing date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date on which the transfer of positions to underwriters is expected to take place. This date is provided by underwriters as part of an announcement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;firstTradeDateAndTime">
-		<rdfs:label xml:lang="en">first trade date and time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">First Date and Time a trade may be executed for this security. All times in Eastern Time Zone only. NOTE: This is a date in the future tense at the time of the Offering.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;formalAwardDateAndTime">
-		<rdfs:label xml:lang="en">formal award date and time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">Date and time the issuer formally accepts a bid for Competitive Issues or, the Date and Time the Bond Purchase Agreement is executed for Negotiated Issues. Time Zone: Include in date/time data or add a term for it?</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;givesRiseTo">
-		<rdfs:label>gives rise to</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;hasSaleMethod">
-		<rdfs:label xml:lang="en">has sale method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecurityOfferingSaleMethod"/>
-		<skos:definition xml:lang="en">Sale Method of the security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-bp-iss-prc;isFinalVersion">
-		<rdfs:label xml:lang="en">is final version</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;isIssuanceGuarantor">
-		<rdfs:label xml:lang="en">is issuance guarantor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;SecurityIssuanceGuarantor"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;isIssueOf">
-		<rdfs:label xml:lang="en">is issue of</rdfs:label>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;isPotentialIssuer">
-		<rdfs:label xml:lang="en">is potential issuer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;PotentialIssuer"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;legalDescription">
-		<rdfs:label xml:lang="en">legal description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The legal description of the Offering, as existing in the Prospectus or Offering statement or another applicable document.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;offeringType">
-		<rdfs:label xml:lang="en">offering type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecurityOfferingType"/>
-		<skos:definition xml:lang="en">The type of Offering.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;pertainsTo">
-		<rdfs:label xml:lang="en">pertains to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;OfferingDocumentInformation"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
-		<skos:definition xml:lang="en">The Offering Document that this information pertains to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;produces">
-		<rdfs:label xml:lang="en">produces</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;refersToIssuanceOf">
-		<rdfs:label xml:lang="en">refers to issuance of</rdfs:label>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;requiredToMakeEligible">
-		<rdfs:label xml:lang="en">required to make eligible</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
+buxmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
+buxmlns:fibo-bp-iss-muni="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"
+buxmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">IssuanceProcess</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">General ontology for the process by which securities are issued. Contains the process features common to all or most securities issuance. These are extended in the process ontologies that are specific to particular types of issuance</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;Announcement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;offeringRequestor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;PotentialIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announcement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;CompetitiveSaleMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecurityOfferingSaleMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">competitive sale method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">No definition</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;IssuanceProcessActivity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance process activity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;NegotiatedSaleMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecurityOfferingSaleMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">negotiated sale method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">No definition</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;Offering">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;hasSaleMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecurityOfferingSaleMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;requiredToMakeEligible"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasDistributionType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecurityOfferingDistributionMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;givesRiseTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offering</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process step of offering a security for issue. This is the making available of a new securities issue through an underwriting.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">It is assumed that this exists for all security types as the precise issuance process is defined among the Offering terms. Terms which only exist for specific types of instrument are given as specialized variants of this class of Thing.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;OfferingDocumentInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DocumentInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;pertainsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offering document information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information pertaining to the Offering Document but not forming part of it.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;PotentialIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;isPotentialIssuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential issuer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;PotentialUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential underwriter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity which will become the underwriter for an issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;PrimaryIdentifierIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary identifier issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which formally issues the primary security identifier to the security. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;PrimarySecurityOfferingDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecurityOfferingDistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary security offering distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The original sale of a company&apos;s securities, in which the proceeds from the sale are received directly by the company.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;SecondarySecurityOfferingDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecurityOfferingDistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secondary security offering distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Offering of a security which has been previously issued.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;SecuritiesIssuanceProcess">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;produces"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasIssuanceGuarantor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecurityIssuanceGuarantor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasPotentialIssuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;PotentialIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;subscriber.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issuance process</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process by which a financial security is issued.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issuance process actor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;SecurityIssuanceGuarantor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;isIssuanceGuarantor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security issuance guarantor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;SecurityOfferingDistributionMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security offering distribution method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The distribution type of a securities Offering.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;SecurityOfferingSaleMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;SaleMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security offering sale method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Method for sale of a new security offering.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-prc;SecurityOfferingType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security offering type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The way in which a Securities Issue is offered.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-bp-iss-prc;documentType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">document type</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;expectedClosingDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expected closing date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Announcement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date on which the transfer of positions to underwriters is expected to take place. This date is provided by underwriters as part of an announcement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;expectedClosingDate.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expected closing date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date on which the transfer of positions to underwriters is expected to take place. This date is provided by underwriters as part of an announcement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;firstTradeDateAndTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first trade date and time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">First Date and Time a trade may be executed for this security. All times in Eastern Time Zone only. NOTE: This is a date in the future tense at the time of the Offering.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;formalAwardDateAndTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formal award date and time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date and time the issuer formally accepts a bid for Competitive Issues or, the Date and Time the Bond Purchase Agreement is executed for Negotiated Issues. Time Zone: Include in date/time data or add a term for it?</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;givesRiseTo">
+bubu<rdfs:label>gives rise to</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;hasSaleMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has sale method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecurityOfferingSaleMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Sale Method of the security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-bp-iss-prc;isFinalVersion">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is final version</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;isIssuanceGuarantor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is issuance guarantor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;SecurityIssuanceGuarantor"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;isIssueOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is issue of</rdfs:label>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;isPotentialIssuer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is potential issuer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;PotentialIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;legalDescription">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The legal description of the Offering, as existing in the Prospectus or Offering statement or another applicable document.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;offeringType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offering type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecurityOfferingType"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of Offering.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;pertainsTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pertains to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;OfferingDocumentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Offering Document that this information pertains to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;produces">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">produces</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;refersToIssuanceOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to issuance of</rdfs:label>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-prc;requiredToMakeEligible">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">required to make eligible</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-prc;Offering"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-doc;OfferingDocument"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/SecuritiesIssuance/IssuanceProcessTerms.rdf
+++ b/bp/SecuritiesIssuance/IssuanceProcessTerms.rdf
@@ -1,580 +1,583 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
-	<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-	<!ENTITY fibo-bp-iss-muni "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-math-qty "https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/">
-	<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
+bu<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bu<!ENTITY fibo-bp-iss-muni "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-math-qty "https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/">
+bu<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-muni="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-math-qty="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/"
-	xmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-		<rdfs:label xml:lang="en">IssuanceProcessTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;AllotmentInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;describesAllotmentOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">allotment information  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Information about the allotment of quantities of the issue to different subscribers. This relates a single instrument allotment against the subscription amounts allotted to each Subscriber.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;IssuanceProgram">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isCollectionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuance program  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A series of issuances over time.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See for example MTN.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;IssuePaymentSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">issue payment schedule  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Schedule for partial payments of an issue.</skos:definition>
-		<skos:editorialNote xml:lang="en">What are the possible forms in which this may be expressed i.e. explicit listing of partial payment amounts and dates, versus specification along the same lines as a coupon schedule (frequency, day/month specification and date roll rules). Assume this is a duplicate of the Partially Paid Issuance Schedule derived from FIBIM. Alternatively, this may be where there is some semantics distinction between debt and equity issue?:</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;IssuePaymentScheduleSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-		<rdfs:label xml:lang="en">issue payment schedule specification  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">no definition</skos:definition>
-		<skos:editorialNote xml:lang="en">This was put in as a kind of &quot;Specified&quot; schedule ahead of the refactoring of schedules and schedule expressions in Jan 2010. We need to determine what is the nature of range of natures of expression of such an issuenac eschedule. In the meantime and in the absence of anything else, this term is redundant. The new term &quot;Issue Payment Schedule&quot; (replacing this which is now a schedule specification), is defined for now as being expressable in any or either form. REVIEW: This looks like possibly a duplicate of the Partially Paid Issuance Schedule derived from FIBIM. Alternatively, this may be where there is some semantics distinction between debt and equity issue?:</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;IssueSubscriptionInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-		<rdfs:label xml:lang="en">issue subscription information  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Information relating to the subscription of the issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;IssuedSecurityIssueInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasPartiallyPaidIssuanceSchedule"/>
-				<owl:allValuesFrom rdf:resource="&fibo-bp-iss-trm;IssuePaymentSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;relatesToSecurity"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issued security issue information</rdfs:label>
-		<terms:description xml:lang="en">FIBIM: &quot;Elements relating to issue preparation/bringing to market (also known as primary market or Initial Public Offering (IPO) issuance) through to issue date.&quot;</terms:description>
-		<skos:definition xml:lang="en">Information about the Issuance of a Security, which is maintained throughout the life of the Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;OfferIssue">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issueOfferingAmount"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;finalStateDescribedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasOfferIdentifier"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/ListedSecurityIdentifier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;offerIssueSeries"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;underwrittenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SecurityUnderwriter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">offer issue  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">An Issue of one or more securities of the same type, as all or part of an Offering of securities to the market.</skos:definition>
-		<skos:editorialNote xml:lang="en">This term is defined as the common concept which brings together MBS deals, Bond With Warrant issues, MTN issues and so on, along with issues of more than one class of share in an equities issue. Many detailed terms have been provided for specific types of issue, most notably Municipal bond issues (from DTCC) and MBS issues from the MBS PoC project. Some of those terms will apply more widely to issues as a whole (like Issuer) while some will not. This may require further review.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;PartiallyPaidIssuanceSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;IssuePaymentSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;expression"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryMeasure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">partially paid issuance schedule  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A Schedule for partial payments of an issue.</skos:definition>
-		<skos:editorialNote xml:lang="en">Model currently assumes that this is always given as a schedule specification (i.e. a set of rules for determining payment events and dates0 and not as an Explicit schedule (a set of discrete dates with details for each). If the latter may be found in prospectuses then they type of schedule needs to be defined as well or instead of this.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;RegistrationInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-		<rdfs:label xml:lang="en">registration information  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Information relating to the registration of a registered security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;SecurityIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractOriginator"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;domiciledIn"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-cty;FederalState"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuerCountryOfRisk"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-cty;Country"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;domicile"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security issuer</rdfs:label>
-		<skos:definition xml:lang="en">A business entity offering securities for sale to investors.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Examples include corporations, investment trusts and government entities.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;SecurityUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
-		<rdfs:label xml:lang="en">security underwriter  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;Subscriber">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;subscribesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">subscriber</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;SubscriptionClosingInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">subscription closing information  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;becomesPartOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">traded instrument issuance process information  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Information on one Security issue, arising from the Issuance Process. Note that one Issuance Process (Offering) may relate to more than on Issue, which itself may be the issue of more than one Traded Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;UnderwriterTakedown">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;UnderwritingProcessDetails"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;underwriterTakedownShares"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;takenDownBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;MuniIssueUnderwriter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">underwriter takedown  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Infomation on Takedown quantity of the security handled by the underwriter (that will be brought into DTC).</skos:definition>
-		<skos:editorialNote xml:lang="en">Question: Do securities issued through processes other than the one formally identified as &quot;Underwriting Process&quot;, have Underwriters? Our research would indicate that agency and non agency MBS issuance processes are not &quot;Underwriting&quot; processes as defined for the DTCC Muni unwriting process, but they do have a step which involves identifying and appointing an underwriter, so the issue is underwritten. It may be that these two processes should be defined as types of (variants on) a more general Underwriting Process, which is itself more general than the one captured separately for DTCC Muni Issuance, which is where this term now lives. Modeling Note: Definition is too DTC specific, from DTCC earliy reviews on Muni process. Need to have a global definition and understanding of this term.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;UnderwritingProcessDetails">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-		<rdfs:label xml:lang="en">underwriting process details  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Information specific to the Underwriting of the Issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;actualClosingDate">
-		<rdfs:label xml:lang="en">actual closing date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The Closing Date for the Issue, recorded after the event.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;announcementDate">
-		<rdfs:label xml:lang="en">announcement date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">Date/time, as announced by the issuer, at which the securities were to be issued and subsequently were issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;appliesTo">
-		<rdfs:label xml:lang="en">applies to  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
-		<skos:definition xml:lang="en">The subscriber about whom this infomation applies.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;becomesPartOf">
-		<rdfs:label xml:lang="en">becomes part of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;comprises">
-		<rdfs:label xml:lang="en">comprises  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;AllotmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;definedAsSecurity">
-		<rdfs:label xml:lang="en">defined as security  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the Security is a Security as defined in relevant Act for the appropriate Jurisdiction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;definedAsSecurity.1">
-		<rdfs:label xml:lang="en">defined as security  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the Security is A Security as defined in Article 8 of the New York Uniform Commercial Code or the equivalent for other Jurisdictions. Known as Article 8 in the NY Jurisdiction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;describesAllotmentOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">describes allotment of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;AllotmentInformation"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;domicile">
-		<rdfs:label xml:lang="en">domicile  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;domiciledIn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;domicile"/>
-		<rdfs:label xml:lang="en">domiciled in state</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;FederalState"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;expression">
-		<rdfs:label xml:lang="en">expression  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;PartiallyPaidIssuanceSchedule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryMeasure"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;finalStateDescribedIn">
-		<rdfs:label xml:lang="en">final state described in  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;firstTradeDate">
-		<rdfs:label xml:lang="en">first trade date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date of the first trade of the security in the secondary market.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;firstTradeSettlementDate">
-		<rdfs:label xml:lang="en">first trade settlement date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date the Issuer and Underwriter exchange money for bonds.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;hasDistributionType">
-		<rdfs:label>has distribution type</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;hasIssuanceInformation">
-		<rdfs:label>has issuance information</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;hasOfferIdentifier">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;isIdentifiedBy"/>
-		<rdfs:label xml:lang="en">has offer identifier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/ListedSecurityIdentifier"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;hasPartiallyPaidIssuanceSchedule">
-		<rdfs:label xml:lang="en">has partially paid issuance schedule  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;IssuePaymentSchedule"/>
-		<skos:definition xml:lang="en">Partially paid issue: Schedule of partial payments and dates.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;identity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">issuer identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
-		<skos:definition xml:lang="en">The identity of the Issuer as a distinct Business Entity.</skos:definition>
-		<skos:editorialNote xml:lang="en">Note that some sources suggest that this can be a non legal entity such as a special purpose vehicle, despite a security being a contract and a contract being expected to be signed by a legal entity. The solution to this mystery is that whatever form the SPV takes, it must be constituted as one or another form of legal entity (corporation, limited liability partnership and so on), and it is as this legal entity that the issuer is a party to the security contract.</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;isCollectionOf">
-		<rdfs:label xml:lang="en">is collection of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuanceProgram"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;isIssueOf">
-		<rdfs:label xml:lang="en">is issue of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issueNominalNumberOfUnits">
-		<rdfs:label xml:lang="en">issue nominal number of units  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Total original quantity of securities issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issueOfferingAmount">
-		<rdfs:label xml:lang="en">issue offering amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Monetary Amount of all securities that are offered through the issue.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issueOfferingUnits">
-		<rdfs:label xml:lang="en">issue offering units  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Quantity of all securities that is offered in an equity or Corporate Bond issue.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issuePrice">
-		<rdfs:label xml:lang="en">issue price  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<skos:definition xml:lang="en">Initial issue price of the security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issuer">
-		<rdfs:label>issuer</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issuerCountryOfRisk">
-		<rdfs:label xml:lang="en">issuer country of risk</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;minimumIssueSubscription">
-		<rdfs:label xml:lang="en">minimum issue subscription  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssueSubscriptionInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-qty;SecuritiesQuantity"/>
-		<skos:definition xml:lang="en">Minimum or incremental denomination required for the transfer or change of ownership of a security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;offerIssueSeries">
-		<rdfs:label xml:lang="en">series  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Uniquely identified collection of securities within an Issue with same Expected Closing Date. The text gives the Series Identifier within the Issuance process. There may be one or more Series within one Issue.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;overAlloted">
-		<rdfs:label xml:lang="en">over alloted  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the subscriber has been over-alloted the requested number of units. REVIEW: Not seen in data terms but implied elsewhere.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;registeredWithRegulator">
-		<rdfs:label xml:lang="en">registered with regulator  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Indicates if the security of the issue has been registered with the Regulator for the appropriate Jurisdiction, pursuant to the relevant Act.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;registeredWithRegulator.1">
-		<rdfs:label xml:lang="en">registered with regulator  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;RegistrationInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the security of the issue has been registered with the appropriate regulator in its jurisdiction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;relatesToSecurity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">relates to security</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<owl:inverseOf rdf:resource="&fibo-bp-iss-trm;hasIssuanceInformation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;securityIssuerDescribedAs">
-		<rdfs:label>security issuer described as</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;series">
-		<rdfs:label xml:lang="en">series  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Series identification for the individual Traded Financial Security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;subscriptionAmount">
-		<rdfs:label xml:lang="en">subscription amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of units of the issue that an individual subscriber is allocated.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;subscriptionPeriod">
-		<rdfs:label xml:lang="en">subscription period  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssueSubscriptionInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">Period during which the security can be subscribed to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;takenDownBy">
-		<rdfs:label xml:lang="en">taken down by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-dbti;MuniIssueUnderwriter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;underwriterTakedownShares">
-		<rdfs:label xml:lang="en">underwriter takedown shares  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Takedown quantity of the security handled by the underwriter (that will be brought into DTC).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;underwrittenBy">
-		<rdfs:label xml:lang="en">underwritten by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;SecurityUnderwriter"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
+buxmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
+buxmlns:fibo-bp-iss-muni="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-math-qty="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/"
+buxmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">IssuanceProcessTerms</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">Ontology for the reference terms used or defined in securities issuance process ontologies. These include the notion of an offer issue and security issue information artifacts.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;AllotmentInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;comprises"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;describesAllotmentOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allotment information  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the allotment of quantities of the issue to different subscribers. This relates a single instrument allotment against the subscription amounts allotted to each Subscriber.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;IssuanceProgram">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isCollectionOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance program  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A series of issuances over time.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">See for example MTN.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;IssuePaymentSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue payment schedule  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Schedule for partial payments of an issue.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">What are the possible forms in which this may be expressed i.e. explicit listing of partial payment amounts and dates, versus specification along the same lines as a coupon schedule (frequency, day/month specification and date roll rules). Assume this is a duplicate of the Partially Paid Issuance Schedule derived from FIBIM. Alternatively, this may be where there is some semantics distinction between debt and equity issue?:</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;IssuePaymentScheduleSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue payment schedule specification  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">no definition</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This was put in as a kind of &quot;Specified&quot; schedule ahead of the refactoring of schedules and schedule expressions in Jan 2010. We need to determine what is the nature of range of natures of expression of such an issuenac eschedule. In the meantime and in the absence of anything else, this term is redundant. The new term &quot;Issue Payment Schedule&quot; (replacing this which is now a schedule specification), is defined for now as being expressable in any or either form. REVIEW: This looks like possibly a duplicate of the Partially Paid Issuance Schedule derived from FIBIM. Alternatively, this may be where there is some semantics distinction between debt and equity issue?:</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;IssueSubscriptionInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue subscription information  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information relating to the subscription of the issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;IssuedSecurityIssueInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasPartiallyPaidIssuanceSchedule"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-bp-iss-trm;IssuePaymentSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;relatesToSecurity"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued security issue information</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">FIBIM: &quot;Elements relating to issue preparation/bringing to market (also known as primary market or Initial Public Offering (IPO) issuance) through to issue date.&quot;</terms:description>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the Issuance of a Security, which is maintained throughout the life of the Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;OfferIssue">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issueOfferingAmount"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;finalStateDescribedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasOfferIdentifier"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/ListedSecurityIdentifier"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;offerIssueSeries"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;underwrittenBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SecurityUnderwriter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offer issue  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Issue of one or more securities of the same type, as all or part of an Offering of securities to the market.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This term is defined as the common concept which brings together MBS deals, Bond With Warrant issues, MTN issues and so on, along with issues of more than one class of share in an equities issue. Many detailed terms have been provided for specific types of issue, most notably Municipal bond issues (from DTCC) and MBS issues from the MBS PoC project. Some of those terms will apply more widely to issues as a whole (like Issuer) while some will not. This may require further review.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;PartiallyPaidIssuanceSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;IssuePaymentSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;expression"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryMeasure"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partially paid issuance schedule  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Schedule for partial payments of an issue.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Model currently assumes that this is always given as a schedule specification (i.e. a set of rules for determining payment events and dates0 and not as an Explicit schedule (a set of discrete dates with details for each). If the latter may be found in prospectuses then they type of schedule needs to be defined as well or instead of this.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;RegistrationInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registration information  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information relating to the registration of a registered security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;SecurityIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractOriginator"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;domiciledIn"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-plc-cty;FederalState"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuerCountryOfRisk"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;domicile"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A business entity offering securities for sale to investors.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Examples include corporations, investment trusts and government entities.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;SecurityUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security underwriter  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;Subscriber">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;subscribesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscriber</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;SubscriptionClosingInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;appliesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscription closing information  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;becomesPartOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded instrument issuance process information  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information on one Security issue, arising from the Issuance Process. Note that one Issuance Process (Offering) may relate to more than on Issue, which itself may be the issue of more than one Traded Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;UnderwriterTakedown">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;UnderwritingProcessDetails"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;underwriterTakedownShares"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;takenDownBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;MuniIssueUnderwriter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriter takedown  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Infomation on Takedown quantity of the security handled by the underwriter (that will be brought into DTC).</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Question: Do securities issued through processes other than the one formally identified as &quot;Underwriting Process&quot;, have Underwriters? Our research would indicate that agency and non agency MBS issuance processes are not &quot;Underwriting&quot; processes as defined for the DTCC Muni unwriting process, but they do have a step which involves identifying and appointing an underwriter, so the issue is underwritten. It may be that these two processes should be defined as types of (variants on) a more general Underwriting Process, which is itself more general than the one captured separately for DTCC Muni Issuance, which is where this term now lives. Modeling Note: Definition is too DTC specific, from DTCC earliy reviews on Muni process. Need to have a global definition and understanding of this term.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;UnderwritingProcessDetails">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriting process details  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information specific to the Underwriting of the Issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;actualClosingDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">actual closing date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Closing Date for the Issue, recorded after the event.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;announcementDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announcement date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date/time, as announced by the issuer, at which the securities were to be issued and subsequently were issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;appliesTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applies to  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The subscriber about whom this infomation applies.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;becomesPartOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes part of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;comprises">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">comprises  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;AllotmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;definedAsSecurity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined as security  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Security is a Security as defined in relevant Act for the appropriate Jurisdiction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;definedAsSecurity.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined as security  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Security is A Security as defined in Article 8 of the New York Uniform Commercial Code or the equivalent for other Jurisdictions. Known as Article 8 in the NY Jurisdiction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;describesAllotmentOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">describes allotment of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;AllotmentInformation"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;domicile">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">domicile  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;domiciledIn">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;domicile"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">domiciled in state</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;FederalState"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;expression">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expression  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;PartiallyPaidIssuanceSchedule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryMeasure"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;finalStateDescribedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">final state described in  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;firstTradeDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first trade date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date of the first trade of the security in the secondary market.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;firstTradeSettlementDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first trade settlement date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date the Issuer and Underwriter exchange money for bonds.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;hasDistributionType">
+bubu<rdfs:label>has distribution type</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;hasIssuanceInformation">
+bubu<rdfs:label>has issuance information</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;hasOfferIdentifier">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;isIdentifiedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has offer identifier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/ListedSecurityIdentifier"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;hasPartiallyPaidIssuanceSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has partially paid issuance schedule  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;IssuePaymentSchedule"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Partially paid issue: Schedule of partial payments and dates.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;identity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-lp;JuridicalPerson"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The identity of the Issuer as a distinct Business Entity.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Note that some sources suggest that this can be a non legal entity such as a special purpose vehicle, despite a security being a contract and a contract being expected to be signed by a legal entity. The solution to this mystery is that whatever form the SPV takes, it must be constituted as one or another form of legal entity (corporation, limited liability partnership and so on), and it is as this legal entity that the issuer is a party to the security contract.</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;isCollectionOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is collection of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuanceProgram"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;isIssueOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is issue of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issueNominalNumberOfUnits">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue nominal number of units  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Total original quantity of securities issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issueOfferingAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue offering amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Monetary Amount of all securities that are offered through the issue.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issueOfferingUnits">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue offering units  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Quantity of all securities that is offered in an equity or Corporate Bond issue.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issuePrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue price  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Initial issue price of the security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issuer">
+bubu<rdfs:label>issuer</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;issuerCountryOfRisk">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer country of risk</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;minimumIssueSubscription">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum issue subscription  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssueSubscriptionInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-qty;SecuritiesQuantity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum or incremental denomination required for the transfer or change of ownership of a security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;offerIssueSeries">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">series  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Uniquely identified collection of securities within an Issue with same Expected Closing Date. The text gives the Series Identifier within the Issuance process. There may be one or more Series within one Issue.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;overAlloted">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">over alloted  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the subscriber has been over-alloted the requested number of units. REVIEW: Not seen in data terms but implied elsewhere.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;registeredWithRegulator">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registered with regulator  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Indicates if the security of the issue has been registered with the Regulator for the appropriate Jurisdiction, pursuant to the relevant Act.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;registeredWithRegulator.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registered with regulator  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;RegistrationInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the security of the issue has been registered with the appropriate regulator in its jurisdiction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;relatesToSecurity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to security</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<owl:inverseOf rdf:resource="&fibo-bp-iss-trm;hasIssuanceInformation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;securityIssuerDescribedAs">
+bubu<rdfs:label>security issuer described as</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;series">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">series  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Series identification for the individual Traded Financial Security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;subscriptionAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscription amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;SubscriptionClosingInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of units of the issue that an individual subscriber is allocated.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;subscriptionPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscription period  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;IssueSubscriptionInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Period during which the security can be subscribed to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;takenDownBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">taken down by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-dbti;MuniIssueUnderwriter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;underwriterTakedownShares">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriter takedown shares  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Takedown quantity of the security handled by the underwriter (that will be brought into DTC).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-trm;underwrittenBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwritten by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;SecurityUnderwriter"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/SecuritiesIssuance/MBSIssuance.rdf
+++ b/bp/SecuritiesIssuance/MBSIssuance.rdf
@@ -1,50 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
-	<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-	<!ENTITY fibo-bp-iss-mbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
+bu<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bu<!ENTITY fibo-bp-iss-mbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"
-	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-mbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/">
-		<rdfs:label>MBSIssuance</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-mbs;MBSSecuritizationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcess"/>
-		<rdfs:label>m b s securitization process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-mbs;ProspectusPart">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;ProvisionalTermsDescription"/>
-		<rdfs:label>prospectus part</rdfs:label>
-		<skos:definition>A part or section of a prospectus for a securities issue.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This may for example be a termsheet, information about tranche breakdown and so on. These are defined as separate information entities in as far as each of these has some specific individual relationship to some other information deliverable, such as a draft of each part which is defined in separate process activities but becomes part of the whole prospectus. Term origin:MBS PoC Reviews</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-mbs;includesDetailsAbout">
-		<rdfs:label>includes details about</rdfs:label>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
+buxmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
+buxmlns:fibo-bp-iss-mbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/">
+bubu<rdfs:label>MBSIssuance</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Ontology of the overall process of issuing mortgage backed securities. These are the process elements that are common to different kinds of MBS issuance (agency and private label).</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-mbs;MBSSecuritizationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcess"/>
+bubu<rdfs:label>m b s securitization process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-mbs;ProspectusPart">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;ProvisionalTermsDescription"/>
+bubu<rdfs:label>prospectus part</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">A part or section of a prospectus for a securities issue.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">This may for example be a termsheet, information about tranche breakdown and so on. These are defined as separate information entities in as far as each of these has some specific individual relationship to some other information deliverable, such as a draft of each part which is defined in separate process activities but becomes part of the whole prospectus. Term origin:MBS PoC Reviews</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-mbs;includesDetailsAbout">
+bubu<rdfs:label>includes details about</rdfs:label>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/SecuritiesIssuance/MuniIssuance.rdf
+++ b/bp/SecuritiesIssuance/MuniIssuance.rdf
@@ -1,907 +1,910 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
-	<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-	<!ENTITY fibo-bp-iss-muni "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
-	<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-bp-prc-fcp "https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
+bu<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bu<!ENTITY fibo-bp-iss-muni "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
+bu<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-bp-prc-fcp "https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"
-	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-muni="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"
-	xmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-bp-prc-fcp="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
-		<rdfs:label xml:lang="en">MuniIssuance</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-trm;Subscriber">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;AnnounceSecuritiesIssue">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;announces"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;announcesIssueOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">announce securities issue</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;BondCounsel">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isBondCounsel"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond counsel</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;Correspondent">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;MuniIssuanceProcessParticipant"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;participatesIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">correspondent</rdfs:label>
-		<skos:definition xml:lang="en">A bank, brokerage or other financial institution that is not a direct DTC member. Correspondents rely on direct DTC Participants to perform their DTC settlement services</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;DTCCMember">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;MuniIssuanceProcessParticipant"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;participatesIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">d t c c member</rdfs:label>
-		<skos:definition xml:lang="en">A firm which is a member of DTCC. Note: this Actor may perform any of the Roles described elsewhere in this Issuance model, i.e. the DTCC Member may also be any of the Actors defined. REVIEW: does this apply to ALL the defined Actor types?</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;DebtAuctionProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-		<rdfs:label xml:lang="en">debt auction process</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;DebtIssueOverAllotmentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
-		<rdfs:label xml:lang="en">debt issue over allotment terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms for Change to an Issue Amount for Debt securities</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;DebtOffering">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;Offering"/>
-		<rdfs:label xml:lang="en">debt offering</rdfs:label>
-		<skos:definition xml:lang="en">The process step of offering a Debt security for issue. REVIEW: What terms belong for all Debt and what are for Underwriting only?</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;DebtUnderwritingClosing">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceClosing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;UnderwriterTakedownForDebt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt underwriting closing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasBondCounsel"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;BondCounsel"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;step"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;DebtOffering"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt underwriting issuance process</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-bp-iss-muni;EquityUnderwritingIssuanceProcess"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;Dissemination">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;UnderwritingProcessActivity"/>
-		<rdfs:label xml:lang="en">dissemination</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;DisseminationUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;PotentialMuniUnderwriter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;makesDecisionOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Dissemination"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dissemination underwriter</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;EquityDemutualizationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-		<rdfs:label xml:lang="en">equity demutualization process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;EquityIPOProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;RegisteredSecurityIssuanceProcess"/>
-		<rdfs:label xml:lang="en">equity i p o process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;EquityUnderwritingIssuanceProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;RegisteredSecurityIssuanceProcess"/>
-		<rdfs:label xml:lang="en">equity underwriting issuance process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceAgent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isAgentIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuance agent</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceClosing">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">issuance closing</rdfs:label>
-		<skos:definition xml:lang="en">The process of crediting the DTC participant account on settlement date with the position for the new issue. The overall closing process includes the exchange of funds that happens outside of DTC.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceCreditingParticipant">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isCreditingParticipant"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuance crediting participant</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceFinancialAdvisor">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;advises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuance financial advisor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssuancePrinter">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;prints"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuance printer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceProcessParticipant">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;ProcessParticipant"/>
-		<rdfs:label xml:lang="en">issuance process participant</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceSettlement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">issuance settlement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssueOverAllotmentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;OfferingDocumentTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;maximumOverAllotmentAmount"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issue over allotment terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms for Change to an Issue Amount. A provision in an underwriting agreement, which allows members of the underwriting syndicate to purchase additional shares at the original price.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Also known as a green shoe. Note that this set of terms does not refer to over-allotment as change to a the total issue amount issued to an individual investor. That would require separate but similar terms. FIBIM has &quot;Over Allotment Amount&quot; as an individual term.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssueSecurities">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;isIssueOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issue securities</rdfs:label>
-		<skos:definition xml:lang="en">The issue contains the details of the security/securities that are brought out by an Issuer in an Offering. An issue is a part of the Offering. An issue contains all securities of the same sub issue type for an Issuer as part of it.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;IssuerCounsel">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isIssuerCounsel"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuer counsel</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;MuniDebtOffering">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;DebtOffering"/>
-		<rdfs:label xml:lang="en">muni debt offering</rdfs:label>
-		<skos:definition xml:lang="en">The process step of offering a Municipal Debt security for issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;MuniIssuanceProcessParticipant">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssuanceProcessParticipant"/>
-		<rdfs:label xml:lang="en">muni issuance process participant</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;Obligor">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;obligorTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">obligor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;PayingAgent">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;facilitatesPayment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">paying agent</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;PotentialMuniUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialUnderwriter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;underwrites"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">potential muni underwriter</rdfs:label>
-		<skos:definition xml:lang="en">An intermediary between an issuer of a security and the investing public. An underwriter can either be DTC Participant or Correspondent who would clear the underwriting deal using the Crediting Participant.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;PrivatePlacement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-		<rdfs:label xml:lang="en">private placement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;ProcessParticipant">
-		<rdfs:label xml:lang="en">process participant</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;RegisteredSecurityIssuanceProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;includesStep"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Registration"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">registered security issuance process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;Registration">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;registeredUnder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">registration</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;RemarketingAgent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;facililtatesRemarketing"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">remarketing agent</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;SecuritiesIssuanceContext">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PrimaryMarket"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;refersToIssuanceOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities issuance context</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuance">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;SecuritiesIssuanceContext"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;givesRiseTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssueSecurities"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-prc;refersToIssuanceOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities underwriting issuance</rdfs:label>
-		<skos:definition xml:lang="en">Underwriting, as a method of Securities Issuance.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasAgent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasFinancialAdvisor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssuanceFinancialAdvisor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasIssuerCounsel"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssuerCounsel"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasObligor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Obligor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasPayingAgent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;PayingAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasPrinter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssuancePrinter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasRemarketingAgent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;RemarketingAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasServicer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Servicer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasSubscriber"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasTransferAgent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;TransferAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasTrustee"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Trustee"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;produces"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;UnderwritingProcessDetails"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;requestedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceRequestor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;underwrittenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;PotentialMuniUnderwriter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities underwriting issuance process</rdfs:label>
-		<skos:definition xml:lang="en">The process by which debt instruments are offered to the market by a syndicate of underwriters who underwrite the issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;Servicer">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;services"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">servicer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;TransferAgent">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;facilitatesTransfer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">transfer agent</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;Trustee">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isTrustee"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">trustee</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;UnderwritingIssuanceClosing">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssuanceClosing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">underwriting issuance closing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;UnderwritingIssuanceRequestor">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;requests"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">underwriting issuance requestor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;UnderwritingProcessActivity">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">underwriting process activity</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-muni;UnderwritingProcessActor">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-muni;underwritingProcessActorHasIdentity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-bp-iss-muni;Correspondent">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-bp-iss-muni;DTCCMember">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">underwriting process actor</rdfs:label>
-		<skos:definition xml:lang="en">any actor within the DTYCC Underwriting Process or any other Underwriting Process. Note: At present all these Actors (e.g. Underwriter) are defined simply as Process Actors and not as specializations of this type of Actor. Therefore this Actor is a Union of all of those.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;actualClosingDate">
-		<rdfs:label xml:lang="en">actual closing date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceClosing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date in which closing has been done for the underwriter of a security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;advises">
-		<rdfs:label xml:lang="en">advises</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceFinancialAdvisor"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;announcementComments">
-		<rdfs:label xml:lang="en">announcement comments</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;AnnounceSecuritiesIssue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Free form description of Purpose of Issue, Source of funds etc.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;announcesIssueOf">
-		<rdfs:label xml:lang="en">announces issue of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;AnnounceSecuritiesIssue"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;disseminationDecisionDateAndTime">
-		<rdfs:label xml:lang="en">dissemination decision date and time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Dissemination"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">Date and Time when the Dissemination Underwriter made the Decision about Dissemination.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;facililtatesRemarketing">
-		<rdfs:label xml:lang="en">facililtates remarketing</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;RemarketingAgent"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;facilitatesPayment">
-		<rdfs:label xml:lang="en">facilitates payment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;PayingAgent"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;facilitatesTransfer">
-		<rdfs:label xml:lang="en">facilitates transfer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;TransferAgent"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;formalAwardDateAndTime">
-		<rdfs:label xml:lang="en">formal award date and time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DebtOffering"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">Date and time the issuer formally accepts a bid for Competitive Issues or, the Date and Time the Bond Purchase Agreement is executed for Negotiated Issues. Time Zone: Include in date/time data or add a term for it?</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;givesRiseTo">
-		<rdfs:label>gives rise to</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasAgent">
-		<rdfs:label xml:lang="en">has agent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasBondCounsel">
-		<rdfs:label xml:lang="en">has bond counsel</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;BondCounsel"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasFinancialAdvisor">
-		<rdfs:label xml:lang="en">has financial advisor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;IssuanceFinancialAdvisor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasIssuanceGuarantor">
-		<rdfs:label>has issuance guarantor</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasIssuerCounsel">
-		<rdfs:label xml:lang="en">has issuer counsel</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;IssuerCounsel"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasObligor">
-		<rdfs:label xml:lang="en">has obligor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;Obligor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasPayingAgent">
-		<rdfs:label xml:lang="en">has paying agent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;PayingAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasPotentialIssuer">
-		<rdfs:label>has potential issuer</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasPrinter">
-		<rdfs:label xml:lang="en">has printer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;IssuancePrinter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasRemarketingAgent">
-		<rdfs:label xml:lang="en">has remarketing agent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;RemarketingAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasServicer">
-		<rdfs:label xml:lang="en">has servicer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;Servicer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasSubscriber">
-		<rdfs:label xml:lang="en">has subscriber</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasTransferAgent">
-		<rdfs:label xml:lang="en">has transfer agent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;TransferAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasTrustee">
-		<rdfs:label xml:lang="en">has trustee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;Trustee"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;includesStep">
-		<rdfs:label xml:lang="en">includes step</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;RegisteredSecurityIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;Registration"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isAgentIn">
-		<rdfs:label xml:lang="en">is agent in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isBondCounsel">
-		<rdfs:label xml:lang="en">is bond counsel</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;BondCounsel"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isCreditingParticipant">
-		<rdfs:label xml:lang="en">is crediting participant</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceCreditingParticipant"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isIssuerCounsel">
-		<rdfs:label xml:lang="en">is issuer counsel</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuerCounsel"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isTrustee">
-		<rdfs:label xml:lang="en">is trustee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Trustee"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;issuanceSettlementDate">
-		<rdfs:label xml:lang="en">issuance settlement date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">Settlement date for the initial Issuance transaction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;makesDecisionOn">
-		<rdfs:label xml:lang="en">makes decision on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DisseminationUnderwriter"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;Dissemination"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;maximumOverAllotmentAmount">
-		<rdfs:label xml:lang="en">maximum over allotment amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DebtIssueOverAllotmentTerms"/>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The maximum amount that is available as part of providing the over-allotment option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;maximumOverAllotmentPercentage">
-		<rdfs:label xml:lang="en">maximum over allotment percentage</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The percentage that is available as part of providing the over-allotment option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;maximumOverAllotmentShares">
-		<rdfs:label xml:lang="en">maximum over allotment shares</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The maximum amount of shares that are available as part of providing the over-allotment option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;obligorTo">
-		<rdfs:label xml:lang="en">obligor to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Obligor"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;offeringRequestor">
-		<rdfs:label>offering requestor</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;overAllotmentAvailable">
-		<rdfs:label xml:lang="en">over allotment available</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether an over-allotment option is available for the security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;overAllotmentExpiryPeriodDays">
-		<rdfs:label xml:lang="en">over allotment expiry period days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of calendar days after the closing of initial offering for expiry of over-allotment option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;participatesIn">
-		<rdfs:label xml:lang="en">participates in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;MuniIssuanceProcessParticipant"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;prints">
-		<rdfs:label xml:lang="en">prints</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuancePrinter"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;produces">
-		<rdfs:label xml:lang="en">produces</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;UnderwritingProcessDetails"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;refersTo">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceClosing"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;registeredUnder">
-		<rdfs:label xml:lang="en">registered under</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Registration"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;requestedBy">
-		<rdfs:label xml:lang="en">requested by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceRequestor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;requests">
-		<rdfs:label xml:lang="en">requests</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceRequestor"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;saleMethod">
-		<rdfs:label xml:lang="en">sale method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;MuniDebtOffering"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Sale Method of the security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;services">
-		<rdfs:label xml:lang="en">services</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Servicer"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;step">
-		<rdfs:label xml:lang="en">step</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;DebtOffering"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;subscriber.1">
-		<rdfs:label>subscriber</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;subscribesTo">
-		<rdfs:label xml:lang="en">subscribes to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<skos:definition xml:lang="en">Subscriber responds to marketing / draft propspectus, indicates interest and is allocated shares / debt units based on interest.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;subscribesTo.1">
-		<rdfs:label xml:lang="en">subscribes to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;underwrites">
-		<rdfs:label xml:lang="en">underwrites</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;PotentialMuniUnderwriter"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;underwritingProcessActorHasIdentity">
-		<rdfs:label xml:lang="en">underwriting process actor has identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;UnderwritingProcessActor"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-bp-iss-muni;Correspondent">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-bp-iss-muni;DTCCMember">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;underwrittenBy">
-		<rdfs:label xml:lang="en">underwritten by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-muni;PotentialMuniUnderwriter"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
+buxmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
+buxmlns:fibo-bp-iss-muni="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"
+buxmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-bp-prc-fcp="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">MuniIssuance</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Ontology for the process in which municipal bonds are issued.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MuniIssuance/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-trm;Subscriber">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;AnnounceSecuritiesIssue">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;announces"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;announcesIssueOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announce securities issue</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;BondCounsel">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isBondCounsel"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond counsel</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;Correspondent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;MuniIssuanceProcessParticipant"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;participatesIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">correspondent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bank, brokerage or other financial institution that is not a direct DTC member. Correspondents rely on direct DTC Participants to perform their DTC settlement services</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;DTCCMember">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;MuniIssuanceProcessParticipant"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;participatesIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">d t c c member</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A firm which is a member of DTCC. Note: this Actor may perform any of the Roles described elsewhere in this Issuance model, i.e. the DTCC Member may also be any of the Actors defined. REVIEW: does this apply to ALL the defined Actor types?</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;DebtAuctionProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt auction process</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;DebtIssueOverAllotmentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt issue over allotment terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for Change to an Issue Amount for Debt securities</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;DebtOffering">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;Offering"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt offering</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process step of offering a Debt security for issue. REVIEW: What terms belong for all Debt and what are for Underwriting only?</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;DebtUnderwritingClosing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceClosing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;UnderwriterTakedownForDebt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt underwriting closing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasBondCounsel"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;BondCounsel"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;step"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;DebtOffering"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt underwriting issuance process</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-bp-iss-muni;EquityUnderwritingIssuanceProcess"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;Dissemination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;UnderwritingProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dissemination</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;DisseminationUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;PotentialMuniUnderwriter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;makesDecisionOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Dissemination"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dissemination underwriter</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;EquityDemutualizationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity demutualization process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;EquityIPOProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;RegisteredSecurityIssuanceProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity i p o process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;EquityUnderwritingIssuanceProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;RegisteredSecurityIssuanceProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity underwriting issuance process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceAgent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isAgentIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance agent</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceClosing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance closing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process of crediting the DTC participant account on settlement date with the position for the new issue. The overall closing process includes the exchange of funds that happens outside of DTC.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceCreditingParticipant">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isCreditingParticipant"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance crediting participant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceFinancialAdvisor">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;advises"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance financial advisor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssuancePrinter">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;prints"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance printer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceProcessParticipant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;ProcessParticipant"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance process participant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssuanceSettlement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance settlement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssueOverAllotmentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;OfferingDocumentTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;maximumOverAllotmentAmount"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue over allotment terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for Change to an Issue Amount. A provision in an underwriting agreement, which allows members of the underwriting syndicate to purchase additional shares at the original price.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Also known as a green shoe. Note that this set of terms does not refer to over-allotment as change to a the total issue amount issued to an individual investor. That would require separate but similar terms. FIBIM has &quot;Over Allotment Amount&quot; as an individual term.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssueSecurities">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;isIssueOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue securities</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issue contains the details of the security/securities that are brought out by an Issuer in an Offering. An issue is a part of the Offering. An issue contains all securities of the same sub issue type for an Issuer as part of it.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;IssuerCounsel">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isIssuerCounsel"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer counsel</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;MuniDebtOffering">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;DebtOffering"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">muni debt offering</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process step of offering a Municipal Debt security for issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;MuniIssuanceProcessParticipant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssuanceProcessParticipant"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">muni issuance process participant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;Obligor">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;obligorTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obligor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;PayingAgent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;facilitatesPayment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">paying agent</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;PotentialMuniUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialUnderwriter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;underwrites"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential muni underwriter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An intermediary between an issuer of a security and the investing public. An underwriter can either be DTC Participant or Correspondent who would clear the underwriting deal using the Crediting Participant.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;PrivatePlacement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">private placement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;ProcessParticipant">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">process participant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;RegisteredSecurityIssuanceProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;includesStep"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Registration"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registered security issuance process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;Registration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;registeredUnder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registration</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;RemarketingAgent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;facililtatesRemarketing"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">remarketing agent</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;SecuritiesIssuanceContext">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;PrimaryMarket"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;refersToIssuanceOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issuance context</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;SecuritiesIssuanceContext"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;givesRiseTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssueSecurities"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-prc;refersToIssuanceOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities underwriting issuance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Underwriting, as a method of Securities Issuance.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasAgent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasFinancialAdvisor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssuanceFinancialAdvisor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasIssuerCounsel"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssuerCounsel"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasObligor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Obligor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasPayingAgent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;PayingAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasPrinter"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;IssuancePrinter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasRemarketingAgent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;RemarketingAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasServicer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Servicer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasSubscriber"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasTransferAgent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;TransferAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;hasTrustee"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;Trustee"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;produces"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;UnderwritingProcessDetails"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;requestedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceRequestor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;underwrittenBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;PotentialMuniUnderwriter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities underwriting issuance process</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process by which debt instruments are offered to the market by a syndicate of underwriters who underwrite the issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;Servicer">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;services"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">servicer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;TransferAgent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;facilitatesTransfer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transfer agent</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;Trustee">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;isTrustee"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trustee</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;UnderwritingIssuanceClosing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-muni;IssuanceClosing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriting issuance closing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;UnderwritingIssuanceRequestor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;requests"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriting issuance requestor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;UnderwritingProcessActivity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriting process activity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-muni;UnderwritingProcessActor">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-muni;underwritingProcessActorHasIdentity"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-muni;Correspondent">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-bp-iss-muni;DTCCMember">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriting process actor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">any actor within the DTYCC Underwriting Process or any other Underwriting Process. Note: At present all these Actors (e.g. Underwriter) are defined simply as Process Actors and not as specializations of this type of Actor. Therefore this Actor is a Union of all of those.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;actualClosingDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">actual closing date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceClosing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date in which closing has been done for the underwriter of a security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;advises">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">advises</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceFinancialAdvisor"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;announcementComments">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announcement comments</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;AnnounceSecuritiesIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Free form description of Purpose of Issue, Source of funds etc.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;announcesIssueOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announces issue of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;AnnounceSecuritiesIssue"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;disseminationDecisionDateAndTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dissemination decision date and time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Dissemination"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date and Time when the Dissemination Underwriter made the Decision about Dissemination.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;facililtatesRemarketing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">facililtates remarketing</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;RemarketingAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;facilitatesPayment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">facilitates payment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;PayingAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;facilitatesTransfer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">facilitates transfer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;TransferAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;formalAwardDateAndTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formal award date and time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DebtOffering"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date and time the issuer formally accepts a bid for Competitive Issues or, the Date and Time the Bond Purchase Agreement is executed for Negotiated Issues. Time Zone: Include in date/time data or add a term for it?</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;givesRiseTo">
+bubu<rdfs:label>gives rise to</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasAgent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has agent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasBondCounsel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has bond counsel</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;BondCounsel"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasFinancialAdvisor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has financial advisor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;IssuanceFinancialAdvisor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasIssuanceGuarantor">
+bubu<rdfs:label>has issuance guarantor</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasIssuerCounsel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has issuer counsel</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;IssuerCounsel"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasObligor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has obligor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;Obligor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasPayingAgent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has paying agent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;PayingAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasPotentialIssuer">
+bubu<rdfs:label>has potential issuer</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasPrinter">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has printer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;IssuancePrinter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasRemarketingAgent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has remarketing agent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;RemarketingAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasServicer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has servicer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;Servicer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasSubscriber">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has subscriber</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasTransferAgent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has transfer agent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;TransferAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;hasTrustee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has trustee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;Trustee"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;includesStep">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes step</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;RegisteredSecurityIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;Registration"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isAgentIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is agent in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isBondCounsel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is bond counsel</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;BondCounsel"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isCreditingParticipant">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is crediting participant</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceCreditingParticipant"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isIssuerCounsel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is issuer counsel</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuerCounsel"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;isTrustee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is trustee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Trustee"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;issuanceSettlementDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuance settlement date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuanceSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Settlement date for the initial Issuance transaction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;makesDecisionOn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">makes decision on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DisseminationUnderwriter"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;Dissemination"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;maximumOverAllotmentAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum over allotment amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DebtIssueOverAllotmentTerms"/>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The maximum amount that is available as part of providing the over-allotment option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;maximumOverAllotmentPercentage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum over allotment percentage</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage that is available as part of providing the over-allotment option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;maximumOverAllotmentShares">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum over allotment shares</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The maximum amount of shares that are available as part of providing the over-allotment option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;obligorTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obligor to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Obligor"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;offeringRequestor">
+bubu<rdfs:label>offering requestor</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;overAllotmentAvailable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">over allotment available</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether an over-allotment option is available for the security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;overAllotmentExpiryPeriodDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">over allotment expiry period days</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssueOverAllotmentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of calendar days after the closing of initial offering for expiry of over-allotment option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;participatesIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">participates in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;MuniIssuanceProcessParticipant"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;prints">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prints</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;IssuancePrinter"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;produces">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">produces</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;UnderwritingProcessDetails"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;refersTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceClosing"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;registeredUnder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registered under</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Registration"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;requestedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requested by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceRequestor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;requests">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requests</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;UnderwritingIssuanceRequestor"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;saleMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sale method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;MuniDebtOffering"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Sale Method of the security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;services">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">services</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;Servicer"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;step">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">step</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;DebtUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;DebtOffering"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;subscriber.1">
+bubu<rdfs:label>subscriber</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;subscribesTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscribes to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Subscriber responds to marketing / draft propspectus, indicates interest and is allocated shares / debt units based on interest.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;subscribesTo.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscribes to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-trm;Subscriber"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;underwrites">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwrites</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;PotentialMuniUnderwriter"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;underwritingProcessActorHasIdentity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriting process actor has identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;UnderwritingProcessActor"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-bp-iss-muni;Correspondent">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-bp-iss-muni;DTCCMember">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-muni;underwrittenBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwritten by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-muni;SecuritiesUnderwritingIssuanceProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-muni;PotentialMuniUnderwriter"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/bp/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
+++ b/bp/SecuritiesIssuance/PrivateLabelMBSIssuance.rdf
@@ -1,868 +1,871 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-ambs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/">
-	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
-	<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-	<!ENTITY fibo-bp-iss-mbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/">
-	<!ENTITY fibo-bp-iss-pmbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/">
-	<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
-	<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-ambs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/">
+bu<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
+bu<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bu<!ENTITY fibo-bp-iss-mbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/">
+bu<!ENTITY fibo-bp-iss-pmbs "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/">
+bu<!ENTITY fibo-bp-iss-prc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
+bu<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"
-	xmlns:fibo-bp-iss-ambs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/"
-	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-mbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"
-	xmlns:fibo-bp-iss-pmbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"
-	xmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
-	xmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/">
-		<rdfs:label xml:lang="en">PrivateLabelMBSIssuance</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;AllocatePrimaryIdentifier">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">allocate primary identifier</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;AllocateRatings">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">allocate ratings</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;AssessPoolSuitabilityForIssuance">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;isAssessmentOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;InAssemblyMortgagePool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">assess pool suitability for issuance</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;AssessRatings">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">assess ratings</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;BrokerDealer">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;commitsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">broker dealer</rdfs:label>
-		<skos:definition xml:lang="en">An entity which may become a primary investor in the issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;CloseDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;resultsIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;resultsInPublicationOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;RemittanceReport"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">close deal</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;DefineNotesParameters">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;resultsIn.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">define notes parameters</rdfs:label>
-		<skos:definition xml:lang="en">the denom of the notes</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;DefinePoolCharacteristics">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;isDefiningOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;NotYetIssuedNonAgencyMortgagePool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">define pool characteristics</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DraftDocumentPart"/>
-		<rdfs:label xml:lang="en">draft tranche notes parameters</rdfs:label>
-		<skos:definition xml:lang="en">Draft of set of information defining the notes breakdown of one tranche. covers denominations and amounts that you can byu of the instrument in this tranche. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;DraftTrancheStructure">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DraftDocumentPart"/>
-		<rdfs:label xml:lang="en">draft tranche structure</rdfs:label>
-		<skos:definition xml:lang="en">Draft of set of information defining the tranches in the tranched issue and how these relate to one another. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;DraftTrancheTermsheet">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
-		<rdfs:label xml:lang="en">draft tranche termsheet</rdfs:label>
-		<skos:definition xml:lang="en">Draft of set of information defining one tranche of a tranched issue. This will become the termsheet of an individual tranche within that issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;DrawUpOfferingMemorandum">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">draw up offering memorandum</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;DrawUpTrancheTermsheets">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;requires"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">draw up tranche termsheets</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;FinalizePoolContent">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;finalizes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;InIssuanceNonAgencyMortgagePool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">finalize pool content</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;FinalizeProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;resultsIn.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">finalize prospectus</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;commitmentBasedOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedDraftProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasResource"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasResource.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">get commitment from investors</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;IdentifyConformingMortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">identify conforming mortgage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;IdentifyUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;resultsIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;PotentialTranchedIssueUnderwriter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">identify underwriter</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;InAssemblyMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InAssembly"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">in assembly mortgage pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;InIssuanceNonAgencyMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InIssuance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">in issuance non agency mortgage pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;IndividualTrancheDefinitions">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSIssueProspectusPart"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;definesTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;definesTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">individual tranche definitions</rdfs:label>
-		<skos:definition xml:lang="en">In reality there is one termsheet that has sets of information for the terms for each Tranche. This class of information identifies the terms of one tranche, but it does not exist as a separate document in its own right. Further Notes ? We may need to firm up the relationship between the individual tranche termsheet and the information about the relationships among these (some of which are quite complex) and the terms that are common to more than one tranche. In practice these may be separate sections of one document. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;Investor">
-		<rdfs:label xml:lang="en">investor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;MBSSecuritizationEnd">
-		<rdfs:label xml:lang="en">m b s securitization end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;MBSSecuritizationStart">
-		<rdfs:label xml:lang="en">m b s securitization start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;MakeSecuritiesAvailableInMarket">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;isIssueOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;requires.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">make securities available in market</rdfs:label>
-		<skos:definition xml:lang="en">What happens here? e.g. notices / marketing (phone calls) Structured Finance: There&apos;s not really notices in the newspaper, it&apos;s a very small market and it&apos;s all based on relationships so there&apos;s no public notice. So you would get an email from the sales person at the bank who has just closed the deal and is now selling these (this bank is the broker/dealer who bought it?) There&apos;s not really much of a secondary market - the initial investors would often hold on to these. There is something around Bloomberg - you can go there and see what&apos;s available, if someone has a number of notes from a iven tranche, that they are willing to sell. So there&apos;s no transpoarency (!!) Sales would be OTC but less transparent e.g. if you look up a normal OTC stock, you would be able to see more of this information, than in these (non Agency) MBS issues and other SF. DOES THIS APPLY IN ALL MBS??.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;MarketIssueToPrimaryInvestors">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasResource.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">market issue to primary investors</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;NonAgencyPoolCreationEnd">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;flow"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;MBSSecuritizationStart"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">non agency pool creation end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;NonAgencyPoolCreationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
-		<rdfs:label xml:lang="en">non agency pool creation process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;NonAgencyPoolCreationStart">
-		<rdfs:label xml:lang="en">non agency pool creation start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;NotYetIssuedNonAgencyMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;NotYetIssued"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">not yet issued non agency mortgage pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;NumberingAgency">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;allocatesIdentifier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AllocatePrimaryIdentifier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;allocatesIdentifier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AllocatePrimaryIdentifier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">numbering agency</rdfs:label>
-		<skos:definition xml:lang="en">The agency which will provide the primary securitiy identifier for the security. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection">
-		<rdfs:label xml:lang="en">PoolLifecycleStateSelection</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;PoolReadyForIssue">
-		<rdfs:label xml:lang="en">pool ready for issue</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-bp-iss-pmbs;FinalizePoolContent">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-bp-iss-pmbs;IdentifyConformingMortgage">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;PoolTrustee">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;mayBecome"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSIssueUnderwriter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool trustee</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;PotentialMBSInvestor">
-		<rdfs:label xml:lang="en">potential m b s investor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;PotentialNonAgencyMBSIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AssessPoolSuitabilityForIssuance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AssessRatings"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">potential non agency m b s issuer</rdfs:label>
-		<skos:definition xml:lang="en">The entity which will become the issuing party for the Tranched MBS Issue. This entity is the principal actor in most of the activities involved in the issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;PotentialTranchedIssueUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialUnderwriter"/>
-		<rdfs:label xml:lang="en">potential tranched issue underwriter</rdfs:label>
-		<skos:definition xml:lang="en">The entity which will become the underwriter for the tranched MBS issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;PrimaryInvestor">
-		<rdfs:label xml:lang="en">primary investor</rdfs:label>
-		<skos:definition xml:lang="en">A party which becomes the primary investor in the issue, by purchasing some of the tranches of the issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;PurchaseMortgageIntoPool">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;addsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;InAssemblyMortgagePool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;isPurchaseOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">purchase mortgage into pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;RatingsAgency">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;allocatesRatings"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AllocateRatings"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">ratings agency</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;RatingsSuitableForIssue">
-		<rdfs:label xml:lang="en">ratings suitable for issue</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-bp-iss-pmbs;DrawUpOfferingMemorandum">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-bp-iss-pmbs;DrawUpTrancheTermsheets">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;RegisterSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
-		<rdfs:label xml:lang="en">register security</rdfs:label>
-		<skos:definition xml:lang="en">After the deal is closed the security is formally registered with some registraton authority This is the &quot;official&quot; bit - there is not a separate &quot;Issue&quot; activity which is official ?????</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;RemittanceReport">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;ReportDocument"/>
-		<rdfs:label xml:lang="en">remittance report</rdfs:label>
-		<skos:definition xml:lang="en">Report containing a specific and limited set of information about the Deal. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TrancheNotesParameters">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSIssueProspectusPart"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;maximumAmount"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;describes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MBSTrancheNote"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tranche notes parameters</rdfs:label>
-		<skos:definition xml:lang="en">One set of information defining the notes breakdown of one tranche. Covers denominations and amounts that you can byu of the instrument in this tranche. Q: Is this really defined in the prospectus? A: yes The prospectus lists the characteristics including e.g. &quot;The notes will be sold in denominations of X AND Increuemtns of Y e.g. $250 000 incremented by $1000. Parameters include: Denominations Minimum amounts what else? Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TrancheStructureAndTermsheet">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSIssueProspectusPart"/>
-		<rdfs:label xml:lang="en">tranche structure and termsheet</rdfs:label>
-		<terms:description xml:lang="en">The termsheet with the terms for individual tranches is a separate component, known as the Tranche Termsheet or Individual Tranche Definitions. These may in practice be in one sheet or document deliverable but is a set of termsheets defining the terms for the set of tranches. Term origin:MBS PoC Reviews</terms:description>
-		<skos:definition xml:lang="en">One sheet defining the MBS structure.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedDraftProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesFinal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tranched draft prospectus</rdfs:label>
-		<skos:definition xml:lang="en">The draft prospectus for a tranched Mortgage Backed Securities issue, as determined by the issuing entity prior to marketing the issue. Certain terms in the draft prospectus will be finalized later in the issuance process to become the actual Prospectus. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSDealSettlement">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;decomposesInto"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSPrimaryDealTransactionSettlementProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tranched m b s deal settlement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialPrimaryMarketTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasCounterparty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;PrimaryInvestor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;follows"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSPrimaryDealTransactionSettlementProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tranched m b s deal transaction</rdfs:label>
-		<skos:definition xml:lang="en">The deal transaction by which the MBS Issue is issued to primary investors. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSIssueProspectusPart">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-mbs;ProspectusPart"/>
-		<rdfs:label xml:lang="en">tranched m b s issue prospectus part</rdfs:label>
-		<skos:definition xml:lang="en">A part or section of a prospectus for a tranched mortgage backed securities issue. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSPrimaryDealTransactionSettlementProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;SettlementProcess"/>
-		<rdfs:label xml:lang="en">tranched m b s primary deal transaction settlement process</rdfs:label>
-		<skos:definition xml:lang="en">The process by which the primary deal transaction is settled. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSProspectusOutline">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasContent.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheTermsheet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;documentBecomesDocument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedDraftProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tranched m b s prospectus outline</rdfs:label>
-		<skos:definition xml:lang="en">An outline of the tranched prospectus, provind an intial representation of the possible tranches and their features. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSSecuritizationProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-mbs;MBSSecuritizationProcess"/>
-		<rdfs:label xml:lang="en">tranched m b s securitization process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;mayIncludeDetailsAbout"/>
-				<owl:onClass rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;includesDetailsAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TrancheStructureAndTermsheet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;includesDetailsAbout.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;IndividualTrancheDefinitions"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tranched offering memorandum</rdfs:label>
-		<terms:description xml:lang="en">The Offering Memorandum will include or attach the terms for two or more individual tranches that will make up the issue, and the structure of the tranches, including how they will relate to one another (priorities and so on). Term origin:MBS PoC Reviews</terms:description>
-		<skos:definition xml:lang="en">The offering memorandum for a tranched MBS issue, setting out basic information about a future issue, for the information of prospective investors and their agents.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;addsTo">
-		<rdfs:label xml:lang="en">adds to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;PurchaseMortgageIntoPool"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;InAssemblyMortgagePool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;allocatesIdentifier">
-		<rdfs:label xml:lang="en">allocates identifier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;NumberingAgency"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;AllocatePrimaryIdentifier"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;allocatesRatings">
-		<rdfs:label xml:lang="en">allocates ratings</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;RatingsAgency"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;AllocateRatings"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;commitmentBasedOn">
-		<rdfs:label xml:lang="en">commitment based on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TranchedDraftProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;commitsTo">
-		<rdfs:label xml:lang="en">commits to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;BrokerDealer"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;decomposesInto">
-		<rdfs:label xml:lang="en">decomposes into</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealSettlement"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSPrimaryDealTransactionSettlementProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;denominationIncrement">
-		<rdfs:label xml:lang="en">denomination increment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TrancheNotesParameters"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;describes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">describes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TrancheNotesParameters"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MBSTrancheNote"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;finalizes.1">
-		<rdfs:label xml:lang="en">finalizes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;FinalizePoolContent"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;InIssuanceNonAgencyMortgagePool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;flow">
-		<rdfs:label xml:lang="en">flow</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;NonAgencyPoolCreationEnd"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;MBSSecuritizationStart"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasContent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;hsaPart"/>
-		<rdfs:label xml:lang="en">has content</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSProspectusOutline"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheStructure"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasContent.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;hsaPart"/>
-		<rdfs:label xml:lang="en">has content</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSProspectusOutline"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheTermsheet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasCounterparty">
-		<rdfs:label xml:lang="en">has counterparty</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;PrimaryInvestor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasPrimaryHolder">
-		<rdfs:label xml:lang="en">has primary holder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;PrimaryInvestor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasPrincipalParty">
-		<rdfs:label xml:lang="en">has principal party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMBSIssuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasResource">
-		<rdfs:label xml:lang="en">has resource</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasResource.1">
-		<rdfs:label xml:lang="en">has resource</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;MarketIssueToPrimaryInvestors"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasResource.2">
-		<rdfs:label xml:lang="en">has resource</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasTrustee">
-		<rdfs:label xml:lang="en">has trustee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;PoolTrustee"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;identifierIssuedBy">
-		<rdfs:label xml:lang="en">identifier issued by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-prc;PrimaryIdentifierIssuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;includesDetailsAbout">
-		<rdfs:label xml:lang="en">includes details about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TrancheStructureAndTermsheet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;includesDetailsAbout.1">
-		<rdfs:label xml:lang="en">includes details about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;IndividualTrancheDefinitions"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;isAssessmentOf">
-		<rdfs:label xml:lang="en">is assessment of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;AssessPoolSuitabilityForIssuance"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;InAssemblyMortgagePool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;isDefiningOf">
-		<rdfs:label xml:lang="en">isDefiningOf</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;DefinePoolCharacteristics"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;NotYetIssuedNonAgencyMortgagePool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;isIssueOf">
-		<rdfs:label xml:lang="en">is issue of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;MakeSecuritiesAvailableInMarket"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;isPurchaseOf">
-		<rdfs:label xml:lang="en">is purchase of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;PurchaseMortgageIntoPool"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;maximumAmount">
-		<rdfs:label xml:lang="en">maximum amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TrancheNotesParameters"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">This has not been seen - incliuded as it&apos;s implicit but we might want to get rid of this. ACTION: Look at example prospectus document, mark up against this model; if this item is not seen, we could remove it</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;mayBecome">
-		<rdfs:label xml:lang="en">may become</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;PoolTrustee"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSIssueUnderwriter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;mayIncludeDetailsAbout">
-		<rdfs:label xml:lang="en">may include details about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;minimumDenomination">
-		<rdfs:label xml:lang="en">minimum denomination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TrancheNotesParameters"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;refersTo">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;IdentifyConformingMortgage"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;requires">
-		<rdfs:label xml:lang="en">requires</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;DrawUpTrancheTermsheets"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;requires.1">
-		<rdfs:label xml:lang="en">requires</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;MakeSecuritiesAvailableInMarket"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;resultsIn">
-		<rdfs:label xml:lang="en">results in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;CloseDeal"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;resultsIn.1">
-		<rdfs:label xml:lang="en">results in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;DefineNotesParameters"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;resultsIn.2">
-		<rdfs:label xml:lang="en">results in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;FinalizeProspectus"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;resultsInPublicationOf">
-		<rdfs:label xml:lang="en">results in publication of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;CloseDeal"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;RemittanceReport"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasTrustee"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;PoolTrustee"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-ambs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/"
+buxmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
+buxmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
+buxmlns:fibo-bp-iss-mbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"
+buxmlns:fibo-bp-iss-pmbs="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"
+buxmlns:fibo-bp-iss-prc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
+buxmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">PrivateLabelMBSIssuance</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">Process ontology for the process of issuance (securitization) of mortgage backed securities by commercial institutions rather than by government agencies.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/AgencyMBSIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcess/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/MBSIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;AllocatePrimaryIdentifier">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocate primary identifier</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;AllocateRatings">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocate ratings</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;AssessPoolSuitabilityForIssuance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;isAssessmentOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;InAssemblyMortgagePool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assess pool suitability for issuance</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;AssessRatings">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assess ratings</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;BrokerDealer">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;commitsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">broker dealer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An entity which may become a primary investor in the issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;CloseDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;resultsIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;resultsInPublicationOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;RemittanceReport"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">close deal</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;DefineNotesParameters">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;resultsIn.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">define notes parameters</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">the denom of the notes</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;DefinePoolCharacteristics">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;isDefiningOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;NotYetIssuedNonAgencyMortgagePool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">define pool characteristics</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DraftDocumentPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draft tranche notes parameters</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Draft of set of information defining the notes breakdown of one tranche. covers denominations and amounts that you can byu of the instrument in this tranche. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;DraftTrancheStructure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DraftDocumentPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draft tranche structure</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Draft of set of information defining the tranches in the tranched issue and how these relate to one another. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;DraftTrancheTermsheet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draft tranche termsheet</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Draft of set of information defining one tranche of a tranched issue. This will become the termsheet of an individual tranche within that issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;DrawUpOfferingMemorandum">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draw up offering memorandum</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;DrawUpTrancheTermsheets">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;requires"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draw up tranche termsheets</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;FinalizePoolContent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;finalizes.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;InIssuanceNonAgencyMortgagePool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">finalize pool content</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;FinalizeProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;resultsIn.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">finalize prospectus</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;commitmentBasedOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedDraftProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasResource"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasResource.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">get commitment from investors</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;IdentifyConformingMortgage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identify conforming mortgage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;IdentifyUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;resultsIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;PotentialTranchedIssueUnderwriter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identify underwriter</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;InAssemblyMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InAssembly"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in assembly mortgage pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;InIssuanceNonAgencyMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;InIssuance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in issuance non agency mortgage pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;IndividualTrancheDefinitions">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityTermSheet"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSIssueProspectusPart"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;definesTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;definesTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">individual tranche definitions</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">In reality there is one termsheet that has sets of information for the terms for each Tranche. This class of information identifies the terms of one tranche, but it does not exist as a separate document in its own right. Further Notes ? We may need to firm up the relationship between the individual tranche termsheet and the information about the relationships among these (some of which are quite complex) and the terms that are common to more than one tranche. In practice these may be separate sections of one document. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;Investor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;MBSSecuritizationEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m b s securitization end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;MBSSecuritizationStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m b s securitization start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;MakeSecuritiesAvailableInMarket">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;isIssueOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;requires.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">make securities available in market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">What happens here? e.g. notices / marketing (phone calls) Structured Finance: There&apos;s not really notices in the newspaper, it&apos;s a very small market and it&apos;s all based on relationships so there&apos;s no public notice. So you would get an email from the sales person at the bank who has just closed the deal and is now selling these (this bank is the broker/dealer who bought it?) There&apos;s not really much of a secondary market - the initial investors would often hold on to these. There is something around Bloomberg - you can go there and see what&apos;s available, if someone has a number of notes from a iven tranche, that they are willing to sell. So there&apos;s no transpoarency (!!) Sales would be OTC but less transparent e.g. if you look up a normal OTC stock, you would be able to see more of this information, than in these (non Agency) MBS issues and other SF. DOES THIS APPLY IN ALL MBS??.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;MarketIssueToPrimaryInvestors">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasResource.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market issue to primary investors</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;NonAgencyPoolCreationEnd">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;flow"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;MBSSecuritizationStart"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency pool creation end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;NonAgencyPoolCreationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;RetailAssetPoolCreationProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency pool creation process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;NonAgencyPoolCreationStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency pool creation start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;NotYetIssuedNonAgencyMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;NotYetIssued"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">not yet issued non agency mortgage pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;NumberingAgency">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;SecuritiesIssuanceProcessActor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-ambs;allocatesIdentifier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-ambs;AllocatePrimaryIdentifier"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;allocatesIdentifier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AllocatePrimaryIdentifier"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numbering agency</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The agency which will provide the primary securitiy identifier for the security. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;PoolLifecycleStateSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">PoolLifecycleStateSelection</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;PoolReadyForIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool ready for issue</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-bp-iss-pmbs;FinalizePoolContent">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-bp-iss-pmbs;IdentifyConformingMortgage">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;PoolTrustee">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;mayBecome"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSIssueUnderwriter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool trustee</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;PotentialMBSInvestor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential m b s investor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;PotentialNonAgencyMBSIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-dbti;PoolBackedSecuritySecuritizationProcessActor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AssessPoolSuitabilityForIssuance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-dbti;assesses"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AssessRatings"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential non agency m b s issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity which will become the issuing party for the Tranched MBS Issue. This entity is the principal actor in most of the activities involved in the issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;PotentialTranchedIssueUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;PotentialUnderwriter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential tranched issue underwriter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity which will become the underwriter for the tranched MBS issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;PrimaryInvestor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary investor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which becomes the primary investor in the issue, by purchasing some of the tranches of the issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;PurchaseMortgageIntoPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;addsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;InAssemblyMortgagePool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;isPurchaseOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase mortgage into pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;RatingsAgency">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;allocatesRatings"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;AllocateRatings"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ratings agency</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;RatingsSuitableForIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ratings suitable for issue</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-bp-iss-pmbs;DrawUpOfferingMemorandum">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-bp-iss-pmbs;DrawUpTrancheTermsheets">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;RegisterSecurity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-prc;IssuanceProcessActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">register security</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">After the deal is closed the security is formally registered with some registraton authority This is the &quot;official&quot; bit - there is not a separate &quot;Issue&quot; activity which is official ?????</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;RemittanceReport">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;ReportDocument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">remittance report</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Report containing a specific and limited set of information about the Deal. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TrancheNotesParameters">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSIssueProspectusPart"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;maximumAmount"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;describes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MBSTrancheNote"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche notes parameters</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One set of information defining the notes breakdown of one tranche. Covers denominations and amounts that you can byu of the instrument in this tranche. Q: Is this really defined in the prospectus? A: yes The prospectus lists the characteristics including e.g. &quot;The notes will be sold in denominations of X AND Increuemtns of Y e.g. $250 000 incremented by $1000. Parameters include: Denominations Minimum amounts what else? Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TrancheStructureAndTermsheet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSIssueProspectusPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche structure and termsheet</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">The termsheet with the terms for individual tranches is a separate component, known as the Tranche Termsheet or Individual Tranche Definitions. These may in practice be in one sheet or document deliverable but is a set of termsheets defining the terms for the set of tranches. Term origin:MBS PoC Reviews</terms:description>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One sheet defining the MBS structure.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedDraftProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesFinal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched draft prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The draft prospectus for a tranched Mortgage Backed Securities issue, as determined by the issuing entity prior to marketing the issue. Certain terms in the draft prospectus will be finalized later in the issuance process to become the actual Prospectus. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSDealSettlement">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;decomposesInto"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSPrimaryDealTransactionSettlementProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s deal settlement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialPrimaryMarketTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasCounterparty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;PrimaryInvestor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;follows"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSPrimaryDealTransactionSettlementProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s deal transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The deal transaction by which the MBS Issue is issued to primary investors. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSIssueProspectusPart">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-mbs;ProspectusPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s issue prospectus part</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A part or section of a prospectus for a tranched mortgage backed securities issue. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSPrimaryDealTransactionSettlementProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;SettlementProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s primary deal transaction settlement process</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process by which the primary deal transaction is settled. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSProspectusOutline">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasContent.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheTermsheet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;documentBecomesDocument"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TranchedDraftProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s prospectus outline</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An outline of the tranched prospectus, provind an intial representation of the possible tranches and their features. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedMBSSecuritizationProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-mbs;MBSSecuritizationProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s securitization process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;mayIncludeDetailsAbout"/>
+bubububu<owl:onClass rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;includesDetailsAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;TrancheStructureAndTermsheet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;includesDetailsAbout.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;IndividualTrancheDefinitions"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched offering memorandum</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">The Offering Memorandum will include or attach the terms for two or more individual tranches that will make up the issue, and the structure of the tranches, including how they will relate to one another (priorities and so on). Term origin:MBS PoC Reviews</terms:description>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The offering memorandum for a tranched MBS issue, setting out basic information about a future issue, for the information of prospective investors and their agents.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;addsTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">adds to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;PurchaseMortgageIntoPool"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;InAssemblyMortgagePool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;allocatesIdentifier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocates identifier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;NumberingAgency"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;AllocatePrimaryIdentifier"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;allocatesRatings">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocates ratings</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;RatingsAgency"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;AllocateRatings"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;commitmentBasedOn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commitment based on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TranchedDraftProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;commitsTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commits to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;BrokerDealer"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;decomposesInto">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">decomposes into</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSPrimaryDealTransactionSettlementProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;denominationIncrement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination increment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TrancheNotesParameters"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;describes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">describes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TrancheNotesParameters"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MBSTrancheNote"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;finalizes.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">finalizes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;FinalizePoolContent"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;InIssuanceNonAgencyMortgagePool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;flow">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">flow</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;NonAgencyPoolCreationEnd"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;MBSSecuritizationStart"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasContent">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;hsaPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has content</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSProspectusOutline"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheStructure"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasContent.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;hsaPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has content</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSProspectusOutline"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheTermsheet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasCounterparty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has counterparty</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;PrimaryInvestor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasPrimaryHolder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has primary holder</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;PrimaryInvestor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasPrincipalParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has principal party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMBSIssuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasResource">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has resource</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasResource.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has resource</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;MarketIssueToPrimaryInvestors"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasResource.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has resource</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;GetCommitmentFromInvestors"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;hasTrustee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has trustee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;PoolTrustee"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;identifierIssuedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifier issued by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-prc;PrimaryIdentifierIssuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;includesDetailsAbout">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes details about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TrancheStructureAndTermsheet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;includesDetailsAbout.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes details about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;IndividualTrancheDefinitions"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;isAssessmentOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is assessment of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;AssessPoolSuitabilityForIssuance"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;InAssemblyMortgagePool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;isDefiningOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">isDefiningOf</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;DefinePoolCharacteristics"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;NotYetIssuedNonAgencyMortgagePool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;isIssueOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is issue of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;MakeSecuritiesAvailableInMarket"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;isPurchaseOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is purchase of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;PurchaseMortgageIntoPool"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;maximumAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TrancheNotesParameters"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">This has not been seen - incliuded as it&apos;s implicit but we might want to get rid of this. ACTION: Look at example prospectus document, mark up against this model; if this item is not seen, we could remove it</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;mayBecome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may become</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;PoolTrustee"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSIssueUnderwriter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;mayIncludeDetailsAbout">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may include details about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TranchedOfferingMemorandum"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;minimumDenomination">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum denomination</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;TrancheNotesParameters"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;refersTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;IdentifyConformingMortgage"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;requires">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requires</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;DrawUpTrancheTermsheets"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;requires.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requires</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;MakeSecuritiesAvailableInMarket"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;resultsIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;CloseDeal"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;TranchedMBSDealTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;resultsIn.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;DefineNotesParameters"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;DraftTrancheNotesParameters"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;resultsIn.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;FinalizeProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-bp-iss-pmbs;resultsInPublicationOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in publication of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-bp-iss-pmbs;CloseDeal"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-pmbs;RemittanceReport"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-pmbs;hasTrustee"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-pmbs;PoolTrustee"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/cae/CorporateEvents/CorporateActionsEvents.rdf
+++ b/cae/CorporateEvents/CorporateActionsEvents.rdf
@@ -1,2195 +1,2198 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-cae-ce-cae "https://spec.edmcouncil.org/fibo/CAE/CorporateEvents/CorporateActionsEvents/">
-	<!ENTITY fibo-der-rgt-raw "https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-msg "https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/">
-	<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-temx-trs "https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/">
-	<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-	<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-cae-ce-cae "https://spec.edmcouncil.org/fibo/CAE/CorporateEvents/CorporateActionsEvents/">
+bu<!ENTITY fibo-der-rgt-raw "https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-msg "https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/">
+bu<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-temx-trs "https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/">
+bu<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bu<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/CAE/CorporateEvents/CorporateActionsEvents/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-cae-ce-cae="https://spec.edmcouncil.org/fibo/CAE/CorporateEvents/CorporateActionsEvents/"
-	xmlns:fibo-der-rgt-raw="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-msg="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"
-	xmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-temx-trs="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"
-	xmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/CAE/CorporateEvents/CorporateActionsEvents/">
-		<rdfs:label xml:lang="en">CorporateActionsEvents</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/CAE/CorporateEvents/CorporateActionsEvents/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
-		<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AbstentionResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">abstention response</rdfs:label>
-		<skos:definition xml:lang="en">Vote expressed as abstain. In this case, the issuing company will add the number of shares to the quorum of the meeting.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the voting right is not executed, it will not be added to the quorum. In this case the response should be &quot;No Action&quot;. . SWIFT definition Vote expressed as abstain. In this case, the issuing company will add the number of shares to the quorum of the meeting. If the voting right is not executed, it will not be added to the quorum. In this case, code NOAC should be used. SWIFT Code: ABST</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AbstentionResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">abstention response message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AdviceOfAPossibleAction">
-		<rdfs:label xml:lang="en">advice of a possible action</rdfs:label>
-		<skos:definition xml:lang="en">Advice - action voluntary This includes a number of things, it&apos;s not always clear why these things are here.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AllOrNoneChoiceCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
-		<rdfs:label xml:lang="en">all or none choice corporate action</rdfs:label>
-		<skos:definition xml:lang="en">A Mandator Corporate Action with some choice for the Holder, where the Holder&apos;s options are limited to all of the stated choices or none of them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AnnouncementMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:label xml:lang="en">announcement message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AnnualGeneralMeeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
-		<rdfs:label xml:lang="en">annual general meeting</rdfs:label>
-		<skos:definition xml:lang="en">Annual General Meeting. SWIFT = MEET</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AssimilationPariPassu">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">assimilation pari passu</rdfs:label>
-		<skos:definition xml:lang="en">Assimilation. Occurs when securities with different characteristics, eg, shares with different entitlements to dividend or voting rights, become identical in all respects, ie, pari-passu. SWIFT = PARI</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
-		<rdfs:label xml:lang="en">attachment action</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;DetachmentAction"/>
-		<skos:definition xml:lang="en">The combination of different security types to create a unit. Units are usually comprised of warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention. Further NOtes: is there some common term for these (see Detachment event)?; Are there separate scenarios for attachment of different kinds of security. Definition says &quot;usually&quot; Warrant. Probably applies to any fungible securities, whether or not warrants. For example two fungible tranches of a debt issues, that are funged later on in their life. Are these ever notified differently or have different details for warrants, fungible debt etc.? No. the message can relate to any, and the event defined here can be defined in terms of &quot;any&quot; securities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AttachmentOrDetachmentNotificationMessage"/>
-		<rdfs:label xml:lang="en">attachment notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of the combination of different security types to create a unit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Units usually comprise warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention. Examples of automatic ones: If you have a unit with warrants and the warrants expore, they would be detached immediately. Is there a Notification? They would have to break up the unit as the unit no longer exists. Have to deliver off the unit and put the bond back into the client&apos;s account or into you position as an operation. depositories would change the CUSIP from the Unit CUSIP to the Bond CUSIP. Who initiates? The issuer has to do this based on the terms. Attavhment and Detachment also applicable to TRahcnes in CDOs. At some point a tranch might attach at 6 and detach at 10% for example. This might be a corporate action as it is declared when the issue is created - the attachment and deta chment points are specified inthe prospectus for the deal and would not be seen as a corporate action. SWIFT full text: &quot;The combination of different security types to create a unit. Units are usually comprised of warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentOrDetachmentNotificationMessage">
-		<rdfs:label xml:lang="en">attachment or detachment notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an action in which the issuer attaches or detaches securities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BankruptcyEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bankruptcy event</rdfs:label>
-		<skos:definition xml:lang="en">Event in which a legal entity arrives at the legal status whereby it is unable to pay creditors.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Bankruptcy usually involves a formal court ruling. Securities may become valueless. Original SWIFT Definition: &quot;Legal status of a company unable to pay creditors. Bankruptcy usually involves a formal court ruling. Securities may become valueless.&quot; - this definition describes the state of Bankruptcy, not the corresponding Event if there is one. May be a message notification of the state and may not be an event as such - REVIEW</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
-		<rdfs:label xml:lang="en">bond action</rdfs:label>
-		<skos:definition xml:lang="en">Some action in relation to a bond, by the Issuer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondDefaultEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DefaultEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond default event</rdfs:label>
-		<skos:definition xml:lang="en">Non payment of interest or non payment of debt principal when due.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondDefaultNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExPostNotification"/>
-		<rdfs:label xml:lang="en">bond default notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of non payment of interest or non payment of debt principal when due.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an Ex Post notification.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondPutRedemption">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;BondAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PutAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.3"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond put redemption</rdfs:label>
-		<skos:definition xml:lang="en">Early redemption of a bond at the election of the bondholder subject to the terms and condition of the issue.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notification in advance of this happening.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BondPutRedemptionInstruction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
-		<rdfs:label xml:lang="en">bond put redemption instruction</rdfs:label>
-		<skos:definition xml:lang="en">Early redemption of a bond at the election of the bondholder subject to the terms and condition of the issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isIssueOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.4"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bonus issue</rdfs:label>
-		<skos:definition xml:lang="en">Event in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding. These may be from current profits or may be from accumulated reserves of the company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are different taxation rules for the Bonus Issue compared to the Dividend. There could also be a difference in the ranking of the shares that are given, to what the holder already holds. Always announce the event on the ones that they hold, and based on the holding they are given additional shares. They may be of a different ranking. Bonus Issues increase the capital base but not the capital value of the company, since all they are doing is diluting the share capital. Difference from Dividend: Increases holding of shareholder. Other similar terms: Awards; Also see difference between Dividend and Bonus. Dividend is from current profits and bonus may be from accumulated reserves of the company. Separate this into 2 terms. We have: Capitalisation Issue Bonus rights Issue Original SWIFT definition - strippoed out synonyms for the formal definition above: &quot;Attribution Gratuite (FR); Scrip Issue (GB); Capitalisation Issue. Security holders are awarded additional assets free of payment from the issuer in priportion to their holding.&quot; More 25 May A scrip issue is the issue of new shares at no charge pro rata to the holder of existing shares. This means the term Scrip Issue is as modeled here &quot;no charge&quot;. But Capitalization becomes close to this in definition. More detail May 25: No change to the par value of the share so why would there be a change inthe capitaliation? Because from an accountingf point of view they change the value of overall capital of the company - they don&apos;t change the market value of the conpany but the accountants will record an increase in the issued capital of the company. This is the disctinction between nominal capital and the market capital. Nominal - there is more nominal share value.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusIssueNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssueNotification"/>
-		<rdfs:label xml:lang="en">bonus issue notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of event in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These may be from current profits or may be from accumulated reserves of the company. SWIFT definition text: &quot;Attribution Gratuite (FR); Scrip Issue (GB); Capitalisation Issue. Security holders are awarded additional assets free of payment from the issuer in priportion to their holding.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusRightsIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssue"/>
-		<rdfs:label xml:lang="en">bonus rights issue</rdfs:label>
-		<skos:definition xml:lang="en">A Rights Issue in which the rights are given to the holders of the referenced shares for free.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Rights = right to buy shares at a specified price. May be given the right for nothing (Bonus Rights Issue) or you may be offered to purchase that right at a subscription price (which you take up or don&apos;t). Bonus Rights Issue: given the option for free. May exercise at the Exercise Price.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusRightsIssueNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssueNotification"/>
-		<rdfs:label xml:lang="en">bonus rights issue notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a Bonus Rights Issue, that is a Rights Issue in which the rights are given to the holders of the referenced shares for free.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusSharePlanDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
-		<rdfs:label xml:lang="en">bonus share plan distribution</rdfs:label>
-		<skos:definition xml:lang="en">Event in which shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications. SWIFT Definition (adapted above) &quot;Typically found in Australia, shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications.&quot; To be researches further. There are certainly Share Plans in Australia, where you can take a dividend as shares. Thewse would be in the nature of Bonus Shares. They are a tradeoff from cash dividends. Other terms to model: A &quot;Scheme of Arrangment&quot; - does this change the capital reserves or is it just another word for restructure. An arrangement with the company&apos;s debtors, and coule potentially change the capital base by converting the debt to shares (see other diagram note with these in).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;BonusSharePlanDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistributionNotification"/>
-		<rdfs:label xml:lang="en">bonus share plan distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of issue of shares from the Share Premium Reserve of the company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are are considered as a capital distribution rather than a disbursement of income, with different tax implications. Typically found in Australia. SWIFT full text: &quot;Typically found in Australia, shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CallAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">call action</rdfs:label>
-		<skos:definition xml:lang="en">Note this is an Issuer action.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CallMeeting">
-		<rdfs:label xml:lang="en">call meeting</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CancellationOfShares">
-		<rdfs:label xml:lang="en">cancellation of shares</rdfs:label>
-		<skos:definition xml:lang="en">The cancellation of shares. Further Notes Only possible with shares not publicly issued i.e. treasury shares</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryDistribution"/>
-		<rdfs:label xml:lang="en">capital distribution</rdfs:label>
-		<skos:definition xml:lang="en">An action in which capital of the issuing company is distributed. Trem Orign:SME Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">capital distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an action in which capital of the issuing company is distributed.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalReservesDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
-		<rdfs:label xml:lang="en">capital reserves distribution</rdfs:label>
-		<skos:definition xml:lang="en">Distribution of capital reserves of the issuing company. Further Notes Distribution comes from earnings and reduces the capital base. REVIEW: How does this differ from CAPG? That is, does this scenario exist outside of funds capital gains distribution?</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalReservesDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistributionNotification"/>
-		<rdfs:label xml:lang="en">capital reserves distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of distribution of capital reserves of the issuing company.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalizationIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">capitalization issue</rdfs:label>
-		<skos:definition xml:lang="en">A general kind of issue which increases the capital base of the company. Other kinds of issue: Like a Bonus Issue except that it would increase the capital. There could be several events which could be considered as Capitalization Issues. 25 May Later research: Scrip or Bonus issue is seen to be synonymous with this but more accurate. However, we question this - if you have the chance to purchase shares at a particular price (which is a right) would extend the definition of .. 20 July: this could have a broader meaning than Capital reserves Distribution It would include distribution of capital and trying to raise capital by additional capital injection Example: If the company issues bonds, that also changes the capital base. Now to change the capital base, there are two directions, up or down. Bonus issue falls into the above because you are increasing the capital base. A rights issue also increateses the capital base. Distributions of capital has the opposite effect. Paying out cash to reduce those items that are in your reserves. the reserves are greater than you need so you pay out cash on those. Labeling: capitalization implies the creation of capital so only suggests an increase the capital base</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalizationIssueNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">capitalization issue notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an issue which increases the capital base of the company.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashAndSecuritiesResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-		<rdfs:label xml:lang="en">cash and securities response</rdfs:label>
-		<skos:definition xml:lang="en">Response is to take a distribution of both securities and cash as offered.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Term:&quot;Cash and Securities&quot; Definition:&quot;Election choice includes a distribution of both cash and securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashDisbursementResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
-		<rdfs:label xml:lang="en">cash disbursement response message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of response opting to take cash.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Term: &quot;Cash&quot; Definition: &quot;Distribution of cash to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashDividendEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">cash dividend event</rdfs:label>
-		<skos:definition xml:lang="en">Distribution of cash to shareholders, in proportion to their equity holding. Ordinary dividends are recurring and regular. Shareholder must take cash and is not offered a choice in the form of distribution.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">cash dividend notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CashResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-		<rdfs:label xml:lang="en">cash response</rdfs:label>
-		<skos:definition xml:lang="en">Response is to take cash.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: &quot;Distribution of cash to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeInDetailsNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.5"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-le-cb;StockCorporation">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">change in details notification</rdfs:label>
-		<skos:definition xml:lang="en">Information regarding a generic change, eg, change in the terms of an issue, change in the identification of a security, change of board lot, change from global to definitive.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeOfSecurityTradingStatusEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.6"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">change of security trading status event</rdfs:label>
-		<skos:definition xml:lang="en">An event in which the trading status of a tradable security changes.</skos:definition>
-		<skos:editorialNote xml:lang="en">Link this to the State Transition diagram (not yet done).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeOfStateEvent">
-		<rdfs:label xml:lang="en">change of state event</rdfs:label>
-		<skos:definition xml:lang="en">Some event relating to some change of state.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeToSmallestNegotiableUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationAction"/>
-		<rdfs:label xml:lang="en">change to smallest negotiable unit</rdfs:label>
-		<skos:definition xml:lang="en">Modification of the smallest negotiable unit of shares in order to obtain a new negotiable unit. SWIFT:SMAL</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChoiceExists">
-		<rdfs:label xml:lang="en">choice exists</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ChoiceOffer">
-		<rdfs:label xml:lang="en">choice offer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ClassActionProposedSettlementEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ManagementAction"/>
-		<rdfs:label xml:lang="en">class action proposed settlement event</rdfs:label>
-		<skos:definition xml:lang="en">Proposed settlement to a class action filing. Situation where interested parties seek restitution for financial loss.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction. 
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-cae-ce-cae="https://spec.edmcouncil.org/fibo/CAE/CorporateEvents/CorporateActionsEvents/"
+buxmlns:fibo-der-rgt-raw="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-msg="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"
+buxmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-temx-trs="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"
+buxmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
+buxmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/CAE/CorporateEvents/CorporateActionsEvents/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CorporateActionsEvents</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">All corporate events and actions, along with definitions of kinds of message in which those events are communicated.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/CAE/CorporateEvents/CorporateActionsEvents/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+bubu<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AbstentionResponse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">abstention response</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Vote expressed as abstain. In this case, the issuing company will add the number of shares to the quorum of the meeting.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">If the voting right is not executed, it will not be added to the quorum. In this case the response should be &quot;No Action&quot;. . SWIFT definition Vote expressed as abstain. In this case, the issuing company will add the number of shares to the quorum of the meeting. If the voting right is not executed, it will not be added to the quorum. In this case, code NOAC should be used. SWIFT Code: ABST</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AbstentionResponseMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">abstention response message</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AdviceOfAPossibleAction">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">advice of a possible action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Advice - action voluntary This includes a number of things, it&apos;s not always clear why these things are here.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AllOrNoneChoiceCorporateAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">all or none choice corporate action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Mandator Corporate Action with some choice for the Holder, where the Holder&apos;s options are limited to all of the stated choices or none of them.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AnnouncementMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announcement message</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AnnualGeneralMeeting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">annual general meeting</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Annual General Meeting. SWIFT = MEET</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AssimilationPariPassu">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assimilation pari passu</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Assimilation. Occurs when securities with different characteristics, eg, shares with different entitlements to dividend or voting rights, become identical in all respects, ie, pari-passu. SWIFT = PARI</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">attachment action</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;DetachmentAction"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The combination of different security types to create a unit. Units are usually comprised of warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention. Further NOtes: is there some common term for these (see Detachment event)?; Are there separate scenarios for attachment of different kinds of security. Definition says &quot;usually&quot; Warrant. Probably applies to any fungible securities, whether or not warrants. For example two fungible tranches of a debt issues, that are funged later on in their life. Are these ever notified differently or have different details for warrants, fungible debt etc.? No. the message can relate to any, and the event defined here can be defined in terms of &quot;any&quot; securities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentNotificationMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AttachmentOrDetachmentNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">attachment notification message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of the combination of different security types to create a unit.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Units usually comprise warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention. Examples of automatic ones: If you have a unit with warrants and the warrants expore, they would be detached immediately. Is there a Notification? They would have to break up the unit as the unit no longer exists. Have to deliver off the unit and put the bond back into the client&apos;s account or into you position as an operation. depositories would change the CUSIP from the Unit CUSIP to the Bond CUSIP. Who initiates? The issuer has to do this based on the terms. Attavhment and Detachment also applicable to TRahcnes in CDOs. At some point a tranch might attach at 6 and detach at 10% for example. This might be a corporate action as it is declared when the issue is created - the attachment and deta chment points are specified inthe prospectus for the deal and would not be seen as a corporate action. SWIFT full text: &quot;The combination of different security types to create a unit. Units are usually comprised of warrants and bond or warrants and equity. Securities may be combined at the request of the security holder or based on market convention.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;AttachmentOrDetachmentNotificationMessage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">attachment or detachment notification message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an action in which the issuer attaches or detaches securities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BankruptcyEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bankruptcy event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Event in which a legal entity arrives at the legal status whereby it is unable to pay creditors.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Bankruptcy usually involves a formal court ruling. Securities may become valueless. Original SWIFT Definition: &quot;Legal status of a company unable to pay creditors. Bankruptcy usually involves a formal court ruling. Securities may become valueless.&quot; - this definition describes the state of Bankruptcy, not the corresponding Event if there is one. May be a message notification of the state and may not be an event as such - REVIEW</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BondAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some action in relation to a bond, by the Issuer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BondDefaultEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DefaultEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond default event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Non payment of interest or non payment of debt principal when due.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BondDefaultNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExPostNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond default notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of non payment of interest or non payment of debt principal when due.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is an Ex Post notification.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BondPutRedemption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;BondAction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PutAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.3"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond put redemption</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Early redemption of a bond at the election of the bondholder subject to the terms and condition of the issue.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Notification in advance of this happening.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BondPutRedemptionInstruction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond put redemption instruction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Early redemption of a bond at the election of the bondholder subject to the terms and condition of the issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BonusIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isIssueOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.4"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bonus issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Event in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding. These may be from current profits or may be from accumulated reserves of the company.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There are different taxation rules for the Bonus Issue compared to the Dividend. There could also be a difference in the ranking of the shares that are given, to what the holder already holds. Always announce the event on the ones that they hold, and based on the holding they are given additional shares. They may be of a different ranking. Bonus Issues increase the capital base but not the capital value of the company, since all they are doing is diluting the share capital. Difference from Dividend: Increases holding of shareholder. Other similar terms: Awards; Also see difference between Dividend and Bonus. Dividend is from current profits and bonus may be from accumulated reserves of the company. Separate this into 2 terms. We have: Capitalisation Issue Bonus rights Issue Original SWIFT definition - strippoed out synonyms for the formal definition above: &quot;Attribution Gratuite (FR); Scrip Issue (GB); Capitalisation Issue. Security holders are awarded additional assets free of payment from the issuer in priportion to their holding.&quot; More 25 May A scrip issue is the issue of new shares at no charge pro rata to the holder of existing shares. This means the term Scrip Issue is as modeled here &quot;no charge&quot;. But Capitalization becomes close to this in definition. More detail May 25: No change to the par value of the share so why would there be a change inthe capitaliation? Because from an accountingf point of view they change the value of overall capital of the company - they don&apos;t change the market value of the conpany but the accountants will record an increase in the issued capital of the company. This is the disctinction between nominal capital and the market capital. Nominal - there is more nominal share value.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BonusIssueNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssueNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bonus issue notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of event in which security holders are awarded additional assets free of payment from the issuer in proportion to their holding.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These may be from current profits or may be from accumulated reserves of the company. SWIFT definition text: &quot;Attribution Gratuite (FR); Scrip Issue (GB); Capitalisation Issue. Security holders are awarded additional assets free of payment from the issuer in priportion to their holding.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BonusRightsIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bonus rights issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Rights Issue in which the rights are given to the holders of the referenced shares for free.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Rights = right to buy shares at a specified price. May be given the right for nothing (Bonus Rights Issue) or you may be offered to purchase that right at a subscription price (which you take up or don&apos;t). Bonus Rights Issue: given the option for free. May exercise at the Exercise Price.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BonusRightsIssueNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssueNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bonus rights issue notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of a Bonus Rights Issue, that is a Rights Issue in which the rights are given to the holders of the referenced shares for free.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BonusSharePlanDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bonus share plan distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Event in which shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications. SWIFT Definition (adapted above) &quot;Typically found in Australia, shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications.&quot; To be researches further. There are certainly Share Plans in Australia, where you can take a dividend as shares. Thewse would be in the nature of Bonus Shares. They are a tradeoff from cash dividends. Other terms to model: A &quot;Scheme of Arrangment&quot; - does this change the capital reserves or is it just another word for restructure. An arrangement with the company&apos;s debtors, and coule potentially change the capital base by converting the debt to shares (see other diagram note with these in).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;BonusSharePlanDistributionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistributionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bonus share plan distribution notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of issue of shares from the Share Premium Reserve of the company.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are are considered as a capital distribution rather than a disbursement of income, with different tax implications. Typically found in Australia. SWIFT full text: &quot;Typically found in Australia, shares are issued from the Share Premium Reserve of the company and are considered as a capital distribution rather than a disbursement of income, with different tax implications.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CallAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Note this is an Issuer action.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CallMeeting">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call meeting</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CancellationOfShares">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cancellation of shares</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The cancellation of shares. Further Notes Only possible with shares not publicly issued i.e. treasury shares</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">capital distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An action in which capital of the issuing company is distributed. Trem Orign:SME Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalDistributionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">capital distribution notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an action in which capital of the issuing company is distributed.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalReservesDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">capital reserves distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Distribution of capital reserves of the issuing company. Further Notes Distribution comes from earnings and reduces the capital base. REVIEW: How does this differ from CAPG? That is, does this scenario exist outside of funds capital gains distribution?</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalReservesDistributionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistributionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">capital reserves distribution notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of distribution of capital reserves of the issuing company.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalizationIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">capitalization issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A general kind of issue which increases the capital base of the company. Other kinds of issue: Like a Bonus Issue except that it would increase the capital. There could be several events which could be considered as Capitalization Issues. 25 May Later research: Scrip or Bonus issue is seen to be synonymous with this but more accurate. However, we question this - if you have the chance to purchase shares at a particular price (which is a right) would extend the definition of .. 20 July: this could have a broader meaning than Capital reserves Distribution It would include distribution of capital and trying to raise capital by additional capital injection Example: If the company issues bonds, that also changes the capital base. Now to change the capital base, there are two directions, up or down. Bonus issue falls into the above because you are increasing the capital base. A rights issue also increateses the capital base. Distributions of capital has the opposite effect. Paying out cash to reduce those items that are in your reserves. the reserves are greater than you need so you pay out cash on those. Labeling: capitalization implies the creation of capital so only suggests an increase the capital base</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CapitalizationIssueNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">capitalization issue notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an issue which increases the capital base of the company.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CashAndSecuritiesResponse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash and securities response</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Response is to take a distribution of both securities and cash as offered.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT: Term:&quot;Cash and Securities&quot; Definition:&quot;Election choice includes a distribution of both cash and securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CashDisbursementResponseMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash disbursement response message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of response opting to take cash.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT: Term: &quot;Cash&quot; Definition: &quot;Distribution of cash to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CashDividendEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash dividend event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Distribution of cash to shareholders, in proportion to their equity holding. Ordinary dividends are recurring and regular. Shareholder must take cash and is not offered a choice in the form of distribution.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CashDividendNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash dividend notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CashResponse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash response</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Response is to take cash.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT: &quot;Distribution of cash to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeInDetailsNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.5"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-be-le-cb;StockCorporation">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">change in details notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information regarding a generic change, eg, change in the terms of an issue, change in the identification of a security, change of board lot, change from global to definitive.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeOfSecurityTradingStatusEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.6"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">change of security trading status event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event in which the trading status of a tradable security changes.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Link this to the State Transition diagram (not yet done).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeOfStateEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">change of state event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some event relating to some change of state.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ChangeToSmallestNegotiableUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">change to smallest negotiable unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Modification of the smallest negotiable unit of shares in order to obtain a new negotiable unit. SWIFT:SMAL</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ChoiceExists">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">choice exists</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ChoiceOffer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">choice offer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ClassActionProposedSettlementEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ManagementAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">class action proposed settlement event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Proposed settlement to a class action filing. Situation where interested parties seek restitution for financial loss.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction. 
 Further Notes:Original SWIFT definition: &quot;Class action filing; Proposed settlement. Situation where interested parties seek restitution for financial loss. Security holder may be offered the opportunity to join a class action proceeding and would need to respond with an instruction.&quot; Description clarifies that the event is not the class action or the initiation of the class action, but the initiation of a proposed settlement, in which holders are encouraged to participate. Note that this is an action with some optional action on the part of the Holder.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CombinedCashAndSecuritiesResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
-		<rdfs:label xml:lang="en">combined cash and securities response message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of response opting to take a distribution of both securities and cash as offered.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Term:&quot;Cash and Securities&quot; Definition:&quot;Election choice includes a distribution of both cash and securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CompanyOptionEvent">
-		<rdfs:label xml:lang="en">company option event</rdfs:label>
-		<skos:definition xml:lang="en">A company option may be granted by the company, allowing the holder to take up shares at some future date(s) at a pre arranged price in the company.</skos:definition>
-		<skos:editorialNote xml:lang="en">Is this an Event? Or is notification of the option the event?</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentDenied">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">consent denied</rdfs:label>
-		<skos:definition xml:lang="en">Vote not to approve the event or proposal. SWIFT: CONN</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentDeniedMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">consent denied message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentGranted.1">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">consent granted</rdfs:label>
-		<skos:definition xml:lang="en">Vote to approve the event or proposal. SWIFT: CONY</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentGrantedMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">consent granted message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitation">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;AbstentionResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;ConsentDenied"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;ConsentGranted.1"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;VotingNoAction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.7"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">consent solicitation</rdfs:label>
-		<skos:definition xml:lang="en">Solicitation of shareholders consent. Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationCommunication">
-		<rdfs:label xml:lang="en">consent solicitation communication</rdfs:label>
-		<skos:definition xml:lang="en">Activity in which the issuer of a security, wanting consent, communicates this to the holders, from whom consent would need to be granted.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationEnd">
-		<rdfs:label xml:lang="en">consent solicitation end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationRequest">
-		<rdfs:label xml:lang="en">consent solicitation request</rdfs:label>
-		<skos:definition xml:lang="en">Solicitation of shareholders consent.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting. SWIFT Full TExt: &quot;Solicitation of shareholders consent. Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationResponse">
-		<rdfs:label xml:lang="en">consent solicitation response</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationStart">
-		<rdfs:label xml:lang="en">consent solicitation start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;ConversionResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conversionActionAvailableResponseTakeNoActionResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;TakeNoActionResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isConversionFrom"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isConversionTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">conversion action</rdfs:label>
-		<skos:definition xml:lang="en">Conversion or optional exchange of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:label xml:lang="en">conversion notification</rdfs:label>
-		<skos:definition xml:lang="en">Conversion or optional exchange of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">conversion response</rdfs:label>
-		<skos:definition xml:lang="en">Response of the holder is to convert. SWIFT: Convert (CONV)</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionSuspensionAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:label xml:lang="en">conversion suspension action</rdfs:label>
-		<skos:definition xml:lang="en">Suspensiion of conversion of securities generally a couple of weeks before a meeting takes place. SWIFT = SCOP</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionSuspensionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:label xml:lang="en">conversion suspension notification</rdfs:label>
-		<skos:definition xml:lang="en">Suspensiion of conversion of securities generally a couple of weeks before a meeting takes place. SWIFT = SCOP</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.8"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.8"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">corporate action</rdfs:label>
-		<skos:definition xml:lang="en">An event which has some effect on the details or terms of an issued Financial Security or on market perception of the value of that security.</skos:definition>
-		<skos:scopeNote xml:lang="en">Removed from scope of this term and moved to Issuer Corporate Action: &quot;This is an action which is compulsory on the issuer of the security.&quot; - REVIEW AND CLEAN OUT OF HERE Earlier review notes (pre refinement of this scope). REVIEW AND CLEAN OUT: Broader definition would also include things which might change the market price (for debt or equity), there asre things fo which you have to notify the market. these do not necessarily include changes to the details of the security. Most CAE will change the market perception. Not all actions which change the market perception are Corporate Events. Suggestion A corporate action is a generic class not actually homogenous, one of whcih si the Corporate Action of providin information to the market. There are legal requirements in most jurisdicitons saying that companies must advise their shareholders or bondhoders, about things whic might change the price. A separate kind of event notifies holders of securities (shares or bonds) of events which require an aciton on the part of the older (mandatory or bvoluntart) of the holder of the share. Then there are a set of events that don&apos;t get classified as CAE but have been included by SWIFT which are the actions by the holder, which would impact the issuer. These include calls on rights. Conclusion: There is one &quot;Corporate Event&quot; superclass of which everything is defined. earlier Event: Event has Terms and Conditions asspciated with it. Ts and Cs include mandatory and voluntary responses.</skos:scopeNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionAnnouncer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;FinancialSecuritiesActor"/>
-		<rdfs:label xml:lang="en">corporate action announcer</rdfs:label>
-		<skos:definition xml:lang="en">The party which makes the CA announcement. Best label for this? unclear. note that they may be issuers of other stock but they do not have to be. You can initiate a corporate action but you are not the issuer of that security, but the action is still about a particular security. Not all actions are bound to specific to a security/. A n action may impact one or more securities, The actions may require different communications. So we should probably distinguish actions versus communications about events. ADD: Communication. Example: Bell breakout. Sample use case for CAE.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionConfirmation">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:label xml:lang="en">corporate action confirmation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionHolderResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">corporate action holder response</rdfs:label>
-		<skos:definition xml:lang="en">Response by the Holder of a security, to a previous Offer made by the Issuer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Some CAE types fall under this heading. The action will specify what choices are available to the Holder by way of a response (for example cash, securities, no action and so on). See list ... Embedded as a scheme in a ISO 15022 field.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionNarrative">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:label xml:lang="en">corporate action narrative</rdfs:label>
-		<skos:definition xml:lang="en">A message containing further narrative about some corporate action. This does not relate to any specific kind of action but is an additional stand-alone message.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Can extend information with user defined language and fields.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionObligation">
-		<rdfs:label xml:lang="en">corporate action obligation</rdfs:label>
-		<skos:definition xml:lang="en">An obligation related to the holding of a Security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Delivery of a security. Not defining direction at this level of the model - one party may have an obligation to deliver security or to pay; other party may have an obligation to deliver or to pay. Or there may be just one.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionPaymentObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionObligation"/>
-		<rdfs:label xml:lang="en">corporate action payment obligation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionSecuritiesDeliveryObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionObligation"/>
-		<rdfs:label xml:lang="en">corporate action securities delivery obligation</rdfs:label>
-		<skos:definition xml:lang="en">Some obligation to deliver some security in the thr context of corporate actions. All cash proceeds and security proceeds can be represented a s acontractual obligation. Where does that obligation arise? Usually in the Contract itself - but there may be other answers to this. Defines what has to be delivered. or paid. Entitlement meanwhile is a calculation based on the Contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionStatusMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:label xml:lang="en">corporate action status message</rdfs:label>
-		<skos:definition xml:lang="en">A message which relates to the status of a corporate action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Example would be if there is a Tender Offer, and the offer has been accepted, then a processing instruction would be sent. Not to be confused with a message about the status of a security or company.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ChangeOfStateEvent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
-		<rdfs:label xml:lang="en">corporate change of status event</rdfs:label>
-		<skos:definition xml:lang="en">Some change to the status of some security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is generally described by a corporate event message. For example, change in trading status, listing status.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateEvent">
-		<rdfs:label xml:lang="en">corporate event</rdfs:label>
-		<skos:definition xml:lang="en">Events v Actions Notifiable versus non notifiable. Whether notfiable could be required by statute or by listing rules. Notifiable: Does this apply only to those events compulsory on the issuer? See Tender Offer. In takeover scenarios, the issuer will have actions incumbent o nthem to inform the market (e..g Aus Part B response). Offerer initiates Part A (Takeover Offer) with the details. Akin to a information memorandum or prospectus on the takeover. All interest parties (and non shareholders) have a potential interest, as it has a potential effect on the shares.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateEventOrActionCommunication">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;Message"/>
-		<rdfs:label xml:lang="en">corporate event or action communication</rdfs:label>
-		<skos:definition xml:lang="en">Communication about an event, action or status. Further Notes Includes name changes, consent (communication only) and others. Pre marketing agreements and so on. Note: some of these are very data driven, some are not. General meetings and so on.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateEventProcess">
-		<rdfs:label xml:lang="en">corporate event process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateModificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
-		<rdfs:label xml:lang="en">corporate modification event</rdfs:label>
-		<skos:definition xml:lang="en">Some change in details of some company, which needs to be described for publicly issued securities issued by that company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Usually described in a corporate event message. Note that the change relates to the company, but notification about this, for publicly issued securities (shares, bonds) is notificed to the holders of each such security, as corporate event messages.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CouponStrip">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;BondAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.9"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">coupon strip</rdfs:label>
-		<skos:definition xml:lang="en">Coupon stripping is the process whereby interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CouponStripNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtIssuerCorporateActionNotification"/>
-		<rdfs:label xml:lang="en">coupon strip notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification that the debt security is to be stripped, that is that interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">THis will result in two securities where previously there was one. REVIEW: precise details for the relation between the stripped instrument and the traded interest and principal components (does one of the remain the same security, or are two new securities created and one retired?); also account for recombination. SWIFT full text: &quot;Coupon stripping is the process whereby interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;CourtDecisionSubsequentMeeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
-		<rdfs:label xml:lang="en">court decision subsequent meeting</rdfs:label>
-		<skos:definition xml:lang="en">Meeting following a court decision.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Named according to the description. Original SWIFT name is &quot;Court Meeting&quot;, which is not what it is.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;Custodian">
-		<rdfs:label xml:lang="en">custodian</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtDrawingNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:label xml:lang="en">debt drawing notification</rdfs:label>
-		<skos:definition xml:lang="en">Redemption in part before the scheduled final maturity date of a security. SWIFT = DRAW</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtInstrumentBuybackNotification">
-		<rdfs:label xml:lang="en">debt instrument buyback notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an event where det securities are bought back by the issuer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See also puts and calls (these are usually pre-arranged). Here the company goes out to the market and buys back their own debt. This does not really need to be a corporate event, they just do it. REVIEW: This term may not be needed. Not a corporate action.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtIssuerCorporateActionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:label xml:lang="en">debt issuer corporate action notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtRedenomination">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.10"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt redenomination</rdfs:label>
-		<skos:definition xml:lang="en">Event by which the unit (currency and/or nominal) of a debt is restated, eg, a debt in a national currency unit is restated in euro.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Would be notified in advance.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DebtSecurityAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:label xml:lang="en">debt security action</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DefaultEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationEvent"/>
-		<rdfs:label xml:lang="en">default event</rdfs:label>
-		<skos:definition xml:lang="en">Event in which something is not paid that should be.</skos:definition>
-		<skos:editorialNote xml:lang="en">Some of these terms may already exist in the CDS model - review and combine.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DetachmentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
-		<rdfs:label xml:lang="en">detachment action</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DetachmentNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AttachmentOrDetachmentNotificationMessage"/>
-		<rdfs:label xml:lang="en">detachment notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of separation of components that comprise a security - usually units comprised of warrants and bond or warrants and equity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Units may be broken up at the request of the security holder or based on market convention. Scope: See Attachment. SWIFT Full text: &quot;Separation of components that comprise a security - usually units comprised of warrants and bond or warrants and equity. Units may be broken up at the request of the security holder or based on market convention.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DeterminationEvent">
-		<rdfs:label xml:lang="en">determination event</rdfs:label>
-		<skos:definition xml:lang="en">An Event in which some amount or other parameter is determined, independently of any other event in which that which was determined is put into use. For example, the event by which interest is determined, as distinct from the event by which interest is paid on a different date or time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DisbursementResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">disbursement response</rdfs:label>
-		<skos:definition xml:lang="en">Response by a holder to some choice of disbursement method, as offered by the issuer in some corporate action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a generalization of a range of possible responses to offers by an issuer, which may be made in a number of Corporate Actions. Not all responses are available in all instances, and the Corporate Action notitificaiton will generally define which actions are held out to the Holder for a specific action; also some action types by their nature will be constrained to a sub set of these kinds of response. Note that this action (of choosing) is communicated to the Issuer by some message; the SWIFT terms for the messages are replicated here as kinds of Action which correspond to those. Hence the Action types and Message types are the same, and have the same origin in the SWIFT messages.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DisbursementResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">disbursement response message</rdfs:label>
-		<skos:definition xml:lang="en">Message conveying the response by a holder to some choice of disbursement method, as offered by the issuer in some corporate action.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DisclosureMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:label xml:lang="en">disclosure message</rdfs:label>
-		<skos:definition xml:lang="en">Disclosure of some fact or facts, by the holder of some security, as a result of some formal requirement imposed upon holders or beneficial owners under some applicable regulation.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The message modeled here is the message in which the disclosure is made. Individual types of disclosure are not modeled and may vary across jurisdictions. A fact about the disclosure is the regulation under which it was required to be made. Another fact is the disclosing party, that is the holder or beneficial owner. Note that in the Business Entities ontology, beneficial ownership is modeled separately from control ownership. This type of message may result from formal requirements placed upon either. SWIFT Full text: &quot;Requirement under some regulations for holders or beneficial owners to disclose&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryDistribution"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dividend distribution</rdfs:label>
-		<skos:definition xml:lang="en">Any event relating to a dividend payment.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:label xml:lang="en">dividend distribution notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendOption">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">dividend option</rdfs:label>
-		<skos:definition xml:lang="en">Distribution of a dividend to shareholder with the choice of payment method. Shareholder must choose the form of payment - stock, cash, or both.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendOptionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">dividend option notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendReinvestment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">dividend reinvestment</rdfs:label>
-		<skos:definition xml:lang="en">Dividend payment where cash dividend is rolled over into additional shares in the issuing company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Announcement would by that either get stock or cash. May have an announcement that pays a stock dividend only - hence this would be a bonus Issue. Dividend reinvestment is a choice on the part of the Holder but is not part of the announcement.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DividendReinvestmentNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">dividend reinvestment notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;Drawing">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
-		<rdfs:label xml:lang="en">drawing</rdfs:label>
-		<skos:definition xml:lang="en">Redemption in part before the scheduled final maturity date of a security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notification in advance of this happening.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DutchAuction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateAction"/>
-		<rdfs:label xml:lang="en">dutch auction</rdfs:label>
-		<skos:definition xml:lang="en">Similar to a tender offer, a Dutch auction is an action by a party wishing to acquire a particular security. Current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings. UPDATE THIS DEFINITION: Similar to a tender offer, a Dutch auction is the result of an action by a third party wishing to acquire a particular security. Current holders of the targeted security are invited (and given a message by the issuer) to make an offer in which they would be willling to sell their holdings. OR It might also represent a separate scenario where third parties do this, as per the original SWIFT defition. You can only go to the Registrar which would the other scenario impossible. Agents and Registrars: The issue issuer os the company which issued the shares (as modeled); Most companies don&apos;t interact directly with the market to find out who they need to disseminate the info to. They can, but more likely the employ &quot;Issuers Agent&quot;. That provides one point of contact from the organization. That agent handles all coms with the Registrars, and to the news wires etc., to disseminate the corporate action. Context: CAE only, or in the context of the Issue? When you issue the security you nominate an Agent, in the prospectus, there is specified an Issuing Agent. This is the one that does these things. Usually a merchant bank etc. in the old days. This is who will have directly facilitated that direct market engagement. Next question: This is part of going public, so these agents are appointed as part of going public.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The party to which the offer is made need not be the holder. Details: Question on &quot;Who is the actor?&quot; Dutch auction would have multiple parties? What is the scenario? Usually happens when a company is about to go into administration. Looking at the scneario descried in the SWIFT definition - not clear if this is the only such scenario. Possibly the issuer has to notif ythe shareholders that the offer is being made. The offer is made by the third party but the notice is sent by the issuer (via their agent) and via the registrar who holds the details of who holds all the shares. Example: Lloyds banking group - most shares would be owned by the market, and a small percentage might be held by private investors. So in this scenario everyone has to be given the opportunity to sell at the given price. so the CAE message is still issued by the Issuer. SWIFT detailed names (synonym?) &quot;Dutch Auction, Bid Tender&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;DutchAuctionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyFormalOfferNotification"/>
-		<rdfs:label xml:lang="en">dutch auction notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a Dutch auction, that is an action by a party wishing to acquire a particular security. Under the terms of this offer, current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See notes for the event itself - there is some unclarity as to whether this notification supports one message flow or several i.e. whether it is from third party, from Issuer&apos;s Agent to holders, from third party to Issuers Agent, or all three. REVIEW SWIFT full text: &quot;Similar to a tender offer, a Dutch auction is an action by a party wishing to acquire a particular security. Current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;EventAnnouncement.1">
-		<rdfs:label xml:lang="en">event announcement</rdfs:label>
-		<skos:definition xml:lang="en">An Event whereby some parties announces its intention to carry out some act at some present or future time. An Announcement is defined relative to the Event that is announced, for example the announcement of the issue of a financial security is defined in relation to the issue of a security (an Issuance Event).</skos:definition>
-		<skos:definition xml:lang="en">The announcement</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;EventNotification">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;communicatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">event notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExPostNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:label xml:lang="en">ex post notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an event that is expected or unexpected and has happened.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExchangeOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOffer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.12"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exchange offer</rdfs:label>
-		<skos:definition xml:lang="en">Exchange offer; Capital reorganisation. Offer to shareholders to exchange their holdings for other securities and/or cash. Exchange offers are usually voluntary. Example: Where the &quot;usually voluntary&quot; comes in is that Announcement Payout Option 1: Cash 2. Stocks 3. Cash and Stock Holder picks option 1, 2 or 3 (= 1 &amp; 2). the voluntary aspect is where it&apos;s an Exchange Offer. It&apos;s mandatory to pick one of 1 - 3. Otherwise defaults to cash on payment date. Option Payout Componnet is the terms for the choice. Exchange Offer may be voluntary, not always Mandator With Choice. for example, there are legal qualifications on what is possible. Preceded by Tender Offer. Consequences dependent on scenarios. Once the firm making the offer gets to a given (legally defined) threshold e.g. 90% then they have the right to acquire all of the outstanding shares. An Exchange Offer is therefore a specialization of a Tender Offer. It&apos;s the specialization where the above mentioned requirements have been met. Further detail: Happens in a wider range of circumsntaces. Is soecifically associated with the issuer. this could be voluntary or not. EXOF could be any of the three (mand, vol, man w choice). tendre is always voluntary.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExchangeOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOfferNotification"/>
-		<rdfs:label xml:lang="en">exchange offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an offer to shareholders to exchange their holdings for other securities and/or cash.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Exchange offers are usually voluntary. Full SWIFT Definition text: &quot;Exchange offer; Capital reorganisation. Offer to shareholders to exchange their holdings for other securities and/or cash. Exchange offers are usually voluntary.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExerciseAction">
-		<rdfs:label xml:lang="en">exercise action</rdfs:label>
-		<skos:definition xml:lang="en">Some action in which spome party decides to exercise some option or some optionality concept.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These include puts and calls - I can put it to you or I can call it from you. can also be full or partial. Hence full call, partial call. Note that in Bonds, only the Issuer can call it, and only the Holder can Put it. However with this exception / narrowing of scope, the meaning of Put and Call are the same as for any other context, it&apos;s just that the implied other two cominations are not realizable in the world of Bonds.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExerciseExChangeOptionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
-		<rdfs:label xml:lang="en">exercise ex change option notification</rdfs:label>
-		<terms:description xml:lang="en">Exchange options are mentioned in the terms and conditions of a security and are valid during the whole lifetime of a security. SWIFT: &quot;Option for shareholders to exchange their holdings for other secuities and/or cash. Exchange options are mentioned in the terms and conditions of a security and are valid during the whole lifetime of a security.&quot;</terms:description>
-		<skos:definition xml:lang="en">Notification of exercise by Holder of an exsting option for shareholders to exchange their holdings for other securities and/or cash.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExerciseExchangeOption">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableChoices"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exercise exchange option</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ExtraordinaryGeneralMeeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
-		<rdfs:label xml:lang="en">extraordinary general meeting</rdfs:label>
-		<skos:definition xml:lang="en">Extraordinary General Meeting</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FinancialSecuritiesActor">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;hasSomeRoleIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial securities actor</rdfs:label>
-		<skos:definition xml:lang="en">Some actor which has some agency in securities issuance or trading, or is some third party in such.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Is generally also a Party to some security, but need not be (e.g. hostile take-over bid actor).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FormalOffer">
-		<rdfs:label xml:lang="en">formal offer</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;DutchAuction">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;ExchangeOffer">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;ShareBuybackOffer">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-cae-ce-cae;TenderOffer">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition xml:lang="en">Event which is an offer to the holder or potential holder or other intersted party, to enter into a trade which is or would be legally binding on the part of the party making the offer (the offeror).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FullCall">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CallAction"/>
-		<rdfs:label xml:lang="en">full call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FullExerciseAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
-		<rdfs:label xml:lang="en">full exercise action</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FundCapitalGainsDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryDistribution"/>
-		<rdfs:label xml:lang="en">fund capital gains distribution</rdfs:label>
-		<skos:definition xml:lang="en">Distribution of profits resulting from the sale of securities. Shareholders of Mutual Funds, Unit Trusts, or Sicavs are recipients of capital gains distributions which are often reinvested in additional shares of the fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;FundCapitalGainsDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistributionNotification"/>
-		<rdfs:label xml:lang="en">fund capital gains distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of distribution to shareholders of funds, of profits resulting from the sale of securities.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Shareholders of Mutual Funds, Unit Trusts, or Sicavs are recipients of capital gains distributions which are often reinvested in additional shares of the fund. SWIFT full text: &quot;Distribution of profits resulting from the sale of securities. Shareholders of Mutual Funds, Unit Trusts, or Sicavs are recipients of capital gains distributions which are often reinvested in additional shares of the fund.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderDisclosure">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-		<rdfs:label xml:lang="en">holder disclosure</rdfs:label>
-		<skos:definition xml:lang="en">An action by a holder to voluntarily disclose some information. Examples: ENRON Disclosure rules. This is an action by the Holder on discovery of their legal requirement. Is there an Issuer action If so there may be an Issuer action asking for such disclosure. Or this may not exist since at the time of the action the Issuer should know all this. Conclusion: From a CA viewpoint specifically, the Disclosure would be from the holder.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderDisclosureMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
-		<rdfs:label xml:lang="en">holder disclosure message</rdfs:label>
-		<skos:definition xml:lang="en">An action by a holder to voluntarily disclose some information.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT:&quot;Requirement under some regulations for holders or beneficial owners to disclose&quot; This comes from examples such as ENRON, and is a message in which the holdler of the security volunteers some information without prompting.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">holder event</rdfs:label>
-		<skos:definition xml:lang="en">A CAE event relating to actions on the part of the holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Change of ownership has a message. Someone has to communicate the exercise.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitatedActionStart">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;flow"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;HolderInitiatedActionInitiation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">holder initated action start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">holder initiated action</rdfs:label>
-		<skos:definition xml:lang="en">Any action initiated by a Holder of a Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedActionEnd">
-		<rdfs:label xml:lang="en">holder initiated action end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedActionInitiation">
-		<rdfs:label xml:lang="en">holder initiated action initiation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedInstruction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InstructionMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">holder initiated instruction</rdfs:label>
-		<skos:definition xml:lang="en">A message being an instruction by the holder of some security, made not in response to come choice offered by the issuer, but made on the holder&apos;s own initiative.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a general category of message. Note that there is one kind of message of this type in the original SWIFT-derived list of event message types, however it is assumed there must be others.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderMeetingResponse">
-		<rdfs:label xml:lang="en">holder meeting response</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InstructionMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">holder response message</rdfs:label>
-		<skos:definition xml:lang="en">A message conveying the Holder&apos;s choice in some Corporate Action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The message identifies the Corporate Action that they are a response to. In the event that they are not, this is highlighted in the message instructions - these are identified as such as in the ISO 15022 descriptions. See worksheet: some responses can be responses to more than one kind of message. Based on the type of notificaiton, there are various applicable response types. Based on the message sent out as a notification there are some or all of these responses, as being the possible responses to the message itself. That is down to the notifying party. Specified in the Notification what available responses there are.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;HolderResponseToChoice">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;givesRiseTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">holder response to choice</rdfs:label>
-		<skos:definition xml:lang="en">Instructions consequent upon notifications. Instruction messages - some of these are responses to notifications. May be MT 565 related - has consent Yes, consent No, no action, accept shares, accept cash and securities etc. There are also ones that can be initiated by holders (not in this process step) such as puts. These can be presented without a notification previously having been sense. These are the ones we deided not to classify as &quot;Corporate Actions&quot; as these can be initiated by the holder. As such these are an instruction rather than a notification.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InformationAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:label xml:lang="en">information action</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These will have an Effective date. Similar to name change - actions where there is nothign the Holder can do about it, but there is an action at a certain date.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InformationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
-		<rdfs:label xml:lang="en">information event</rdfs:label>
-		<skos:definition xml:lang="en">A corporate event which is simply a notification about something. People may wish to respond</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InstalmentCall">
-		<rdfs:label xml:lang="en">instalment call</rdfs:label>
-		<skos:definition xml:lang="en">Increase of share capital through additional payment on face value of partly-paid shares, with part payments in several instalments. SWIFT = PPMT</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InstalmentDefault">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DefaultEvent"/>
-		<rdfs:label xml:lang="en">instalment default</rdfs:label>
-		<skos:definition xml:lang="en">Non payment of a call by the beneficial owner, resulting in either a court action by the issuer or the sale of the securities to recover costs and/or a forfeit of partially paid securities. SWIFT = INDE</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InstructionMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:label xml:lang="en">instruction message</rdfs:label>
-		<skos:definition xml:lang="en">A message which embodies some instruction.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review whether we need this.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PaymentOrInterestPaymentAction"/>
-		<rdfs:label xml:lang="en">interest payment</rdfs:label>
-		<skos:definition xml:lang="en">Payment of Interest to the Holder. Further notes: Are there options on the Holder? Yes, you can opt to be paid in a certain currency. It is not always defined in the security terms. So if the Terms in the Security terms sheet gives you an option, there is a choice for the Holder at this point. Such choices would include: - Currency - Pay in Kind (&quot;Spinoff&quot; or PiK - see PiK corporate Action) Could be mandatory. If there were an option then the letter announcing it would require a response. This is usually stated in the message. Is there a message even if there is no option? Yes. Usually have to generate the events artificially as the Servicing organization. you can&apos;t rely on a feed or message coming in but because it is part of the security contract the above has to generate at the expected time, and arrange the payments. Q: That is the point at there was a choice you would expect to see a message, or end up still having to generate it but with the choices. A: The ones with Choices come as announcements and don&apos;t ave to be generated by the Service. Older definitin (re-scoped now: An Event in which a payment occurs. Anything can have a payment event. If a thing hits a pay date, whether it&apos;s voluntary or mandatory, that&apos;s a payment event. Divide into: Securities Cash Combination Payment or Distribution? Are these exclusive? Take an event that&apos;s always a combination of options, and an option is a combination of payouts. Generates transactions - determine what txns happen when a customer chooses that option. Distribution / delivery: generic concept Payment - implis cash distribution. So payment is specialization of distribution.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InterestPayment"/>
-		<rdfs:label xml:lang="en">interest payment action</rdfs:label>
-		<skos:definition xml:lang="en">Regular interest payment, only in cash, distributed to holders of an interest bearing asset. According to the terms of the issue, a bondholder may be able to elect the currency interest is paid in.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentInKind">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
-		<rdfs:label xml:lang="en">interest payment in kind</rdfs:label>
-		<skos:definition xml:lang="en">Interest payment, in any kind except cash, distributed to holders of an interest bearing asset. SWIFT = PINK</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentWithPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
-		<rdfs:label xml:lang="en">interest payment with principal</rdfs:label>
-		<skos:definition xml:lang="en">A payment of a portion of the principal of an interest bearing asset, in addition to the interest payment. SWIFT = PRII</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestRateAdjustment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.13"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">interest rate adjustment</rdfs:label>
-		<skos:definition xml:lang="en">Scheduled change to the coupon rate for a floating or adjustable rate security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The SWIFT definition as given defines the notification of the interest rate change, not the adjustment. Adjusted to describe the event. REVIEW: Is this really an action? Usually consider that it&apos;s expected. Given definition was for the announcement. SWIFT full definition &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;InterestRateAdjustmentNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExPostNotification"/>
-		<rdfs:label xml:lang="en">interest rate adjustment notification</rdfs:label>
-		<skos:definition xml:lang="en">Announcement of the current coupon rate for a floating or adjustable rate security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Definition as given refers to this notification (message) rather than the event itself. This is done for completeness, and sent out as a Notification by the Issuer or the Issuer&apos;s Agent. SWIFT Full definition: &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;announcedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionAnnouncer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuer corporate action</rdfs:label>
-		<skos:definition xml:lang="en">Some corporate action initiated by the issuer of the Security. This is an action which is compulsory on the issuer of the security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is most of the kinds of action generally thought of as &quot;Corporate Actions&quot;. These may be mandaytory, voluntary, or mandatory with one or more choices fo rthe holder to make. This is the term for which it is mandatory on the issuer to notify this event to the marketplace and / or to holders of the security.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerCorporateActionAnnouncer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionAnnouncer"/>
-		<rdfs:label xml:lang="en">issuer corporate action announcer</rdfs:label>
-		<skos:definition xml:lang="en">The announcer of an event which is also the issuer of the security that the event is about.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;hasSubject"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issuer corporate action notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an action by the issuer of the security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerFormalOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">issuer formal offer</rdfs:label>
-		<skos:definition xml:lang="en">An action in which the issuer of the security makes a formal offer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Encompasses Exchange Offer and Repurchase Offer. Note that there are also offers made by third parties. These do not come under this term.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerFormalOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">issuer formal offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of some formal offer by the issuer of the security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;LiquidationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationEvent"/>
-		<rdfs:label xml:lang="en">liquidation event</rdfs:label>
-		<skos:definition xml:lang="en">Liquidating dividend/Liquidation consist of a distribution of cash, assets, or both. Debt may be paid in order of priority based on preferred claims to assets specified by the security. SWIFT = LIQU</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ListingStatusDelistingMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:label xml:lang="en">listing status delisting message</rdfs:label>
-		<skos:definition xml:lang="en">Security is no longer able to comply with the listing requirements of a stock exchange and is removed from official board quotation.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ManagementAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">management action</rdfs:label>
-		<skos:definition xml:lang="en">An event relating to the management of a company or other concern.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCashDividendEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendEvent"/>
-		<rdfs:label xml:lang="en">mandatory cash dividend event</rdfs:label>
-		<skos:definition xml:lang="en">Cash dividend with no option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCashDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendNotification"/>
-		<rdfs:label xml:lang="en">mandatory cash dividend notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">mandatory corporate action</rdfs:label>
-		<skos:definition xml:lang="en">An event where there are no choice on the part of the Holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">for the purposes of clarity: Mandatory here means mandatory on the holder. Corporate Events as a whole are defined in terms of being mandatory on the part of the Issuer. In other words, Mandatory actions versus mandatory reactions. See Barron&apos;s: Dictionary of banking terms - no definition of Corporate Action.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCorporateEventProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventProcess"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;hasStart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;MandatoryEventStart"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mandatory corporate event process</rdfs:label>
-		<skos:definition xml:lang="en">Mandatory corporate event: Action requires an action by the shareholder Corporate action event initiated by the corporation. Participation by shareholders is mandatory (for those relating to shares).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryEventEnd">
-		<rdfs:label xml:lang="en">mandatory event end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryEventStart">
-		<rdfs:label xml:lang="en">mandatory event start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryPutEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PutAction"/>
-		<rdfs:label xml:lang="en">mandatory put event</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;OptionalPut"/>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is a Put Bond, which is a kind of option in the sense that in return for getting less yield it allows you to put it back to the issuer. This means Put is a voluntary event. Therefore Mandatory Put is nonsensical? discussion: Or is it? If you are the issuer (therefore the granter of the option) then the event is to the holder). Partly paid shre for example gives the issuer the right to call funds but also has the right to put. So put is not by definition ... someone can have the right to put something. Conclusion: these do not appear to make sense as terms. A put bond allows the holder to redeem the issue. So this is by definition a voluntary event. Conclusion: go back to Pershing and find out what this term meant. Also we don&apos;t even know what kind of security this event was intended to refer to. We assume it refers to Put bond. This is on the assumption that Options can&apos;t be defined as having corporate action.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
-		<rdfs:label xml:lang="en">mandatory with choice corporate action</rdfs:label>
-		<skos:definition xml:lang="en">An event which is going to happen but there are choices to be made by the Holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is usually some default, e.g. if you don&apos;t choose by the payment date there is some default e.g. the issue currency. Voluntary differ from this in that the Holder chooses whether to do anything or not.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MaturityExtension">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;BondAction"/>
-		<rdfs:label xml:lang="en">maturity extension</rdfs:label>
-		<skos:definition xml:lang="en">As stipulated in a bond&apos;s Terms and Conditions, the issuer or the bondholder may prolong the maturity date of a bond. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This would ne notified in advance. Fits into the normal &quot;Action&quot; workflow. SWIFT = EXTM</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MaturityExtensionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:label xml:lang="en">maturity extension notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an extension to the maturity date of a bond by the issuer, in line with existing terms and conditions.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As stipulated in a bond&apos;s Terms and Conditions, the issuer or the bondholder may prolong the maturity date of a bond. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval. Note that the definition given for this in SWIFT is really narrative. New definition drafted in its place. SWIFT Full Text &quot;As stipulated in a bond&apos;s Terms and Conditions, the issuer or the bondholder may prolong the maturity date of a bond. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;Meeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ManagementAction"/>
-		<rdfs:label xml:lang="en">meeting</rdfs:label>
-		<skos:definition xml:lang="en">A Management Event in which stakeholders meet one another either face to face or through some electronic or voice medium, in order to process some management activity (the Agenda).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MeetingProcessEnd">
-		<rdfs:label xml:lang="en">meeting process end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;MeetingProcessStart">
-		<rdfs:label xml:lang="en">meeting process start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;NonIssuerCorporateActionAnnouncer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionAnnouncer"/>
-		<rdfs:label xml:lang="en">non issuer corporate action announcer</rdfs:label>
-		<skos:definition xml:lang="en">The announcer of an event which is not the issuer of the security that the event is about.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;NotificationEvent">
-		<rdfs:label xml:lang="en">notification event</rdfs:label>
-		<skos:definition xml:lang="en">A notification to the shareholders that therre is a corporate action out there. This is distinct from the CA itself. not the same as Event Announcement. There are steps between when the announcement happens and the rest Announcement: at the level of sub custodians. then you gether the people who are affected by the event that&apos;s to come. Then you send the announcement - a notification to the holder, informing them of the options that are available to them. If it&apos;s mandatory these distinctions still happen, but there is no choice. So still announcement is made, then when it effects people you send out notificaiton and collect responses. &quot;EVENT&quot;: two aspects: The event itself Events within the Corporat eAction, e.g. notification, deadline when a responses is due by, payment dates, Define as: lifecycle of the Corporate Action. Sometimes have to re-notify, there may be changes in the life oc the &quot;Corporate Event&quot;. So the Corporate Event is a sequence of events.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;NotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:label xml:lang="en">notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an event.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Some events have a preliminiary notification followed by a confirmation of that. For example MT564 would have a preliminary notification. MT564 is not exclusively messages sent by an issuer, it may also be sent by a third party. Relationship Facts: sent by Related term: SWIFT Corporate Action Notification: &quot;The process of notifying of an upcoming corporate action. It provides corporate action details including the different options.&quot; (source for that term: SWIFT CAE analysis)</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;OddLotSale"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">odd lot offer</rdfs:label>
-		<skos:definition xml:lang="en">Offer by issuer to allow holders of an odd lot of a security to order a commission-free transaction at market price, to sell the odd lot, or to buy an amount of shares which will bring the position to a round lot (board lot). SWIFT = ODLT</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotOfferMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:label xml:lang="en">odd lot offer message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotSale">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">odd lot sale</rdfs:label>
-		<skos:definition xml:lang="en">Sale of odd-lot back to the issuing company.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotSaleInstruction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;OddLotSale"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">odd lot sale instruction</rdfs:label>
-		<skos:definition xml:lang="en">Notification of holder choice to sell odd-lot back to the issuing company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is in response to the Issuer-initiated Corporate Action in which they make an Odd Lot Offer. SWIFT: Term:&quot;Odd Lot Sale&quot; Definition:&quot;Sale of odd-lot back to the issuing company.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OptionalCashDividendEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendEvent"/>
-		<rdfs:label xml:lang="en">optional cash dividend event</rdfs:label>
-		<skos:definition xml:lang="en">Cash dividend with currency options. This is a dividend payment where payment is mandatorily in the form of Cash. The choice is what currency the cash is to be received in.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OptionalCashDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendNotification"/>
-		<rdfs:label xml:lang="en">optional cash dividend notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OptionalPut">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PutAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
-		<rdfs:label xml:lang="en">optional put</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OrdinaryGeneralMeeting">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
-		<rdfs:label xml:lang="en">ordinary general meeting</rdfs:label>
-		<skos:definition xml:lang="en">Ordinary General Meeting SWIFT = OMET</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OrganizationModificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
-		<rdfs:label xml:lang="en">organization modification event</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;OrganizationNameChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;OrganizationModificationEvent"/>
-		<rdfs:label xml:lang="en">organization name change</rdfs:label>
-		<skos:definition xml:lang="en">The issuing company changes it&apos;s name. Event shows the change from old name to new name and may involve surrendering physical shares with the old name to the registrar. SWIFT = NAME</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialCall">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CallAction"/>
-		<rdfs:label xml:lang="en">partial call action</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialDefeasanceAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationAction"/>
-		<rdfs:label xml:lang="en">partial defeasance action</rdfs:label>
-		<skos:definition xml:lang="en">The setting aside by a borrower of cash or bonds sufficient to service the borrower&apos;s debt.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From Free dictionary: Both the borrower&apos;s debt and the offsetting cash or bonds are removed from the balance sheet. In securities trading, where a clearing house becomes counterparty to each side of a trade, after the trade has been agreed. This is necessary to facilitate netting, and reduce counterparty risk exposure. The term has become popular recently, because of the growth of central counterparty clearing services in European cash equities markets. Origin: http://financial-dictionary.thefreedictionary.com/defeasance SWIFT: Term:PDEF; &quot;Partial Defeasance/Prefunding&quot; Definition:&quot;Issuer has money set aside to redeem a portion of an issue and the indenture states that the securities could be called earlier than the stated maturity.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PartialExerciseEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
-		<rdfs:label xml:lang="en">partial exercise event</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PaymentOrInterestPaymentAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">payment or interest payment action</rdfs:label>
-		<skos:definition xml:lang="en">The payment of some mandatory payment as defined in the contractual terms of the security, such as interst payment of amortization. this is income generated to the HOlder because of the security contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is distinct from any other kind of distribution based on the Issuer deciding to do something;l in this case the OIssuer has no choice (these are payments defined in contractual terms) and if they do not do it,. this is a Default</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PayoutOptionTerms">
-		<rdfs:label xml:lang="en">payout option terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PlaceOfIncorporationChange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;OrganizationModificationEvent"/>
-		<rdfs:label xml:lang="en">place of incorporation change</rdfs:label>
-		<skos:definition xml:lang="en">Changes in the state of incorporation for US companies and changes in the place of incorporation for foreign companies. Where shares need to be registered following the incorporation change, the holder(s) may have to elect the registrar. SWIFT = PLAC</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PostMergerSecuritiesExchange">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;definesAdditional"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;exchangesFrom"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;exchangesInto"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">post merger securities exchange</rdfs:label>
-		<skos:definition xml:lang="en">Mandatory or voluntary exchange of an outstanding securities as the result of two or more companies combining assets. Cash payments may accompany share exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an action as a result of the Merger, not the merger itself.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PostMergerSecuritiesExchangeNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">post merger securities exchange notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of mandatory or voluntary exchange of outstanding securities as the result of two or more companies combining assets.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Cash payments may accompany share exchange. Note that the event to which this applies was labeled &quot;Merger&quot; in source material but refers to the exchange of securities following a merger, not the merger itself. SWIFT full definition &quot;Mandatory or voluntary exchange of an outstanding securities as the result of two or more companies combining assets. Cash payments may accompany share exchange.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PriorityIssue">
-		<rdfs:label xml:lang="en">priority issue</rdfs:label>
-		<skos:definition xml:lang="en">Form of open or public offer where priority is given to existing shareholders due to limited amount of securities available in the offer. Shareholders can buy a type of security during a short period of time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;PutAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-		<rdfs:label xml:lang="en">put action</rdfs:label>
-		<skos:definition xml:lang="en">The putting of some debt security back to its issuer by the holder</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note this is a holder action. There may be terms in the security giving the holder the ability to redeem early. If so, this is the event where that happens. Could apply to MTN as well as Bonds. We have defined MTN as a kind of Bond in this model. Review discussion: scope fo this: You could in theory put a share but no-one has come across this. Issuer may buy back shares at a given price but that&apos;s a different context - there&apos;s message for that. Makes an offer to repurchase shares. So therefore it is not possible in principle to have a call fo ra non debt instrument. In other circumstances e.g. compulsory acquisition in a takeover, is equivalent to this but it&apos;s a different term.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;Redemption">
-		<rdfs:label xml:lang="en">redemption</rdfs:label>
-		<skos:definition xml:lang="en">Repayment in full of a debt security, investment trust or a preferred stock issue, at stated maturity. SWIFT = REDM</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RemarketingAgreementInitiated">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.14"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;PerpetualFloatingRateNote"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">remarketing agreement initiated</rdfs:label>
-		<skos:definition xml:lang="en">Event in which a remarketing agreement is initiated for a Perpetual Floating Rate Note, following the collapse of such note.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT Definition (incomplete for our purposes): &quot;After the collapse of the perpetual floating rate note, the bond issuers negotiate an interest rate with bondholders. If agreement is not reached, bond holders have the right to redeem the bond.&quot; Note also that the SWIFT definition refers to two possible events: the initiation of the agreement (implied, and assumed to be &quot;this&quot; event), and the failure to reach agreement, which event initiates the state whereby the bondholders have the right to redeem the bond.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ReverseStockSplit">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AdviceOfAPossibleAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.15"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">reverse stock split</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;oversubscriptionAmount"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.16"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">rights distribution</rdfs:label>
-		<skos:definition xml:lang="en">The distribution of rights to shareholders, in proportion to their equity holding.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Does the Rights Distribution have to be proportion to the Shareholding? Sometimes this is offered at market prices, so all you are doing is offering shareholders the right to purchase. Conclusion: Not &quot;in proportion&quot; at all. REVISE: May also have Bonus Rights Issue, where you don&apos; have a subscriptiojn price. This works like a rights issue but without a price attached to it. The rate of how many you can buy is definitely in proportion to your holding. The rate of distribution of the right is proportional to the holdings. Another difference: A Rights thing you have to pay for the additional shares if you choose to purchase them (exercise the right) whereas a Bonus Issue you do not pay, you get them outright for free. TWO PARTS: 1. Distribution of the rights in proportion to their holding 2. Exercise of the Rights. Hence RHDI v EXRI where EXRI is the exercising of the right to purchase the shares. The Rights that are distributed is a formal &quot;Rights&quot; instrument. This may have the sort of features we see in other rights instruments, such as restriction in when you can exercise it.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsDistributionNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssueNotification"/>
-		<rdfs:label xml:lang="en">rights distribution notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of the distribution of rights to shareholders, in proportion to their equity holding.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsExerciseEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderEvent"/>
-		<rdfs:label xml:lang="en">rights exercise event</rdfs:label>
-		<skos:definition xml:lang="en">Exercising the right to purchase the shares. Furhter Notes: This is an action on the part of the holder. SWIFT: Call/exercise on nil-paid securities/rights resulting from a rights distribution (RHDI) (To be used for the second event in case rights issue is dealt with in 2 events, first event being the RHDI).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There is a rights trading period overlaps with rights subscriptiuon period (you can trade the rights) Rights exercise period - expiry date. Some time after the expiry the new shares are distributed. This is the distribution.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isDistributionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;SubscriptionRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">rights issue</rdfs:label>
-		<skos:definition xml:lang="en">Some issue of rights to holders.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;RightsIssueNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssueNotification"/>
-		<rdfs:label xml:lang="en">rights issue notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of some issue of rights to holders.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ScripDividend">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">scrip dividend</rdfs:label>
-		<skos:definition xml:lang="en">Dividend paid in the form of scrip (temporary certificate) which represents the company&apos;s promise to pay a cash dividend. Occurs when earnings are sufficient but issuer wishes to conserve cash holdings. Shareholders are not offered a choice.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ScripDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">scrip dividend notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo"/>
-				<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities combination or detachment</rdfs:label>
-		<skos:definition xml:lang="en">An event in which a security is split into separate securities or separate seucrities are combined into one security. Includes splits, detachments, attachments and so on.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecuritiesDisbursementResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
-		<rdfs:label xml:lang="en">securities disbursement response message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of response opting to take the securities offered.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Term:&quot;Securities Option&quot; Definition:&quot;Distribution of securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecurityAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">security action</rdfs:label>
-		<skos:definition xml:lang="en">Some action taken with respect to some Security, by the Issuer of that security. THIS IS REDUNDANT</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecurityDeliveryResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-		<rdfs:label xml:lang="en">security delivery response</rdfs:label>
-		<skos:definition xml:lang="en">Response is to take the securities</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: &quot;Distribution of securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SecurityModificationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
-		<rdfs:label xml:lang="en">security modification event</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:label xml:lang="en">share action</rdfs:label>
-		<skos:definition xml:lang="en">Some action relating to equity shares. Add: relationship to Share</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareBuybackOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOffer"/>
-		<rdfs:label xml:lang="en">share buyback offer</rdfs:label>
-		<skos:definition xml:lang="en">Issuer bid; Reduction of circulation shares; Reverse Rights. Offer by Issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareBuybackOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOfferNotification"/>
-		<rdfs:label xml:lang="en">share buyback offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an offer by the issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT extra text, presumably synonyms: &quot;Issuer bid; Reduction of circulation shares; Reverse Rights.&quot; Scope: Shares only? The definition implies Shares but can this apply to Debt security. Issuer of debt securities could repurchase. In the case of Debt repurchase you would purchase the debt and then cancel the debt. Also RePo market - would this Notification be used and this action apply? No. SWIFT definition full text: &quot;Issuer bid; Reduction of circulation shares; Reverse Rights. Offer by Issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueChangeAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">share value change action</rdfs:label>
-		<skos:definition xml:lang="en">Event in which there is some change to the value of Shares.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Added to accommodate events like decrease in value. Definition there refers explicitly to Shares. Identify whether applicable to other types of instrument (I can&apos;t think of any).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueChangeNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">share value change notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a change in the face value of a share.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are styled as a kind of Action not simply an Event, since this is something that the issuer carries out.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueDecreaseAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeAction"/>
-		<rdfs:label xml:lang="en">share value decrease action</rdfs:label>
-		<skos:definition xml:lang="en">Reduction of the share capital and face value of a single share. The number of the circulating shares remains unchanged. May include a capital pay-out to shareholder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a type of Action. Not the same as the resulting change of value from a stock split or similar. Here we have the change of the par value.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueDecreaseNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeNotification"/>
-		<rdfs:label xml:lang="en">share value decrease notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a reduction of the share capital and face value of a single share.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The number of the circulating shares remains unchanged. May include a capital pay-out to shareholder. SWIFT full text: &quot;Reduction of the share capital and face value of a single share. The number of the circulating shares remains unchanged. May include a capital pay-out to shareholder.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueIncreaseAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeAction"/>
-		<rdfs:label xml:lang="en">share value increase action</rdfs:label>
-		<skos:definition xml:lang="en">Increase of the share capital. The face value of the single share is changed without modification of the number of shares in circulation. May include a capital payout to shareholder.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueIncreaseNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeNotification"/>
-		<rdfs:label xml:lang="en">share value increase notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an increase of the share capital. The face value of the single share is changed without modification of the number of shares in circulation.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">May include a capital payout to shareholder. 
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CombinedCashAndSecuritiesResponseMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">combined cash and securities response message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of response opting to take a distribution of both securities and cash as offered.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT: Term:&quot;Cash and Securities&quot; Definition:&quot;Election choice includes a distribution of both cash and securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CompanyOptionEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">company option event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A company option may be granted by the company, allowing the holder to take up shares at some future date(s) at a pre arranged price in the company.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Is this an Event? Or is notification of the option the event?</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentDenied">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent denied</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Vote not to approve the event or proposal. SWIFT: CONN</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentDeniedMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent denied message</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentGranted.1">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent granted</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Vote to approve the event or proposal. SWIFT: CONY</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentGrantedMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent granted message</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;AbstentionResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;ConsentDenied"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;ConsentGranted.1"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;VotingNoAction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.7"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent solicitation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Solicitation of shareholders consent. Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationCommunication">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent solicitation communication</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Activity in which the issuer of a security, wanting consent, communicates this to the holders, from whom consent would need to be granted.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent solicitation end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationRequest">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent solicitation request</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Solicitation of shareholders consent.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting. SWIFT Full TExt: &quot;Solicitation of shareholders consent. Procedure aimed at obtaining consent of holders to proposal by issuer or a third party without a formal general meeting.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationResponse">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent solicitation response</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConsentSolicitationStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consent solicitation start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;ConversionResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conversionActionAvailableResponseTakeNoActionResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;TakeNoActionResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isConversionFrom"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isConversionTo"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conversion action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Conversion or optional exchange of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conversion notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Conversion or optional exchange of securities (generally convertible bonds or preferred shares) into another form of securities (usually common shares) at a pre-stated price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionResponse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conversion response</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Response of the holder is to convert. SWIFT: Convert (CONV)</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionSuspensionAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conversion suspension action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Suspensiion of conversion of securities generally a couple of weeks before a meeting takes place. SWIFT = SCOP</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ConversionSuspensionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conversion suspension notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Suspensiion of conversion of securities generally a couple of weeks before a meeting takes place. SWIFT = SCOP</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.8"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.8"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event which has some effect on the details or terms of an issued Financial Security or on market perception of the value of that security.</skos:definition>
+bubu<skos:scopeNote rdf:datatype="&rdf;langString" xml:lang="en">Removed from scope of this term and moved to Issuer Corporate Action: &quot;This is an action which is compulsory on the issuer of the security.&quot; - REVIEW AND CLEAN OUT OF HERE Earlier review notes (pre refinement of this scope). REVIEW AND CLEAN OUT: Broader definition would also include things which might change the market price (for debt or equity), there asre things fo which you have to notify the market. these do not necessarily include changes to the details of the security. Most CAE will change the market perception. Not all actions which change the market perception are Corporate Events. Suggestion A corporate action is a generic class not actually homogenous, one of whcih si the Corporate Action of providin information to the market. There are legal requirements in most jurisdicitons saying that companies must advise their shareholders or bondhoders, about things whic might change the price. A separate kind of event notifies holders of securities (shares or bonds) of events which require an aciton on the part of the older (mandatory or bvoluntart) of the holder of the share. Then there are a set of events that don&apos;t get classified as CAE but have been included by SWIFT which are the actions by the holder, which would impact the issuer. These include calls on rights. Conclusion: There is one &quot;Corporate Event&quot; superclass of which everything is defined. earlier Event: Event has Terms and Conditions asspciated with it. Ts and Cs include mandatory and voluntary responses.</skos:scopeNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionAnnouncer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;FinancialSecuritiesActor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate action announcer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which makes the CA announcement. Best label for this? unclear. note that they may be issuers of other stock but they do not have to be. You can initiate a corporate action but you are not the issuer of that security, but the action is still about a particular security. Not all actions are bound to specific to a security/. A n action may impact one or more securities, The actions may require different communications. So we should probably distinguish actions versus communications about events. ADD: Communication. Example: Bell breakout. Sample use case for CAE.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionConfirmation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate action confirmation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionHolderResponse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate action holder response</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Response by the Holder of a security, to a previous Offer made by the Issuer.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Some CAE types fall under this heading. The action will specify what choices are available to the Holder by way of a response (for example cash, securities, no action and so on). See list ... Embedded as a scheme in a ISO 15022 field.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionNarrative">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate action narrative</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A message containing further narrative about some corporate action. This does not relate to any specific kind of action but is an additional stand-alone message.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Can extend information with user defined language and fields.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionObligation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate action obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An obligation related to the holding of a Security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Delivery of a security. Not defining direction at this level of the model - one party may have an obligation to deliver security or to pay; other party may have an obligation to deliver or to pay. Or there may be just one.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionPaymentObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate action payment obligation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionSecuritiesDeliveryObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate action securities delivery obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some obligation to deliver some security in the thr context of corporate actions. All cash proceeds and security proceeds can be represented a s acontractual obligation. Where does that obligation arise? Usually in the Contract itself - but there may be other answers to this. Defines what has to be delivered. or paid. Entitlement meanwhile is a calculation based on the Contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateActionStatusMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate action status message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A message which relates to the status of a corporate action.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Example would be if there is a Tender Offer, and the offer has been accepted, then a processing instruction would be sent. Not to be confused with a message about the status of a security or company.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateChangeOfStatusEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ChangeOfStateEvent"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate change of status event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some change to the status of some security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is generally described by a corporate event message. For example, change in trading status, listing status.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Events v Actions Notifiable versus non notifiable. Whether notfiable could be required by statute or by listing rules. Notifiable: Does this apply only to those events compulsory on the issuer? See Tender Offer. In takeover scenarios, the issuer will have actions incumbent o nthem to inform the market (e..g Aus Part B response). Offerer initiates Part A (Takeover Offer) with the details. Akin to a information memorandum or prospectus on the takeover. All interest parties (and non shareholders) have a potential interest, as it has a potential effect on the shares.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateEventOrActionCommunication">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;Message"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate event or action communication</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Communication about an event, action or status. Further Notes Includes name changes, consent (communication only) and others. Pre marketing agreements and so on. Note: some of these are very data driven, some are not. General meetings and so on.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateEventProcess">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate event process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CorporateModificationEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate modification event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some change in details of some company, which needs to be described for publicly issued securities issued by that company.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Usually described in a corporate event message. Note that the change relates to the company, but notification about this, for publicly issued securities (shares, bonds) is notificed to the holders of each such security, as corporate event messages.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CouponStrip">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;BondAction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.9"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon strip</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Coupon stripping is the process whereby interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CouponStripNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtIssuerCorporateActionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon strip notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification that the debt security is to be stripped, that is that interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">THis will result in two securities where previously there was one. REVIEW: precise details for the relation between the stripped instrument and the traded interest and principal components (does one of the remain the same security, or are two new securities created and one retired?); also account for recombination. SWIFT full text: &quot;Coupon stripping is the process whereby interest coupons for future payment dates are separated from the security corpus that entitles the holder to the principal repayment.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;CourtDecisionSubsequentMeeting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">court decision subsequent meeting</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Meeting following a court decision.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Named according to the description. Original SWIFT name is &quot;Court Meeting&quot;, which is not what it is.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;Custodian">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">custodian</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DebtDrawingNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt drawing notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Redemption in part before the scheduled final maturity date of a security. SWIFT = DRAW</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DebtInstrumentBuybackNotification">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt instrument buyback notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an event where det securities are bought back by the issuer.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">See also puts and calls (these are usually pre-arranged). Here the company goes out to the market and buys back their own debt. This does not really need to be a corporate event, they just do it. REVIEW: This term may not be needed. Not a corporate action.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DebtIssuerCorporateActionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt issuer corporate action notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DebtRedenomination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.10"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt redenomination</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Event by which the unit (currency and/or nominal) of a debt is restated, eg, a debt in a national currency unit is restated in euro.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Would be notified in advance.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DebtSecurityAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt security action</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DefaultEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Event in which something is not paid that should be.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Some of these terms may already exist in the CDS model - review and combine.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DetachmentAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">detachment action</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DetachmentNotificationMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AttachmentOrDetachmentNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">detachment notification message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of separation of components that comprise a security - usually units comprised of warrants and bond or warrants and equity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Units may be broken up at the request of the security holder or based on market convention. Scope: See Attachment. SWIFT Full text: &quot;Separation of components that comprise a security - usually units comprised of warrants and bond or warrants and equity. Units may be broken up at the request of the security holder or based on market convention.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DeterminationEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determination event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Event in which some amount or other parameter is determined, independently of any other event in which that which was determined is put into use. For example, the event by which interest is determined, as distinct from the event by which interest is paid on a different date or time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DisbursementResponse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">disbursement response</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Response by a holder to some choice of disbursement method, as offered by the issuer in some corporate action.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a generalization of a range of possible responses to offers by an issuer, which may be made in a number of Corporate Actions. Not all responses are available in all instances, and the Corporate Action notitificaiton will generally define which actions are held out to the Holder for a specific action; also some action types by their nature will be constrained to a sub set of these kinds of response. Note that this action (of choosing) is communicated to the Issuer by some message; the SWIFT terms for the messages are replicated here as kinds of Action which correspond to those. Hence the Action types and Message types are the same, and have the same origin in the SWIFT messages.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DisbursementResponseMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">disbursement response message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Message conveying the response by a holder to some choice of disbursement method, as offered by the issuer in some corporate action.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DisclosureMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">disclosure message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Disclosure of some fact or facts, by the holder of some security, as a result of some formal requirement imposed upon holders or beneficial owners under some applicable regulation.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The message modeled here is the message in which the disclosure is made. Individual types of disclosure are not modeled and may vary across jurisdictions. A fact about the disclosure is the regulation under which it was required to be made. Another fact is the disclosing party, that is the holder or beneficial owner. Note that in the Business Entities ontology, beneficial ownership is modeled separately from control ownership. This type of message may result from formal requirements placed upon either. SWIFT Full text: &quot;Requirement under some regulations for holders or beneficial owners to disclose&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DividendDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareAction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryDistribution"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any event relating to a dividend payment.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DividendDistributionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend distribution notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DividendOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Distribution of a dividend to shareholder with the choice of payment method. Shareholder must choose the form of payment - stock, cash, or both.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DividendOptionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend option notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DividendReinvestment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend reinvestment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Dividend payment where cash dividend is rolled over into additional shares in the issuing company.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Announcement would by that either get stock or cash. May have an announcement that pays a stock dividend only - hence this would be a bonus Issue. Dividend reinvestment is a choice on the part of the Holder but is not part of the announcement.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DividendReinvestmentNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend reinvestment notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;Drawing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">drawing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Redemption in part before the scheduled final maturity date of a security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Notification in advance of this happening.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DutchAuction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dutch auction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Similar to a tender offer, a Dutch auction is an action by a party wishing to acquire a particular security. Current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings. UPDATE THIS DEFINITION: Similar to a tender offer, a Dutch auction is the result of an action by a third party wishing to acquire a particular security. Current holders of the targeted security are invited (and given a message by the issuer) to make an offer in which they would be willling to sell their holdings. OR It might also represent a separate scenario where third parties do this, as per the original SWIFT defition. You can only go to the Registrar which would the other scenario impossible. Agents and Registrars: The issue issuer os the company which issued the shares (as modeled); Most companies don&apos;t interact directly with the market to find out who they need to disseminate the info to. They can, but more likely the employ &quot;Issuers Agent&quot;. That provides one point of contact from the organization. That agent handles all coms with the Registrars, and to the news wires etc., to disseminate the corporate action. Context: CAE only, or in the context of the Issue? When you issue the security you nominate an Agent, in the prospectus, there is specified an Issuing Agent. This is the one that does these things. Usually a merchant bank etc. in the old days. This is who will have directly facilitated that direct market engagement. Next question: This is part of going public, so these agents are appointed as part of going public.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The party to which the offer is made need not be the holder. Details: Question on &quot;Who is the actor?&quot; Dutch auction would have multiple parties? What is the scenario? Usually happens when a company is about to go into administration. Looking at the scneario descried in the SWIFT definition - not clear if this is the only such scenario. Possibly the issuer has to notif ythe shareholders that the offer is being made. The offer is made by the third party but the notice is sent by the issuer (via their agent) and via the registrar who holds the details of who holds all the shares. Example: Lloyds banking group - most shares would be owned by the market, and a small percentage might be held by private investors. So in this scenario everyone has to be given the opportunity to sell at the given price. so the CAE message is still issued by the Issuer. SWIFT detailed names (synonym?) &quot;Dutch Auction, Bid Tender&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;DutchAuctionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyFormalOfferNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dutch auction notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of a Dutch auction, that is an action by a party wishing to acquire a particular security. Under the terms of this offer, current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">See notes for the event itself - there is some unclarity as to whether this notification supports one message flow or several i.e. whether it is from third party, from Issuer&apos;s Agent to holders, from third party to Issuers Agent, or all three. REVIEW SWIFT full text: &quot;Similar to a tender offer, a Dutch auction is an action by a party wishing to acquire a particular security. Current holders of the targeted security are invited to make an offer in which they would be willling to sell their holdings.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;EventAnnouncement.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">event announcement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Event whereby some parties announces its intention to carry out some act at some present or future time. An Announcement is defined relative to the Event that is announced, for example the announcement of the issue of a financial security is defined in relation to the issue of a security (an Issuance Event).</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The announcement</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;EventNotification">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;communicatedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">event notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ExPostNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ex post notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an event that is expected or unexpected and has happened.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ExchangeOffer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOffer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.12"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange offer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Exchange offer; Capital reorganisation. Offer to shareholders to exchange their holdings for other securities and/or cash. Exchange offers are usually voluntary. Example: Where the &quot;usually voluntary&quot; comes in is that Announcement Payout Option 1: Cash 2. Stocks 3. Cash and Stock Holder picks option 1, 2 or 3 (= 1 &amp; 2). the voluntary aspect is where it&apos;s an Exchange Offer. It&apos;s mandatory to pick one of 1 - 3. Otherwise defaults to cash on payment date. Option Payout Componnet is the terms for the choice. Exchange Offer may be voluntary, not always Mandator With Choice. for example, there are legal qualifications on what is possible. Preceded by Tender Offer. Consequences dependent on scenarios. Once the firm making the offer gets to a given (legally defined) threshold e.g. 90% then they have the right to acquire all of the outstanding shares. An Exchange Offer is therefore a specialization of a Tender Offer. It&apos;s the specialization where the above mentioned requirements have been met. Further detail: Happens in a wider range of circumsntaces. Is soecifically associated with the issuer. this could be voluntary or not. EXOF could be any of the three (mand, vol, man w choice). tendre is always voluntary.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ExchangeOfferNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOfferNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange offer notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an offer to shareholders to exchange their holdings for other securities and/or cash.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Exchange offers are usually voluntary. Full SWIFT Definition text: &quot;Exchange offer; Capital reorganisation. Offer to shareholders to exchange their holdings for other securities and/or cash. Exchange offers are usually voluntary.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ExerciseAction">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercise action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some action in which spome party decides to exercise some option or some optionality concept.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These include puts and calls - I can put it to you or I can call it from you. can also be full or partial. Hence full call, partial call. Note that in Bonds, only the Issuer can call it, and only the Holder can Put it. However with this exception / narrowing of scope, the meaning of Put and Call are the same as for any other context, it&apos;s just that the implied other two cominations are not realizable in the world of Bonds.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ExerciseExChangeOptionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercise ex change option notification</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">Exchange options are mentioned in the terms and conditions of a security and are valid during the whole lifetime of a security. SWIFT: &quot;Option for shareholders to exchange their holdings for other secuities and/or cash. Exchange options are mentioned in the terms and conditions of a security and are valid during the whole lifetime of a security.&quot;</terms:description>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of exercise by Holder of an exsting option for shareholders to exchange their holdings for other securities and/or cash.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ExerciseExchangeOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableChoices"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercise exchange option</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ExtraordinaryGeneralMeeting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">extraordinary general meeting</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Extraordinary General Meeting</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;FinancialSecuritiesActor">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;hasSomeRoleIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial securities actor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some actor which has some agency in securities issuance or trading, or is some third party in such.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Is generally also a Party to some security, but need not be (e.g. hostile take-over bid actor).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;FormalOffer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formal offer</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-cae-ce-cae;DutchAuction">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-cae-ce-cae;ExchangeOffer">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-cae-ce-cae;ShareBuybackOffer">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-cae-ce-cae;TenderOffer">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Event which is an offer to the holder or potential holder or other intersted party, to enter into a trade which is or would be legally binding on the part of the party making the offer (the offeror).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;FullCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CallAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">full call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;FullExerciseAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">full exercise action</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;FundCapitalGainsDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund capital gains distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Distribution of profits resulting from the sale of securities. Shareholders of Mutual Funds, Unit Trusts, or Sicavs are recipients of capital gains distributions which are often reinvested in additional shares of the fund.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;FundCapitalGainsDistributionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalDistributionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund capital gains distribution notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of distribution to shareholders of funds, of profits resulting from the sale of securities.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Shareholders of Mutual Funds, Unit Trusts, or Sicavs are recipients of capital gains distributions which are often reinvested in additional shares of the fund. SWIFT full text: &quot;Distribution of profits resulting from the sale of securities. Shareholders of Mutual Funds, Unit Trusts, or Sicavs are recipients of capital gains distributions which are often reinvested in additional shares of the fund.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderDisclosure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder disclosure</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An action by a holder to voluntarily disclose some information. Examples: ENRON Disclosure rules. This is an action by the Holder on discovery of their legal requirement. Is there an Issuer action If so there may be an Issuer action asking for such disclosure. Or this may not exist since at the time of the action the Issuer should know all this. Conclusion: From a CA viewpoint specifically, the Disclosure would be from the holder.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderDisclosureMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder disclosure message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An action by a holder to voluntarily disclose some information.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT:&quot;Requirement under some regulations for holders or beneficial owners to disclose&quot; This comes from examples such as ENRON, and is a message in which the holdler of the security volunteers some information without prompting.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A CAE event relating to actions on the part of the holder.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Change of ownership has a message. Someone has to communicate the exercise.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitatedActionStart">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;flow"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;HolderInitiatedActionInitiation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder initated action start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder initiated action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any action initiated by a Holder of a Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedActionEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder initiated action end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedActionInitiation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder initiated action initiation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderInitiatedInstruction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InstructionMessage"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder initiated instruction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A message being an instruction by the holder of some security, made not in response to come choice offered by the issuer, but made on the holder&apos;s own initiative.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a general category of message. Note that there is one kind of message of this type in the original SWIFT-derived list of event message types, however it is assumed there must be others.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderMeetingResponse">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder meeting response</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderResponseMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InstructionMessage"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder response message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A message conveying the Holder&apos;s choice in some Corporate Action.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The message identifies the Corporate Action that they are a response to. In the event that they are not, this is highlighted in the message instructions - these are identified as such as in the ISO 15022 descriptions. See worksheet: some responses can be responses to more than one kind of message. Based on the type of notificaiton, there are various applicable response types. Based on the message sent out as a notification there are some or all of these responses, as being the possible responses to the message itself. That is down to the notifying party. Specified in the Notification what available responses there are.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;HolderResponseToChoice">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;givesRiseTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder response to choice</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Instructions consequent upon notifications. Instruction messages - some of these are responses to notifications. May be MT 565 related - has consent Yes, consent No, no action, accept shares, accept cash and securities etc. There are also ones that can be initiated by holders (not in this process step) such as puts. These can be presented without a notification previously having been sense. These are the ones we deided not to classify as &quot;Corporate Actions&quot; as these can be initiated by the holder. As such these are an instruction rather than a notification.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InformationAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">information action</rdfs:label>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These will have an Effective date. Similar to name change - actions where there is nothign the Holder can do about it, but there is an action at a certain date.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InformationEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">information event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A corporate event which is simply a notification about something. People may wish to respond</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InstalmentCall">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instalment call</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Increase of share capital through additional payment on face value of partly-paid shares, with part payments in several instalments. SWIFT = PPMT</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InstalmentDefault">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DefaultEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instalment default</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Non payment of a call by the beneficial owner, resulting in either a court action by the issuer or the sale of the securities to recover costs and/or a forfeit of partially paid securities. SWIFT = INDE</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InstructionMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instruction message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A message which embodies some instruction.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review whether we need this.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PaymentOrInterestPaymentAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest payment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Payment of Interest to the Holder. Further notes: Are there options on the Holder? Yes, you can opt to be paid in a certain currency. It is not always defined in the security terms. So if the Terms in the Security terms sheet gives you an option, there is a choice for the Holder at this point. Such choices would include: - Currency - Pay in Kind (&quot;Spinoff&quot; or PiK - see PiK corporate Action) Could be mandatory. If there were an option then the letter announcing it would require a response. This is usually stated in the message. Is there a message even if there is no option? Yes. Usually have to generate the events artificially as the Servicing organization. you can&apos;t rely on a feed or message coming in but because it is part of the security contract the above has to generate at the expected time, and arrange the payments. Q: That is the point at there was a choice you would expect to see a message, or end up still having to generate it but with the choices. A: The ones with Choices come as announcements and don&apos;t ave to be generated by the Service. Older definitin (re-scoped now: An Event in which a payment occurs. Anything can have a payment event. If a thing hits a pay date, whether it&apos;s voluntary or mandatory, that&apos;s a payment event. Divide into: Securities Cash Combination Payment or Distribution? Are these exclusive? Take an event that&apos;s always a combination of options, and an option is a combination of payouts. Generates transactions - determine what txns happen when a customer chooses that option. Distribution / delivery: generic concept Payment - implis cash distribution. So payment is specialization of distribution.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InterestPayment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest payment action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Regular interest payment, only in cash, distributed to holders of an interest bearing asset. According to the terms of the issue, a bondholder may be able to elect the currency interest is paid in.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentInKind">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest payment in kind</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Interest payment, in any kind except cash, distributed to holders of an interest bearing asset. SWIFT = PINK</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InterestPaymentWithPrincipal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InterestPaymentAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest payment with principal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A payment of a portion of the principal of an interest bearing asset, in addition to the interest payment. SWIFT = PRII</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InterestRateAdjustment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DebtSecurityAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.13"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate adjustment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Scheduled change to the coupon rate for a floating or adjustable rate security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The SWIFT definition as given defines the notification of the interest rate change, not the adjustment. Adjusted to describe the event. REVIEW: Is this really an action? Usually consider that it&apos;s expected. Given definition was for the announcement. SWIFT full definition &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;InterestRateAdjustmentNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExPostNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate adjustment notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Announcement of the current coupon rate for a floating or adjustable rate security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Definition as given refers to this notification (message) rather than the event itself. This is done for completeness, and sent out as a Notification by the Issuer or the Issuer&apos;s Agent. SWIFT Full definition: &quot;Announcement of the current coupon rate for a floating or adjustable rate security.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerCorporateAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;announcedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionAnnouncer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer corporate action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some corporate action initiated by the issuer of the Security. This is an action which is compulsory on the issuer of the security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is most of the kinds of action generally thought of as &quot;Corporate Actions&quot;. These may be mandaytory, voluntary, or mandatory with one or more choices fo rthe holder to make. This is the term for which it is mandatory on the issuer to notify this event to the marketplace and / or to holders of the security.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerCorporateActionAnnouncer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionAnnouncer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer corporate action announcer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The announcer of an event which is also the issuer of the security that the event is about.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;hasSubject"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer corporate action notification message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an action by the issuer of the security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerFormalOffer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer formal offer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An action in which the issuer of the security makes a formal offer.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Encompasses Exchange Offer and Repurchase Offer. Note that there are also offers made by third parties. These do not come under this term.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;IssuerFormalOfferNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer formal offer notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of some formal offer by the issuer of the security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;LiquidationEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">liquidation event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Liquidating dividend/Liquidation consist of a distribution of cash, assets, or both. Debt may be paid in order of priority based on preferred claims to assets specified by the security. SWIFT = LIQU</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ListingStatusDelistingMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listing status delisting message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Security is no longer able to comply with the listing requirements of a stock exchange and is removed from official board quotation.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ManagementAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">management action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event relating to the management of a company or other concern.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCashDividendEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory cash dividend event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Cash dividend with no option.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCashDividendNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory cash dividend notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCorporateAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory corporate action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event where there are no choice on the part of the Holder.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">for the purposes of clarity: Mandatory here means mandatory on the holder. Corporate Events as a whole are defined in terms of being mandatory on the part of the Issuer. In other words, Mandatory actions versus mandatory reactions. See Barron&apos;s: Dictionary of banking terms - no definition of Corporate Action.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryCorporateEventProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventProcess"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;hasStart"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;MandatoryEventStart"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory corporate event process</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mandatory corporate event: Action requires an action by the shareholder Corporate action event initiated by the corporation. Participation by shareholders is mandatory (for those relating to shares).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryEventEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory event end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryEventStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory event start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryPutEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PutAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory put event</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;OptionalPut"/>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There is a Put Bond, which is a kind of option in the sense that in return for getting less yield it allows you to put it back to the issuer. This means Put is a voluntary event. Therefore Mandatory Put is nonsensical? discussion: Or is it? If you are the issuer (therefore the granter of the option) then the event is to the holder). Partly paid shre for example gives the issuer the right to call funds but also has the right to put. So put is not by definition ... someone can have the right to put something. Conclusion: these do not appear to make sense as terms. A put bond allows the holder to redeem the issue. So this is by definition a voluntary event. Conclusion: go back to Pershing and find out what this term meant. Also we don&apos;t even know what kind of security this event was intended to refer to. We assume it refers to Put bond. This is on the assumption that Options can&apos;t be defined as having corporate action.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MandatoryWithChoiceCorporateAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory with choice corporate action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event which is going to happen but there are choices to be made by the Holder.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There is usually some default, e.g. if you don&apos;t choose by the payment date there is some default e.g. the issue currency. Voluntary differ from this in that the Holder chooses whether to do anything or not.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MaturityExtension">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;BondAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity extension</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">As stipulated in a bond&apos;s Terms and Conditions, the issuer or the bondholder may prolong the maturity date of a bond. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This would ne notified in advance. Fits into the normal &quot;Action&quot; workflow. SWIFT = EXTM</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MaturityExtensionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity extension notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an extension to the maturity date of a bond by the issuer, in line with existing terms and conditions.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">As stipulated in a bond&apos;s Terms and Conditions, the issuer or the bondholder may prolong the maturity date of a bond. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval. Note that the definition given for this in SWIFT is really narrative. New definition drafted in its place. SWIFT Full Text &quot;As stipulated in a bond&apos;s Terms and Conditions, the issuer or the bondholder may prolong the maturity date of a bond. After extension, the security may differ from original issue (new rate or maturity date). May be subject to bondholder&apos;s approval.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;Meeting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ManagementAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">meeting</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Management Event in which stakeholders meet one another either face to face or through some electronic or voice medium, in order to process some management activity (the Agenda).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MeetingProcessEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">meeting process end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;MeetingProcessStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">meeting process start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;NonIssuerCorporateActionAnnouncer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionAnnouncer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non issuer corporate action announcer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The announcer of an event which is not the issuer of the security that the event is about.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;NotificationEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notification event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A notification to the shareholders that therre is a corporate action out there. This is distinct from the CA itself. not the same as Event Announcement. There are steps between when the announcement happens and the rest Announcement: at the level of sub custodians. then you gether the people who are affected by the event that&apos;s to come. Then you send the announcement - a notification to the holder, informing them of the options that are available to them. If it&apos;s mandatory these distinctions still happen, but there is no choice. So still announcement is made, then when it effects people you send out notificaiton and collect responses. &quot;EVENT&quot;: two aspects: The event itself Events within the Corporat eAction, e.g. notification, deadline when a responses is due by, payment dates, Define as: lifecycle of the Corporate Action. Sometimes have to re-notify, there may be changes in the life oc the &quot;Corporate Event&quot;. So the Corporate Event is a sequence of events.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;NotificationMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notification message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an event.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Some events have a preliminiary notification followed by a confirmation of that. For example MT564 would have a preliminary notification. MT564 is not exclusively messages sent by an issuer, it may also be sent by a third party. Relationship Facts: sent by Related term: SWIFT Corporate Action Notification: &quot;The process of notifying of an upcoming corporate action. It provides corporate action details including the different options.&quot; (source for that term: SWIFT CAE analysis)</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotOffer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;OddLotSale"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">odd lot offer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Offer by issuer to allow holders of an odd lot of a security to order a commission-free transaction at market price, to sell the odd lot, or to buy an amount of shares which will bring the position to a round lot (board lot). SWIFT = ODLT</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotOfferMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">odd lot offer message</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotSale">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">odd lot sale</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Sale of odd-lot back to the issuing company.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OddLotSaleInstruction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;OddLotSale"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">odd lot sale instruction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of holder choice to sell odd-lot back to the issuing company.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is in response to the Issuer-initiated Corporate Action in which they make an Odd Lot Offer. SWIFT: Term:&quot;Odd Lot Sale&quot; Definition:&quot;Sale of odd-lot back to the issuing company.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OptionalCashDividendEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">optional cash dividend event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Cash dividend with currency options. This is a dividend payment where payment is mandatorily in the form of Cash. The choice is what currency the cash is to be received in.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OptionalCashDividendNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CashDividendNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">optional cash dividend notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OptionalPut">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;PutAction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VoluntaryCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">optional put</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OrdinaryGeneralMeeting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;Meeting"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ordinary general meeting</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Ordinary General Meeting SWIFT = OMET</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OrganizationModificationEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">organization modification event</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;OrganizationNameChange">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;OrganizationModificationEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">organization name change</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuing company changes it&apos;s name. Event shows the change from old name to new name and may involve surrendering physical shares with the old name to the registrar. SWIFT = NAME</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PartialCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CallAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partial call action</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PartialDefeasanceAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;InformationAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partial defeasance action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The setting aside by a borrower of cash or bonds sufficient to service the borrower&apos;s debt.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">From Free dictionary: Both the borrower&apos;s debt and the offsetting cash or bonds are removed from the balance sheet. In securities trading, where a clearing house becomes counterparty to each side of a trade, after the trade has been agreed. This is necessary to facilitate netting, and reduce counterparty risk exposure. The term has become popular recently, because of the growth of central counterparty clearing services in European cash equities markets. Origin: http://financial-dictionary.thefreedictionary.com/defeasance SWIFT: Term:PDEF; &quot;Partial Defeasance/Prefunding&quot; Definition:&quot;Issuer has money set aside to redeem a portion of an issue and the indenture states that the securities could be called earlier than the stated maturity.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PartialExerciseEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partial exercise event</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PaymentOrInterestPaymentAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment or interest payment action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The payment of some mandatory payment as defined in the contractual terms of the security, such as interst payment of amortization. this is income generated to the HOlder because of the security contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is distinct from any other kind of distribution based on the Issuer deciding to do something;l in this case the OIssuer has no choice (these are payments defined in contractual terms) and if they do not do it,. this is a Default</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PayoutOptionTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payout option terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PlaceOfIncorporationChange">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;OrganizationModificationEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">place of incorporation change</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Changes in the state of incorporation for US companies and changes in the place of incorporation for foreign companies. Where shares need to be registered following the incorporation change, the holder(s) may have to elect the registrar. SWIFT = PLAC</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PostMergerSecuritiesExchange">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;definesAdditional"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;exchangesFrom"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;exchangesInto"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">post merger securities exchange</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mandatory or voluntary exchange of an outstanding securities as the result of two or more companies combining assets. Cash payments may accompany share exchange.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is an action as a result of the Merger, not the merger itself.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PostMergerSecuritiesExchangeNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">post merger securities exchange notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of mandatory or voluntary exchange of outstanding securities as the result of two or more companies combining assets.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Cash payments may accompany share exchange. Note that the event to which this applies was labeled &quot;Merger&quot; in source material but refers to the exchange of securities following a merger, not the merger itself. SWIFT full definition &quot;Mandatory or voluntary exchange of an outstanding securities as the result of two or more companies combining assets. Cash payments may accompany share exchange.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PriorityIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">priority issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Form of open or public offer where priority is given to existing shareholders due to limited amount of securities available in the offer. Shareholders can buy a type of security during a short period of time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;PutAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ExerciseAction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">put action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The putting of some debt security back to its issuer by the holder</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note this is a holder action. There may be terms in the security giving the holder the ability to redeem early. If so, this is the event where that happens. Could apply to MTN as well as Bonds. We have defined MTN as a kind of Bond in this model. Review discussion: scope fo this: You could in theory put a share but no-one has come across this. Issuer may buy back shares at a given price but that&apos;s a different context - there&apos;s message for that. Makes an offer to repurchase shares. So therefore it is not possible in principle to have a call fo ra non debt instrument. In other circumstances e.g. compulsory acquisition in a takeover, is equivalent to this but it&apos;s a different term.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;Redemption">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Repayment in full of a debt security, investment trust or a preferred stock issue, at stated maturity. SWIFT = REDM</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;RemarketingAgreementInitiated">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.14"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;PerpetualFloatingRateNote"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">remarketing agreement initiated</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Event in which a remarketing agreement is initiated for a Perpetual Floating Rate Note, following the collapse of such note.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT Definition (incomplete for our purposes): &quot;After the collapse of the perpetual floating rate note, the bond issuers negotiate an interest rate with bondholders. If agreement is not reached, bond holders have the right to redeem the bond.&quot; Note also that the SWIFT definition refers to two possible events: the initiation of the agreement (implied, and assumed to be &quot;this&quot; event), and the failure to reach agreement, which event initiates the state whereby the bondholders have the right to redeem the bond.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ReverseStockSplit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AdviceOfAPossibleAction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.15"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reverse stock split</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;RightsDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;oversubscriptionAmount"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.16"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rights distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The distribution of rights to shareholders, in proportion to their equity holding.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Does the Rights Distribution have to be proportion to the Shareholding? Sometimes this is offered at market prices, so all you are doing is offering shareholders the right to purchase. Conclusion: Not &quot;in proportion&quot; at all. REVISE: May also have Bonus Rights Issue, where you don&apos; have a subscriptiojn price. This works like a rights issue but without a price attached to it. The rate of how many you can buy is definitely in proportion to your holding. The rate of distribution of the right is proportional to the holdings. Another difference: A Rights thing you have to pay for the additional shares if you choose to purchase them (exercise the right) whereas a Bonus Issue you do not pay, you get them outright for free. TWO PARTS: 1. Distribution of the rights in proportion to their holding 2. Exercise of the Rights. Hence RHDI v EXRI where EXRI is the exercising of the right to purchase the shares. The Rights that are distributed is a formal &quot;Rights&quot; instrument. This may have the sort of features we see in other rights instruments, such as restriction in when you can exercise it.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;RightsDistributionNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;RightsIssueNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rights distribution notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of the distribution of rights to shareholders, in proportion to their equity holding.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;RightsExerciseEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rights exercise event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Exercising the right to purchase the shares. Furhter Notes: This is an action on the part of the holder. SWIFT: Call/exercise on nil-paid securities/rights resulting from a rights distribution (RHDI) (To be used for the second event in case rights issue is dealt with in 2 events, first event being the RHDI).</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There is a rights trading period overlaps with rights subscriptiuon period (you can trade the rights) Rights exercise period - expiry date. Some time after the expiry the new shares are distributed. This is the distribution.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;RightsIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isDistributionOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;SubscriptionRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rights issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some issue of rights to holders.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;RightsIssueNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CapitalizationIssueNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rights issue notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of some issue of rights to holders.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ScripDividend">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scrip dividend</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Dividend paid in the form of scrip (temporary certificate) which represents the company&apos;s promise to pay a cash dividend. Occurs when earnings are sufficient but issuer wishes to conserve cash holdings. Shareholders are not offered a choice.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ScripDividendNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scrip dividend notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo"/>
+bubububu<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities combination or detachment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event in which a security is split into separate securities or separate seucrities are combined into one security. Includes splits, detachments, attachments and so on.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;SecuritiesDisbursementResponseMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities disbursement response message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of response opting to take the securities offered.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT: Term:&quot;Securities Option&quot; Definition:&quot;Distribution of securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;SecurityAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some action taken with respect to some Security, by the Issuer of that security. THIS IS REDUNDANT</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;SecurityDeliveryResponse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security delivery response</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Response is to take the securities</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT: &quot;Distribution of securities to holders.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;SecurityModificationEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateModificationEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security modification event</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ShareAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some action relating to equity shares. Add: relationship to Share</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ShareBuybackOffer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOffer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share buyback offer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Issuer bid; Reduction of circulation shares; Reverse Rights. Offer by Issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ShareBuybackOfferNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerFormalOfferNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share buyback offer notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an offer by the issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT extra text, presumably synonyms: &quot;Issuer bid; Reduction of circulation shares; Reverse Rights.&quot; Scope: Shares only? The definition implies Shares but can this apply to Debt security. Issuer of debt securities could repurchase. In the case of Debt repurchase you would purchase the debt and then cancel the debt. Also RePo market - would this Notification be used and this action apply? No. SWIFT definition full text: &quot;Issuer bid; Reduction of circulation shares; Reverse Rights. Offer by Issuing company to existing shareholders to repurchase the company&apos;s own shares or other securities convertible into shares.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueChangeAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share value change action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Event in which there is some change to the value of Shares.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Added to accommodate events like decrease in value. Definition there refers explicitly to Shares. Identify whether applicable to other types of instrument (I can&apos;t think of any).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueChangeNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share value change notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of a change in the face value of a share.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are styled as a kind of Action not simply an Event, since this is something that the issuer carries out.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueDecreaseAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share value decrease action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Reduction of the share capital and face value of a single share. The number of the circulating shares remains unchanged. May include a capital pay-out to shareholder.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a type of Action. Not the same as the resulting change of value from a stock split or similar. Here we have the change of the par value.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueDecreaseNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share value decrease notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of a reduction of the share capital and face value of a single share.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The number of the circulating shares remains unchanged. May include a capital pay-out to shareholder. SWIFT full text: &quot;Reduction of the share capital and face value of a single share. The number of the circulating shares remains unchanged. May include a capital pay-out to shareholder.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueIncreaseAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share value increase action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Increase of the share capital. The face value of the single share is changed without modification of the number of shares in circulation. May include a capital payout to shareholder.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ShareValueIncreaseNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareValueChangeNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share value increase notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an increase of the share capital. The face value of the single share is changed without modification of the number of shares in circulation.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">May include a capital payout to shareholder. 
 Further Notes:SWIFT Full Text: &quot;Increase of the share capital. The face value of the single share is changed without modification of the number of shares in circulation. May include a capital payout to shareholder.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SharesDistributionEvent">
-		<rdfs:label xml:lang="en">shares distribution event</rdfs:label>
-		<skos:definition xml:lang="en">The distribution of shares in response to the exercise of some rights.</skos:definition>
-		<skos:editorialNote xml:lang="en">not in CAE lists. This would not involve any further announcements.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SharesPremiumDividendPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">shares premium dividend payment</rdfs:label>
-		<skos:definition xml:lang="en">This corporate event pays shareholders an amount in cash issued from the shares premium reserve. It is similar to a dividend but with different tax implications. SWIFT = SHPR</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SharesPremiumDividendPaymentNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">shares premium dividend payment notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;SpinOff">
-		<rdfs:label xml:lang="en">spin off</rdfs:label>
-		<skos:definition xml:lang="en">Demerger; Distribution; Unbundling. A distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares. Spin-off represents a form of divestiture resulting in an independent company.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;StockDividend">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
-		<rdfs:label xml:lang="en">stock dividend</rdfs:label>
-		<skos:definition xml:lang="en">Dividend paid to shareholders in the form of shares of stock in the issuing company or in another company. Shareholder must take stock and is not offered a choice in the form of distribution.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;StockDividendNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
-		<rdfs:label xml:lang="en">stock dividend notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;StockSplit">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AdviceOfAPossibleAction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.17"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">stock split</rdfs:label>
-		<skos:definition xml:lang="en">The increase in a company&apos;s number of outstanding shares of stock without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SWIFT: Change in nominal value; Subdivision.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TakeNoActionNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;TakeNoActionResponse"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">take no action notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a Take No Action response. SWIFT: Term: NOAC Definition: &quot;Take no action&quot;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TakeNoActionResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">take no action response</rdfs:label>
-		<skos:definition xml:lang="en">Take No Action. SWIFT: Term: NOAC Definition: &quot;Take no action&quot;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TaxReclaimActivity">
-		<rdfs:label xml:lang="en">tax reclaim activity</rdfs:label>
-		<skos:definition xml:lang="en">We dont&apos; have detailed information on what kinds of activities there are, but there may be a broad range of these. For instance, may be giving the issuer&apos;s location, or the rules for tax reclaims. Different rules exist. May set the rules on each action. For instance, It versus Fr, different rules. The CA notificaiton may be setting out the rules on each tax reclaim. Example: Aus: Issuer may make declaration to tax department, that securities are widely issued, this has some effect on withholding etc. Countries may have standing rules fo rreclaims, but may be special rules at an issue action level for large issue action. this would go out as a message (notification) using this message code. Similar to VAT in Canada - as an individual you pay VAT and reclaim it when you leave the country. Fill out a form etc. Then they send the VAT back. Conclusions: A general activity of Tax Reclaim - not formally modeled, just iterated here; notification which is the SWIFT message notoification type.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TaxReclaimActivityMessage">
-		<rdfs:label xml:lang="en">tax reclaim activity message</rdfs:label>
-		<skos:definition xml:lang="en">Message about some Tax Reclaim activity. SWIFT:&quot;Event related to tax reclaim activities.&quot;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TenderOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.18"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tender offer</rdfs:label>
-		<skos:definition xml:lang="en">Offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices. Generally, the objective of a tender is to take control of the target company.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The announcer is not the issuer of the shares. The party to which the offer is made need not be the holder. Assumption: someone else trying to take over ythe company.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TenderOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyFormalOfferNotification"/>
-		<rdfs:label xml:lang="en">tender offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of an offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Generally, the objective of a tender is to take control of the target company. SWIFT whole text: &quot;Offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices. Generally, the objective of a tender is to take control of the target company.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionAnnouncement">
-		<rdfs:label xml:lang="en">third party action announcement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionChoiceExists">
-		<rdfs:label xml:lang="en">third party action choice exists</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionChoiceOffer">
-		<rdfs:label xml:lang="en">third party action choice offer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionHolderResponseToChoice">
-		<rdfs:label xml:lang="en">third party action holder response to choice</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionNotification">
-		<rdfs:label xml:lang="en">third party action notification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;announcedBy.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;NonIssuerCorporateActionAnnouncer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">third party corporate action</rdfs:label>
-		<skos:definition xml:lang="en">Some action initiated by some third party to the security, i.e. not the issuer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example an offer made in the context of a takeover bid. Quesytion: if a third party makes such an action, doe sthe issuer also have to send out the notification? If the company is listed ,then the issuer is also obligated to notify holders that this thing is taking place. If both companies are listed, both have to send out a notificaiton to the market that they are doing this action. So the target company has to notify the market. sothere is a separate message which is the target company notifying its holders that a Tender Offer etc. is taking place. Is this in the ISO 15022 list? Are they both done with the same message? Example: Company B makes a bid in private to Company A. Discussion may go on in private. At some point you have to legally make it clear. So then Company A says &quot;we are being approached by company B&quot; and Company B has to put out a message saying &quot;We are going to try and take over Company B&quot;. Are they the same message? The &quot;Tender Offer&quot; message type is rich enough that both things can be conveyed. So when we try to semantically distinguish the message from the action? The party making the bid completes different fields in the message, to those filled in by the target company. This then marks out the semantics of &quot;This is a bid offer and I am the 3rd party&quot; or &quot;I am reporting a bid offer&quot;. Semantically: There is an event and there is a message describing the event. TElling the market about something happening to a company can be something your company is doing, or something causing a change in circumstances. Either way, the issuer of the affected securities has to identify and notify that there is something which might be affecting the price of their securities. May be internal or external things, and either way the issuer has to notify the market.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionEnd">
-		<rdfs:label xml:lang="en">third party corporate action end</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionIssuerMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">third party corporate action issuer message</rdfs:label>
-		<skos:definition xml:lang="en">Message from security issuer, notifying holders of a third party action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These actions are initiated by some party other than the issuer. The issuer would also send out a message to holders, in order that they are formally notified of the action. Note also that the CAE message types may be the same in both cases.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:label xml:lang="en">third party corporate action notification message</rdfs:label>
-		<skos:definition xml:lang="en">Notification of a third party corporate action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There will be two lots of notification message for third party action.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionOriginatorMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">third party corporate action originator message</rdfs:label>
-		<skos:definition xml:lang="en">Message from a third party, notifying holders of a third party action.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These actions are initiated by some party other than the issuer. As well as this message, the issuer would also send out a message to holders, in order that they are formally notified of the action. Note also that the CAE message types may be the same in both cases.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionStart">
-		<rdfs:label xml:lang="en">third party corporate action start</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyFormalOfferNotification">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage"/>
-		<rdfs:label xml:lang="en">third party formal offer notification</rdfs:label>
-		<skos:definition xml:lang="en">Notification of some third party offer, to the shareholders.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This message may be circulated by the third party or by the issuer REVIEW: to be confirmed.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusActiveMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;TradingStatusMessage"/>
-		<rdfs:label xml:lang="en">trading status active message</rdfs:label>
-		<skos:definition xml:lang="en">Trading in security has commenced or security has been re-activated after a supsension in trading.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">trading status message</rdfs:label>
-		<skos:definition xml:lang="en">A message about trading status.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are a number of such messages. Events v Status: See e.g. Active: this relates to one state OR two transitions (transition from pre-issuance to Trading, or from Suspended to Trading).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusSuspendedMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;TradingStatusMessage"/>
-		<rdfs:label xml:lang="en">trading status suspended message</rdfs:label>
-		<skos:definition xml:lang="en">Trading in the security has been suspended.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryCorporateAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:label xml:lang="en">voluntary corporate action</rdfs:label>
-		<skos:definition xml:lang="en">An event with some choice on the part of the Holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Voluntary on the part of the Holder. This refers to voluntary types of actions (not necessarily for dividends). Rights take-up is an example.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryCorporateEventProcess">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventProcess"/>
-		<rdfs:label xml:lang="en">voluntary corporate event process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:label xml:lang="en">voluntary distribution</rdfs:label>
-		<skos:definition xml:lang="en">An action in which funds are distributed voluntarily by the issuer of a security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is distinct from expected and contractually obligation distributions such as payments of interest or repayments of debt capital. 29 June notes: Have Income Services these then divide into: Interest income Dividend income If income includes both interest and dividend, this may be artificial and not useful - not how the business uses the term. If we include Capital Gains Distribiution? Older notes Pay date: examples - splits and so on. Also Calls. (Options calls; Debt calls have different meaning) Applies to either. Call is &quot;to you&quot; where distributing is &quot;from you&quot;.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoteAgainstManagement">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">vote against management</rdfs:label>
-		<skos:definition xml:lang="en">Vote against management.</skos:definition>
-		<skos:editorialNote xml:lang="en">It is not clear how this is distinct from Consent Denied. It is not a response to a Consent message, but it is a voting response of some sort. Possibly a specialization of Consent Denied? Keep it distinct for now. Consent Denied is not necessarily a vote against management, since management may have one or another view about the proposal that is on the table, that is defined in the Consent message. SWIFT: AMGT</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VoteAgainstManagementMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">vote against management message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VotingNoAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
-		<rdfs:label xml:lang="en">voting no action</rdfs:label>
-		<skos:definition xml:lang="en">Option for the account owner not to take part in the event. SWIFT: NOAC</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VotingNoActionMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
-		<rdfs:label xml:lang="en">voting no action message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VotingResponse">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-		<rdfs:label xml:lang="en">voting response</rdfs:label>
-		<skos:definition xml:lang="en">Some response to a voting activity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;VotingResponseMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:label xml:lang="en">voting response message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;WarrantExerciseAction">
-		<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
-		<rdfs:label xml:lang="en">warrant exercise action</rdfs:label>
-		<skos:definition xml:lang="en">Option offered to holders to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time (which usually corresponds to the life of the issue). Fiurther Notes: Note this is the issuer offering the holders the opportunity to do this exercise, it is not the exercise itself - misnamed in SWIFT. SWIFT = EXWA</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-cae-ce-cae;WorthlessSecurityBookingOut">
-		<rdfs:label xml:lang="en">worthless security booking out</rdfs:label>
-		<skos:definition xml:lang="en">Booking out of some worthless security by the Issuer. SWIFT:&quot;Booking out of valueless securities.&quot;</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;announcedBy">
-		<rdfs:label xml:lang="en">announced by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionAnnouncer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;announcedBy.1">
-		<rdfs:label xml:lang="en">announced by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;NonIssuerCorporateActionAnnouncer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;availableChoices">
-		<rdfs:subPropertyOf rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-		<rdfs:label xml:lang="en">available choices</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ExerciseExchangeOption"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;availableResponse">
-		<rdfs:label xml:lang="en">available response</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;communicatedBy">
-		<rdfs:label xml:lang="en">communicated by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;EventNotification"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conversionActionAvailableResponseTakeNoActionResponse">
-		<rdfs:subPropertyOf rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
-		<rdfs:label xml:lang="en">conversion action available response take no action response</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;TakeNoActionResponse"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conveys">
-		<rdfs:label xml:lang="en">conveys</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conveys.1">
-		<rdfs:label xml:lang="en">conveys</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conveys.2">
-		<rdfs:label xml:lang="en">conveys</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;definesAdditional">
-		<rdfs:label xml:lang="en">defines additional</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;effectiveDate">
-		<rdfs:label xml:lang="en">effective date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;InformationAction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;exchangesFrom">
-		<rdfs:label xml:lang="en">exchanges from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;exchangesInto">
-		<rdfs:label xml:lang="en">exchanges into</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;flow">
-		<rdfs:label xml:lang="en">flow</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderInitatedActionStart"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;HolderInitiatedActionInitiation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;givesRiseTo">
-		<rdfs:label xml:lang="en">gives rise to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderResponseToChoice"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;hasSomeRoleIn">
-		<rdfs:label xml:lang="en">has some role in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;FinancialSecuritiesActor"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;hasStart">
-		<rdfs:label xml:lang="en">has start</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateEventProcess"/>
-		<rdfs:range rdf:resource="&fibo-cae-ce-cae;MandatoryEventStart"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;holderHasChoices">
-		<rdfs:label xml:lang="en">holder has choices</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isAbout">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-msg;hasSubject"/>
-		<rdfs:label xml:lang="en">is about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;TradingStatusMessage"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isConversionFrom">
-		<rdfs:label xml:lang="en">is conversion from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isConversionTo">
-		<rdfs:label xml:lang="en">is conversion to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isDistributionOf">
-		<rdfs:label xml:lang="en">is distribution of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsIssue"/>
-		<rdfs:range rdf:resource="&fibo-der-rgt-raw;SubscriptionRight"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isIssueOf">
-		<rdfs:label xml:lang="en">is issue of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;mandatory">
-		<rdfs:label xml:lang="en">mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BonusRightsIssue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;mandatory.1">
-		<rdfs:label xml:lang="en">mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the action is mandatory on the Holder.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;mandatory.2">
-		<rdfs:label xml:lang="en">mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;MandatoryCashDividendEvent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the action is mandatory on the Holder. This is &quot;yes&quot; i.e. it is a mandatory event.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;mandatory.3">
-		<rdfs:label xml:lang="en">mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;OptionalCashDividendEvent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the action is mandatory on the Holder. This is &quot;no&quot; i.e. it is a voluntary event.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;oversubscriptionAmount">
-		<rdfs:label xml:lang="en">oversubscription amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount of additional rights that may be purchased by the holder over and above the initial allocation. Further notes: In addition to a Subscription Price (see the Price term in the Subscription rights term), there is an additional privilege extended to the holders, to subscribe to additional shares. This also is in a certain proportion. This is to catch if not enough rights were subscribed, you may be left with some left over. These can then be given to the over-subscribers. Additional terms: if this exists there is a ratio for this as well. Notes Some people may pass up the right, and another person may pick this up through over-subscription. Therefore there is no oversubscription on a Bonus issue because people are getting it for free.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.1">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BankruptcyEvent"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.10">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;DebtRedenomination"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.11">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;EventAnnouncement.1"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.12">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ExchangeOffer"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.13">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;InterestRateAdjustment"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.14">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RemarketingAgreementInitiated"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;PerpetualFloatingRateNote"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.15">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ReverseStockSplit"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.16">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<skos:definition xml:lang="en">The Rights Distribution relates to Share.</skos:definition>
-		<skos:editorialNote xml:lang="en">REVIEW: Share or Publicly Traded Share?</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.17">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.18">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;TenderOffer"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.2">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BondDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.3">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BondPutRedemption"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.4">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.5">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ChangeInDetailsNotification"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-be-le-cb;StockCorporation">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.6">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ChangeOfSecurityTradingStatusEvent"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.7">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConsentSolicitation"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.8">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">The business entity to which the corporate event relates. It is from this that the securities affected are determined.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.9">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CouponStrip"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;requiresResponse">
-		<rdfs:label xml:lang="en">requires response</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the notification refers to an event which requires a response from the holder of the security .</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;requiresResponse.1">
-		<rdfs:label xml:lang="en">requires response</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ShareValueChangeNotification"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;subscriptionPrice">
-		<rdfs:label xml:lang="en">subscription price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The price at which the Subscription Rights instrument itself may be purchased.</skos:definition>
-	</owl:ObjectProperty>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;SharesDistributionEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">shares distribution event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The distribution of shares in response to the exercise of some rights.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">not in CAE lists. This would not involve any further announcements.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;SharesPremiumDividendPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">shares premium dividend payment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">This corporate event pays shareholders an amount in cash issued from the shares premium reserve. It is similar to a dividend but with different tax implications. SWIFT = SHPR</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;SharesPremiumDividendPaymentNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">shares premium dividend payment notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;SpinOff">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spin off</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Demerger; Distribution; Unbundling. A distribution of subsidiary stock to the shareholders of the parent company without a surrender of shares. Spin-off represents a form of divestiture resulting in an independent company.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;StockDividend">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistribution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stock dividend</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Dividend paid to shareholders in the form of shares of stock in the issuing company or in another company. Shareholder must take stock and is not offered a choice in the form of distribution.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;StockDividendNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;DividendDistributionNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stock dividend notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;StockSplit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;AdviceOfAPossibleAction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ShareAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.17"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stock split</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The increase in a company&apos;s number of outstanding shares of stock without any change in the shareholder&apos;s equity or the aggregate market value at the time of the split.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SWIFT: Change in nominal value; Subdivision.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;TakeNoActionNotificationMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;conveys.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;TakeNoActionResponse"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">take no action notification message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of a Take No Action response. SWIFT: Term: NOAC Definition: &quot;Take no action&quot;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;TakeNoActionResponse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">take no action response</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Take No Action. SWIFT: Term: NOAC Definition: &quot;Take no action&quot;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;TaxReclaimActivity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax reclaim activity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">We dont&apos; have detailed information on what kinds of activities there are, but there may be a broad range of these. For instance, may be giving the issuer&apos;s location, or the rules for tax reclaims. Different rules exist. May set the rules on each action. For instance, It versus Fr, different rules. The CA notificaiton may be setting out the rules on each tax reclaim. Example: Aus: Issuer may make declaration to tax department, that securities are widely issued, this has some effect on withholding etc. Countries may have standing rules fo rreclaims, but may be special rules at an issue action level for large issue action. this would go out as a message (notification) using this message code. Similar to VAT in Canada - as an individual you pay VAT and reclaim it when you leave the country. Fill out a form etc. Then they send the VAT back. Conclusions: A general activity of Tax Reclaim - not formally modeled, just iterated here; notification which is the SWIFT message notoification type.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;TaxReclaimActivityMessage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax reclaim activity message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Message about some Tax Reclaim activity. SWIFT:&quot;Event related to tax reclaim activities.&quot;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;TenderOffer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;relatesTo.18"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tender offer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices. Generally, the objective of a tender is to take control of the target company.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The announcer is not the issuer of the shares. The party to which the offer is made need not be the holder. Assumption: someone else trying to take over ythe company.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;TenderOfferNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyFormalOfferNotification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tender offer notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of an offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Generally, the objective of a tender is to take control of the target company. SWIFT whole text: &quot;Offer made to shareholders, normally by a third party, requesting them to sell (tender) their shares for a specified price usually at a premium over prevailing market prices. Generally, the objective of a tender is to take control of the target company.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionAnnouncement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party action announcement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionChoiceExists">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party action choice exists</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionChoiceOffer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party action choice offer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionHolderResponseToChoice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party action holder response to choice</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyActionNotification">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party action notification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;announcedBy.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-cae-ce-cae;NonIssuerCorporateActionAnnouncer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party corporate action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some action initiated by some third party to the security, i.e. not the issuer.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example an offer made in the context of a takeover bid. Quesytion: if a third party makes such an action, doe sthe issuer also have to send out the notification? If the company is listed ,then the issuer is also obligated to notify holders that this thing is taking place. If both companies are listed, both have to send out a notificaiton to the market that they are doing this action. So the target company has to notify the market. sothere is a separate message which is the target company notifying its holders that a Tender Offer etc. is taking place. Is this in the ISO 15022 list? Are they both done with the same message? Example: Company B makes a bid in private to Company A. Discussion may go on in private. At some point you have to legally make it clear. So then Company A says &quot;we are being approached by company B&quot; and Company B has to put out a message saying &quot;We are going to try and take over Company B&quot;. Are they the same message? The &quot;Tender Offer&quot; message type is rich enough that both things can be conveyed. So when we try to semantically distinguish the message from the action? The party making the bid completes different fields in the message, to those filled in by the target company. This then marks out the semantics of &quot;This is a bid offer and I am the 3rd party&quot; or &quot;I am reporting a bid offer&quot;. Semantically: There is an event and there is a message describing the event. TElling the market about something happening to a company can be something your company is doing, or something causing a change in circumstances. Either way, the issuer of the affected securities has to identify and notify that there is something which might be affecting the price of their securities. May be internal or external things, and either way the issuer has to notify the market.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party corporate action end</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionIssuerMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party corporate action issuer message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Message from security issuer, notifying holders of a third party action.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These actions are initiated by some party other than the issuer. The issuer would also send out a message to holders, in order that they are formally notified of the action. Note also that the CAE message types may be the same in both cases.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party corporate action notification message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of a third party corporate action.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There will be two lots of notification message for third party action.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionOriginatorMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party corporate action originator message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Message from a third party, notifying holders of a third party action.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These actions are initiated by some party other than the issuer. As well as this message, the issuer would also send out a message to holders, in order that they are formally notified of the action. Note also that the CAE message types may be the same in both cases.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyCorporateActionStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party corporate action start</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;ThirdPartyFormalOfferNotification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateActionNotificationMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party formal offer notification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Notification of some third party offer, to the shareholders.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This message may be circulated by the third party or by the issuer REVIEW: to be confirmed.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusActiveMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;TradingStatusMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading status active message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Trading in security has commenced or security has been re-activated after a supsension in trading.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventOrActionCommunication"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-cae-ce-cae;isAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading status message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A message about trading status.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There are a number of such messages. Events v Status: See e.g. Active: this relates to one state OR two transitions (transition from pre-issuance to Trading, or from Suspended to Trading).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;TradingStatusSuspendedMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;TradingStatusMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading status suspended message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Trading in the security has been suspended.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryCorporateAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voluntary corporate action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event with some choice on the part of the Holder.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Voluntary on the part of the Holder. This refers to voluntary types of actions (not necessarily for dividends). Rights take-up is an example.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryCorporateEventProcess">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateEventProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voluntary corporate event process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;VoluntaryDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voluntary distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An action in which funds are distributed voluntarily by the issuer of a security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is distinct from expected and contractually obligation distributions such as payments of interest or repayments of debt capital. 29 June notes: Have Income Services these then divide into: Interest income Dividend income If income includes both interest and dividend, this may be artificial and not useful - not how the business uses the term. If we include Capital Gains Distribiution? Older notes Pay date: examples - splits and so on. Also Calls. (Options calls; Debt calls have different meaning) Applies to either. Call is &quot;to you&quot; where distributing is &quot;from you&quot;.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;VoteAgainstManagement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">vote against management</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Vote against management.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">It is not clear how this is distinct from Consent Denied. It is not a response to a Consent message, but it is a voting response of some sort. Possibly a specialization of Consent Denied? Keep it distinct for now. Consent Denied is not necessarily a vote against management, since management may have one or another view about the proposal that is on the table, that is defined in the Consent message. SWIFT: AMGT</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;VoteAgainstManagementMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">vote against management message</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;VotingNoAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voting no action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Option for the account owner not to take part in the event. SWIFT: NOAC</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;VotingNoActionMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;VotingResponseMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voting no action message</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;VotingResponse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voting response</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some response to a voting activity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;VotingResponseMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voting response message</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;WarrantExerciseAction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-cae-ce-cae;SecurityAction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">warrant exercise action</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Option offered to holders to buy (call warrant) or to sell (put warrant) a specific amount of stock, cash, or commodity, at a predetermined price, during a predetermined period of time (which usually corresponds to the life of the issue). Fiurther Notes: Note this is the issuer offering the holders the opportunity to do this exercise, it is not the exercise itself - misnamed in SWIFT. SWIFT = EXWA</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-cae-ce-cae;WorthlessSecurityBookingOut">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">worthless security booking out</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Booking out of some worthless security by the Issuer. SWIFT:&quot;Booking out of valueless securities.&quot;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;announcedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announced by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionAnnouncer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;announcedBy.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">announced by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ThirdPartyCorporateAction"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;NonIssuerCorporateActionAnnouncer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;availableChoices">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">available choices</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ExerciseExchangeOption"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;availableResponse">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">available response</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;communicatedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">communicated by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;EventNotification"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;IssuerCorporateActionNotificationMessage"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conversionActionAvailableResponseTakeNoActionResponse">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-cae-ce-cae;availableResponse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conversion action available response take no action response</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;TakeNoActionResponse"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conveys">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conveys</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;DisbursementResponseMessage"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;DisbursementResponse"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conveys.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conveys</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderInitiatedInstruction"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;HolderInitiatedAction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;conveys.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conveys</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;CorporateActionHolderResponse"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;definesAdditional">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines additional</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;effectiveDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effective date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;InformationAction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;exchangesFrom">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchanges from</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;exchangesInto">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchanges into</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;PostMergerSecuritiesExchange"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;flow">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">flow</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderInitatedActionStart"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;HolderInitiatedActionInitiation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;givesRiseTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gives rise to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;HolderResponseToChoice"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;HolderResponseMessage"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;hasSomeRoleIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has some role in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;FinancialSecuritiesActor"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;hasStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has start</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;MandatoryCorporateEventProcess"/>
+bubu<rdfs:range rdf:resource="&fibo-cae-ce-cae;MandatoryEventStart"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;holderHasChoices">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder has choices</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isAbout">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-msg;hasSubject"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;TradingStatusMessage"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isConversionFrom">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is conversion from</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isConversionTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is conversion to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConversionAction"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isDistributionOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is distribution of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-der-rgt-raw;SubscriptionRight"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;isIssueOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is issue of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;mandatory">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BonusRightsIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;mandatory.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;IssuerCorporateAction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the action is mandatory on the Holder.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;mandatory.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;MandatoryCashDividendEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the action is mandatory on the Holder. This is &quot;yes&quot; i.e. it is a mandatory event.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;mandatory.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;OptionalCashDividendEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the action is mandatory on the Holder. This is &quot;no&quot; i.e. it is a voluntary event.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;oversubscriptionAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">oversubscription amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of additional rights that may be purchased by the holder over and above the initial allocation. Further notes: In addition to a Subscription Price (see the Price term in the Subscription rights term), there is an additional privilege extended to the holders, to subscribe to additional shares. This also is in a certain proportion. This is to catch if not enough rights were subscribed, you may be left with some left over. These can then be given to the over-subscribers. Additional terms: if this exists there is a ratio for this as well. Notes Some people may pass up the right, and another person may pick this up through over-subscription. Therefore there is no oversubscription on a Bonus issue because people are getting it for free.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;SecuritiesCombinationOrDetachment"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BankruptcyEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.10">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;DebtRedenomination"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.11">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;EventAnnouncement.1"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.12">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ExchangeOffer"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.13">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;InterestRateAdjustment"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.14">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RemarketingAgreementInitiated"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;PerpetualFloatingRateNote"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.15">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ReverseStockSplit"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.16">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Rights Distribution relates to Share.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">REVIEW: Share or Publicly Traded Share?</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.17">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;StockSplit"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.18">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;TenderOffer"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BondDefaultEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BondPutRedemption"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.4">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;BonusIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.5">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ChangeInDetailsNotification"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-be-le-cb;StockCorporation">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.6">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ChangeOfSecurityTradingStatusEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.7">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ConsentSolicitation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.8">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CorporateAction"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The business entity to which the corporate event relates. It is from this that the securities affected are determined.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;relatesTo.9">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;CouponStrip"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;requiresResponse">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requires response</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;NotificationMessage"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the notification refers to an event which requires a response from the holder of the security .</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;requiresResponse.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requires response</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;ShareValueChangeNotification"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-cae-ce-cae;subscriptionPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscription price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-cae-ce-cae;RightsDistribution"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price at which the Subscription Rights instrument itself may be purchased.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/civ/Funds/CIV.rdf
+++ b/civ/Funds/CIV.rdf
@@ -1,2777 +1,2780 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/">
-	<!ENTITY fibo-be-fctx-fne "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/">
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
-	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
-	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-accx-bal "https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
-	<!ENTITY fibo-fnd-bus-pol "https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/">
+bu<!ENTITY fibo-be-fctx-fne "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
+bu<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
+bu<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-accx-bal "https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
+bu<!ENTITY fibo-fnd-bus-pol "https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
+bu<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"
-	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"
-	xmlns:fibo-be-fctx-fne="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"
-	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
-	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-accx-bal="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
-	xmlns:fibo-fnd-bus-pol="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
-		<rdfs:label xml:lang="en">CIV</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesClassification/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;AccumulatingShareClass">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
-		<rdfs:label xml:lang="en">accumulating share class</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-civ-fnd-civ;DistributingShareClass"/>
-		<skos:definition xml:lang="en">A share class in which there is no option to reinvest.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This fact would be determined by the fund unit having a specific Fund Distribution Policy of Accumulating.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;AnnualReportingPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;ReportingFrequencyPolicy"/>
-		<rdfs:label xml:lang="en">annual reporting policy</rdfs:label>
-		<skos:definition xml:lang="en">Reports are presented once a year</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;AnnualizedPerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">annualized performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">Annualized performance determination.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;AssetClassStrategy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifiesAssetTypesBy"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassifier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">asset class strategy</rdfs:label>
-		<skos:definition xml:lang="en">Strategy which is asset class based.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">EFAMA: The type of securities or other holdings that may be invested in. FIBIM: Strategy which is asset class based. Can implement this in terms of a classification of those things. Wording implies this is a policy.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;Benchmark">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifiedAs"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">benchmark</rdfs:label>
-		<skos:definition xml:lang="en">A reference index used to measure fund performance.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;BricksAndMortarHolding">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/PortfolioHolding"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;takesFormOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bricks and mortar holding</rdfs:label>
-		<skos:definition xml:lang="en">A holding of built property.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;CommonShareInFund">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
-		<rdfs:label xml:lang="en">common share in fund</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-civ-fnd-civ;PreferredShareInFund"/>
-		<skos:definition xml:lang="en">A share unit in a fund, which is classified as a Common Share class.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">SR Review session notes: US: Closed and open ended funds may have common and preferred shares.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;CurrencyStrategy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:label xml:lang="en">currency strategy</rdfs:label>
-		<skos:definition xml:lang="en">Strategy which is currency based.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;DebtStakeInFund">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesRelationshipWith"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt stake in fund</rdfs:label>
-		<skos:definition xml:lang="en">A stake held in a fund by way of a Bond Unit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that you cannot buy fractional amounts in a bond. Review Session Note: Similar to what happens in a CDO where the collaterial manager and the issuer are two different entities. So model this along the same lines as the SPV in the structured finance model. Therefore: further modeling and review required</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;DistributingShareClass">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
-		<rdfs:label xml:lang="en">distributing share class</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;EquityAsset">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolding"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity asset</rdfs:label>
-		<skos:definition xml:lang="en">The holding of equity securities in a portfolio.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;EquityFund">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;contains"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;EquityPortfolio"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity fund</rdfs:label>
-		<skos:definition xml:lang="en">A fund which invests in at least 85% shares.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;EquityPortfolio">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-		<rdfs:label xml:lang="en">equity portfolio</rdfs:label>
-		<skos:definition xml:lang="en">A portfolio which has at least 85% exposure to shares.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;EquityStakeInFund">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesRelationshipWith"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity stake in fund</rdfs:label>
-		<skos:definition xml:lang="en">A stake held in a fund by way of a Share Class Unit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Theoretically you can buy a fraction of a share in a fund. This would depend on the legal structure of the fund, e.g. a minimum investment. There is always a distribution plan.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;Fund">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/Pool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;domicile"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-cty;Country"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;administeredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundAdministrator"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;advisedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;InvestmentAdvisor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;describedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;distributedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDistributor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;domicile"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAccountant"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundAccountant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAccountingInformation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAdditionalInformation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;OtherInvestmentFundInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAuditor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundAuditor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDataProvider"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDataProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDepository"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDepositary"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDistributionPolicy.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasFundIdentification"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;OrganizationIdentifier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasFundPolicy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestmentPolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasLegalForm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasManagementCompany"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasObjective"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasPerformanceDeterminationMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasRelatedFundTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasSubscriptionTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasTradableUnit"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasTransferAgent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundTransferAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasUnitIssuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;legallyRecordedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;promotedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPromoter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;supervisedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundSupervisoryAuthority"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund</rdfs:label>
-		<skos:definition xml:lang="en">Distinct pool of financial instruments managed by a single investment policy.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From EFAMA DD: The word fund can refer to either an investment pool, umbrella or share class, and is commonly refered to as a collective investment vehicle (can have ISIN or not). The meaning here is for the investment pool (of which an Umbrella fund is also one such) and not to the share class.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundAccountant">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:label xml:lang="en">fund accountant</rdfs:label>
-		<skos:definition xml:lang="en">The party that keeps accounting records of the available assets and liabilities of the Fund. It calculates dealing prices, the Net Asset Value (NAV) of the Fund, and may provide fund performance and tax data. Can be subcontracted by the FundAdministrator.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundAdministrator">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;mayAlsoBe"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund administrator</rdfs:label>
-		<skos:definition xml:lang="en">Entity that has to fulfil the legal and supervisory requirements of the fund. Responsible for all the business purposes around the investment pool, and so is reponsible for the issuing of the shares.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the unit is a bond, then the issuer is separate from the Fund Administrator. WG11 text: The party in charge of financial accounting, NAV calculation, management and performance fee calculation. Can also be in charge of orders centralisation and registration. Definition origin:EFAMA DD</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundAuditor">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:label xml:lang="en">fund auditor</rdfs:label>
-		<skos:definition xml:lang="en">The party that is in charge of examining and verifying a fund&apos;s financial and accounting records as well as supporting documents and fulfilment of legal requirements. Definition origin:EFAMA DD</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundBondClassUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDistributiojnPolicy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasExpectedCoupon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundBondUnitCoupon"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;setsOutTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDebt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund bond class unit</rdfs:label>
-		<skos:definition xml:lang="en">A fund unit which takes the form of debt in that fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From EFAMA Review: called denominations e.g. issued in $5000 pieces. You cannot buy fractional amounts in a bond.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundBondUnitCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasPolicyTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund bond unit coupon</rdfs:label>
-		<skos:definition xml:lang="en">A fixed coupon paid out to holders of the Fund Bond Unit.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundCashDistributionPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
-		<rdfs:label xml:lang="en">fund cash distribution policy</rdfs:label>
-		<skos:definition xml:lang="en">Policy for distribution of cash dividends or notes in the event that the fund units have a distribution policy of &quot;Cash&quot; rather than &quot;Reinvestment&quot;.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundCouponPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundCashDistributionPolicy"/>
-		<rdfs:label xml:lang="en">fund coupon policy</rdfs:label>
-		<skos:definition xml:lang="en">Terms for the expected distribution of bond unit coupons.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDataProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund data provider</rdfs:label>
-		<skos:definition xml:lang="en">A party which supplies market data to a fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDebt">
-		<rdfs:label xml:lang="en">fund debt</rdfs:label>
-		<skos:definition xml:lang="en">Debt issued by a Fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This would normally be held by participants in that pool. in this case the pool is a fund which is formed by each of the participants extending credit to that pool and holding bond units in the pool representing that debt.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDepositary">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;providesDepositaryServiceFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund depositary</rdfs:label>
-		<skos:definition xml:lang="en">The party that holds and safeguards holdings owned by a fund. It is also responsible for compliance of the portfolio with legal ratios etc.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The depository may delegate custody to another entity (custodian). Definition origin:EFAMA DD</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDistributionPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
-		<rdfs:label xml:lang="en">fund distribution policy</rdfs:label>
-		<skos:definition xml:lang="en">The overal diustribution policy or policy limitations for the fund itself.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that individual classes of Fund Unit also have specific distribution polcies as they effect that class of unit. This class is for terms with wording of the form: &quot; ... whether or not it is possible to hold shares ...&quot; for a given parameter.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDistributor">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:label xml:lang="en">fund distributor</rdfs:label>
-		<skos:definition xml:lang="en">an entity through which a fund may be bought by or for an investor. This may be on a discretionary or advisory basis, or as an execution-only service. Definition origin:EFAMA DD</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDividendPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundCashDistributionPolicy"/>
-		<rdfs:label xml:lang="en">fund dividend policy</rdfs:label>
-		<skos:definition xml:lang="en">Terms for the expected distributions of dividends.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundEquity">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/PoolEquity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-acc-aeq;representsAnInterestIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund equity</rdfs:label>
-		<skos:definition xml:lang="en">A share or proportion of the capital gains in a fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestmentObjective">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasIntendedRiskLevel"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;RiskLevel"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;statedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund investment objective</rdfs:label>
-		<skos:definition xml:lang="en">The aim of a Fund e.g outperfom a given benchmark.</skos:definition>
-		<skos:editorialNote xml:lang="en">This could be broken down into other terms that can be itemised here, that are not in the EFAMA DD explicitly. Examples may include: - Risk level - Return - Exposure to different markets</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestmentPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;stipulatesBenchmark"/>
-				<owl:onClass rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;constrains"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;sets"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund investment policy</rdfs:label>
-		<skos:definition xml:lang="en">The policy within which the fund acts in order to achieve the stated fund objectives.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">EFAMA Note: Model distinguishes between strategy (what you intend to invest in) and portfolio structure (what is held). This semantics matches the EFAMA DD &quot;Fund Investment Policy&quot; No stated definition in EFAMA DD (&quot;Further discussion required&quot;).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isPartOf.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund investment restrictions set</rdfs:label>
-		<skos:definition xml:lang="en">Limitations that apply to the fund as a whole, such as risk factors. these are used to determine whether the fund is appropriate for a given type of investor to invest in.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are defined by the overall Fund investment policy. Not the same as the detailed policies for investing in percentages of this or that.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestor">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isUnitHolder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund investor</rdfs:label>
-		<skos:definition xml:lang="en">A party which invests in the Fund. It does this by holding some tradable unit (which represents some stake) in that fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Facts about investor tolerance and so on, are facts about Investor.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestorType">
-		<rdfs:label xml:lang="en">fund investor type</rdfs:label>
-		<skos:definition xml:lang="en">The type of party that is eligible to invest in a fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundLegalContract">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;OrganizationCoveringAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalFormDocumentation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund legal contract</rdfs:label>
-		<skos:definition xml:lang="en">For a fund which is constituted under the law of contract, the contract that embodies the fund legal form.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From ISO FIBIM &quot;Umbrella Fund&quot; narrative: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundLegalForm">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifiedAs.3"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-fctx-fne;FundsSPV">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-le-cb;Corporation">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-civ-fnd-civ;FundLegalContract">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-corp-corp;JointStockCompany">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund legal form</rdfs:label>
-		<skos:definition xml:lang="en">The legal form of the fund, eg Joint Stock Company, SPV etc.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This term does not cover the structure of the fund (Open or Closed, Open Ended or Closed Ended); these facts are covered in separate terms. This fact is the legal form which the fund takes, as a legal entity of some kind. It refers to a selection of possible legal forms, such as Joint Stock Company. This has been defined as a separate, relative class of thing rather than simply a relationship, so as to be able to model relationships to the fund legal form regardless of what form that takes. For example, the various kinds of Stake&quot; in the fund have a relationship to the legal entity which is the fund, regardless of what kind of entity that is.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundLegalFormDocumentation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-cor;Constitution"/>
-		<rdfs:label xml:lang="en">fund legal form documentation</rdfs:label>
-		<skos:definition xml:lang="en">For a fund which is constituted under the law of contract, the constitution or articles that define the fund. These are embodied in a Contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From ISO FIBIM &quot;Umbrella Fund&quot; narrative: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundManagementCompany">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:label xml:lang="en">fund management company</rdfs:label>
-		<skos:definition xml:lang="en">The party that sets up the fund, decides the investment strategy, appoints the agents, and is responsible for the promotion and the marketing of the fund. It makes all of the important decisions related to the fund. Also called fund promotor or fund sponsor or fund manager.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In the US: operates on a percentage of the Portfolio assets under management.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundManager">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundManagementCompany"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund manager</rdfs:label>
-		<skos:definition xml:lang="en">The party that sets up the fund, decides the investment strategy, appoints the agents, and is responsible for the promotion and the marketing of the fund. It makes all of the important decisions related to the fund. Also called fund promotor or fund sponsor. This is a dupliucate of Fund Management Company at the moment</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundOrderDesk">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;providerHasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund order desk</rdfs:label>
-		<skos:definition xml:lang="en">The Fund Order Desk is a party to the Fund Order Desk Account.</skos:definition>
-		<skos:editorialNote xml:lang="en">This party would presumably be identified as the Fund Management Company in terms of what legal entity fulcils this role? to be determined at further review.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundOrderDeskPhysicalFormDocument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:label xml:lang="en">fund order desk physical form document</rdfs:label>
-		<skos:definition xml:lang="en">A phsyical form obtained through the main fund order desk.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPortfolio">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;InvestmentPortfolio"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;assessedAgainst"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasLiquidity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Liquidity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;implementsFundPolicy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;managedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;holds"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/PortfolioHolding"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;strategy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund portfolio</rdfs:label>
-		<skos:definition xml:lang="en">An account containing a number of financial instruments along with cash positions in one or more currencies and belonging to a Fund</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
-		<rdfs:label xml:lang="en">fund portfolio investment limitations</rdfs:label>
-		<skos:definition xml:lang="en">Detailed Policy on approximately how the portfolio is to be allocated to achieve the stated investment goals. This underpins the detailed strategy of how to achieve this.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Defined as &quot;Strategy&quot; in FIBIM and elsewhere. WG11: Rough allocation of the portfolio.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesAllocations"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;constrains"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund portfolio investment policy</rdfs:label>
-		<skos:definition xml:lang="en">Intended allocation of the portfolio to meet the stated investment strategy and goals.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">ISO FIBIM: Rough allocation of the portfolio.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundProcessingForm">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;ControlDocument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;mayBe.1"/>
-				<owl:onClass rdf:resource="&fibo-civ-fnd-civ;FundOrderDeskPhysicalFormDocument"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund processing form</rdfs:label>
-		<skos:definition xml:lang="en">The form of documentation or control mechanism required for some funds processing activity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equates to the &quot;Physical Form&quot; in SIO FIBIM for certain activities in funds processing. May or may not be a written physical document. ISO FIBIM Definition: Specifies whether a physical form is required.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundProcessingGeneralTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:label xml:lang="en">fund processing general terms</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms for general processing of the fund. These set out what the investor and the fund may or may not do.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundProcessingTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesMainFundOrderDeskAccount"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundsProcessingAccount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDefaultSettlementConvention"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund processing terms</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms for processing of the fund. These set out what the investor and the fund may or may not do. These include terms for redemption and subscription processing as well as general processing terms. ISO FIBIM definition: Processing characteristics linked to the instrument, ie, not to the market.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These include Fund Subscription Terms, Fund Redemption Terms. and terms which relate to general processing and restrictions or otherwise on the holder. FPP notes: FPP presentation identifies many of these terms under the heading of Valuation Dealing characteristics. May need to revise which goes where in line with FPP. See also terms under NAV Valuation Calculation Method. Others of these terms appear in FPP under Instrument Restrictions. These cover the subscription, redemption and holding amounts and units and minimum holding period.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPromoter">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:label xml:lang="en">fund promoter</rdfs:label>
-		<skos:definition xml:lang="en">An entity that promotes a fund. May be an investor, pension fund, bank, insurance company or management company</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Prospectus"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;anticipates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;outlines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund prospectus</rdfs:label>
-		<skos:definition xml:lang="en">The Prospectus for the Fund. This is a document made available publicly for potential investors. It will include facts about the fund investment objective, investment focus and other details of the fund. Some of this information becomes binding on the fund once it is issued, while other information is guidelines only.</skos:definition>
-		<skos:editorialNote xml:lang="en">EFAMA Review description for this: The fund is issued with a prospectus; there is material in the prospectus that is binding; material that is expected but not binding, and information that may or may not be in the prospectus or a given fund.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundRedemptionRestriction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-		<rdfs:label xml:lang="en">fund redemption restriction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundRedemptionTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAdditionalRedemptionRestrictions"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;ReferToFundOrderDesk"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund redemption terms</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms for redemption of units in the fund. These set out what the investor and the fund may or may not do.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundReinvestmentPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
-		<rdfs:label xml:lang="en">fund reinvestment policy</rdfs:label>
-		<skos:definition xml:lang="en">Terms for the expected reinvestment of profits on fund units.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundReportingTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAccountingReportingFrequency"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;ReportingFrequencyPolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund reporting terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms describing the accounting methods and reporting arrangements used by the fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundShareClassUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/EquityInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;confersOwnershipOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDistributionPolicy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasExpectedDividend"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnitDividend"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund share class unit</rdfs:label>
-		<skos:definition xml:lang="en">The legal structure in which you can purchase part of an investment pool, defined by a variety of characteristics like investor type, minimum size of investment, distribution type, fee and currency. A fund unit which gives the holder an equity stake in the fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From review sessions: Theoretically you can buy a fraction of a share in a fund. This would depend on the legal structure of the fund, e.g. a minimum investment. There is always a distribution plan.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundShareClassUnitDividend">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasPolicyTerms.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund share class unit dividend</rdfs:label>
-		<skos:definition xml:lang="en">Expected dividend payment from a Fund Unit. REVIEW: Does this apply to the Fund as a whole or to a unit in the fund? This term will be redefined following the Funds model restructuring</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundStructure">
-		<rdfs:label xml:lang="en">fund structure</rdfs:label>
-		<skos:definition xml:lang="en">One of the different ways in which a Fund may be structured.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundSubscriptionTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;relateTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund subscription terms</rdfs:label>
-		<skos:definition xml:lang="en">Subscription terms for the fund. Further notes: ISO FIBIM, EFAMA DD and FPP combine terms for subscription, redemption and general holding requirements. These have been separated here as they are different kinds of term, but this can be reviewed. Subscription Terms are identified as terms of the fund and not the fund unit, since terms for how you might subscribe can&apos;t be binding one someone who has not yet subscribed.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundSupervisoryAuthority">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund supervisory authority</rdfs:label>
-		<skos:definition xml:lang="en">The legal entity which supervises the fund or fund industry</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundTransferAgent">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:label xml:lang="en">fund transfer agent</rdfs:label>
-		<skos:definition xml:lang="en">An entity that undertakes the execution of subscription, redemption and switch orders on behalf of a fund. Definition origin:EFAMA DD</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;denominationCurrency"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDetails"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasFundProcessingTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasFundProcessingTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasSecurityIdentifier"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/InternationalSecuritiesIdentificationNumber"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasSecurityIdentifier"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/SecurityIdentifier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isOpenEndedOrClosed"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;OpenEndedOrClosed"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-sec;legallyRecordedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund unit</rdfs:label>
-		<skos:definition xml:lang="en">A unit in a fund, which may be traded and is a contract between the fund and the holder of that unit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If it is a closed fund, you can still trade the units. You trade back with the fund. Not with a counterparty. Therefore this is a tradable contract, though it may not necessarily be a transferable contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnitDistributionMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DistributionMethod"/>
-		<rdfs:label xml:lang="en">fund unit distribution method</rdfs:label>
-		<skos:definition xml:lang="en">The normal distribution policy for funds.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnitDistributionPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDistributionPolicy.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund unit distribution policy</rdfs:label>
-		<skos:definition xml:lang="en">Income policy relating to the unit, e.g. if income is paid out or retained in the fund and how this is treated, including distribution policy details for dividends and coupons.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnitHolding">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/PortfolioHolding"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;consistsOf"/>
-				<owl:allValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund unit holding</rdfs:label>
-		<skos:definition xml:lang="en">A holding of a unit in another fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
-		<rdfs:label xml:lang="en">fund units settlement terms convention</rdfs:label>
-		<skos:definition xml:lang="en">Default settlement terms which may apply to a fund, trading of for units in the fund and for redemption of fund units.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From EFAMA DD Review Notes: Default settlement terms. Related to the Unit. Usually the terms are set already at the fund level, and won&apos;t vary at share class level between different share classes, but they are facts about the share classes / Notes / Bonds i.e. what you can trade. In fact this happens already - different kinds of investors may have different settlement dates. In this example you announce it earlier - not the same. This may be a separate fact. Conesnsus:Review</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsCashDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
-		<rdfs:label xml:lang="en">funds cash distribution</rdfs:label>
-		<skos:definition xml:lang="en">Accrued income is distributed periodically to the investor.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-		<rdfs:label xml:lang="en">funds processing</rdfs:label>
-		<skos:definition xml:lang="en">The context of managing and processing funds, issuing funds units etc. This is the context in which the different parties involved in a fund are defined as parties.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessingAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Account"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;accountHasProvider"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundOrderDesk"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">funds processing account</rdfs:label>
-		<skos:definition xml:lang="en">An account used specifically in the processing of funds. Like all accounts this is (per FIBIM definition) a business relationship between two entities; one entity is the account owner, the other entity is the account servicer. Please refer to Financial global model for treatment of accounts relationships in this model.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Derived from FIBIM definition for &quot;Account&quot;, which is: &quot;Business relationship between two entities; one entity is the account owner, the other entity is the account servicer.&quot; this corresponds to the Global Terms definition for Account.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">funds processing party</rdfs:label>
-		<skos:definition xml:lang="en">A party involved in the processing of funds in some way.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessingPassport">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasInformationAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;mayBeDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;setsOutTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">funds processing passport</rdfs:label>
-		<skos:definition xml:lang="en">The Funds Processing Passport. This is defined as a document. This has terms drawn from elsewhere in the model which are defined as part of the FPP for reasons defined in the FPP descriptions.</skos:definition>
-		<skos:editorialNote xml:lang="en">Please see FPP Data Descriptions for more information (when available - not included in this model). See EFAMA website for this. Also see XLS for terms of this. These terms are often but net necessarily part of the Prospectus. See also the Thing Formerly Referred To As Investment. The definitions in the FPP descriptions may not be accurate. This is defining what kind of information is requested. Further Action: Now that we have defined sets of formal contractual terems for subvscriptions, redemptions and general terms, and since these terms don&apos;t have a direct relationship to any one Contract at present (as contractual terms should do), there may be a relationship between those terms and the FPP. To be handled in next review.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessingReferent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;SynechdocalThing"/>
-		<rdfs:label xml:lang="en">funds processing referent</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;GrossOfFeePerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">gross of fee performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">Performance determined gross of fee. Review: Is this mutually exclusive with the other listed method? It sounds like it is not.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;HedgeFund">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:label xml:lang="en">hedge fund</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed Review notes (EFAMA?) Also only closed ended according to regulations. This is not always a kind of closed fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;IncomeAccumulation">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
-		<rdfs:label xml:lang="en">income accumulation</rdfs:label>
-		<skos:definition xml:lang="en">Accrued income is not distributed and instead remains reflected within the unit/share price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;InvestmentAdvisor">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">investment advisor</rdfs:label>
-		<skos:definition xml:lang="en">The party that provides investment guidance at a fee. Definition origin:EFAMA DD</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;JurisdictionStrategy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifies.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">jurisdiction strategy</rdfs:label>
-		<skos:definition xml:lang="en">Strategy which is jurisdiction based.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;Liquidity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;denominatedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">liquidity</rdfs:label>
-		<skos:definition xml:lang="en">Precise definition needed for liquidity, and check that it is modeled accordingly.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;MoneyWeightedRateOfReturnPerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">money weighted rate of return performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">Money weighted rate of return.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isCalculatedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">net asset value calculation method</rdfs:label>
-		<skos:definition xml:lang="en">Parameters for the calculation of the net asset value for an investment fund/fund class.</skos:definition>
-		<skos:editorialNote xml:lang="en">These terms were in the ISO FIBIM model but correspond to some details in the EFAMA DD.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;NoteFundUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:label xml:lang="en">note fund unit</rdfs:label>
-		<skos:definition xml:lang="en">Need a legal definition - to follow. This is one of the mechanisms by which an investor may hold an interest in a fund, but is not a Bond or a Share.</skos:definition>
-		<skos:editorialNote xml:lang="en">It is not possible to determine at this time whether some of the policy facts that apply to bund and share class units apply to all fund units including this one. Once this is defined, all Fund Distribution Policy terms and relationships should be rechecked.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;NoteStakeInFund">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesRelationshipWith"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">note stake in fund</rdfs:label>
-		<skos:definition xml:lang="en">A stake held in a fund by way of a note.</skos:definition>
-		<skos:editorialNote xml:lang="en">Need a legal definition - to follow. This is one of the mechanisms by which an investor may hold an interest in a fund, but is not a Bond or a Share. Therefore it&apos;s not clear what sort of stake to label this as - usually a stake in anything must be either equity or debt.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;OpenEndedOrClosed">
-		<rdfs:label xml:lang="en">open ended or closed</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;OrganizationStrategy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definedInRelationTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">organization strategy</rdfs:label>
-		<skos:definition xml:lang="en">Strategy which is organization based.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;OtherInvestmentFundInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">other investment fund information</rdfs:label>
-		<skos:definition xml:lang="en">Things which are not part of the prospectus but are important if you want to understand the fund.</skos:definition>
-		<skos:editorialNote xml:lang="en">See terms in EFAMA spreadsheet. These are properties of the fund but are not legally binding. Author follow-up note: I have managed to find a &quot;home&quot; for disposition for most of the entries that are in the spreadsheet. It is not clear which of the spreadsheet terms are indended to come under the general heading in this class. The first place I would look is in the terms I have defined as &quot;Fund Processing Terms&quot;, which are defined as formal, legal contractual terms. If any of those are not legally binding on some party, then this is where they belong instead.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;PerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">A method for performance determination (e.g. Time weighted and money weighted, annualized, gross of fee) along with the time frame in which this is determined. PLUS Performances NamePeriod</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;PortfolioBenchmark">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesBenchmark"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">portfolio benchmark</rdfs:label>
-		<skos:definition xml:lang="en">Security or other price against which the performance of the portfolio is evaluated.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;InvestmentStrategy"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;includes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">portfolio investment strategy</rdfs:label>
-		<skos:definition xml:lang="en">The manner in which the portfolio manager tries to reach the funds objectives.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Describes how you get there. E.g fully invested v not fully invested. MB Note: The terms labeled &quot;Strategy&quot; in EFAMA and in FIBIM are more like dictionary definition of policy, while &quot;How you get there&quot; is a dictionary definition of Strategy. Therefore original labels may be reversed from dictionary definition of the global semantics these are derived from.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;PortfolioManager">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isPartOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundManagementCompany"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">portfolio manager</rdfs:label>
-		<skos:definition xml:lang="en">Person or entity responsible for day to day investment decisions for a fund or asset.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;PreferredShareInFund">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
-		<rdfs:label xml:lang="en">preferred share in fund</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;PrivateEquityHolding">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/PortfolioHolding"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PrivatelyHeldShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">private equity holding</rdfs:label>
-		<skos:definition xml:lang="en">A holding of private equity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;ReferToFundOrderDesk">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundRedemptionRestriction"/>
-		<rdfs:label xml:lang="en">refer to fund order desk</rdfs:label>
-		<skos:definition xml:lang="en">Restriction requiring an investor to refer to the fund order desk prior to redeeming a fund.</skos:definition>
-		<skos:editorialNote xml:lang="en">While it&apos;s unclear from original data models, it&apos;s likely that this restriction is actually to learn from the fund order desk of any other individual kinds of restriction that will apply. This is itself treated as a kind of restriction here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;ReportingFrequencyPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;ReportingPolicy"/>
-		<rdfs:label xml:lang="en">reporting frequency policy</rdfs:label>
-		<skos:definition xml:lang="en">Frequency with which financial reports will be presented.</skos:definition>
-		<skos:editorialNote xml:lang="en">This could theoretically be defined in terms of a Frequency (reciprocal of time), but since this kind of reporting in accounting is always either annual or semi-annual these are defined as policies for the provision of such reports</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;RiskLevel">
-		<rdfs:label xml:lang="en">risk level</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;SectorStrategy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:label xml:lang="en">sector strategy</rdfs:label>
-		<skos:definition xml:lang="en">Strategy which is sector based.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;SemiAnnualReportingPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;ReportingFrequencyPolicy"/>
-		<rdfs:label xml:lang="en">semi annual reporting policy</rdfs:label>
-		<skos:definition xml:lang="en">Reports are presented twice a year.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;StakeInFund">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;Stake"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesRelationshipWith"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;givesOwnershipOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifiedAs.5"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">stake in fund</rdfs:label>
-		<skos:definition xml:lang="en">The holding of some portion in a fund, by some party. This stake will generally tak ethe form of some sort of unit in that fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;SubFund">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;subFund.1"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;supervisedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;SubfundSupervisoryAuthority"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">sub fund</rdfs:label>
-		<skos:definition xml:lang="en">A set of share classes is a compartment of an umbrella fund. In this case, subfund is a synonym of investment fund and therefore has the same attributes as investment fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The terms given for Fund may relate to fund, sub fund or umbrella. Sub Fund is differentiated by the fact that it is part of an umbrella fund, otherwise it is the same as any other fund. ISO FIBIM Definition for SubFundIndicator (property of InvestmentFund): &quot;Indicates whether the investment fund is a subfund, when it is a compartment of an umbrella fund. In this case, subfund is a synonym of investment fund and therefore has the same attributes as investment fund.&quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;SubFundManager">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundManager"/>
-		<rdfs:label xml:lang="en">sub fund manager</rdfs:label>
-		<skos:definition xml:lang="en">A sub fund manager is ...</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;SubfundSupervisoryAuthority">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundSupervisoryAuthority"/>
-		<rdfs:label xml:lang="en">subfund supervisory authority</rdfs:label>
-		<skos:definition xml:lang="en">The legal entity which supervises the fund or fund industry(for a subfund located in a different country)</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;TimeWeightedRateOfReturnPerformanceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">time weighted rate of return performance determination method</rdfs:label>
-		<skos:definition xml:lang="en">Time weighted rate of return.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;UmbrellaFund">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasSubFund"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;SubFund"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">umbrella fund</rdfs:label>
-		<skos:definition xml:lang="en">Fund structure which has one or more investment pools.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An umbrella consists of several funds, and is a pool. ISO FIBIM definition: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company. However it is not clear how this uniquely defines an umbrella fund as such.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;UnitIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;issues"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">unit issuer</rdfs:label>
-		<skos:definition xml:lang="en">The party which issues the Fund Unit.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;accountingYearEndDate">
-		<rdfs:label xml:lang="en">accounting year end date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition xml:lang="en">Last day of the accounting year for the fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;additionalRestrictions">
-		<rdfs:label xml:lang="en">additional restrictions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;OrganizationStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Other restrictions or treatment information in respect of this strategy and the organization to which it refers.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;administeredBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">administered by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundAdministrator"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;advisedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">advised by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;InvestmentAdvisor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;allowedInvestorType">
-		<rdfs:label xml:lang="en">allowed investor type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestorType"/>
-		<skos:definition xml:lang="en">Type of investor that can invest in the fund class.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;anticipatedVolatility">
-		<rdfs:label xml:lang="en">anticipated volatility</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;anticipates">
-		<rdfs:label xml:lang="en">anticipates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;appliesTo">
-		<rdfs:label xml:lang="en">applies to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-		<skos:definition xml:lang="en">Portfolio to which the Benchmark is applied.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;assessedAgainst">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
-		<rdfs:label xml:lang="en">assessed against</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;authorizedCountry">
-		<rdfs:label xml:lang="en">authorized country</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<skos:definition xml:lang="en">Country in which it is authorised to commercialise the fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;backEndLoadApplicable">
-		<rdfs:label xml:lang="en">back end load applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether an exit charge, eg, CDSC, on redemption orders for this class can be applied.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;benchmarkWeight">
-		<rdfs:label xml:lang="en">benchmark weight</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Instrument weighting in the benchmark for the portfolio.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;blacklisted">
-		<rdfs:label xml:lang="en">blacklisted</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;OrganizationStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the strategy in framed so as to include the referenced business entity as being blacklisted. If yes, the strategy prevents investment in securities issued by that organization.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;clearFundsRequired">
-		<rdfs:label xml:lang="en">clear funds required</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether cleared funds may be required before a subscription order can be executed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;closedEndFund">
-		<rdfs:label xml:lang="en">closed end fund</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Closed to new investments. So there are a fixed number of units. May be open or closed to new units being issued (whether or not the units can be traded).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;closedFund">
-		<rdfs:label xml:lang="en">closed fund</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Closed to new investors. So an existing investor can buy new shares.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;confersOwnershipOf">
-		<rdfs:label xml:lang="en">confers ownership of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundEquity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;consistsOf">
-		<rdfs:label xml:lang="en">consists of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitHolding"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;contains">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;hasPortfolio"/>
-		<rdfs:label xml:lang="en">contains</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;EquityFund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;EquityPortfolio"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;couponPaymentDate">
-		<rdfs:label xml:lang="en">coupon payment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition xml:lang="en">The date at which the coupon is distributed to the bond unit holder.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;couponPaymentFrequency">
-		<rdfs:label xml:lang="en">coupon payment frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">The frequency with which income is allocated (or deemed to be allocated) to investors (eg. six-monthly, yearly, etc).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;currency">
-		<rdfs:label xml:lang="en">currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;CurrencyStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">Currency of the investment.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;dealingFrequencyDescription">
-		<rdfs:label xml:lang="en">dealing frequency description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Description of frequency at which the subscriptions and redemptions are done.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;decimalPlaceRounding">
-		<rdfs:label xml:lang="en">decimal place rounding</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of decimal places to which quantities of units/shares are rounded.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;declarationChannel">
-		<rdfs:label xml:lang="en">declaration channel</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Means of the net asset value publication, eg, a newspaper.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definedInRelationTo">
-		<rdfs:label xml:lang="en">defined in relation to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;OrganizationStrategy"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definesAllocations">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-bus-pol;sets"/>
-		<rdfs:label xml:lang="en">defines allocations</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definesBenchmark">
-		<rdfs:label xml:lang="en">defines benchmark</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definesMainFundOrderDeskAccount">
-		<rdfs:label xml:lang="en">defines main fund order desk account</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundsProcessingAccount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definesRelationshipWith">
-		<rdfs:label xml:lang="en">defines relationship with</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;denominatedIn">
-		<rdfs:label xml:lang="en">denominated in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Liquidity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;denomination">
-		<rdfs:label xml:lang="en">denomination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">Denomination Currency of the fund - Currency in which the fund unit is issued or redenominated and the currency of the NAV calculation.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;denominationCurrency">
-		<rdfs:label xml:lang="en">denomination currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;describedIn">
-		<rdfs:label xml:lang="en">described in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;description">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The manner in which the manager tries to reach the funds objectives</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;description.1">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Description of the benchmark used to determine the performance of a portfolio.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;distributedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">distributed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDistributor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;distributionWithReinvestment">
-		<rdfs:label xml:lang="en">distribution with reinvestment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReinvestmentPolicy"/>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">It is possible to hold shares for which the accrued income is distributed, but then reinvested automatically in additional units/shares allocated to the investor.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;dividendPaymentDate">
-		<rdfs:label xml:lang="en">dividend payment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition xml:lang="en">Day and month on which the dividends would normally be paid.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;dividendPaymentFrequency">
-		<rdfs:label xml:lang="en">dividend payment frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">The frequency with which income is allocated (or deemed to be allocated) to investors (eg. six-monthly, yearly, etc).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;domicile">
-		<rdfs:label xml:lang="en">domicile</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<skos:definition xml:lang="en">Country in which the investment fund is domiciled.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;dualFund">
-		<rdfs:label xml:lang="en">dual fund</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the fund has two prices.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;effectiveDate">
-		<rdfs:label xml:lang="en">effective date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Date/time as from which the processing characteristic is valid.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;effectivePeriod">
-		<rdfs:label xml:lang="en">effective period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">Period during which the investment guideline is valid.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;effectivePeriod.1">
-		<rdfs:label xml:lang="en">effective period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">Period during which the instrument is used as a benchmark for the portfolio.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;embodies">
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundLegalContract"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundLegalFormDocumentation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;endOfFiscalYear">
-		<rdfs:label xml:lang="en">end of fiscal year</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition xml:lang="en">Day and month on any given year at which the books are closed and profit and loss is determined.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;exCouponDate">
-		<rdfs:label xml:lang="en">ex coupon date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition xml:lang="en">The date at which the coupon is substracted from the NAV</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;exDivDate">
-		<rdfs:label xml:lang="en">ex div date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition xml:lang="en">The date at which the dividend is substracted from the NAV</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-civ-fnd-civ;firstAccountingYearEndDate">
-		<rdfs:label xml:lang="en">first accounting year end date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
-		<skos:definition xml:lang="en">Last day of the first accounting year for the fund.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-civ-fnd-civ;firstNAVCalculationDate">
-		<rdfs:label xml:lang="en">first n a v calculation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<skos:definition xml:lang="en">The first date of NAV calculation</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;frontEndLoadApplicable">
-		<rdfs:label xml:lang="en">front end load applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether a front end charge on subscription orders for this class can be applied.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;fundClassTypeIdentifier">
-		<rdfs:label xml:lang="en">fund class type identifier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">A textual identification of the class of fund units. This is used to uniquely identify a particular class of fund units, and thereby identify features of this type of unit within the fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;fundHasRelatedParty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-prc;hasRelatedParty"/>
-		<rdfs:label xml:lang="en">fund has related party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;fundStructure">
-		<rdfs:label xml:lang="en">fund structure</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundStructure"/>
-		<skos:definition xml:lang="en">Structure of the subfund, eg, single fund, multi-class.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;givesOwnershipOf">
-		<rdfs:label xml:lang="en">gives ownership of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAccountant">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">has accountant</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundAccountant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAccountingInformation">
-		<rdfs:label xml:lang="en">has accounting information</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAccountingReportingFrequency">
-		<rdfs:label xml:lang="en">has accounting reporting frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;ReportingFrequencyPolicy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAdditionalInformation">
-		<rdfs:label xml:lang="en">has additional information</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;OtherInvestmentFundInformation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAdditionalRedemptionRestrictions">
-		<rdfs:label xml:lang="en">has additional redemption restrictions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;ReferToFundOrderDesk"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAuditor">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">has auditor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundAuditor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasContactDetails">
-		<rdfs:label xml:lang="en">has contact details</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioManager"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDataProvider">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">has data provider</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDataProvider"/>
-		<skos:definition xml:lang="en">has an organization which is the data provider and is legally responsible for the information provided</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDefaultSettlementConvention">
-		<rdfs:label xml:lang="en">has default settlement convention</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDepository">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">has depository</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDepositary"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDetails">
-		<rdfs:label xml:lang="en">has details</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
-		<skos:definition xml:lang="en">Information on the net asset value calculation of the investment fund component.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDistributiojnPolicy">
-		<rdfs:label xml:lang="en">has distributiojn policy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundBondClassUnit"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDistributionPolicy">
-		<rdfs:label xml:lang="en">has distribution policy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDistributionPolicy.1">
-		<rdfs:label xml:lang="en">has distribution policy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
-		<skos:definition xml:lang="en">Income policy relating to a class type, ie, if income is paid out or retained in the fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a fact about each individual type of Fund Unit. Additional facts may apply to the Fund as a whole - to be reviewed. Need to determine if there is an overall distribution policy term applicable to the Fund. Kept as a place holder in case there is.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDistributionPolicy.2">
-		<rdfs:label xml:lang="en">has distribution policy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
-		<skos:definition xml:lang="en">Income policy relating to a class type, ie, if income is paid out or retained in the fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasExpectedCoupon">
-		<rdfs:label xml:lang="en">has expected coupon</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundBondClassUnit"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundBondUnitCoupon"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasExpectedDividend">
-		<rdfs:label xml:lang="en">has expected dividend</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnitDividend"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasFundIdentification">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;isIdentifiedBy"/>
-		<rdfs:label xml:lang="en">has fund identification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;OrganizationIdentifier"/>
-		<skos:definition xml:lang="en">Identification of the investment fund. Note this relationship has no parent, and is a sibling to the identifiaciton relationship for Incorporated Company. As BEI work progresses, these should both have a parent relationship for all legal entitity identification.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasFundPolicy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-bus-pol;pursuesPolicy"/>
-		<rdfs:label xml:lang="en">has fund policy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestmentPolicy"/>
-		<skos:definition xml:lang="en">Overall policy for amounts invested, limitations etc. Not the same as the detailed Portfolio policy.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasFundProcessingTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has fund processing terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasInformationAbout">
-		<rdfs:label xml:lang="en">has information about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingPassport"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasIntendedRiskLevel">
-		<rdfs:label xml:lang="en">has intended risk level</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;RiskLevel"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasIssueDate">
-		<rdfs:label xml:lang="en">has issue date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
-		<skos:definition xml:lang="en">Date of first NAV calculation and start of performance calculations (same as launch date)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasLegalForm">
-		<rdfs:label xml:lang="en">has legal form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasLiquidity">
-		<rdfs:label xml:lang="en">has liquidity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Liquidity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasManagementCompany">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">has management company</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundManager"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasObjective">
-		<rdfs:label xml:lang="en">has objective</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/Pool"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-		<skos:definition xml:lang="en">The business objective for which the pool was brought into being.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasPerformanceDeterminationMethod">
-		<rdfs:label xml:lang="en">has performance determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasPolicyTerms">
-		<rdfs:label xml:lang="en">has policy terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundBondUnitCoupon"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasPolicyTerms.1">
-		<rdfs:label xml:lang="en">has policy terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnitDividend"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
-		<skos:definition xml:lang="en">Terms for the expected distributions of dividends.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasPortfolio">
-		<rdfs:label xml:lang="en">has portfolio</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasRelatedFundTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;hasRelatedTerms"/>
-		<rdfs:label xml:lang="en">has related fund terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasRelatedTerms">
-		<rdfs:label xml:lang="en">has related terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingReferent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasSecurityIdentifier">
-		<rdfs:label xml:lang="en">has security identifier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/SecurityIdentifier"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasSubFund">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
-		<rdfs:label xml:lang="en">has sub fund</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;UmbrellaFund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;SubFund"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasSubscriptionTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;hasRelatedFundTerms"/>
-		<rdfs:label xml:lang="en">has subscription terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasTradableUnit">
-		<rdfs:label xml:lang="en">has tradable unit</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasTransferAgent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">has transfer agent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundTransferAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasUnitIssuer">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">has unit issuer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;historicPricingIndicator">
-		<rdfs:label xml:lang="en">historic pricing indicator</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Indicates whether the price is historic or forward.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;holderMayReinvest">
-		<rdfs:label xml:lang="en">holder may reinvest</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;DistributingShareClass"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the holder may reinvest dividends in the fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;holdingTransferable">
-		<rdfs:label xml:lang="en">holding transferable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether registered investors are able to transfer some or all of their holdings to third parties.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;holds">
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifiedAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifiedAs.3">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-be-fctx-fne;FundsSPV">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-be-le-cb;Corporation">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-civ-fnd-civ;FundLegalContract">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-be-corp-corp;JointStockCompany">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifiedAs.5">
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifies.1">
-		<rdfs:label xml:lang="en">identifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;JurisdictionStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<skos:definition xml:lang="en">Jurisdiction (country, county, state, province, city) of the investment.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifiesAssetTypesBy">
-		<rdfs:label xml:lang="en">identifies asset types by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;AssetClassStrategy"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassifier"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;implementsFundPolicy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-bus-pol;implementsPolicy"/>
-		<rdfs:label xml:lang="en">implements fund policy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;inceptionDate">
-		<rdfs:label xml:lang="en">inception date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Authorization date in the country of origin.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;inceptionDate.1">
-		<rdfs:label xml:lang="en">inception date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Authorization date in the country of origin. Further Notes See definition in Inception Date for Fund. Separate fact exists here. Same definition used. EFAMA Review notes: Inception Date exists as soon as there is a prospectus, so it is a fact about a Share Class even if the share class is never formally issued or offered to the public. Legal structure exists even if something is not launched. Editor question: Review stated this was a fact about Share Class; confirm this fact does not apply to Bond and Note units, or was the term Share Class being used to mean all three? Meanwhile I have put the term &quot;Issue Date&quot; as a fact about all Fund Unit, as this is given a sa separate term in the EFAMA DD spreadsheet. MAy come clearer in the next version of that.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;includeRelatedFirms">
-		<rdfs:label xml:lang="en">include related firms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;OrganizationStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the strategy includes firms which are related in some way to the referenced organization.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;includes">
-		<rdfs:label xml:lang="en">includes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;inclusion">
-		<rdfs:label xml:lang="en">inclusion</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the referred strategy is included. No means this description refers to the exclusion of what is described, from the portfolio.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;initialApplicationForm">
-		<rdfs:label xml:lang="en">initial application form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
-		<skos:definition xml:lang="en">Physical application form for the initial subscription by the investor.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;investmentFocus">
-		<rdfs:label xml:lang="en">investment focus</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The information about the area the fund is mostly invested into (for example stock market in Germany).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isCalculatedIn">
-		<rdfs:label xml:lang="en">is calculated in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isOpenEndedOrClosed">
-		<rdfs:label xml:lang="en">is open ended or closed</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;OpenEndedOrClosed"/>
-		<skos:definition xml:lang="en">Whether the fund is open ended or closed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isPartOf">
-		<rdfs:label xml:lang="en">is part of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioManager"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundManagementCompany"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isPartOf.1">
-		<rdfs:label xml:lang="en">is part of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isSubFundOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isPartOf"/>
-		<rdfs:label xml:lang="en">is sub fund of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;SubFund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;UmbrellaFund"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isUnitHolder">
-		<rdfs:label xml:lang="en">is unit holder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;issuePrice">
-		<rdfs:label xml:lang="en">issue price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<skos:definition xml:lang="en">The price at which the Fund Unit was first issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;issues">
-		<rdfs:label xml:lang="en">issues</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-civ-fnd-civ;launchDate">
-		<rdfs:label xml:lang="en">launch date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<skos:definition xml:lang="en">Date of first NAV calculation and start of performance calculations</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;legallyRecordedIn">
-		<rdfs:label xml:lang="en">fund legally recorded in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<skos:definition xml:lang="en">Relationship note: This relationship has no obvious parent; it is similar to Security legally recorded in Jurisdiction, but that inherits from Contract jurisdiction whereas a Fund is a Pool not a Contract. So the meaning is not the same. Assign parent relationship in future if a more general one exists; at present there is none.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;limitedSharesAreIssued">
-		<rdfs:label xml:lang="en">limited shares are issued</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not new shares can be issued in the fund. This is what makes it a closed end or open end fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;mainFundOrderDesk">
-		<rdfs:label xml:lang="en">main fund order desk</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the fund order desk is the principal entity appointed by the fund to which orders should be submitted.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;managedBy">
-		<rdfs:label xml:lang="en">managed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;PortfolioManager"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumDeviation">
-		<rdfs:label xml:lang="en">maximum deviation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Maximum allowable deviation from the benchmark.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumInvestmentAmount">
-		<rdfs:label xml:lang="en">maximum investment amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Maximum amount that may be invested in the specified strategy.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumInvestmentPercentage">
-		<rdfs:label xml:lang="en">maximum investment percentage</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Maximum percentage that may be invested in the specified strategy.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumPurchasingFee">
-		<rdfs:label xml:lang="en">maximum purchasing fee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
-		<skos:definition xml:lang="en">Maximum percentage or fixed amount of money due when purchasing fund shares Definition origin:EFAMA DD</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumRedemptionAmount">
-		<rdfs:label xml:lang="en">maximum redemption amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Maximum quantity of securities, expressed as an amount that can be sold.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumRedemptionFee">
-		<rdfs:label xml:lang="en">maximum redemption fee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
-		<skos:definition xml:lang="en">Maximum percentage or fixed amount of money due when redeeming fund shares Definition origin:EFAMA DD</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumRedemptionPercentage">
-		<rdfs:label xml:lang="en">maximum redemption percentage</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Maximum quantity of securities, expressed as a percentage that can be sold.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumRedemptionUnits">
-		<rdfs:label xml:lang="en">maximum redemption units</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Maximum number of shares/units that may be redeemed on a single dealing day.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;mayAlsoBe">
-		<rdfs:label xml:lang="en">may also be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundAdministrator"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
-		<skos:definition xml:lang="en">The unit issuer would be the fund administrator (except when it is a Bond).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;mayBe.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;identifiedAs"/>
-		<rdfs:label xml:lang="en">may be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundOrderDeskPhysicalFormDocument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;mayBeDefinedIn">
-		<rdfs:label xml:lang="en">may be defined in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingPassport"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumDeviation">
-		<rdfs:label xml:lang="en">minimum deviation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Minimum allowable deviation from the benchmark.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumHoldingPeriod">
-		<rdfs:label xml:lang="en">minimum holding period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
-		<skos:definition xml:lang="en">Period, in days, during which the units/shares must be held following their issue before redemption will be permitted.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumInitialSubscriptionAmount">
-		<rdfs:label xml:lang="en">minimum initial subscription amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Minimum initial subscription value.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumInitialSubscriptionUnits">
-		<rdfs:label xml:lang="en">minimum initial subscription units</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Minimum initial number of units/shares that must be purchased.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumInvestmentAmount">
-		<rdfs:label xml:lang="en">minimum investment amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Minimum amount that has to be invested in the specified strategy.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumInvestmentPercentage">
-		<rdfs:label xml:lang="en">minimum investment percentage</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Minimum percentage that has to be invested in the specified strategy.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumRatingRestriction">
-		<rdfs:label xml:lang="en">minimum rating restriction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-tem;Rating"/>
-		<skos:definition xml:lang="en">The minimum rating of securities to be invested in.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumRemainingHoldingAmount">
-		<rdfs:label xml:lang="en">minimum remaining holding amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Minimum value of units/shares that must be retained to avoid automatic redemption.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumRemainingHoldingUnits">
-		<rdfs:label xml:lang="en">minimum remaining holding units</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Minimum number of units/shares that must be retained to avoid automatic redemption.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumSubscriptionAmount">
-		<rdfs:label xml:lang="en">minimum subscription amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Minimum subscription value for existing investors.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumSubscriptionUnits">
-		<rdfs:label xml:lang="en">minimum subscription units</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Minimum number of units/shares that must be purchased by existing investors.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;name">
-		<rdfs:label xml:lang="en">name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Name of the investment fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;name.1">
-		<rdfs:label xml:lang="en">name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Name given to the defined strategy.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;outlines">
-		<rdfs:label xml:lang="en">outlines</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
-		<owl:inverseOf rdf:resource="&fibo-civ-fnd-civ;statedIn"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;percentageInvested">
-		<rdfs:label xml:lang="en">percentage invested</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The percentage of funds that is to be invested at any given time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;performanceDeterminationTimeframe">
-		<rdfs:label xml:lang="en">performance determination timeframe</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The timeframe on which the performance is reported (e.g. 1month, 1 year, YTD).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;performanceFee">
-		<rdfs:label xml:lang="en">performance fee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
-		<skos:definition xml:lang="en">Fees paid for the achivements of predefined outperformance objectives Definition origin:EFAMA DD</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;physicalDocumentRequired">
-		<rdfs:label xml:lang="en">physical document required</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether a phsyical form is required through the main fund order desk. Yes: A phsyical form is required through the main fund order desk. No: A phsyical form is not required through the main fund order desk.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;processingCountry">
-		<rdfs:label xml:lang="en">processing country</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<skos:definition xml:lang="en">Country in which the processing characteristic applies.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;processingPartyHasIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">processing party has identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">The organization which plays the role of the funds processing party</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;productGroupDescription">
-		<rdfs:label xml:lang="en">product group description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Company specific description of a group of funds.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;promotedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
-		<rdfs:label xml:lang="en">promoted by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPromoter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;providerHasIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">provider has identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;providesDepositaryServiceFor">
-		<rdfs:label xml:lang="en">provides depositary service for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundDepositary"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;purchasingFee">
-		<rdfs:label xml:lang="en">purchasing fee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
-		<skos:definition xml:lang="en">Actual percentage or fixed amount of money due when purchasing fund shares Definition origin:EFAMA DD</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionCutoffDateTime">
-		<rdfs:label xml:lang="en">redemption cutoff date time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">Last date/time at which an order to redeem can be given.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionCycleInBusinessDays">
-		<rdfs:label xml:lang="en">redemption cycle in business days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The last business day following the day on which a redemption order is priced (T) by which settlement will be due for orders placed with the main Fund Order Desk. Alternatively, if proceeds will be paid following receipt of written renunciation, the last business day following receipt of the relevant renunciation documentation by the main Fund Order Desk (R) by which the proceeds will be sent.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionDealingFrequency">
-		<rdfs:label xml:lang="en">redemption dealing frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">Frequency at which the redemptions are done.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionFee">
-		<rdfs:label xml:lang="en">redemption fee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
-		<skos:definition xml:lang="en">Actual percentage or fixed amount of money due when redeeming fund shares Definition origin:EFAMA DD</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionForm">
-		<rdfs:label xml:lang="en">redemption form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
-		<skos:definition xml:lang="en">Physical written instruction/renunciation form for redemption of units/shares by the investor.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionInAmountAllowed">
-		<rdfs:label xml:lang="en">redemption in amount allowed</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether redemptions in amount are allowed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionPeriod">
-		<rdfs:label xml:lang="en">redemption period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">Specific period, eg, for some guaranteed funds, during which the units/shares may be redeemed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-civ-fnd-civ;registrationDate">
-		<rdfs:label xml:lang="en">registration date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<skos:definition xml:lang="en">The date at which the fund is legally approved in a country other than the country of origin.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;reinvestmentFrequency">
-		<rdfs:label xml:lang="en">reinvestment frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReinvestmentPolicy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">For units where there is Reinvestment distribution, the frequency with which the reinvestment takes place (this will be the same or less frequently than the Dividend Payment Frequency), otherwise this fact does not apply.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;relateTo">
-		<rdfs:label xml:lang="en">relate to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;setsOutTerms">
-		<rdfs:label xml:lang="en">sets out terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingPassport"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;setsOutTermsFor">
-		<rdfs:label xml:lang="en">sets out terms for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundBondClassUnit"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDebt"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;settlementPeriodInBusinessDays">
-		<rdfs:label xml:lang="en">settlement period in business days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The last business day following the day on which a subscription order is priced (T) by which settlement will be due for orders placed with the main Fund Order Desk, eg. T+3.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;signatureRequired">
-		<rdfs:label xml:lang="en">signature required</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether a phsyical form with the investor&apos;s written signature is required through the main fund order desk. Yes:A phsyical form with the investor&apos;s written signature is required through the main fund order desk.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedDistributionFee">
-		<rdfs:label xml:lang="en">stated distribution fee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedIn">
-		<rdfs:label xml:lang="en">stated in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedInvestmentAim">
-		<rdfs:label xml:lang="en">stated investment aim</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The stated aim of the Fund in words, e.g outperfom a given benchmark.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedManagementFee">
-		<rdfs:label xml:lang="en">stated management fee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The fee that is stated in the Prospectus as being what is to be charged for management. Further notes: Can be monetary amount or a percentage or a combination. Action: simple type is wrong.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedObjective">
-		<rdfs:label xml:lang="en">stated objective</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The stated objective of the fund, in words.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;stipulatesBenchmark">
-		<rdfs:label xml:lang="en">stipulates benchmark</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentPolicy"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subFund">
-		<rdfs:label xml:lang="en">sub fund</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the investment fund is a subfund, when it is a compartment of an umbrella fund. If so, subfund is a synonym of investment fund and therefore has the same attributes as investment fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subFund.1">
-		<rdfs:label xml:lang="en">is sub fund</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;SubFund"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The investment fund is a subfund, when it is a compartment of an umbrella fund. In this case, subfund is a synonym of investment fund and therefore has the same attributes as investment fund.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subscriptionCutoffDateTime">
-		<rdfs:label xml:lang="en">subscription cutoff date time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">Last date/time at which an order to subscribe can be given.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subscriptionDealingFrequency">
-		<rdfs:label xml:lang="en">subscription dealing frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">Frequency at which the subscriptions are done.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subscriptionPeriod">
-		<rdfs:label xml:lang="en">subscription period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">Specific period, eg, for some guaranteed funds, during which the units/shares may be subscribed to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subscriptionsInAmountAllowed">
-		<rdfs:label xml:lang="en">subscriptions in amount allowed</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether subscriptions in amount are allowed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subsequentApplicationForm">
-		<rdfs:label xml:lang="en">subsequent application form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
-		<skos:definition xml:lang="en">Physical application form for subsequent investments by the same investor.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;supervisedBy">
-		<rdfs:label xml:lang="en">supervised by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundSupervisoryAuthority"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;switchingChargeable">
-		<rdfs:label xml:lang="en">switching chargeable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether a switching charge for changing between sub-funds of the same umbrella can be applied.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;switchingFee">
-		<rdfs:label xml:lang="en">switching fee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
-		<skos:definition xml:lang="en">Actual percentage or fixed amount of money due when switching to another fund. Definition origin:EFAMA DD</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;takesFormOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-		<rdfs:label xml:lang="en">takes form of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;BricksAndMortarHolding"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;trackingError">
-		<rdfs:label xml:lang="en">tracking error</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">See RiskFactors narrative in EFAMA DD</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;typeOfSecurities">
-		<rdfs:label xml:lang="en">type of securities</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The type of securities or other holdings that may be invested in.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;valuationFrequency">
-		<rdfs:label xml:lang="en">valuation frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">Frequency of the net asset value calculation.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;valuationFrequencyTextualDescription">
-		<rdfs:label xml:lang="en">valuation frequency textual description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Description of the frequency of the net asset value calculation.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;valueAtRisk">
-		<rdfs:label xml:lang="en">value at risk</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">See RiskClassification_NameOf in EFAMA DD Applies to Fund not Portfolio.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"
+buxmlns:fibo-be-fctx-fne="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"
+buxmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
+buxmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-accx-bal="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
+buxmlns:fibo-fnd-bus-pol="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+buxmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CIV</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Reference data terms and non time dependent facts about funds and CIVs.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/FundEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesClassification/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;AccumulatingShareClass">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accumulating share class</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-civ-fnd-civ;DistributingShareClass"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A share class in which there is no option to reinvest.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This fact would be determined by the fund unit having a specific Fund Distribution Policy of Accumulating.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;AnnualReportingPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;ReportingFrequencyPolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">annual reporting policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Reports are presented once a year</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;AnnualizedPerformanceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">annualized performance determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Annualized performance determination.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;AssetClassStrategy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifiesAssetTypesBy"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassifier"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset class strategy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Strategy which is asset class based.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">EFAMA: The type of securities or other holdings that may be invested in. FIBIM: Strategy which is asset class based. Can implement this in terms of a classification of those things. Wording implies this is a policy.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;Benchmark">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifiedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">benchmark</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A reference index used to measure fund performance.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;BricksAndMortarHolding">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/PortfolioHolding"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;takesFormOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bricks and mortar holding</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A holding of built property.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;CommonShareInFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">common share in fund</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-civ-fnd-civ;PreferredShareInFund"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A share unit in a fund, which is classified as a Common Share class.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">SR Review session notes: US: Closed and open ended funds may have common and preferred shares.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;CurrencyStrategy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">currency strategy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Strategy which is currency based.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;DebtStakeInFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesRelationshipWith"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt stake in fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A stake held in a fund by way of a Bond Unit.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note that you cannot buy fractional amounts in a bond. Review Session Note: Similar to what happens in a CDO where the collaterial manager and the issuer are two different entities. So model this along the same lines as the SPV in the structured finance model. Therefore: further modeling and review required</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;DistributingShareClass">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">distributing share class</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;EquityAsset">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolding"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity asset</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The holding of equity securities in a portfolio.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;EquityFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;contains"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;EquityPortfolio"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A fund which invests in at least 85% shares.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;EquityPortfolio">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity portfolio</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A portfolio which has at least 85% exposure to shares.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;EquityStakeInFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesRelationshipWith"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity stake in fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A stake held in a fund by way of a Share Class Unit.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Theoretically you can buy a fraction of a share in a fund. This would depend on the legal structure of the fund, e.g. a minimum investment. There is always a distribution plan.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;Fund">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/Pool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;domicile"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;administeredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundAdministrator"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;advisedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;InvestmentAdvisor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;describedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;distributedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDistributor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;domicile"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAccountant"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundAccountant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAccountingInformation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAdditionalInformation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;OtherInvestmentFundInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAuditor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundAuditor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDataProvider"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDataProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDepository"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDepositary"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDistributionPolicy.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasFundIdentification"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;OrganizationIdentifier"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasFundPolicy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestmentPolicy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasLegalForm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasManagementCompany"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundManager"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasObjective"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasPerformanceDeterminationMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasRelatedFundTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasSubscriptionTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasTradableUnit"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasTransferAgent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundTransferAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasUnitIssuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;legallyRecordedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;promotedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPromoter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;supervisedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundSupervisoryAuthority"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Distinct pool of financial instruments managed by a single investment policy.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">From EFAMA DD: The word fund can refer to either an investment pool, umbrella or share class, and is commonly refered to as a collective investment vehicle (can have ISIN or not). The meaning here is for the investment pool (of which an Umbrella fund is also one such) and not to the share class.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundAccountant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund accountant</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party that keeps accounting records of the available assets and liabilities of the Fund. It calculates dealing prices, the Net Asset Value (NAV) of the Fund, and may provide fund performance and tax data. Can be subcontracted by the FundAdministrator.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundAdministrator">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;mayAlsoBe"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund administrator</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Entity that has to fulfil the legal and supervisory requirements of the fund. Responsible for all the business purposes around the investment pool, and so is reponsible for the issuing of the shares.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">If the unit is a bond, then the issuer is separate from the Fund Administrator. WG11 text: The party in charge of financial accounting, NAV calculation, management and performance fee calculation. Can also be in charge of orders centralisation and registration. Definition origin:EFAMA DD</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundAuditor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund auditor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party that is in charge of examining and verifying a fund&apos;s financial and accounting records as well as supporting documents and fulfilment of legal requirements. Definition origin:EFAMA DD</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundBondClassUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDistributiojnPolicy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasExpectedCoupon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundBondUnitCoupon"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;setsOutTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDebt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund bond class unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A fund unit which takes the form of debt in that fund.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">From EFAMA Review: called denominations e.g. issued in $5000 pieces. You cannot buy fractional amounts in a bond.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundBondUnitCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasPolicyTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund bond unit coupon</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A fixed coupon paid out to holders of the Fund Bond Unit.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundCashDistributionPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund cash distribution policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Policy for distribution of cash dividends or notes in the event that the fund units have a distribution policy of &quot;Cash&quot; rather than &quot;Reinvestment&quot;.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundCouponPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundCashDistributionPolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund coupon policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for the expected distribution of bond unit coupons.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDataProvider">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund data provider</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which supplies market data to a fund.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDebt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund debt</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Debt issued by a Fund.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This would normally be held by participants in that pool. in this case the pool is a fund which is formed by each of the participants extending credit to that pool and holding bond units in the pool representing that debt.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDepositary">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;providesDepositaryServiceFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund depositary</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party that holds and safeguards holdings owned by a fund. It is also responsible for compliance of the portfolio with legal ratios etc.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The depository may delegate custody to another entity (custodian). Definition origin:EFAMA DD</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDistributionPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund distribution policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The overal diustribution policy or policy limitations for the fund itself.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note that individual classes of Fund Unit also have specific distribution polcies as they effect that class of unit. This class is for terms with wording of the form: &quot; ... whether or not it is possible to hold shares ...&quot; for a given parameter.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDistributor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund distributor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">an entity through which a fund may be bought by or for an investor. This may be on a discretionary or advisory basis, or as an execution-only service. Definition origin:EFAMA DD</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundDividendPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundCashDistributionPolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund dividend policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for the expected distributions of dividends.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundEquity">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/PoolEquity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-acc-aeq;representsAnInterestIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund equity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A share or proportion of the capital gains in a fund.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestmentObjective">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasIntendedRiskLevel"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;RiskLevel"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;statedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund investment objective</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The aim of a Fund e.g outperfom a given benchmark.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This could be broken down into other terms that can be itemised here, that are not in the EFAMA DD explicitly. Examples may include: - Risk level - Return - Exposure to different markets</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestmentPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;stipulatesBenchmark"/>
+bubububu<owl:onClass rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;constrains"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;sets"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund investment policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The policy within which the fund acts in order to achieve the stated fund objectives.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">EFAMA Note: Model distinguishes between strategy (what you intend to invest in) and portfolio structure (what is held). This semantics matches the EFAMA DD &quot;Fund Investment Policy&quot; No stated definition in EFAMA DD (&quot;Further discussion required&quot;).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isPartOf.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund investment restrictions set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Limitations that apply to the fund as a whole, such as risk factors. these are used to determine whether the fund is appropriate for a given type of investor to invest in.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are defined by the overall Fund investment policy. Not the same as the detailed policies for investing in percentages of this or that.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isUnitHolder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund investor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which invests in the Fund. It does this by holding some tradable unit (which represents some stake) in that fund.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Facts about investor tolerance and so on, are facts about Investor.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestorType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund investor type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of party that is eligible to invest in a fund.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundLegalContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;OrganizationCoveringAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalFormDocumentation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund legal contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">For a fund which is constituted under the law of contract, the contract that embodies the fund legal form.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">From ISO FIBIM &quot;Umbrella Fund&quot; narrative: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundLegalForm">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifiedAs.3"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-be-fctx-fne;FundsSPV">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-be-le-cb;Corporation">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-civ-fnd-civ;FundLegalContract">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-be-corp-corp;JointStockCompany">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund legal form</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The legal form of the fund, eg Joint Stock Company, SPV etc.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This term does not cover the structure of the fund (Open or Closed, Open Ended or Closed Ended); these facts are covered in separate terms. This fact is the legal form which the fund takes, as a legal entity of some kind. It refers to a selection of possible legal forms, such as Joint Stock Company. This has been defined as a separate, relative class of thing rather than simply a relationship, so as to be able to model relationships to the fund legal form regardless of what form that takes. For example, the various kinds of Stake&quot; in the fund have a relationship to the legal entity which is the fund, regardless of what kind of entity that is.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundLegalFormDocumentation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-cor;Constitution"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund legal form documentation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">For a fund which is constituted under the law of contract, the constitution or articles that define the fund. These are embodied in a Contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">From ISO FIBIM &quot;Umbrella Fund&quot; narrative: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundManagementCompany">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund management company</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party that sets up the fund, decides the investment strategy, appoints the agents, and is responsible for the promotion and the marketing of the fund. It makes all of the important decisions related to the fund. Also called fund promotor or fund sponsor or fund manager.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In the US: operates on a percentage of the Portfolio assets under management.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundManager">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundManagementCompany"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund manager</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party that sets up the fund, decides the investment strategy, appoints the agents, and is responsible for the promotion and the marketing of the fund. It makes all of the important decisions related to the fund. Also called fund promotor or fund sponsor. This is a dupliucate of Fund Management Company at the moment</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundOrderDesk">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;providerHasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund order desk</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Fund Order Desk is a party to the Fund Order Desk Account.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This party would presumably be identified as the Fund Management Company in terms of what legal entity fulcils this role? to be determined at further review.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundOrderDeskPhysicalFormDocument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund order desk physical form document</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A phsyical form obtained through the main fund order desk.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPortfolio">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;InvestmentPortfolio"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;assessedAgainst"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasLiquidity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Liquidity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;implementsFundPolicy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;managedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioManager"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/PortfolioHolding"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;strategy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund portfolio</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An account containing a number of financial instruments along with cash positions in one or more currencies and belonging to a Fund</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund portfolio investment limitations</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Detailed Policy on approximately how the portfolio is to be allocated to achieve the stated investment goals. This underpins the detailed strategy of how to achieve this.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Defined as &quot;Strategy&quot; in FIBIM and elsewhere. WG11: Rough allocation of the portfolio.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesAllocations"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;constrains"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund portfolio investment policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Intended allocation of the portfolio to meet the stated investment strategy and goals.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">ISO FIBIM: Rough allocation of the portfolio.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundProcessingForm">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;ControlDocument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;mayBe.1"/>
+bubububu<owl:onClass rdf:resource="&fibo-civ-fnd-civ;FundOrderDeskPhysicalFormDocument"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund processing form</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The form of documentation or control mechanism required for some funds processing activity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Equates to the &quot;Physical Form&quot; in SIO FIBIM for certain activities in funds processing. May or may not be a written physical document. ISO FIBIM Definition: Specifies whether a physical form is required.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundProcessingGeneralTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund processing general terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal terms for general processing of the fund. These set out what the investor and the fund may or may not do.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundProcessingTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesMainFundOrderDeskAccount"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundsProcessingAccount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDefaultSettlementConvention"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund processing terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal terms for processing of the fund. These set out what the investor and the fund may or may not do. These include terms for redemption and subscription processing as well as general processing terms. ISO FIBIM definition: Processing characteristics linked to the instrument, ie, not to the market.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These include Fund Subscription Terms, Fund Redemption Terms. and terms which relate to general processing and restrictions or otherwise on the holder. FPP notes: FPP presentation identifies many of these terms under the heading of Valuation Dealing characteristics. May need to revise which goes where in line with FPP. See also terms under NAV Valuation Calculation Method. Others of these terms appear in FPP under Instrument Restrictions. These cover the subscription, redemption and holding amounts and units and minimum holding period.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPromoter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund promoter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An entity that promotes a fund. May be an investor, pension fund, bank, insurance company or management company</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Prospectus"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;anticipates"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;outlines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Prospectus for the Fund. This is a document made available publicly for potential investors. It will include facts about the fund investment objective, investment focus and other details of the fund. Some of this information becomes binding on the fund once it is issued, while other information is guidelines only.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">EFAMA Review description for this: The fund is issued with a prospectus; there is material in the prospectus that is binding; material that is expected but not binding, and information that may or may not be in the prospectus or a given fund.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundRedemptionRestriction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund redemption restriction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundRedemptionTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAdditionalRedemptionRestrictions"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;ReferToFundOrderDesk"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund redemption terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal terms for redemption of units in the fund. These set out what the investor and the fund may or may not do.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundReinvestmentPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund reinvestment policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for the expected reinvestment of profits on fund units.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundReportingTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasAccountingReportingFrequency"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;ReportingFrequencyPolicy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund reporting terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms describing the accounting methods and reporting arrangements used by the fund.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundShareClassUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/EquityInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;confersOwnershipOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDistributionPolicy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasExpectedDividend"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnitDividend"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund share class unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The legal structure in which you can purchase part of an investment pool, defined by a variety of characteristics like investor type, minimum size of investment, distribution type, fee and currency. A fund unit which gives the holder an equity stake in the fund.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">From review sessions: Theoretically you can buy a fraction of a share in a fund. This would depend on the legal structure of the fund, e.g. a minimum investment. There is always a distribution plan.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundShareClassUnitDividend">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasPolicyTerms.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund share class unit dividend</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Expected dividend payment from a Fund Unit. REVIEW: Does this apply to the Fund as a whole or to a unit in the fund? This term will be redefined following the Funds model restructuring</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundStructure">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund structure</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One of the different ways in which a Fund may be structured.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundSubscriptionTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;relateTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund subscription terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Subscription terms for the fund. Further notes: ISO FIBIM, EFAMA DD and FPP combine terms for subscription, redemption and general holding requirements. These have been separated here as they are different kinds of term, but this can be reviewed. Subscription Terms are identified as terms of the fund and not the fund unit, since terms for how you might subscribe can&apos;t be binding one someone who has not yet subscribed.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundSupervisoryAuthority">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund supervisory authority</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The legal entity which supervises the fund or fund industry</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundTransferAgent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund transfer agent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An entity that undertakes the execution of subscription, redemption and switch orders on behalf of a fund. Definition origin:EFAMA DD</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;denominationCurrency"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDetails"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasFundProcessingTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasFundProcessingTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasSecurityIdentifier"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/InternationalSecuritiesIdentificationNumber"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasSecurityIdentifier"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/SecurityIdentifier"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isOpenEndedOrClosed"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;OpenEndedOrClosed"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-sec;legallyRecordedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A unit in a fund, which may be traded and is a contract between the fund and the holder of that unit.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">If it is a closed fund, you can still trade the units. You trade back with the fund. Not with a counterparty. Therefore this is a tradable contract, though it may not necessarily be a transferable contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnitDistributionMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund unit distribution method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The normal distribution policy for funds.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnitDistributionPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasDistributionPolicy.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund unit distribution policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Income policy relating to the unit, e.g. if income is paid out or retained in the fund and how this is treated, including distribution policy details for dividends and coupons.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnitHolding">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/PortfolioHolding"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;consistsOf"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund unit holding</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A holding of a unit in another fund.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund units settlement terms convention</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Default settlement terms which may apply to a fund, trading of for units in the fund and for redemption of fund units.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">From EFAMA DD Review Notes: Default settlement terms. Related to the Unit. Usually the terms are set already at the fund level, and won&apos;t vary at share class level between different share classes, but they are facts about the share classes / Notes / Bonds i.e. what you can trade. In fact this happens already - different kinds of investors may have different settlement dates. In this example you announce it earlier - not the same. This may be a separate fact. Conesnsus:Review</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsCashDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funds cash distribution</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Accrued income is distributed periodically to the investor.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funds processing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The context of managing and processing funds, issuing funds units etc. This is the context in which the different parties involved in a fund are defined as parties.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessingAccount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;accountHasProvider"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundOrderDesk"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funds processing account</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An account used specifically in the processing of funds. Like all accounts this is (per FIBIM definition) a business relationship between two entities; one entity is the account owner, the other entity is the account servicer. Please refer to Financial global model for treatment of accounts relationships in this model.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Derived from FIBIM definition for &quot;Account&quot;, which is: &quot;Business relationship between two entities; one entity is the account owner, the other entity is the account servicer.&quot; this corresponds to the Global Terms definition for Account.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessingParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funds processing party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party involved in the processing of funds in some way.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessingPassport">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasInformationAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;mayBeDefinedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;setsOutTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funds processing passport</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Funds Processing Passport. This is defined as a document. This has terms drawn from elsewhere in the model which are defined as part of the FPP for reasons defined in the FPP descriptions.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Please see FPP Data Descriptions for more information (when available - not included in this model). See EFAMA website for this. Also see XLS for terms of this. These terms are often but net necessarily part of the Prospectus. See also the Thing Formerly Referred To As Investment. The definitions in the FPP descriptions may not be accurate. This is defining what kind of information is requested. Further Action: Now that we have defined sets of formal contractual terems for subvscriptions, redemptions and general terms, and since these terms don&apos;t have a direct relationship to any one Contract at present (as contractual terms should do), there may be a relationship between those terms and the FPP. To be handled in next review.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundsProcessingReferent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;SynechdocalThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funds processing referent</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;GrossOfFeePerformanceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gross of fee performance determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Performance determined gross of fee. Review: Is this mutually exclusive with the other listed method? It sounds like it is not.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;HedgeFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">hedge fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed Review notes (EFAMA?) Also only closed ended according to regulations. This is not always a kind of closed fund.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;IncomeAccumulation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">income accumulation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Accrued income is not distributed and instead remains reflected within the unit/share price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;InvestmentAdvisor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment advisor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party that provides investment guidance at a fee. Definition origin:EFAMA DD</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;JurisdictionStrategy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifies.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">jurisdiction strategy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Strategy which is jurisdiction based.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;Liquidity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;denominatedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">liquidity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Precise definition needed for liquidity, and check that it is modeled accordingly.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;MoneyWeightedRateOfReturnPerformanceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">money weighted rate of return performance determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Money weighted rate of return.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isCalculatedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">net asset value calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Parameters for the calculation of the net asset value for an investment fund/fund class.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">These terms were in the ISO FIBIM model but correspond to some details in the EFAMA DD.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;NoteFundUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">note fund unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Need a legal definition - to follow. This is one of the mechanisms by which an investor may hold an interest in a fund, but is not a Bond or a Share.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">It is not possible to determine at this time whether some of the policy facts that apply to bund and share class units apply to all fund units including this one. Once this is defined, all Fund Distribution Policy terms and relationships should be rechecked.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;NoteStakeInFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesRelationshipWith"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">note stake in fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A stake held in a fund by way of a note.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Need a legal definition - to follow. This is one of the mechanisms by which an investor may hold an interest in a fund, but is not a Bond or a Share. Therefore it&apos;s not clear what sort of stake to label this as - usually a stake in anything must be either equity or debt.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;OpenEndedOrClosed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">open ended or closed</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;OrganizationStrategy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definedInRelationTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">organization strategy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Strategy which is organization based.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;OtherInvestmentFundInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">other investment fund information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Things which are not part of the prospectus but are important if you want to understand the fund.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">See terms in EFAMA spreadsheet. These are properties of the fund but are not legally binding. Author follow-up note: I have managed to find a &quot;home&quot; for disposition for most of the entries that are in the spreadsheet. It is not clear which of the spreadsheet terms are indended to come under the general heading in this class. The first place I would look is in the terms I have defined as &quot;Fund Processing Terms&quot;, which are defined as formal, legal contractual terms. If any of those are not legally binding on some party, then this is where they belong instead.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;PerformanceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">performance determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A method for performance determination (e.g. Time weighted and money weighted, annualized, gross of fee) along with the time frame in which this is determined. PLUS Performances NamePeriod</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;PortfolioBenchmark">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;appliesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesBenchmark"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">portfolio benchmark</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Security or other price against which the performance of the portfolio is evaluated.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;InvestmentStrategy"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;includes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">portfolio investment strategy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The manner in which the portfolio manager tries to reach the funds objectives.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Describes how you get there. E.g fully invested v not fully invested. MB Note: The terms labeled &quot;Strategy&quot; in EFAMA and in FIBIM are more like dictionary definition of policy, while &quot;How you get there&quot; is a dictionary definition of Strategy. Therefore original labels may be reversed from dictionary definition of the global semantics these are derived from.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;PortfolioManager">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;isPartOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundManagementCompany"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">portfolio manager</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Person or entity responsible for day to day investment decisions for a fund or asset.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;PreferredShareInFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">preferred share in fund</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;PrivateEquityHolding">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/PortfolioHolding"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PrivatelyHeldShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">private equity holding</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A holding of private equity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;ReferToFundOrderDesk">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundRedemptionRestriction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refer to fund order desk</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Restriction requiring an investor to refer to the fund order desk prior to redeeming a fund.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">While it&apos;s unclear from original data models, it&apos;s likely that this restriction is actually to learn from the fund order desk of any other individual kinds of restriction that will apply. This is itself treated as a kind of restriction here.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;ReportingFrequencyPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;ReportingPolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reporting frequency policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Frequency with which financial reports will be presented.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This could theoretically be defined in terms of a Frequency (reciprocal of time), but since this kind of reporting in accounting is always either annual or semi-annual these are defined as policies for the provision of such reports</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;RiskLevel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">risk level</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;SectorStrategy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sector strategy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Strategy which is sector based.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;SemiAnnualReportingPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;ReportingFrequencyPolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">semi annual reporting policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Reports are presented twice a year.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;StakeInFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;Stake"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;definesRelationshipWith"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;givesOwnershipOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;identifiedAs.5"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stake in fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The holding of some portion in a fund, by some party. This stake will generally tak ethe form of some sort of unit in that fund.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;SubFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;subFund.1"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;supervisedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;SubfundSupervisoryAuthority"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sub fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of share classes is a compartment of an umbrella fund. In this case, subfund is a synonym of investment fund and therefore has the same attributes as investment fund.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The terms given for Fund may relate to fund, sub fund or umbrella. Sub Fund is differentiated by the fact that it is part of an umbrella fund, otherwise it is the same as any other fund. ISO FIBIM Definition for SubFundIndicator (property of InvestmentFund): &quot;Indicates whether the investment fund is a subfund, when it is a compartment of an umbrella fund. In this case, subfund is a synonym of investment fund and therefore has the same attributes as investment fund.&quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;SubFundManager">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundManager"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sub fund manager</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A sub fund manager is ...</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;SubfundSupervisoryAuthority">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundSupervisoryAuthority"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subfund supervisory authority</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The legal entity which supervises the fund or fund industry(for a subfund located in a different country)</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;TimeWeightedRateOfReturnPerformanceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">time weighted rate of return performance determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Time weighted rate of return.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;UmbrellaFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;hasSubFund"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;SubFund"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">umbrella fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Fund structure which has one or more investment pools.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">An umbrella consists of several funds, and is a pool. ISO FIBIM definition: In securities, a collective investment scheme that has a contractual or a corporate form. When it has a contractual form, a fund is constituted under either the law of contract or under the trust law and thus it is not a legal entity. In its corporate form, a fund is a legal entity and is structured as a company. However it is not clear how this uniquely defines an umbrella fund as such.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;UnitIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;issues"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-civ-fnd-civ;processingPartyHasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unit issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which issues the Fund Unit.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;accountingYearEndDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accounting year end date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Last day of the accounting year for the fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;additionalRestrictions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">additional restrictions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;OrganizationStrategy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Other restrictions or treatment information in respect of this strategy and the organization to which it refers.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;administeredBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">administered by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundAdministrator"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;advisedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">advised by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;InvestmentAdvisor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;allowedInvestorType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allowed investor type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestorType"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Type of investor that can invest in the fund class.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;anticipatedVolatility">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">anticipated volatility</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;anticipates">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">anticipates</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;appliesTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applies to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Portfolio to which the Benchmark is applied.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;assessedAgainst">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assessed against</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;authorizedCountry">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">authorized country</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Country in which it is authorised to commercialise the fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;backEndLoadApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">back end load applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether an exit charge, eg, CDSC, on redemption orders for this class can be applied.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;benchmarkWeight">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">benchmark weight</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Instrument weighting in the benchmark for the portfolio.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;blacklisted">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">blacklisted</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;OrganizationStrategy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the strategy in framed so as to include the referenced business entity as being blacklisted. If yes, the strategy prevents investment in securities issued by that organization.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;clearFundsRequired">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">clear funds required</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether cleared funds may be required before a subscription order can be executed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;closedEndFund">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">closed end fund</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Closed to new investments. So there are a fixed number of units. May be open or closed to new units being issued (whether or not the units can be traded).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;closedFund">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">closed fund</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Closed to new investors. So an existing investor can buy new shares.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;confersOwnershipOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers ownership of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundEquity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;consistsOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consists of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitHolding"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;contains">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;hasPortfolio"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contains</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;EquityFund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;EquityPortfolio"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;couponPaymentDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon payment date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the coupon is distributed to the bond unit holder.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;couponPaymentFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon payment frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The frequency with which income is allocated (or deemed to be allocated) to investors (eg. six-monthly, yearly, etc).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;currency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;CurrencyStrategy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Currency of the investment.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;dealingFrequencyDescription">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dealing frequency description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Description of frequency at which the subscriptions and redemptions are done.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;decimalPlaceRounding">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">decimal place rounding</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of decimal places to which quantities of units/shares are rounded.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;declarationChannel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">declaration channel</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Means of the net asset value publication, eg, a newspaper.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definedInRelationTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined in relation to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;OrganizationStrategy"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definesAllocations">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-bus-pol;sets"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines allocations</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definesBenchmark">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines benchmark</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definesMainFundOrderDeskAccount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines main fund order desk account</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundsProcessingAccount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;definesRelationshipWith">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines relationship with</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;denominatedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denominated in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Liquidity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;denomination">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Denomination Currency of the fund - Currency in which the fund unit is issued or redenominated and the currency of the NAV calculation.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;denominationCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;describedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">described in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;description">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The manner in which the manager tries to reach the funds objectives</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;description.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Description of the benchmark used to determine the performance of a portfolio.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;distributedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">distributed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDistributor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;distributionWithReinvestment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">distribution with reinvestment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReinvestmentPolicy"/>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">It is possible to hold shares for which the accrued income is distributed, but then reinvested automatically in additional units/shares allocated to the investor.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;dividendPaymentDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend payment date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Day and month on which the dividends would normally be paid.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;dividendPaymentFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend payment frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The frequency with which income is allocated (or deemed to be allocated) to investors (eg. six-monthly, yearly, etc).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;domicile">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">domicile</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Country in which the investment fund is domiciled.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;dualFund">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dual fund</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the fund has two prices.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;effectiveDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effective date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date/time as from which the processing characteristic is valid.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;effectivePeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effective period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Period during which the investment guideline is valid.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;effectivePeriod.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effective period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Period during which the instrument is used as a benchmark for the portfolio.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;embodies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundLegalContract"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundLegalFormDocumentation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;endOfFiscalYear">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">end of fiscal year</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Day and month on any given year at which the books are closed and profit and loss is determined.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;exCouponDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ex coupon date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the coupon is substracted from the NAV</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;exDivDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ex div date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the dividend is substracted from the NAV</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-civ-fnd-civ;firstAccountingYearEndDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first accounting year end date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Last day of the first accounting year for the fund.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-civ-fnd-civ;firstNAVCalculationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first n a v calculation date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The first date of NAV calculation</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;frontEndLoadApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">front end load applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether a front end charge on subscription orders for this class can be applied.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;fundClassTypeIdentifier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund class type identifier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A textual identification of the class of fund units. This is used to uniquely identify a particular class of fund units, and thereby identify features of this type of unit within the fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;fundHasRelatedParty">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-prc;hasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund has related party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;fundStructure">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund structure</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundStructure"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Structure of the subfund, eg, single fund, multi-class.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;givesOwnershipOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gives ownership of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAccountant">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has accountant</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundAccountant"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAccountingInformation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has accounting information</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAccountingReportingFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has accounting reporting frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReportingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;ReportingFrequencyPolicy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAdditionalInformation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has additional information</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;OtherInvestmentFundInformation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAdditionalRedemptionRestrictions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has additional redemption restrictions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;ReferToFundOrderDesk"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasAuditor">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has auditor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundAuditor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasContactDetails">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has contact details</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioManager"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDataProvider">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has data provider</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDataProvider"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">has an organization which is the data provider and is legally responsible for the information provided</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDefaultSettlementConvention">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has default settlement convention</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDepository">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has depository</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDepositary"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDetails">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has details</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information on the net asset value calculation of the investment fund component.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDistributiojnPolicy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has distributiojn policy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundBondClassUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDistributionPolicy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has distribution policy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDistributionPolicy.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has distribution policy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Income policy relating to a class type, ie, if income is paid out or retained in the fund.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a fact about each individual type of Fund Unit. Additional facts may apply to the Fund as a whole - to be reviewed. Need to determine if there is an overall distribution policy term applicable to the Fund. Kept as a place holder in case there is.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasDistributionPolicy.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has distribution policy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnitDistributionMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Income policy relating to a class type, ie, if income is paid out or retained in the fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasExpectedCoupon">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has expected coupon</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundBondClassUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundBondUnitCoupon"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasExpectedDividend">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has expected dividend</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnitDividend"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasFundIdentification">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-aap-agt;isIdentifiedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has fund identification</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;OrganizationIdentifier"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Identification of the investment fund. Note this relationship has no parent, and is a sibling to the identifiaciton relationship for Incorporated Company. As BEI work progresses, these should both have a parent relationship for all legal entitity identification.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasFundPolicy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-bus-pol;pursuesPolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has fund policy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestmentPolicy"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Overall policy for amounts invested, limitations etc. Not the same as the detailed Portfolio policy.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasFundProcessingTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has fund processing terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasInformationAbout">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has information about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingPassport"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasIntendedRiskLevel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has intended risk level</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;RiskLevel"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasIssueDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has issue date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date of first NAV calculation and start of performance calculations (same as launch date)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasLegalForm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has legal form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasLiquidity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has liquidity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Liquidity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasManagementCompany">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has management company</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundManager"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasObjective">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has objective</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/Pool"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The business objective for which the pool was brought into being.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasPerformanceDeterminationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has performance determination method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasPolicyTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has policy terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundBondUnitCoupon"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundCouponPolicy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasPolicyTerms.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has policy terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnitDividend"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDividendPolicy"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for the expected distributions of dividends.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasPortfolio">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has portfolio</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasRelatedFundTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;hasRelatedTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has related fund terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasRelatedTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has related terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingReferent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasSecurityIdentifier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has security identifier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/SecurityIdentifier"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasSubFund">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has sub fund</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;UmbrellaFund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;SubFund"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasSubscriptionTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;hasRelatedFundTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has subscription terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasTradableUnit">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tradable unit</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasTransferAgent">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has transfer agent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundTransferAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;hasUnitIssuer">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has unit issuer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;historicPricingIndicator">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">historic pricing indicator</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Indicates whether the price is historic or forward.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;holderMayReinvest">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder may reinvest</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;DistributingShareClass"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the holder may reinvest dividends in the fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;holdingTransferable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holding transferable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether registered investors are able to transfer some or all of their holdings to third parties.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;holds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifiedAs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifiedAs.3">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundLegalForm"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-be-fctx-fne;FundsSPV">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-be-le-cb;Corporation">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-civ-fnd-civ;FundLegalContract">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-be-corp-corp;JointStockCompany">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifiedAs.5">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;StakeInFund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifies.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;JurisdictionStrategy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Jurisdiction (country, county, state, province, city) of the investment.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;identifiesAssetTypesBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies asset types by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;AssetClassStrategy"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassifier"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;implementsFundPolicy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-bus-pol;implementsPolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">implements fund policy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;inceptionDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inception date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Authorization date in the country of origin.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;inceptionDate.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inception date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Authorization date in the country of origin. Further Notes See definition in Inception Date for Fund. Separate fact exists here. Same definition used. EFAMA Review notes: Inception Date exists as soon as there is a prospectus, so it is a fact about a Share Class even if the share class is never formally issued or offered to the public. Legal structure exists even if something is not launched. Editor question: Review stated this was a fact about Share Class; confirm this fact does not apply to Bond and Note units, or was the term Share Class being used to mean all three? Meanwhile I have put the term &quot;Issue Date&quot; as a fact about all Fund Unit, as this is given a sa separate term in the EFAMA DD spreadsheet. MAy come clearer in the next version of that.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;includeRelatedFirms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">include related firms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;OrganizationStrategy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the strategy includes firms which are related in some way to the referenced organization.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;includes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;inclusion">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inclusion</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the referred strategy is included. No means this description refers to the exclusion of what is described, from the portfolio.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;initialApplicationForm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">initial application form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Physical application form for the initial subscription by the investor.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;investmentFocus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment focus</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioInvestmentStrategy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The information about the area the fund is mostly invested into (for example stock market in Germany).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isCalculatedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is calculated in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isOpenEndedOrClosed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is open ended or closed</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;OpenEndedOrClosed"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the fund is open ended or closed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isPartOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is part of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioManager"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundManagementCompany"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isPartOf.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is part of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isSubFundOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isPartOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is sub fund of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;SubFund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;UmbrellaFund"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;isUnitHolder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is unit holder</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;issuePrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price at which the Fund Unit was first issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;issues">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issues</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-civ-fnd-civ;launchDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">launch date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date of first NAV calculation and start of performance calculations</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;legallyRecordedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund legally recorded in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Relationship note: This relationship has no obvious parent; it is similar to Security legally recorded in Jurisdiction, but that inherits from Contract jurisdiction whereas a Fund is a Pool not a Contract. So the meaning is not the same. Assign parent relationship in future if a more general one exists; at present there is none.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;limitedSharesAreIssued">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">limited shares are issued</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundShareClassUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not new shares can be issued in the fund. This is what makes it a closed end or open end fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;mainFundOrderDesk">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">main fund order desk</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the fund order desk is the principal entity appointed by the fund to which orders should be submitted.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;managedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">managed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;PortfolioManager"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumDeviation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum deviation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum allowable deviation from the benchmark.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumInvestmentAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum investment amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum amount that may be invested in the specified strategy.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumInvestmentPercentage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum investment percentage</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum percentage that may be invested in the specified strategy.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumPurchasingFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum purchasing fee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum percentage or fixed amount of money due when purchasing fund shares Definition origin:EFAMA DD</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumRedemptionAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum redemption amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum quantity of securities, expressed as an amount that can be sold.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumRedemptionFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum redemption fee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum percentage or fixed amount of money due when redeeming fund shares Definition origin:EFAMA DD</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumRedemptionPercentage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum redemption percentage</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum quantity of securities, expressed as a percentage that can be sold.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;maximumRedemptionUnits">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum redemption units</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum number of shares/units that may be redeemed on a single dealing day.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;mayAlsoBe">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may also be</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundAdministrator"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;UnitIssuer"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The unit issuer would be the fund administrator (except when it is a Bond).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;mayBe.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;identifiedAs"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundOrderDeskPhysicalFormDocument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;mayBeDefinedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be defined in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingPassport"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumDeviation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum deviation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PortfolioBenchmark"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum allowable deviation from the benchmark.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumHoldingPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum holding period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Period, in days, during which the units/shares must be held following their issue before redemption will be permitted.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumInitialSubscriptionAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum initial subscription amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum initial subscription value.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumInitialSubscriptionUnits">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum initial subscription units</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum initial number of units/shares that must be purchased.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumInvestmentAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum investment amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum amount that has to be invested in the specified strategy.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumInvestmentPercentage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum investment percentage</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentLimitations"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum percentage that has to be invested in the specified strategy.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumRatingRestriction">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum rating restriction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-tem;Rating"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The minimum rating of securities to be invested in.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumRemainingHoldingAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum remaining holding amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum value of units/shares that must be retained to avoid automatic redemption.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumRemainingHoldingUnits">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum remaining holding units</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum number of units/shares that must be retained to avoid automatic redemption.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumSubscriptionAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum subscription amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum subscription value for existing investors.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;minimumSubscriptionUnits">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum subscription units</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Minimum number of units/shares that must be purchased by existing investors.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;name">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Name of the investment fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;name.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolioInvestmentPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Name given to the defined strategy.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;outlines">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">outlines</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
+bubu<owl:inverseOf rdf:resource="&fibo-civ-fnd-civ;statedIn"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;percentageInvested">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage invested</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage of funds that is to be invested at any given time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;performanceDeterminationTimeframe">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">performance determination timeframe</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;PerformanceDeterminationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The timeframe on which the performance is reported (e.g. 1month, 1 year, YTD).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;performanceFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">performance fee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Fees paid for the achivements of predefined outperformance objectives Definition origin:EFAMA DD</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;physicalDocumentRequired">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">physical document required</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether a phsyical form is required through the main fund order desk. Yes: A phsyical form is required through the main fund order desk. No: A phsyical form is not required through the main fund order desk.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;processingCountry">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">processing country</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Country in which the processing characteristic applies.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;processingPartyHasIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">processing party has identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingParty"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The organization which plays the role of the funds processing party</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;productGroupDescription">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">product group description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Company specific description of a group of funds.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;promotedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-civ-fnd-civ;fundHasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">promoted by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundPromoter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;providerHasIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">provider has identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;providesDepositaryServiceFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">provides depositary service for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundDepositary"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;purchasingFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchasing fee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Actual percentage or fixed amount of money due when purchasing fund shares Definition origin:EFAMA DD</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionCutoffDateTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption cutoff date time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Last date/time at which an order to redeem can be given.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionCycleInBusinessDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption cycle in business days</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The last business day following the day on which a redemption order is priced (T) by which settlement will be due for orders placed with the main Fund Order Desk. Alternatively, if proceeds will be paid following receipt of written renunciation, the last business day following receipt of the relevant renunciation documentation by the main Fund Order Desk (R) by which the proceeds will be sent.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionDealingFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption dealing frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Frequency at which the redemptions are done.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption fee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Actual percentage or fixed amount of money due when redeeming fund shares Definition origin:EFAMA DD</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionForm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Physical written instruction/renunciation form for redemption of units/shares by the investor.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionInAmountAllowed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption in amount allowed</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether redemptions in amount are allowed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;redemptionPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundRedemptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Specific period, eg, for some guaranteed funds, during which the units/shares may be redeemed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-civ-fnd-civ;registrationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registration date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the fund is legally approved in a country other than the country of origin.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;reinvestmentFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reinvestment frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundReinvestmentPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">For units where there is Reinvestment distribution, the frequency with which the reinvestment takes place (this will be the same or less frequently than the Dividend Payment Frequency), otherwise this fact does not apply.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;relateTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relate to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;setsOutTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundsProcessingPassport"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;setsOutTermsFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out terms for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundBondClassUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundDebt"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;settlementPeriodInBusinessDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement period in business days</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnitsSettlementTermsConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The last business day following the day on which a subscription order is priced (T) by which settlement will be due for orders placed with the main Fund Order Desk, eg. T+3.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;signatureRequired">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">signature required</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether a phsyical form with the investor&apos;s written signature is required through the main fund order desk. Yes:A phsyical form with the investor&apos;s written signature is required through the main fund order desk.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedDistributionFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stated distribution fee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stated in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedInvestmentAim">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stated investment aim</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentObjective"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The stated aim of the Fund in words, e.g outperfom a given benchmark.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedManagementFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stated management fee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The fee that is stated in the Prospectus as being what is to be charged for management. Further notes: Can be monetary amount or a percentage or a combination. Action: simple type is wrong.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;statedObjective">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stated objective</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProspectus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The stated objective of the fund, in words.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;stipulatesBenchmark">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stipulates benchmark</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentPolicy"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;Benchmark"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subFund">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sub fund</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the investment fund is a subfund, when it is a compartment of an umbrella fund. If so, subfund is a synonym of investment fund and therefore has the same attributes as investment fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subFund.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is sub fund</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;SubFund"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The investment fund is a subfund, when it is a compartment of an umbrella fund. In this case, subfund is a synonym of investment fund and therefore has the same attributes as investment fund.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subscriptionCutoffDateTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscription cutoff date time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Last date/time at which an order to subscribe can be given.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subscriptionDealingFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscription dealing frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Frequency at which the subscriptions are done.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subscriptionPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscription period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Specific period, eg, for some guaranteed funds, during which the units/shares may be subscribed to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subscriptionsInAmountAllowed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscriptions in amount allowed</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether subscriptions in amount are allowed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;subsequentApplicationForm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subsequent application form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundProcessingForm"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Physical application form for subsequent investments by the same investor.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;supervisedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">supervised by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundSupervisoryAuthority"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;switchingChargeable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">switching chargeable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundProcessingGeneralTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether a switching charge for changing between sub-funds of the same umbrella can be applied.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;switchingFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">switching fee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundSubscriptionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Fee"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Actual percentage or fixed amount of money due when switching to another fund. Definition origin:EFAMA DD</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;takesFormOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes form of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;BricksAndMortarHolding"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;trackingError">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tracking error</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">See RiskFactors narrative in EFAMA DD</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;typeOfSecurities">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">type of securities</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of securities or other holdings that may be invested in.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;valuationFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Frequency of the net asset value calculation.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;valuationFrequencyTextualDescription">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation frequency textual description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;NetAssetValueCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Description of the frequency of the net asset value calculation.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-civ-fnd-civ;valueAtRisk">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value at risk</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestmentRestrictionsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">See RiskClassification_NameOf in EFAMA DD Applies to Fund not Portfolio.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/civ/FundsExt/CIVClassification.rdf
+++ b/civ/FundsExt/CIVClassification.rdf
@@ -1,59 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
-	<!ENTITY fibo-civ-fnd-clx "https://spec.edmcouncil.org/fibo/CIV/FundsExt/CIVClassification/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
+bu<!ENTITY fibo-civ-fnd-clx "https://spec.edmcouncil.org/fibo/CIV/FundsExt/CIVClassification/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/CIV/FundsExt/CIVClassification/"
-	xmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"
-	xmlns:fibo-civ-fnd-clx="https://spec.edmcouncil.org/fibo/CIV/FundsExt/CIVClassification/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/CIV/FundsExt/CIVClassification/">
-		<rdfs:label xml:lang="en">CIVClassification</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/CIV/FundsExt/CIVClassification/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;Fund">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-clx;FundClassification">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/ClassificationSchemes/Classifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund classification</rdfs:label>
-		<skos:definition xml:lang="en">The category of the fund according to the asset class. This is a published code by which the Fund is classified. Further notes: Could be EFCF codes. This is the way in which &quot;Type of fund&quot; is articulated.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-clx;FundClassificationScheme">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/ClassificationSchemes/ClassificationScheme"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/defines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-clx;FundClassification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fund classification scheme</rdfs:label>
-		<skos:definition xml:lang="en">A published scheme for the category of a fund according to the asset class.</skos:definition>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"
+buxmlns:fibo-civ-fnd-clx="https://spec.edmcouncil.org/fibo/CIV/FundsExt/CIVClassification/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/CIV/FundsExt/CIVClassification/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CIVClassification</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology contains only the classification facets information for funds concepts.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/CIV/FundsExt/CIVClassification/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;Fund">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-clx;FundClassification">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/ClassificationSchemes/Classifier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/classifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund classification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The category of the fund according to the asset class. This is a published code by which the Fund is classified. Further notes: Could be EFCF codes. This is the way in which &quot;Type of fund&quot; is articulated.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-clx;FundClassificationScheme">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/ClassificationSchemes/ClassificationScheme"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/defines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-clx;FundClassification"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund classification scheme</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A published scheme for the category of a fund according to the asset class.</skos:definition>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/AssetDerivatives/AssetBaskets.rdf
+++ b/der/AssetDerivatives/AssetBaskets.rdf
@@ -1,208 +1,211 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-ass-bas "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-ass-bas "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-ass-bas="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/">
-		<rdfs:label xml:lang="en">AssetBaskets</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bas;BasketOfEquityIndices">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfIndices"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-bas;EquitiesBasketIndexConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">basket of equity indices</rdfs:label>
-		<skos:definition xml:lang="en">A basket of indices which are all equity-only indices.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bas;EquitiesBasketIndexConstituent">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfIndicesConstituent"/>
-		<rdfs:label xml:lang="en">equities basket index constituent</rdfs:label>
-		<skos:definition xml:lang="en">An index which makes up a part of a Basket.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an index which is a component of a (locally defined) Basket, and NOT a constituent of an index - that is a separate term.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bas;EquitiesBasketShareConstituent">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/SecuritiesBasketConstituent"/>
-		<rdfs:label xml:lang="en">equities basket share constituent</rdfs:label>
-		<skos:definition xml:lang="en">A security which makes up a part of the Basket.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bas;EquitiesMixedBasket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/MixedBasket"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesBasketIndexConstituent">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesBasketShareConstituent">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equities mixed basket</rdfs:label>
-		<skos:definition xml:lang="en">A basket which has a mix of constituents which are shares and equity indices.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bas;EquitiesSingleNameBasket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
-				<owl:onClass rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equities single name basket</rdfs:label>
-		<skos:definition xml:lang="en">A basket of securities consisting only of equities securities (publicly issued and traded shares).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bas;EquityBasket">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesBasketIndexConstituent">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesBasketShareConstituent">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity basket</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-ass-bas;BasketOfEquityIndices">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesMixedBasket">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesSingleNameBasket">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition xml:lang="en">Any basket of equity consituents. This may be a basket of shares, of equity indices or a basket which is mixture of both.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bas;EquityBasketObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-		<rdfs:label xml:lang="en">equity basket observable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bas;EquityBasketOptionAnnex">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-bas;defines"/>
-				<owl:onClass rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-bas;specifiesCompositionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-bas;EquitiesSingleNameBasket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity basket option annex</rdfs:label>
-		<skos:definition xml:lang="en">An annex to an Equities Basket Option, setting out in detail the composition of the Basket.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This consists of a list of the constituents with the composition of each (as a number of shares or as a monetary amount (nominal). More often it would be specified as a weight rather than a notional. If equal weight it would be 1 share of each. Or it could be specified as 20% of this and 30% of that. This is irrelevant to whether it&apos;s an index or a single stock that makes up the constituent. Will have a total notional value fo rthe basket, and then the percentage will determine the number of shares that woulb be boiught to make up that basket. These ratios are possibly determine through some negotiation. If a basket changes its constituents then the constituents that would ... Indices (if regared as a type of basket) then when the authority decides to rebase the index, then - this would impact on the original peception of the index. When its rebased, you value the of at that time and work out the ratio of shares that give you the same equivalent value. [move this comment to Index Underlyer] Changes to the basket: This can still change during the life of the option, due to corporate actions.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bas;SetOfEquityIndexConstituents">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-bas;hasMember"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;EquityIndexConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-ass;drawnFrom"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;EquityReferenceIndex"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">set of equity index constituents</rdfs:label>
-		<skos:definition xml:lang="en">A defined set of the constituents of some named index.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, the top ten members of the S&amp;P500 index.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;defines">
-		<rdfs:label xml:lang="en">defines</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-bas;EquityBasketOptionAnnex"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;hasMember">
-		<rdfs:label xml:lang="en">has member</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-bas;SetOfEquityIndexConstituents"/>
-		<rdfs:range rdf:resource="&fibo-ind-mkt-bas;EquityIndexConstituent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;numberOfShares">
-		<rdfs:label xml:lang="en">number of shares</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of this share that makes up this component of the index.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;percentage">
-		<rdfs:label xml:lang="en">percentage</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The percentage of the basket which this constituent makes up.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;specifiesCompositionOf">
-		<rdfs:label xml:lang="en">specifies composition of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-bas;EquityBasketOptionAnnex"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-bas;EquitiesSingleNameBasket"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-ass-bas="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AssetBaskets</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Underlier concepts for derivatives based on baskets of security assets or indices based on these. At present these are all equity based assets.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bas;BasketOfEquityIndices">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfIndices"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-bas;EquitiesBasketIndexConstituent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">basket of equity indices</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A basket of indices which are all equity-only indices.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bas;EquitiesBasketIndexConstituent">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfIndicesConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equities basket index constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An index which makes up a part of a Basket.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is an index which is a component of a (locally defined) Basket, and NOT a constituent of an index - that is a separate term.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bas;EquitiesBasketShareConstituent">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/SecuritiesBasketConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equities basket share constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security which makes up a part of the Basket.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bas;EquitiesMixedBasket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/MixedBasket"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesBasketIndexConstituent">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesBasketShareConstituent">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equities mixed basket</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A basket which has a mix of constituents which are shares and equity indices.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bas;EquitiesSingleNameBasket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equities single name basket</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A basket of securities consisting only of equities securities (publicly issued and traded shares).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bas;EquityBasket">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesBasketIndexConstituent">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesBasketShareConstituent">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity basket</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-der-ass-bas;BasketOfEquityIndices">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesMixedBasket">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-der-ass-bas;EquitiesSingleNameBasket">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any basket of equity consituents. This may be a basket of shares, of equity indices or a basket which is mixture of both.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bas;EquityBasketObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity basket observable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bas;EquityBasketOptionAnnex">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-bas;defines"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-bas;specifiesCompositionOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-bas;EquitiesSingleNameBasket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity basket option annex</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An annex to an Equities Basket Option, setting out in detail the composition of the Basket.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This consists of a list of the constituents with the composition of each (as a number of shares or as a monetary amount (nominal). More often it would be specified as a weight rather than a notional. If equal weight it would be 1 share of each. Or it could be specified as 20% of this and 30% of that. This is irrelevant to whether it&apos;s an index or a single stock that makes up the constituent. Will have a total notional value fo rthe basket, and then the percentage will determine the number of shares that woulb be boiught to make up that basket. These ratios are possibly determine through some negotiation. If a basket changes its constituents then the constituents that would ... Indices (if regared as a type of basket) then when the authority decides to rebase the index, then - this would impact on the original peception of the index. When its rebased, you value the of at that time and work out the ratio of shares that give you the same equivalent value. [move this comment to Index Underlyer] Changes to the basket: This can still change during the life of the option, due to corporate actions.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bas;SetOfEquityIndexConstituents">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-bas;hasMember"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;EquityIndexConstituent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-ass;drawnFrom"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;EquityReferenceIndex"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">set of equity index constituents</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A defined set of the constituents of some named index.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example, the top ten members of the S&amp;P500 index.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;defines">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-bas;EquityBasketOptionAnnex"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;hasMember">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has member</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-bas;SetOfEquityIndexConstituents"/>
+bubu<rdfs:range rdf:resource="&fibo-ind-mkt-bas;EquityIndexConstituent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;numberOfShares">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of shares</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of this share that makes up this component of the index.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;percentage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-bas;EquitiesBasketShareConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage of the basket which this constituent makes up.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-bas;specifiesCompositionOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies composition of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-bas;EquityBasketOptionAnnex"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-bas;EquitiesSingleNameBasket"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/AssetDerivatives/AssetDerivatives.rdf
+++ b/der/AssetDerivatives/AssetDerivatives.rdf
@@ -1,265 +1,268 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-ass-bas "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/">
-	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-	<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
-	<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-ass-bas "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/">
+bu<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bu<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
+bu<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-ass-bas="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"
-	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
-	xmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-		<rdfs:label>AssetDerivatives</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;AssetUnderlier">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-dbx;underlierHasIdentity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-mkt-bas;ReferenceIndex">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>asset underlier</rdfs:label>
-		<skos:definition>An underlyer made up of one or a basket of securities or security indices.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This may be an equity (single stock), an equity index, bond, basket of stocks and so on. Different types of options, swaps (swal floating leg) and so on, may have specific types of underlyer from this list.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;DebtDerivativeContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetDerivativeContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-ass;debtDerivativeContractHasUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;DebtObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>debt derivative contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;DebtObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-dbx;underlierHasIdentity"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>debt observable</rdfs:label>
-		<skos:definition>The instrument which is defined as the Reference Asset for this leg. This is the instrument the interest cashflows of which become payable under this leg of the Swap.</skos:definition>
-		<skos:editorialNote>Currently defined as a tradable debt instrument only. Review and confirm.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;EquityDerivativeContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetDerivativeContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-ass;hasUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>equity derivative contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;EquityIndexObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-		<rdfs:label>equity index observable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;EquityObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-dbx;underlierHasIdentity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-ass-bas;EquityBasket">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-mkt-bas;EquityReferenceIndex">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-eq-eq;PubliclyTradedShare">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>equity observable</rdfs:label>
-		<skos:definition>An equity underlying component, which can be either a single equity asset, an equity index, or a custom basket of equity assets.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>FpML: &apos;Specifies the underlying component, which can be either a single asset, an index, or a custom basket of assets.&apos; Note that this refers to the observable, whether or not it is also the deliverable. That is, for the equity or basket or index in question, the value of something about it is observed, and the instrument is based on that. This may for example be the dividend, or it may be the value of an equity trading index.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;FuturesContractDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;UnderlyingSecurityDelivery"/>
-		<rdfs:label>futures contract delivery</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;RealizedVariableLeg">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-ass;definedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>realized variable leg</rdfs:label>
-		<skos:definition>Leg which relates to some statistical measure of performance of the underlying.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is generally the floating leg of a statistical type of swap or a dividend swap. The other leg of these swaps is implied, and is simply the strike. Payment is netted up at maturity and so there is no stream of cashflows either way. Earlier notes: Typically these are defined for swaps where there is only one leg; payments are determined at maturity of the swap contract and may go either way. Payments are determined by comparison of the value of the statistical measure at maturity with the pre-defined strike value of that parameter.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;RealizedVariableSwapSideTerms">
-		<rdfs:label>realized variable swap side terms</rdfs:label>
-		<skos:definition>Terms for legs which relate to some statistical measure of performance of the underlying.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This generally defines the floating leg of a statistical type of swap or a dividend swap. The other leg of these swaps is implied, and is simply the strike. Payment is netted up at maturity and so there is no stream of cashflows either way. Earlier notes: Typically these are defined for swaps where there is only one leg; payments are determined at maturity of the swap contract and may go either way. Payments are determined by comparison of the value of the statistical measure at maturity with the pre-defined strike value of that parameter.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;SecurityCashEquivalentDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
-		<rdfs:label>security cash equivalent delivery</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;SecurityForwardDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-		<rdfs:label>security forward delivery</rdfs:label>
-		<skos:definition>Forward delivery of an Asset (Equity or Debt) either in the form of the asset itself (the observable) or the cash equivalent.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;SetOfEquityIndexConstituentsObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-		<rdfs:label>set of equity index constituents observable</rdfs:label>
-		<skos:definition>An observable (underlying) which is made up of a set of constituents of an index.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is a relative &quot;Underlying&quot; term which should include all facts about how the set of constituents is determined, made up and observed e.g. where price source should be. This is in line with how all observables are done. This then has an identity in the form of a &quot;Set of Index Constituents&quot; that is the actual collection itself.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;SingleSettlementSwap">
-		<rdfs:label>single settlement swap</rdfs:label>
-		<skos:definition>A Swap Transaction which relates to some statistical measure of performance of the underlying.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Typically these swaps only have one leg; payments are determined at maturity of the swap contract and may go either way. Payments are determined by comparison of the value of the statistical measure at maturity with the pre-defined strike value of that parameter.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;SingleShareObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-		<rdfs:label>single share observable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;StatisticalSwapContract">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
-		<rdfs:label>statistical swap contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-ass;UnderlyingSecurityDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
-		<rdfs:label>underlying security delivery</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;cashDelivery">
-		<rdfs:label>cash delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-ass;SecurityCashEquivalentDelivery"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;cashDelivery.1">
-		<rdfs:label>cash delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-ass;UnderlyingSecurityDelivery"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;debtDerivativeContractHasUnderlying">
-		<rdfs:label>debt derivative contract has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-ass;DebtDerivativeContract"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;DebtObservable"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;definedAs">
-		<rdfs:label>defined as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-ass;RealizedVariableLeg"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;drawnFrom">
-		<rdfs:label>drawn from</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;forwardPrice">
-		<rdfs:label>forward price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition>The forward price per share, index or basket.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;hasStrikeLeg">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
-		<rdfs:label>has strike leg</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-ass;SingleSettlementSwap"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;hasUnderlying">
-		<rdfs:label>has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-		<owl:equivalentClass rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-ass-bas="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"
+buxmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
+buxmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
+buxmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bubu<rdfs:label>AssetDerivatives</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Common concepts for derivatives based on securities as their underliers, including those based on indices or baskets of these assets. Incudes details of kinds of asset and asset observable legs and statistical swap contracts.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;AssetUnderlier">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-dbx;underlierHasIdentity"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-ind-mkt-bas;ReferenceIndex">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>asset underlier</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">An underlyer made up of one or a basket of securities or security indices.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">This may be an equity (single stock), an equity index, bond, basket of stocks and so on. Different types of options, swaps (swal floating leg) and so on, may have specific types of underlyer from this list.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;DebtDerivativeContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetDerivativeContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-ass;debtDerivativeContractHasUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;DebtObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>debt derivative contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;DebtObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-dbx;underlierHasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>debt observable</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">The instrument which is defined as the Reference Asset for this leg. This is the instrument the interest cashflows of which become payable under this leg of the Swap.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&xsd;string">Currently defined as a tradable debt instrument only. Review and confirm.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;EquityDerivativeContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetDerivativeContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-ass;hasUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>equity derivative contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;EquityIndexObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bubu<rdfs:label>equity index observable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;EquityObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-dbx;underlierHasIdentity"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-ass-bas;EquityBasket">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-ind-mkt-bas;EquityReferenceIndex">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-eq-eq;PubliclyTradedShare">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>equity observable</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">An equity underlying component, which can be either a single equity asset, an equity index, or a custom basket of equity assets.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">FpML: &apos;Specifies the underlying component, which can be either a single asset, an index, or a custom basket of assets.&apos; Note that this refers to the observable, whether or not it is also the deliverable. That is, for the equity or basket or index in question, the value of something about it is observed, and the instrument is based on that. This may for example be the dividend, or it may be the value of an equity trading index.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;FuturesContractDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;UnderlyingSecurityDelivery"/>
+bubu<rdfs:label>futures contract delivery</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;RealizedVariableLeg">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-ass;definedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>realized variable leg</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Leg which relates to some statistical measure of performance of the underlying.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">This is generally the floating leg of a statistical type of swap or a dividend swap. The other leg of these swaps is implied, and is simply the strike. Payment is netted up at maturity and so there is no stream of cashflows either way. Earlier notes: Typically these are defined for swaps where there is only one leg; payments are determined at maturity of the swap contract and may go either way. Payments are determined by comparison of the value of the statistical measure at maturity with the pre-defined strike value of that parameter.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;RealizedVariableSwapSideTerms">
+bubu<rdfs:label>realized variable swap side terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Terms for legs which relate to some statistical measure of performance of the underlying.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">This generally defines the floating leg of a statistical type of swap or a dividend swap. The other leg of these swaps is implied, and is simply the strike. Payment is netted up at maturity and so there is no stream of cashflows either way. Earlier notes: Typically these are defined for swaps where there is only one leg; payments are determined at maturity of the swap contract and may go either way. Payments are determined by comparison of the value of the statistical measure at maturity with the pre-defined strike value of that parameter.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;SecurityCashEquivalentDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
+bubu<rdfs:label>security cash equivalent delivery</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;SecurityForwardDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bubu<rdfs:label>security forward delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Forward delivery of an Asset (Equity or Debt) either in the form of the asset itself (the observable) or the cash equivalent.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;SetOfEquityIndexConstituentsObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bubu<rdfs:label>set of equity index constituents observable</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">An observable (underlying) which is made up of a set of constituents of an index.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">This is a relative &quot;Underlying&quot; term which should include all facts about how the set of constituents is determined, made up and observed e.g. where price source should be. This is in line with how all observables are done. This then has an identity in the form of a &quot;Set of Index Constituents&quot; that is the actual collection itself.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;SingleSettlementSwap">
+bubu<rdfs:label>single settlement swap</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">A Swap Transaction which relates to some statistical measure of performance of the underlying.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Typically these swaps only have one leg; payments are determined at maturity of the swap contract and may go either way. Payments are determined by comparison of the value of the statistical measure at maturity with the pre-defined strike value of that parameter.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;SingleShareObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bubu<rdfs:label>single share observable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;StatisticalSwapContract">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
+bubu<rdfs:label>statistical swap contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-ass;UnderlyingSecurityDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
+bubu<rdfs:label>underlying security delivery</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;cashDelivery">
+bubu<rdfs:label>cash delivery</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-ass;SecurityCashEquivalentDelivery"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;cashDelivery.1">
+bubu<rdfs:label>cash delivery</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-ass;UnderlyingSecurityDelivery"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;debtDerivativeContractHasUnderlying">
+bubu<rdfs:label>debt derivative contract has underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-ass;DebtDerivativeContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;DebtObservable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;definedAs">
+bubu<rdfs:label>defined as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-ass;RealizedVariableLeg"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;drawnFrom">
+bubu<rdfs:label>drawn from</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;forwardPrice">
+bubu<rdfs:label>forward price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The forward price per share, index or basket.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;hasStrikeLeg">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
+bubu<rdfs:label>has strike leg</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-ass;SingleSettlementSwap"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-ass;hasUnderlying">
+bubu<rdfs:label>has underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bubu<owl:equivalentClass rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/AssetDerivatives/BondOptions.rdf
+++ b/der/AssetDerivatives/BondOptions.rdf
@@ -1,93 +1,96 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-ass-bo "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondOptions/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-ass-bo "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondOptions/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondOptions/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-ass-bo="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondOptions/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondOptions/">
-		<rdfs:label xml:lang="en">BondOptions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondOptions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bo;BondOptionUnderlyingTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
-		<rdfs:label xml:lang="en">bond option underlying transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction which is defined in a bond option contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase or sale of the deliverable underlying (in this case a bond) as defined in the option contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bo;BondUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;DebtObservable"/>
-		<rdfs:label xml:lang="en">bond underlying</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-bo;OTCBondOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;DebtDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-bo;definesOptionalBondOptionUnderlyingTransaction"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-bo;BondOptionUnderlyingTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-bo;oTCBondOptionHasUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-bo;BondUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c bond option</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML Definition (unusable): A component describing a Bond Option product.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-bo;definesOptionalBondOptionUnderlyingTransaction">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;definesOptional"/>
-		<rdfs:label xml:lang="en">defines optional bond option underlying transaction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-bo;OTCBondOption"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-bo;BondOptionUnderlyingTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-bo;oTCBondOptionHasUnderlying">
-		<rdfs:label xml:lang="en">o t c bond option has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-bo;OTCBondOption"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-bo;BondUnderlying"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-bo;underlyingBondPrice">
-		<rdfs:label xml:lang="en">underlying bond price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-bo;BondOptionUnderlyingTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The price at which the bond is bought and sold in the underlying transaction.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-ass-bo="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondOptions/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondOptions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BondOptions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Option instruments with an underlying bond asset.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondOptions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bo;BondOptionUnderlyingTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond option underlying transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction which is defined in a bond option contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase or sale of the deliverable underlying (in this case a bond) as defined in the option contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bo;BondUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;DebtObservable"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond underlying</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-bo;OTCBondOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;DebtDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-bo;definesOptionalBondOptionUnderlyingTransaction"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-bo;BondOptionUnderlyingTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-bo;oTCBondOptionHasUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-bo;BondUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c bond option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpML Definition (unusable): A component describing a Bond Option product.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-bo;definesOptionalBondOptionUnderlyingTransaction">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;definesOptional"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines optional bond option underlying transaction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-bo;OTCBondOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-bo;BondOptionUnderlyingTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-bo;oTCBondOptionHasUnderlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c bond option has underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-bo;OTCBondOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-bo;BondUnderlying"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-bo;underlyingBondPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying bond price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-bo;BondOptionUnderlyingTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price at which the bond is bought and sold in the underlying transaction.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/AssetDerivatives/BondReturnSwaps.rdf
+++ b/der/AssetDerivatives/BondReturnSwaps.rdf
@@ -1,51 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-ass-brs "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondReturnSwaps/">
-	<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-ass-brs "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondReturnSwaps/">
+bu<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondReturnSwaps/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-ass-brs="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondReturnSwaps/"
-	xmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondReturnSwaps/">
-		<rdfs:label xml:lang="en">BondReturnSwaps</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondReturnSwaps/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-ass-brs;DebtAssetInterestReturnStream">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;SimpleReturnStream"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReferenceAsset"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;DebtObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt asset interest return stream</rdfs:label>
-		<skos:definition xml:lang="en">A leg which embodies the interest payments on a debt instrument which is the reference asset for a Swap.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-brs;DebtSecurityDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;UnderlyingSecurityDelivery"/>
-		<rdfs:label xml:lang="en">debt security delivery</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-ass-brs="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondReturnSwaps/"
+buxmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondReturnSwaps/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BondReturnSwaps</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Swaps which give a return on one leg based on the interest rate returns on a debt instrument.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/BondReturnSwaps/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-brs;DebtAssetInterestReturnStream">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;SimpleReturnStream"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReferenceAsset"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;DebtObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt asset interest return stream</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A leg which embodies the interest payments on a debt instrument which is the reference asset for a Swap.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-brs;DebtSecurityDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;UnderlyingSecurityDelivery"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt security delivery</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/AssetDerivatives/EquityForwards.rdf
+++ b/der/AssetDerivatives/EquityForwards.rdf
@@ -1,288 +1,291 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-ass-eqf "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityForwards/">
-	<!ENTITY fibo-der-ass-eqs "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/">
-	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-ass-eqf "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityForwards/">
+bu<!ENTITY fibo-der-ass-eqs "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/">
+bu<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityForwards/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-ass-eqf="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityForwards/"
-	xmlns:fibo-der-ass-eqs="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/"
-	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityForwards/">
-		<rdfs:label xml:lang="en">EquityForwards</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityForwards/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<rdfs:Datatype rdf:about="&xsd;string">
-	</rdfs:Datatype>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;CalculationAgentAdjustmentMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod"/>
-		<rdfs:label xml:lang="en">calculation agent adjustment method</rdfs:label>
-		<skos:definition xml:lang="en">The calculation agent has the right to adjust the terms following a corporate event</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;DividendAdjustmentPeriod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<rdfs:label xml:lang="en">dividend adjustment period</rdfs:label>
-		<skos:definition xml:lang="en">A period used to calculate the Deviation between Expected Dividend and Actual Dividend in that Period.</skos:definition>
-		<skos:editorialNote xml:lang="en">Referred to in formal terms for OTC Equity Forwards and Options. REVIEW: It does not look as though we have completely pinned down the meaning on this one, only that it&apos;s a piece of data that&apos;s used for something. We really need to see and model details of those deviation claculations, along with who does them and when. Also they may not directly be facts about the contract as such. REVIEW FpML: &apos;A single Dividend Adjustment Period.&apos;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
-		<rdfs:label xml:lang="en">equity forward buyer</rdfs:label>
-		<skos:definition xml:lang="en">The party that buys this forwward contract, that is the party which pays for this instrument and receives the rights defined by it.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See note in Seller. See 2000 ISDA definitions Article 11.1 (b). FpML: &apos;A reference to the party that buys this instrument, ie. pays for this instrument and receives the rights defined by it. See 2000 ISDA definitions Article 11.1 (b). In the case of FRAs this the fixed rate payer.&apos; Interpretation: this is the party which is the counterparty to the contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardCashSettlement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-		<rdfs:label xml:lang="en">equity forward cash settlement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqf;dividendAdjustment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;DividendAdjustmentPeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqf;hasConditions"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqs;DividendConditions"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqf;hasEffectiveDate"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqf;hasMethodOfAdjustment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardDeliveryCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardSeller"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity forward contract</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed</skos:definition>
-		<skos:editorialNote xml:lang="en">FpMl definition (unusable): A component describing an Equity Forward product.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardDeliveryCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
-		<rdfs:label xml:lang="en">equity forward delivery commitment</rdfs:label>
-		<skos:definition xml:lang="en">The commitment to deliver an equity underlying at the maturity of an OTC Equity Forward contract.</skos:definition>
-		<skos:editorialNote xml:lang="en">Or, presumably, some cash equivalent in the event that the undelying is non deliverable, or for a non deliverable forward generally.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardSeller">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
-		<rdfs:label xml:lang="en">equity forward seller</rdfs:label>
-		<skos:definition xml:lang="en">The party that sells or writes this forward instrument, that is the party which grants the rights defined by this instrument and in return receives a payment for it.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The forward is always written by the party that is committing to sell the underlying, and is always bought by the party that is committing to take delivery of the underlying on the settlement date. The forward contract is the same as a conventional secondary market sale transaction but with the difference that the settlement date is in the future. See 2000 ISDA definitions Article 11.1 (a). FpML: &apos;A reference to the party that sells (&quot;writes&quot;) this instrument, i.e. that grants the rights defined by this instrument and in return receives a payment for it. See 2000 ISDA definitions Article 11.1 (a). In the case of FRAs this is the floating rate payer.&apos; Interpretation: this is the party which is the principal or writing party to the contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardCashSettlement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity forward transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction in which one party commits at the present to delivery of an equity security or securities or cash equivalent in the future.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;EquitySecurityDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;UnderlyingSecurityDelivery"/>
-		<rdfs:label xml:lang="en">equity security delivery</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;EquityValuation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;undertakenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityValuationCalculationAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity valuation</rdfs:label>
-		<skos:definition xml:lang="en">The act of valuation of an equity underlying (share, basket or index) during the life of an OTC equity option or forward.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML: &apos;The parameters for defining when valuation of the underlying takes place.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;EquityValuationCalculationAgent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;CalculationAgent"/>
-		<rdfs:label xml:lang="en">equity valuation calculation agent</rdfs:label>
-		<skos:definition xml:lang="en">The entity which carries out the valuation of an asset underlying an equity forward or option, or from which the valuation of the underlying is to be taken.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;AdjustmentMethod"/>
-		<rdfs:label xml:lang="en">forward contract adjustment method</rdfs:label>
-		<skos:definition xml:lang="en">Method by which adjustments will be made to the forward contract should one or more of a number of extraordinary events occur.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML: Defines how adjustments will be made to the contract should one or more of the extraordinary events occur.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqf;OptionsExchangeAdjustmentMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod"/>
-		<rdfs:label xml:lang="en">options exchange adjustment method</rdfs:label>
-		<skos:definition xml:lang="en">The trade will be adjusted according to ... exchange on which the options (??) are listed</skos:definition>
-		<skos:editorialNote xml:lang="en">REVIEW: Seems to be traded-option-underlying specific.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;dividendAdjustment">
-		<rdfs:label xml:lang="en">dividend adjustment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-eqf;DividendAdjustmentPeriod"/>
-		<skos:definition xml:lang="en">One or more Dividend Adjustment Periods, which are used to calculate the Deviation between Expected Dividend and Actual Dividend in that Period.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;hasConditions">
-		<rdfs:label xml:lang="en">has conditions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-eqs;DividendConditions"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;hasEffectiveDate">
-		<rdfs:label xml:lang="en">has effective date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-		<skos:definition xml:lang="en">The Effective date for a forward starting derivative. This is the starting date for the contract. Further notes: FpML: &apos;Effective date for a forward starting derivative. If this element is not present, the effective date is the trade date. Note that FpML has this typed as &quot;adjustableDate or relativeDate&quot;. Our Determined Date is wider in scope than this and may need to be narrowed down depending on what is the true range of ways in which this date may be defined in a forward contract. Note that the optionality identified in the FpML definition is not reflected here. The assumption is that this exists as a legal fact, and that if that legal fact is not reflected in the FpML message then the trade date is taken to be the (legal) Effective Date. Therefore this term always exists from a legal perspective.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;hasMethodOfAdjustment">
-		<rdfs:label xml:lang="en">has method of adjustment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;notionalAmount">
-		<rdfs:label xml:lang="en">notional amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">DEFINITION NEEDED FpML: &apos;The notional amount.&apos; (thanks!)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;numberOfUnits">
-		<rdfs:label xml:lang="en">number of units</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;NonNegativeIntegerValue"/>
-		<skos:definition xml:lang="en">The price per asset, index or basket observed on the trade or effective date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqf;priceSource">
-		<rdfs:label xml:lang="en">price source</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardCashSettlement"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">The Price source to be used to determine the settlement price.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqf;settlementMethodElection">
-		<rdfs:label xml:lang="en">settlement method election</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardCashSettlement"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">How the forward will be settled.</skos:definition>
-	</owl:DatatypeProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-ass-eqf="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityForwards/"
+buxmlns:fibo-der-ass-eqs="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/"
+buxmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityForwards/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">EquityForwards</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Forward contracts based on an underlying equity instrument.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityForwards/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<rdfs:Datatype rdf:about="&xsd;string">
+bu</rdfs:Datatype>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;CalculationAgentAdjustmentMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calculation agent adjustment method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The calculation agent has the right to adjust the terms following a corporate event</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;DividendAdjustmentPeriod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend adjustment period</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A period used to calculate the Deviation between Expected Dividend and Actual Dividend in that Period.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Referred to in formal terms for OTC Equity Forwards and Options. REVIEW: It does not look as though we have completely pinned down the meaning on this one, only that it&apos;s a piece of data that&apos;s used for something. We really need to see and model details of those deviation claculations, along with who does them and when. Also they may not directly be facts about the contract as such. REVIEW FpML: &apos;A single Dividend Adjustment Period.&apos;</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardBuyer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity forward buyer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party that buys this forwward contract, that is the party which pays for this instrument and receives the rights defined by it.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">See note in Seller. See 2000 ISDA definitions Article 11.1 (b). FpML: &apos;A reference to the party that buys this instrument, ie. pays for this instrument and receives the rights defined by it. See 2000 ISDA definitions Article 11.1 (b). In the case of FRAs this the fixed rate payer.&apos; Interpretation: this is the party which is the counterparty to the contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardCashSettlement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity forward cash settlement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqf;dividendAdjustment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;DividendAdjustmentPeriod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqf;hasConditions"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqs;DividendConditions"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqf;hasEffectiveDate"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqf;hasMethodOfAdjustment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardDeliveryCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasSeller"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardSeller"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity forward contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpMl definition (unusable): A component describing an Equity Forward product.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardDeliveryCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity forward delivery commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The commitment to deliver an equity underlying at the maturity of an OTC Equity Forward contract.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Or, presumably, some cash equivalent in the event that the undelying is non deliverable, or for a non deliverable forward generally.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardSeller">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity forward seller</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party that sells or writes this forward instrument, that is the party which grants the rights defined by this instrument and in return receives a payment for it.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The forward is always written by the party that is committing to sell the underlying, and is always bought by the party that is committing to take delivery of the underlying on the settlement date. The forward contract is the same as a conventional secondary market sale transaction but with the difference that the settlement date is in the future. See 2000 ISDA definitions Article 11.1 (a). FpML: &apos;A reference to the party that sells (&quot;writes&quot;) this instrument, i.e. that grants the rights defined by this instrument and in return receives a payment for it. See 2000 ISDA definitions Article 11.1 (a). In the case of FRAs this is the floating rate payer.&apos; Interpretation: this is the party which is the principal or writing party to the contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;side"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardCashSettlement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;side.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity forward transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction in which one party commits at the present to delivery of an equity security or securities or cash equivalent in the future.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;EquitySecurityDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;UnderlyingSecurityDelivery"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity security delivery</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;EquityValuation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;undertakenBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityValuationCalculationAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity valuation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The act of valuation of an equity underlying (share, basket or index) during the life of an OTC equity option or forward.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">FpML: &apos;The parameters for defining when valuation of the underlying takes place.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;EquityValuationCalculationAgent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;CalculationAgent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity valuation calculation agent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity which carries out the valuation of an asset underlying an equity forward or option, or from which the valuation of the underlying is to be taken.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;AdjustmentMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward contract adjustment method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Method by which adjustments will be made to the forward contract should one or more of a number of extraordinary events occur.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">FpML: Defines how adjustments will be made to the contract should one or more of the extraordinary events occur.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqf;OptionsExchangeAdjustmentMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">options exchange adjustment method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The trade will be adjusted according to ... exchange on which the options (??) are listed</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">REVIEW: Seems to be traded-option-underlying specific.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;dividendAdjustment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend adjustment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-eqf;DividendAdjustmentPeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One or more Dividend Adjustment Periods, which are used to calculate the Deviation between Expected Dividend and Actual Dividend in that Period.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;hasConditions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has conditions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-eqs;DividendConditions"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;hasEffectiveDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has effective date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Effective date for a forward starting derivative. This is the starting date for the contract. Further notes: FpML: &apos;Effective date for a forward starting derivative. If this element is not present, the effective date is the trade date. Note that FpML has this typed as &quot;adjustableDate or relativeDate&quot;. Our Determined Date is wider in scope than this and may need to be narrowed down depending on what is the true range of ways in which this date may be defined in a forward contract. Note that the optionality identified in the FpML definition is not reflected here. The assumption is that this exists as a legal fact, and that if that legal fact is not reflected in the FpML message then the trade date is taken to be the (legal) Effective Date. Therefore this term always exists from a legal perspective.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;hasMethodOfAdjustment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has method of adjustment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-eqf;ForwardContractAdjustmentMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;notionalAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notional amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">DEFINITION NEEDED FpML: &apos;The notional amount.&apos; (thanks!)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqf;numberOfUnits">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of units</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;NonNegativeIntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price per asset, index or basket observed on the trade or effective date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqf;priceSource">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price source</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardCashSettlement"/>
+bubu<rdfs:range rdf:resource="&xsd;string"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Price source to be used to determine the settlement price.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqf;settlementMethodElection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement method election</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqf;EquityForwardCashSettlement"/>
+bubu<rdfs:range rdf:resource="&xsd;string"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How the forward will be settled.</skos:definition>
+bu</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/der/AssetDerivatives/EquityOptions.rdf
+++ b/der/AssetDerivatives/EquityOptions.rdf
@@ -1,346 +1,349 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-ass-bas "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/">
-	<!ENTITY fibo-der-ass-eqo "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityOptions/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-etd-eto "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-ass-bas "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/">
+bu<!ENTITY fibo-der-ass-eqo "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityOptions/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-etd-eto "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityOptions/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-ass-bas="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"
-	xmlns:fibo-der-ass-eqo="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityOptions/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-etd-eto="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityOptions/">
-		<rdfs:label xml:lang="en">EquityOptions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityOptions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;BasketOptionStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionExerciseTermsSet"/>
-		<rdfs:label xml:lang="en">basket option strike terms</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms for the exercise of an Equity Basket Option. Further Notes Review 10 Feb: Strike price for Basket depends what is in the basket Single names: can come up with a value for the basket as a whole. Basket of Indices - would be different. Each constituent is an index. Basket that mixes single name as well as indices.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityBasketOptionOTCContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;hasAnnex"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-bas;EquityBasketOptionAnnex"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;underlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-bas;EquityBasketObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity basket option o t c contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityIndexOptionOTCContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;underlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity index option o t c contract</rdfs:label>
-		<skos:definition xml:lang="en">An option in which the underlyer is an equity index.</skos:definition>
-		<skos:editorialNote xml:lang="en">Created to capture terms specific to index options. Note however that in FpML, there are no additional and different terms for basket options, so it maybe assumed that terms such as contract multiplier, which are defined for index options, are also applicable to basket options (a basket being a locally defined collection of securities which is otherwise similar to a published index of shares). Outcome of above question: see notes from 03 Feb review. The Basket Option must have an Annex which details the basket constituents. Also we are to add Contract types here for Basket Option contract and Custom Index Option.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityIndexOptionStrikeTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionExerciseTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;includesSpecification"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity index option strike terms set</rdfs:label>
-		<skos:definition xml:lang="en">The strike price in respect of an index option transaction, is the level of the relevant index specified or otherwise determined in the transaction; This can be expressed either as a percentage of notional amount or as an absolute value.</skos:definition>
-		<skos:editorialNote xml:lang="en">Adapted out of FpML equityStike (see original definition below); it is not clear whether the final provision in that definition (that the price can be expressed either as a percentage of notional or an absolute value) is intended to refer to index strike as well as single share option strike. REVIEW FpML equityStrike (complex type): A type for defining the strike price for an equity option. The strike price is either: (i) in respect of an index option transaction, the level of the relevant index specified or otherwise determined in the transaction; or (ii) in respect of a share option transaction, the price per share specified or otherwise determined in the transaction. This can be expressed either as a percentage of notional amount or as an absolute value.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOTCBasketOptionTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOTCOptionTransaction"/>
-		<rdfs:label xml:lang="en">equity o t c basket option transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOTCOptionTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCDerivativeTransaction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-		<rdfs:label xml:lang="en">equity o t c option transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction which is defined in an equity options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase or sale of the equity underlying or some cash equivalent thereof, as defined in the option contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionCallTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOTCOptionTransaction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
-		<rdfs:label xml:lang="en">equity option call transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction which is defined in an equity options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase of the equity underlying or some cash equivalent thereof, as defined in the option contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionEntitlement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-		<rdfs:label xml:lang="en">equity option entitlement</rdfs:label>
-		<skos:definition xml:lang="en">The entitlements to the holder, comprised in an option contract or transaction supplement. FpML: &apos;The number of shares per option comprised in the option transaction supplement.&apos; In FpML this is an either / or: Either a whole number representing the number of shares per option, or a multiplier to be applied to an index underlyer (and, presumably, a basket underlyer)</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
-		<rdfs:label xml:lang="en">equity option exercise terms set</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms setting out the price or level at which the Equity option is to be struck.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML equityStrike (complex type): A type for defining the strike price for an equity option. The strike price is either: (i) in respect of an index option transaction, the level of the relevant index specified or otherwise determined in the transaction; or (ii) in respect of a share option transaction, the price per share specified or otherwise determined in the transaction. This can be expressed either as a percentage of notional amount or as an absolute value.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionOTCContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;maySpecify"/>
-				<owl:onClass rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;hasLocalJurisdiction"/>
-				<owl:onClass rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;hasRelevantJurisdiction"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;underlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqo;EquityOTCOptionTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity option o t c contract</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed</skos:definition>
-		<skos:editorialNote xml:lang="en">FpMl definition (unusable): A component describing an Equity Option product.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionPutTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOTCOptionTransaction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
-		<rdfs:label xml:lang="en">equity option put transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction which is defined in an equity options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the sale of the equity underlying or some cash equivalent thereof, as defined in the option contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;IndexOrBasketOptionEntitlement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionEntitlement"/>
-		<rdfs:label xml:lang="en">index or basket option entitlement</rdfs:label>
-		<skos:definition xml:lang="en">The entitlements to the holder of a basket or index option, comprised in an option contract or transaction supplement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;ShareOptionEntitlement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionEntitlement"/>
-		<rdfs:label xml:lang="en">share option entitlement</rdfs:label>
-		<skos:definition xml:lang="en">The entitlements to the holder of a single share option, comprised in an option contract or transaction supplement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;ShareOptionOTCContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;underlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SingleShareObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">share option o t c contract</rdfs:label>
-		<skos:definition xml:lang="en">An option in which the underlyer is a single publicly issued and traded share.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqo;ShareOptionStrikeTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionExerciseTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqo;includesSpecification.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;AbsolutePriceStrikeSpecification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">share option strike terms set</rdfs:label>
-		<skos:definition xml:lang="en">The strike price is the price per share specified or otherwise determined in the transaction. This can be expressed either as a percentage of notional amount or as an absolute value. FpML equityStrike (complex type): A type for defining the strike price for an equity option. The strike price is either: (i) in respect of an index option transaction, the level of the relevant index specified or otherwise determined in the transaction; or (ii) in respect of a share option transaction, the price per share specified or otherwise determined in the transaction. This can be expressed either as a percentage of notional amount or as an absolute value.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;contractMultiplier">
-		<rdfs:label xml:lang="en">contract multiplier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityIndexOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The contract multiplier associated with the index option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;exchangeLookalike">
-		<rdfs:label xml:lang="en">exchange lookalike</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the corresponding transaction is to be treated as an &apos;exchange look-alike&apos;. If Yes, then the relevant share adjustments will follow that for a corresponding designated contract listed on the related exchange</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqo;extraordinaryEventsTreatment">
-		<rdfs:label xml:lang="en">extraordinary events treatment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;ShareOptionOTCContract"/>
-		<skos:definition xml:lang="en">Events affecting the issuer of those shares that may require the terms of the transaction to be adjusted.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;hasAnnex">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has annex</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityBasketOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-bas;EquityBasketOptionAnnex"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;hasLocalJurisdiction">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasGoverningJurisdiction"/>
-		<rdfs:label xml:lang="en">has local jurisdiction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;hasRelevantJurisdiction">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasGoverningJurisdiction"/>
-		<rdfs:label xml:lang="en">has relevant jurisdiction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;includesSpecification">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;includesSpecificationTerm"/>
-		<rdfs:label xml:lang="en">includes specification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityIndexOptionStrikeTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;includesSpecification.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;includesSpecificationTerm"/>
-		<rdfs:label xml:lang="en">includes specification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;ShareOptionStrikeTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;AbsolutePriceStrikeSpecification"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;maySpecify">
-		<rdfs:label xml:lang="en">may specify</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;multiplier">
-		<rdfs:label xml:lang="en">multiplier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;IndexOrBasketOptionEntitlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The contract multiplier associated with an index or basket option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;nearestIndexProvision">
-		<rdfs:label xml:lang="en">nearest index provision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityBasketOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">For an index option transaction, whether the Nearest Index Contract provision is applicable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;notionalAmount">
-		<rdfs:label xml:lang="en">notional amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">&apos;The notional amount.&apos; Further notes: Presumably all options have a notional amount. This is defined here for Eqiuty Option. FpML: &apos;The notional amount.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;novationAllowable">
-		<rdfs:label xml:lang="en">novation allowable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;novationRequired">
-		<rdfs:label xml:lang="en">novation required</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;numberOfOptions">
-		<rdfs:label xml:lang="en">number of options</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The price per equity security, index or basket observed on the trade or effective date. FpML: &apos;The price per asset, index or basket observed on the trade or effective date.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;numberOfShares">
-		<rdfs:label xml:lang="en">number of shares</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;ShareOptionEntitlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The number of shares per option comprised in the option. FpML: &apos;The number of shares per option comprised in the option transaction supplement.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;sharesPerOption">
-		<rdfs:label xml:lang="en">shares per option</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;ShareOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of shares per option defined for the option contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;underlying">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-ass-bas="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"
+buxmlns:fibo-der-ass-eqo="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityOptions/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-etd-eto="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityOptions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">EquityOptions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Options based on underlying equity instruments, baskets or indices. Additional terms specific to OTC equity options.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquityOptions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;BasketOptionStrikeTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionExerciseTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">basket option strike terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal terms for the exercise of an Equity Basket Option. Further Notes Review 10 Feb: Strike price for Basket depends what is in the basket Single names: can come up with a value for the basket as a whole. Basket of Indices - would be different. Each constituent is an index. Basket that mixes single name as well as indices.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityBasketOptionOTCContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;hasAnnex"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-bas;EquityBasketOptionAnnex"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;underlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-bas;EquityBasketObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity basket option o t c contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityIndexOptionOTCContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;underlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity index option o t c contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option in which the underlyer is an equity index.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Created to capture terms specific to index options. Note however that in FpML, there are no additional and different terms for basket options, so it maybe assumed that terms such as contract multiplier, which are defined for index options, are also applicable to basket options (a basket being a locally defined collection of securities which is otherwise similar to a published index of shares). Outcome of above question: see notes from 03 Feb review. The Basket Option must have an Annex which details the basket constituents. Also we are to add Contract types here for Basket Option contract and Custom Index Option.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityIndexOptionStrikeTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionExerciseTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;includesSpecification"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity index option strike terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The strike price in respect of an index option transaction, is the level of the relevant index specified or otherwise determined in the transaction; This can be expressed either as a percentage of notional amount or as an absolute value.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Adapted out of FpML equityStike (see original definition below); it is not clear whether the final provision in that definition (that the price can be expressed either as a percentage of notional or an absolute value) is intended to refer to index strike as well as single share option strike. REVIEW FpML equityStrike (complex type): A type for defining the strike price for an equity option. The strike price is either: (i) in respect of an index option transaction, the level of the relevant index specified or otherwise determined in the transaction; or (ii) in respect of a share option transaction, the price per share specified or otherwise determined in the transaction. This can be expressed either as a percentage of notional amount or as an absolute value.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOTCBasketOptionTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOTCOptionTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity o t c basket option transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOTCOptionTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCDerivativeTransaction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity o t c option transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction which is defined in an equity options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase or sale of the equity underlying or some cash equivalent thereof, as defined in the option contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionCallTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOTCOptionTransaction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity option call transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction which is defined in an equity options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase of the equity underlying or some cash equivalent thereof, as defined in the option contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionEntitlement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity option entitlement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entitlements to the holder, comprised in an option contract or transaction supplement. FpML: &apos;The number of shares per option comprised in the option transaction supplement.&apos; In FpML this is an either / or: Either a whole number representing the number of shares per option, or a multiplier to be applied to an index underlyer (and, presumably, a basket underlyer)</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionExerciseTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity option exercise terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms setting out the price or level at which the Equity option is to be struck.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">FpML equityStrike (complex type): A type for defining the strike price for an equity option. The strike price is either: (i) in respect of an index option transaction, the level of the relevant index specified or otherwise determined in the transaction; or (ii) in respect of a share option transaction, the price per share specified or otherwise determined in the transaction. This can be expressed either as a percentage of notional amount or as an absolute value.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionOTCContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;maySpecify"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;hasLocalJurisdiction"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;hasRelevantJurisdiction"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;underlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqo;EquityOTCOptionTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity option o t c contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpMl definition (unusable): A component describing an Equity Option product.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;EquityOptionPutTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOTCOptionTransaction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity option put transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction which is defined in an equity options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the sale of the equity underlying or some cash equivalent thereof, as defined in the option contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;IndexOrBasketOptionEntitlement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionEntitlement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index or basket option entitlement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entitlements to the holder of a basket or index option, comprised in an option contract or transaction supplement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;ShareOptionEntitlement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionEntitlement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share option entitlement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entitlements to the holder of a single share option, comprised in an option contract or transaction supplement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;ShareOptionOTCContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;underlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SingleShareObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share option o t c contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option in which the underlyer is a single publicly issued and traded share.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqo;ShareOptionStrikeTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqo;EquityOptionExerciseTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqo;includesSpecification.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;AbsolutePriceStrikeSpecification"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share option strike terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The strike price is the price per share specified or otherwise determined in the transaction. This can be expressed either as a percentage of notional amount or as an absolute value. FpML equityStrike (complex type): A type for defining the strike price for an equity option. The strike price is either: (i) in respect of an index option transaction, the level of the relevant index specified or otherwise determined in the transaction; or (ii) in respect of a share option transaction, the price per share specified or otherwise determined in the transaction. This can be expressed either as a percentage of notional amount or as an absolute value.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;contractMultiplier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract multiplier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityIndexOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The contract multiplier associated with the index option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;exchangeLookalike">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange lookalike</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the corresponding transaction is to be treated as an &apos;exchange look-alike&apos;. If Yes, then the relevant share adjustments will follow that for a corresponding designated contract listed on the related exchange</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqo;extraordinaryEventsTreatment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">extraordinary events treatment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;ShareOptionOTCContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Events affecting the issuer of those shares that may require the terms of the transaction to be adjusted.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;hasAnnex">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has annex</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityBasketOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-bas;EquityBasketOptionAnnex"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;hasLocalJurisdiction">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasGoverningJurisdiction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has local jurisdiction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;hasRelevantJurisdiction">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasGoverningJurisdiction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has relevant jurisdiction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;includesSpecification">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;includesSpecificationTerm"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes specification</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityIndexOptionStrikeTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;includesSpecification.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;includesSpecificationTerm"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes specification</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;ShareOptionStrikeTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;AbsolutePriceStrikeSpecification"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;maySpecify">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may specify</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;multiplier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiplier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;IndexOrBasketOptionEntitlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The contract multiplier associated with an index or basket option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;nearestIndexProvision">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">nearest index provision</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityBasketOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">For an index option transaction, whether the Nearest Index Contract provision is applicable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;notionalAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notional amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&apos;The notional amount.&apos; Further notes: Presumably all options have a notional amount. This is defined here for Eqiuty Option. FpML: &apos;The notional amount.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;novationAllowable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">novation allowable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;novationRequired">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">novation required</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;numberOfOptions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of options</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price per equity security, index or basket observed on the trade or effective date. FpML: &apos;The price per asset, index or basket observed on the trade or effective date.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;numberOfShares">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of shares</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;ShareOptionEntitlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of shares per option comprised in the option. FpML: &apos;The number of shares per option comprised in the option transaction supplement.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;sharesPerOption">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">shares per option</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;ShareOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of shares per option defined for the option contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqo;underlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqo;EquityOptionOTCContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/AssetDerivatives/EquitySwaps.rdf
+++ b/der/AssetDerivatives/EquitySwaps.rdf
@@ -1,394 +1,397 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-ass-eqs "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/">
-	<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-ass-eqs "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/">
+bu<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-ass-eqs="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/"
-	xmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/">
-		<rdfs:label xml:lang="en">EquitySwaps</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;CorrelationLegTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">correlation leg terms</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed. FpML refers to this but does not define its meaning. Correslation between two prices</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Correlation Buyer is deemed to be the Equity Amount Receiver, Correlation Seller is deemed to be the Equity Amount Payer. FpML: &apos;Correlation Leg. Correlation Buyer is deemed to be the Equity Amount Receiver, Correlation Seller is deemed to be the Equity Amount Payer.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;CovarianceLegTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
-		<rdfs:label xml:lang="en">covariance leg terms</rdfs:label>
-		<skos:definition xml:lang="en">A statistical leg based on covariance. REVIEW: This kmight specify the same kind of thing as Correlation Leg using different mathematics / different legal terms (in which case we need to model it as a different thing even though to the investor it has the same rationale and behavior. The relative movement of one thing to the other over a period of time. So this adds a time base to the Correlation calculation. difference with Correelation: The time base in correlation swap is implicit anyway (it&apos;s the duration of the contract. so Covariance is what allows you to explan x% of the vaqriabiltiy of the price of this asset with relation to that asset.</skos:definition>
-		<skos:editorialNote xml:lang="en">Original review note: Co-variance Leg Another statistical swap leg type where the stike determines the payout. Structured the same as the Correlation Leg. more notes 17 March: Covariane is actually the way you measure correlation. So people talk about this as a statistical leg but actually Talks about movement of price THe highter the covariance between two prices the more correlated they are. more general note: unlike fx market where e.g. I cna build a price out od AUS/USD and build a price out of that. In option markets I don&apos;t have that opportunity - one owiuld end up overpricing the option. The variability in the price of AUS/USD v AUS/GBP impacts on these calculations. By using three legs I cna put together a cros inthe options. Buy Aus/USD Option, .buy USD/GBP Option and sell the correlation Swap. This sells the correlationbeteen AUS/USD and AUS/GBP leaving me with a realistic price for AUS/GBP thereby enabling me to cross markets. So the swap enables me not to end up overpricing the option. THis basic principle is why correslation swaps are used. So correslation is a relatively new concept.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionLeg">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableLeg"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-ass;definedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqs;DispersionLegTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dispersion leg</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionLegTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
-		<rdfs:label xml:lang="en">dispersion leg terms</rdfs:label>
-		<skos:definition xml:lang="en">Either leg of a Dispersion Swap. This is a structure defining one or other underlying component of a Dispersion Swap.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Both legs are Return Legs, there is no Payment Leg. Model review notes: Dispersion Swap is a basket, where the constituents of the basket would typically include indices. So it may be Long the index and short the top 20 constituents of that index. Typically index v some form of the constituents, is what makes up a dispersion swap. Also (statistical swaps) - Market Disruption Event. For instance - define what dates are observed, so some dates get dropped due to market disruption events There would be some contractual terms about this, defining for instance the kinds of events defined as market disruptions, and the fact that the dates when these happen, these observations are not made. Look at examples.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionSwapContract">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
-		<rdfs:label xml:lang="en">dispersion swap contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionSwapIndexConstituentsLegTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqs;DispersionLegTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying.6"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SetOfEquityIndexConstituentsObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dispersion swap index constituents leg terms</rdfs:label>
-		<skos:definition xml:lang="en">The side of a dispersion swap where the underlying is a defined sub-set of an index, i.e. a set of constituents of that index.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionSwapIndexLegTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqs;DispersionLegTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying.7"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dispersion swap index leg terms</rdfs:label>
-		<skos:definition xml:lang="en">The side of a dispersion swap which has a particular index as its underlying. Further notes: This is a leg of a dispersion swap, which is defined by the index itself. This may be set against the other leg which is made up of a defined part of that index. Review comment: aren&apos;t really legs.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionSwapTransaction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
-				<owl:onClass rdf:resource="&fibo-der-ass-eqs;DispersionLeg"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dispersion swap transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DividendConditions">
-		<rdfs:label xml:lang="en">dividend conditions</rdfs:label>
-		<skos:definition xml:lang="en">Conditions governing the payment of dividends to the receiver of the equity forward.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML has a set of terms for Dividend Conditions which are usable across a range of derivatives, including Forward. Many of the definitions of individual terms refer specifically to equity return (swaps) and it is not clear whether each such term also applies to Equity forwards (i.e. the definition is more specific than it should be), or if these are terms unique to Equity Return Swaps, among which are terms applicable to Equity forwards. REVIEW: 19 May: If you have a forward contract with a dividend before you settle there must be some terms to determine how the dividend is resolved. Similar question would apply with Bond Interst? No becaues this is a known amount so it is taken into account in the price that&apos;s been agreed (discount premium). Whether it&apos;s cum or ex coupon therefore doesn&apos;t affect pricing; with Dividend this is not the case, there afore there are contractual trerms about how that is to be resolved. FpML: A type describing the conditions governing the payment of dividends to the receiver of the equity return. With the exception of the dividend payout ratio, which is defined for each of the underlying components.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DividendLegDividendPeriod">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqs;hasSomeDividendPeriods"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqs;DividendPeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dividend leg dividend period</rdfs:label>
-		<skos:definition xml:lang="en">A part of a Dividend Leg, which is the dividend period and the terms relating to this.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DividendPeriod">
-		<rdfs:label xml:lang="en">dividend period</rdfs:label>
-		<skos:definition xml:lang="en">A dividend payment period.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;DividendStream">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;SimpleReturnStream"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqs;hasComponent.1"/>
-				<owl:onClass rdf:resource="&fibo-der-ass-eqs;SpecialDividendLegTerm"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqs;hasComponent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqs;DividendLegDividendPeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SingleShareObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReferenceAsset"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dividend stream</rdfs:label>
-		<skos:definition xml:lang="en">The Floating Payment Leg of a Dividend Swap. Swap dividend payment rates. Earlier notes this behaves very like a variance swap but instead of betting in pure variance you take a bet on dividend. What practically in one of these: The difference between th ereal life dividend and the one you think it should be. so I say it should bte 2% over the next 10 years, so I swap 2% for the actual dividend amount So then there is one single payment at the end which nets these up. So in the above example ... they are usually 3 month or 6 month contracts, so if for instance th edividend if quarterly, there might be 2 dividends where the difference is netted up at the end.for example. (Us 1/4ly usually , Eur 6 months). Depends on the company&apos;s articles of association etc. e.g. Unilever is 6 mo)/ Structurally, Div Swap corr Swap and Var Swap are structured similarly, with one strike at the beginning. Strike may be expressed in terms of the (price) variance (the variance of the returns) , the correlation between typically 2 underlyers. or the dividend for each of these three types of swap respectively. 17 march Dividend is a flow based on a share, so is this not the same as a Return Swap in that the dividend is the return on the dividend? Also recall that with stocks themselves, there is no comitment by the issuer to pay the dividends. FpML: &apos;Dividend leg.&apos;; &apos;Floating Payment Leg of a Dividend Swap.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;EquityCorrelationSwapContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;StatisticalSwapContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity correlation swap contract</rdfs:label>
-		<skos:definition xml:lang="en">no definition FpML (unusable): A correlation swap.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;EquityDividendSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity dividend swap</rdfs:label>
-		<skos:definition xml:lang="en">No definition FpML: Specifies the structure of the dividend swap transaction supplement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;EquityReturnSwapContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;ReturnSwapContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity return swap contract</rdfs:label>
-		<skos:definition xml:lang="en">No definition FpML has no distinct product type for this, instead the schema for Return Swaps has content which is an Equity Swap Transaction Supplement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;EquityVarianceSwapContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;StatisticalSwapContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity variance swap contract</rdfs:label>
-		<skos:definition xml:lang="en">no definition FpML (unusable): Specifies the structure of a variance swap.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;SpecialDividendLegTerm">
-		<rdfs:label xml:lang="en">special dividend leg term</rdfs:label>
-		<skos:definition xml:lang="en">Special dividends and memorial dividends which are applicable. FpML: &apos;If present and true, then special dividends and memorial dividends are applicable.&apos; Note that &quot;if true&quot; (a yes/no term) and &quot;if present&quot; (this term, which is the presence of the thing) are two separate meanings. FpML implies the truth of the Yes/No fact by the presence or absence of this term. However, although FpML definition says &quot;if present and true&quot;, the term is just a &quot;boolean&quot; ie a YTes/no applicability term. Not sure where the special dividends themselves are defined.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;SwapStrikeTerms">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
-		<rdfs:label xml:lang="en">swap strike terms</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms defining the strike leg on a swap that has a strike leg.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This kind of leg exists for variance swaps and other similar swaps. The realization of this leg is not a cashflow but a netting out against the terms defined in the other leg. Notes from Strike Leg: The abstract leg implied by the strike in a statistical swap. 
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-ass-eqs="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/"
+buxmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">EquitySwaps</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Swap contracts in which one leg gives some form of return on an equity asset, including dividend returns, total asset returns equity dispersion and correlation measurement terms. Many of these return calculations are based on a variety of calculation methods and may vary widely.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/EquitySwaps/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;CorrelationLegTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">correlation leg terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed. FpML refers to this but does not define its meaning. Correslation between two prices</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Correlation Buyer is deemed to be the Equity Amount Receiver, Correlation Seller is deemed to be the Equity Amount Payer. FpML: &apos;Correlation Leg. Correlation Buyer is deemed to be the Equity Amount Receiver, Correlation Seller is deemed to be the Equity Amount Payer.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;CovarianceLegTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">covariance leg terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A statistical leg based on covariance. REVIEW: This kmight specify the same kind of thing as Correlation Leg using different mathematics / different legal terms (in which case we need to model it as a different thing even though to the investor it has the same rationale and behavior. The relative movement of one thing to the other over a period of time. So this adds a time base to the Correlation calculation. difference with Correelation: The time base in correlation swap is implicit anyway (it&apos;s the duration of the contract. so Covariance is what allows you to explan x% of the vaqriabiltiy of the price of this asset with relation to that asset.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Original review note: Co-variance Leg Another statistical swap leg type where the stike determines the payout. Structured the same as the Correlation Leg. more notes 17 March: Covariane is actually the way you measure correlation. So people talk about this as a statistical leg but actually Talks about movement of price THe highter the covariance between two prices the more correlated they are. more general note: unlike fx market where e.g. I cna build a price out od AUS/USD and build a price out of that. In option markets I don&apos;t have that opportunity - one owiuld end up overpricing the option. The variability in the price of AUS/USD v AUS/GBP impacts on these calculations. By using three legs I cna put together a cros inthe options. Buy Aus/USD Option, .buy USD/GBP Option and sell the correlation Swap. This sells the correlationbeteen AUS/USD and AUS/GBP leaving me with a realistic price for AUS/GBP thereby enabling me to cross markets. So the swap enables me not to end up overpricing the option. THis basic principle is why correslation swaps are used. So correslation is a relatively new concept.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionLeg">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableLeg"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-ass;definedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqs;DispersionLegTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dispersion leg</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionLegTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dispersion leg terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Either leg of a Dispersion Swap. This is a structure defining one or other underlying component of a Dispersion Swap.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Both legs are Return Legs, there is no Payment Leg. Model review notes: Dispersion Swap is a basket, where the constituents of the basket would typically include indices. So it may be Long the index and short the top 20 constituents of that index. Typically index v some form of the constituents, is what makes up a dispersion swap. Also (statistical swaps) - Market Disruption Event. For instance - define what dates are observed, so some dates get dropped due to market disruption events There would be some contractual terms about this, defining for instance the kinds of events defined as market disruptions, and the fact that the dates when these happen, these observations are not made. Look at examples.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionSwapContract">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dispersion swap contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionSwapIndexConstituentsLegTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqs;DispersionLegTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying.6"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SetOfEquityIndexConstituentsObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dispersion swap index constituents leg terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The side of a dispersion swap where the underlying is a defined sub-set of an index, i.e. a set of constituents of that index.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionSwapIndexLegTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-eqs;DispersionLegTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying.7"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dispersion swap index leg terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The side of a dispersion swap which has a particular index as its underlying. Further notes: This is a leg of a dispersion swap, which is defined by the index itself. This may be set against the other leg which is made up of a defined part of that index. Review comment: aren&apos;t really legs.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DispersionSwapTransaction">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-ass-eqs;DispersionLeg"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dispersion swap transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DividendConditions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend conditions</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Conditions governing the payment of dividends to the receiver of the equity forward.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpML has a set of terms for Dividend Conditions which are usable across a range of derivatives, including Forward. Many of the definitions of individual terms refer specifically to equity return (swaps) and it is not clear whether each such term also applies to Equity forwards (i.e. the definition is more specific than it should be), or if these are terms unique to Equity Return Swaps, among which are terms applicable to Equity forwards. REVIEW: 19 May: If you have a forward contract with a dividend before you settle there must be some terms to determine how the dividend is resolved. Similar question would apply with Bond Interst? No becaues this is a known amount so it is taken into account in the price that&apos;s been agreed (discount premium). Whether it&apos;s cum or ex coupon therefore doesn&apos;t affect pricing; with Dividend this is not the case, there afore there are contractual trerms about how that is to be resolved. FpML: A type describing the conditions governing the payment of dividends to the receiver of the equity return. With the exception of the dividend payout ratio, which is defined for each of the underlying components.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DividendLegDividendPeriod">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqs;hasSomeDividendPeriods"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqs;DividendPeriod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend leg dividend period</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A part of a Dividend Leg, which is the dividend period and the terms relating to this.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DividendPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend period</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A dividend payment period.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;DividendStream">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;SimpleReturnStream"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqs;hasComponent.1"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-ass-eqs;SpecialDividendLegTerm"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqs;hasComponent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqs;DividendLegDividendPeriod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SingleShareObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReferenceAsset"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend stream</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Floating Payment Leg of a Dividend Swap. Swap dividend payment rates. Earlier notes this behaves very like a variance swap but instead of betting in pure variance you take a bet on dividend. What practically in one of these: The difference between th ereal life dividend and the one you think it should be. so I say it should bte 2% over the next 10 years, so I swap 2% for the actual dividend amount So then there is one single payment at the end which nets these up. So in the above example ... they are usually 3 month or 6 month contracts, so if for instance th edividend if quarterly, there might be 2 dividends where the difference is netted up at the end.for example. (Us 1/4ly usually , Eur 6 months). Depends on the company&apos;s articles of association etc. e.g. Unilever is 6 mo)/ Structurally, Div Swap corr Swap and Var Swap are structured similarly, with one strike at the beginning. Strike may be expressed in terms of the (price) variance (the variance of the returns) , the correlation between typically 2 underlyers. or the dividend for each of these three types of swap respectively. 17 march Dividend is a flow based on a share, so is this not the same as a Return Swap in that the dividend is the return on the dividend? Also recall that with stocks themselves, there is no comitment by the issuer to pay the dividends. FpML: &apos;Dividend leg.&apos;; &apos;Floating Payment Leg of a Dividend Swap.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;EquityCorrelationSwapContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;StatisticalSwapContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity correlation swap contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">no definition FpML (unusable): A correlation swap.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;EquityDividendSwap">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity dividend swap</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">No definition FpML: Specifies the structure of the dividend swap transaction supplement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;EquityReturnSwapContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;ReturnSwapContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity return swap contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">No definition FpML has no distinct product type for this, instead the schema for Return Swaps has content which is an Equity Swap Transaction Supplement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;EquityVarianceSwapContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;StatisticalSwapContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity variance swap contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">no definition FpML (unusable): Specifies the structure of a variance swap.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;SpecialDividendLegTerm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">special dividend leg term</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Special dividends and memorial dividends which are applicable. FpML: &apos;If present and true, then special dividends and memorial dividends are applicable.&apos; Note that &quot;if true&quot; (a yes/no term) and &quot;if present&quot; (this term, which is the presence of the thing) are two separate meanings. FpML implies the truth of the Yes/No fact by the presence or absence of this term. However, although FpML definition says &quot;if present and true&quot;, the term is just a &quot;boolean&quot; ie a YTes/no applicability term. Not sure where the special dividends themselves are defined.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;SwapStrikeTerms">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">swap strike terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal terms defining the strike leg on a swap that has a strike leg.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This kind of leg exists for variance swaps and other similar swaps. The realization of this leg is not a cashflow but a netting out against the terms defined in the other leg. Notes from Strike Leg: The abstract leg implied by the strike in a statistical swap. 
 Further Notes:This is effectively an abstract leg - there are no streams of payments. Rather, there is one payment on maturity of the contract, which is based on a netting out of this Strike leg and the outcome of the Realized Statistic Leg.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;TotalReturnLeg">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
-		<rdfs:label xml:lang="en">total return leg</rdfs:label>
-		<skos:definition xml:lang="en">A leg in which the total return on an asset is paid.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Used in Total Return Swaps. This is distinguished from the more general Return Leg by the addition of increase or decrease in the value of the underlying asset. General notes from Q2 2010 reviews: Used in the context of credit - have a TRS or a CDS. The difference being: Swap an individeual company&apos;s credit margin vis a vis a reference like basis over libor. Example BHP Billiton&apos;s spread against LIBOR. In contract, with a CDS someone will pay the spread while the other person will only pay in the event of the A default.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ass-eqs;VarianceLegTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying.8"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">variance leg terms</rdfs:label>
-		<skos:definition xml:lang="en">A return which is driven by a Variance Calculation. Variance of a single price (over time - how is this modeled? Is this the duration of the contract or some defined period or poeriods of time). The variance gets its time basis from the negotiated period in the contract, e.g. Variance over 3 months. Check: Is this always the duration of the contract or can it be for example a set of time scales (say monthly) ove the life of say a 6 month contract, and take an average?? This is logically possible but we don&apos;t know if this is what this is. FpML: A type describing return which is driven by a Variance Calculation. More notes 17 Mar Varianc v covariance Variance is a surrogate for option. Talks about random fluctuation in prices If you look at options theory (black scholes) then the price of an option is 1rily dependent in variation in the price. The more variable the more expensive ot maintain a portfolio that is indifferent to the next move in price. So this Variance Swap allows you to extract that option price (i.e. the variance as above) into the variability of the underlying price. So then the asset being traded is in fact the asset that the price references. context: This is all about controlling the price of an asset (from the point of view of the portfolio holder). similarly with the variance on an index you are picking up on the generic market stability. Recall that an index is controlling an underlying portfolio, but with the index you talk directly about the price (in an index swap), this gives you control of a portfolio that is represented by that index. Basket Swap is this - difference is agreed basket (Index, which has a publisher) versus Basket where the &quot;index&quot; (we don&apos;t call it that here) is a basket of securities.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;correlationAmount">
-		<rdfs:label xml:lang="en">correlation amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The Equity Amount to which the Equity Payment Date relates in relation to each Equity Payment Date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;declaredCashDividendPercentage">
-		<rdfs:label xml:lang="en">declared cash dividend percentage</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The declared Cash Dividend Percentage. FpML: &apos;Declared Cash Dividend Percentage.&apos; Not clear what this means. Action: Move to dated terms.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;declaredCashEquivalentDividendPercentage">
-		<rdfs:label xml:lang="en">declared cash equivalent dividend percentage</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The declared Cash Equivalent Dividend Percentage. FpML: &apos;Declared Cash Equivalent Dividend Percentage.&apos; This means the equivalent cash value of a divdends paid in kind. Needs terms about how and where abnd by whom the price of those is defined. See &quot;Underlying&quot; relative term. Action: Move to dated terms.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqs;determinationMethod">
-		<rdfs:label xml:lang="en">determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
-		<skos:definition xml:lang="en">The method according to which an amount or a date is determined.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;fixedStrike">
-		<rdfs:label xml:lang="en">fixed strike</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendLegDividendPeriod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The strike amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;hasComponent">
-		<rdfs:label xml:lang="en">has component</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-eqs;DividendLegDividendPeriod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;hasComponent.1">
-		<rdfs:label xml:lang="en">has component</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-eqs;SpecialDividendLegTerm"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;hasSomeDividendPeriods">
-		<rdfs:label xml:lang="en">has some dividend periods</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendLegDividendPeriod"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-eqs;DividendPeriod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;materialDividendsApplicable">
-		<rdfs:label xml:lang="en">material dividends applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether material non cash dividends are applicable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;notionalAmount">
-		<rdfs:label xml:lang="en">notional amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqs;pricingSource">
-		<rdfs:label xml:lang="en">pricing source</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;TotalReturnLeg"/>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;realizedVarianceAmount">
-		<rdfs:label xml:lang="en">realized variance amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;VarianceLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount to which the Equity Payment Date relates, in relation to each Equity Payment Date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqs;relativeDeterminationMethod">
-		<rdfs:label xml:lang="en">relative determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
-		<skos:definition xml:lang="en">&apos;A reference to a notional amount determination method defined elsewhere in this document.&apos;</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqs;relativeNotionalAmount">
-		<rdfs:label xml:lang="en">relative notional amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
-		<skos:definition xml:lang="en">A notional amount specified by reference.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;specialDividendTermsApplicable">
-		<rdfs:label xml:lang="en">special dividend terms applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether special dividends and memorial dividends are applicable. FpML: &apos;If present and true, then special dividends and memorial dividends are applicable.&apos; Note that &quot;if true&quot; (a yes/no term) and &quot;if present&quot; (this term, which is the presence of the thing) are two separate meanings. FpML implies the truth of the Yes/No fact by the presence or absence of the corresponding dividend term.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;strike">
-		<rdfs:label xml:lang="en">strike</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;SwapStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The strike amount defined for this leg.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying.1">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;SingleShareObservable"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying.6">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DispersionSwapIndexConstituentsLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;SetOfEquityIndexConstituentsObservable"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying.7">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DispersionSwapIndexLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying.8">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-ass-eqs;VarianceLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
-	</owl:ObjectProperty>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;TotalReturnLeg">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">total return leg</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A leg in which the total return on an asset is paid.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Used in Total Return Swaps. This is distinguished from the more general Return Leg by the addition of increase or decrease in the value of the underlying asset. General notes from Q2 2010 reviews: Used in the context of credit - have a TRS or a CDS. The difference being: Swap an individeual company&apos;s credit margin vis a vis a reference like basis over libor. Example BHP Billiton&apos;s spread against LIBOR. In contract, with a CDS someone will pay the spread while the other person will only pay in the event of the A default.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ass-eqs;VarianceLegTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;RealizedVariableSwapSideTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ass-eqs;underlying.8"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">variance leg terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A return which is driven by a Variance Calculation. Variance of a single price (over time - how is this modeled? Is this the duration of the contract or some defined period or poeriods of time). The variance gets its time basis from the negotiated period in the contract, e.g. Variance over 3 months. Check: Is this always the duration of the contract or can it be for example a set of time scales (say monthly) ove the life of say a 6 month contract, and take an average?? This is logically possible but we don&apos;t know if this is what this is. FpML: A type describing return which is driven by a Variance Calculation. More notes 17 Mar Varianc v covariance Variance is a surrogate for option. Talks about random fluctuation in prices If you look at options theory (black scholes) then the price of an option is 1rily dependent in variation in the price. The more variable the more expensive ot maintain a portfolio that is indifferent to the next move in price. So this Variance Swap allows you to extract that option price (i.e. the variance as above) into the variability of the underlying price. So then the asset being traded is in fact the asset that the price references. context: This is all about controlling the price of an asset (from the point of view of the portfolio holder). similarly with the variance on an index you are picking up on the generic market stability. Recall that an index is controlling an underlying portfolio, but with the index you talk directly about the price (in an index swap), this gives you control of a portfolio that is represented by that index. Basket Swap is this - difference is agreed basket (Index, which has a publisher) versus Basket where the &quot;index&quot; (we don&apos;t call it that here) is a basket of securities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;correlationAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">correlation amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Equity Amount to which the Equity Payment Date relates in relation to each Equity Payment Date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;declaredCashDividendPercentage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">declared cash dividend percentage</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The declared Cash Dividend Percentage. FpML: &apos;Declared Cash Dividend Percentage.&apos; Not clear what this means. Action: Move to dated terms.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;declaredCashEquivalentDividendPercentage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">declared cash equivalent dividend percentage</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The declared Cash Equivalent Dividend Percentage. FpML: &apos;Declared Cash Equivalent Dividend Percentage.&apos; This means the equivalent cash value of a divdends paid in kind. Needs terms about how and where abnd by whom the price of those is defined. See &quot;Underlying&quot; relative term. Action: Move to dated terms.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqs;determinationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determination method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method according to which an amount or a date is determined.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;fixedStrike">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed strike</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendLegDividendPeriod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The strike amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;hasComponent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has component</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-eqs;DividendLegDividendPeriod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;hasComponent.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has component</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-eqs;SpecialDividendLegTerm"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;hasSomeDividendPeriods">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has some dividend periods</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendLegDividendPeriod"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-eqs;DividendPeriod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;materialDividendsApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">material dividends applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether material non cash dividends are applicable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;notionalAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notional amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqs;pricingSource">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pricing source</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;TotalReturnLeg"/>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;realizedVarianceAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">realized variance amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;VarianceLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount to which the Equity Payment Date relates, in relation to each Equity Payment Date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqs;relativeDeterminationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relative determination method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&apos;A reference to a notional amount determination method defined elsewhere in this document.&apos;</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-ass-eqs;relativeNotionalAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relative notional amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A notional amount specified by reference.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;specialDividendTermsApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">special dividend terms applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether special dividends and memorial dividends are applicable. FpML: &apos;If present and true, then special dividends and memorial dividends are applicable.&apos; Note that &quot;if true&quot; (a yes/no term) and &quot;if present&quot; (this term, which is the presence of the thing) are two separate meanings. FpML implies the truth of the Yes/No fact by the presence or absence of the corresponding dividend term.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;strike">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;SwapStrikeTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The strike amount defined for this leg.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;CorrelationLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DividendStream"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;SingleShareObservable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying.6">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DispersionSwapIndexConstituentsLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;SetOfEquityIndexConstituentsObservable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying.7">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;DispersionSwapIndexLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ass-eqs;underlying.8">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-ass-eqs;VarianceLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;EquityIndexObservable"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/CommoditiesDerivatives/Commodities.rdf
+++ b/der/CommoditiesDerivatives/Commodities.rdf
@@ -1,154 +1,157 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-com-com "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/Commodities/">
-	<!ENTITY fibo-der-com-del "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/">
-	<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-com-com "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/Commodities/">
+bu<!ENTITY fibo-der-com-del "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/">
+bu<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/Commodities/"
-	xmlns:fibo-der-com-com="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/Commodities/"
-	xmlns:fibo-der-com-del="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"
-	xmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/Commodities/">
-		<rdfs:label xml:lang="en">Commodities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/Commodities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;AgriculturalProduct">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/NegotiableCommodity"/>
-		<rdfs:label xml:lang="en">agricultural product</rdfs:label>
-		<skos:definition xml:lang="en">A commodity which is some agrigultural product, including grain, fruit and meat.</skos:definition>
-		<skos:editorialNote xml:lang="en">This term was produced to group known commodity types but it is not known if this grouping is made in practice or if grain, meat products etc. are defined separately, and it is not clear if this is the preferred term for this. However since other derivatives types are so groups, it makes sense to do so here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;BaseMetal">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/NegotiableCommodity"/>
-		<rdfs:label xml:lang="en">base metal</rdfs:label>
-		<skos:definition xml:lang="en">Any metal which is not precious.</skos:definition>
-		<skos:editorialNote xml:lang="en">Assume this does not include alloys. Therefore the complete and exhaustive list of these may be found in the Periodic Table of the elements, though it must be noted that certain metals will always and automatically be excluded from featuring in any commodities market in base metals, for example: 1. The unstable ones (Ca, K) 2. The radioactive ones 3. The or any liquid ones (Hg) 4. The man made ones? Alternatively, there may somewhere be an exhaustive (and much shorter) list of those base metals in which there is &quot;a market&quot;.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;Bullion">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/NegotiableCommodity"/>
-		<rdfs:label xml:lang="en">bullion</rdfs:label>
-		<skos:definition xml:lang="en">Any precious metal.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Includes (exhaustively?): Gold Silver Platinum</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;BullionMeasurementUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;UnitOfMass"/>
-		<rdfs:label xml:lang="en">bullion measurement unit</rdfs:label>
-		<skos:definition xml:lang="en">Units in which bullion may be measured.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;ElectricityCommodity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;EnergyCommodity"/>
-		<rdfs:label xml:lang="en">electricity commodity</rdfs:label>
-		<skos:definition xml:lang="en">Electricity as a commodity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;EnergyCommodity">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/NegotiableCommodity"/>
-		<rdfs:label xml:lang="en">energy commodity</rdfs:label>
-		<skos:definition xml:lang="en">A commodity which relates to the provision or distribution of energy.</skos:definition>
-		<skos:editorialNote xml:lang="en">Further review and refinement required. For example there is a distinction between power and energy (measured according to the basic physics of those commodities, i.e. Watts and Watt Hours).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;EnergyTransmissionRights">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;EnergyCommodity"/>
-		<rdfs:label xml:lang="en">energy transmission rights</rdfs:label>
-		<skos:definition xml:lang="en">Rights to the transmission of power across an electricity distribution network.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;GasCommodity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;EnergyCommodity"/>
-		<rdfs:label xml:lang="en">gas commodity</rdfs:label>
-		<skos:definition xml:lang="en">Combustible hydrocarbon in gasous phase.</skos:definition>
-		<skos:editorialNote xml:lang="en">Need a precise definition e.g. which gas (ethane, methane) is commonly used and transmitted. Vocabulary note: This is not the American English word Gas, which refers to liquid motor spirit. Review whether we have the right word for US English usage here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;GrainCommodity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;AgriculturalProduct"/>
-		<rdfs:label xml:lang="en">grain commodity</rdfs:label>
-		<skos:definition xml:lang="en">A commodity which is a kind of grain, such as wheat.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;ImperialWeightMeasurementUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;BullionMeasurementUnit"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;UnitOfMass"/>
-		<rdfs:label xml:lang="en">imperial weight measurement unit</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;MeatCommodity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;AgriculturalProduct"/>
-		<rdfs:label xml:lang="en">meat commodity</rdfs:label>
-		<skos:definition xml:lang="en">A commodity which is a kind of meat, such as pork bellies.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;MetricWeightMeasurementUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;BullionMeasurementUnit"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;UnitOfMass"/>
-		<rdfs:label xml:lang="en">metric weight measurement unit</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;OilCommodity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;EnergyCommodity"/>
-		<rdfs:label xml:lang="en">oil commodity</rdfs:label>
-		<skos:definition xml:lang="en">Oil as a commodity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This has detailed grades and is measured in barrels.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;OilGrade">
-		<rdfs:label xml:lang="en">oil grade</rdfs:label>
-		<skos:definition xml:lang="en">The grade of oil which is defined as this oil commodity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;TroyOunces">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-com;BullionMeasurementUnit"/>
-		<rdfs:label xml:lang="en">troy ounces</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-com;UnitOfMass">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-		<rdfs:label xml:lang="en">unit of mass</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-com;bullionType">
-		<rdfs:label xml:lang="en">is of bullion type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-com;Bullion"/>
-		<rdfs:range rdf:resource="&fibo-der-com-del;BullionTypeSelection"/>
-		<skos:definition xml:lang="en">The type of bullion i.e. the metal which this bullion commodity is (Gold, Silver etc.).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-com;hasGrade">
-		<rdfs:label xml:lang="en">has grade</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-com;OilCommodity"/>
-		<rdfs:range rdf:resource="&fibo-der-com-com;OilGrade"/>
-		<skos:definition xml:lang="en">The grade of oil e.g. Brent Crude.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-com;measurementUnit">
-		<rdfs:label xml:lang="en">measurement unit</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-com;Bullion"/>
-		<rdfs:range rdf:resource="&fibo-der-com-com;BullionMeasurementUnit"/>
-		<skos:definition xml:lang="en">The unit of measure which is used to measure this metal in the context of it being defined as a negotiable, bullion commodity.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-com-com="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/Commodities/"
+buxmlns:fibo-der-com-del="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"
+buxmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/Commodities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Commodities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Commodities, classified into different types including bullion, agricultural products and energy commodities.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/Commodities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;AgriculturalProduct">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/NegotiableCommodity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agricultural product</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commodity which is some agrigultural product, including grain, fruit and meat.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This term was produced to group known commodity types but it is not known if this grouping is made in practice or if grain, meat products etc. are defined separately, and it is not clear if this is the preferred term for this. However since other derivatives types are so groups, it makes sense to do so here.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;BaseMetal">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/NegotiableCommodity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">base metal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any metal which is not precious.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Assume this does not include alloys. Therefore the complete and exhaustive list of these may be found in the Periodic Table of the elements, though it must be noted that certain metals will always and automatically be excluded from featuring in any commodities market in base metals, for example: 1. The unstable ones (Ca, K) 2. The radioactive ones 3. The or any liquid ones (Hg) 4. The man made ones? Alternatively, there may somewhere be an exhaustive (and much shorter) list of those base metals in which there is &quot;a market&quot;.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;Bullion">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/NegotiableCommodity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bullion</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any precious metal.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Includes (exhaustively?): Gold Silver Platinum</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;BullionMeasurementUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;UnitOfMass"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bullion measurement unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Units in which bullion may be measured.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;ElectricityCommodity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;EnergyCommodity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">electricity commodity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Electricity as a commodity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;EnergyCommodity">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/NegotiableCommodity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">energy commodity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commodity which relates to the provision or distribution of energy.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Further review and refinement required. For example there is a distinction between power and energy (measured according to the basic physics of those commodities, i.e. Watts and Watt Hours).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;EnergyTransmissionRights">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;EnergyCommodity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">energy transmission rights</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Rights to the transmission of power across an electricity distribution network.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;GasCommodity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;EnergyCommodity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gas commodity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Combustible hydrocarbon in gasous phase.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Need a precise definition e.g. which gas (ethane, methane) is commonly used and transmitted. Vocabulary note: This is not the American English word Gas, which refers to liquid motor spirit. Review whether we have the right word for US English usage here.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;GrainCommodity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;AgriculturalProduct"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">grain commodity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commodity which is a kind of grain, such as wheat.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;ImperialWeightMeasurementUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;BullionMeasurementUnit"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;UnitOfMass"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">imperial weight measurement unit</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;MeatCommodity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;AgriculturalProduct"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">meat commodity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commodity which is a kind of meat, such as pork bellies.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;MetricWeightMeasurementUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;BullionMeasurementUnit"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;UnitOfMass"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">metric weight measurement unit</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;OilCommodity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;EnergyCommodity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">oil commodity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Oil as a commodity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This has detailed grades and is measured in barrels.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;OilGrade">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">oil grade</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The grade of oil which is defined as this oil commodity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;TroyOunces">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-com;BullionMeasurementUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">troy ounces</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-com;UnitOfMass">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unit of mass</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-com;bullionType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is of bullion type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-com;Bullion"/>
+bubu<rdfs:range rdf:resource="&fibo-der-com-del;BullionTypeSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of bullion i.e. the metal which this bullion commodity is (Gold, Silver etc.).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-com;hasGrade">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has grade</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-com;OilCommodity"/>
+bubu<rdfs:range rdf:resource="&fibo-der-com-com;OilGrade"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The grade of oil e.g. Brent Crude.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-com;measurementUnit">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">measurement unit</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-com;Bullion"/>
+bubu<rdfs:range rdf:resource="&fibo-der-com-com;BullionMeasurementUnit"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The unit of measure which is used to measure this metal in the context of it being defined as a negotiable, bullion commodity.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/CommoditiesDerivatives/CommoditiesContracts.rdf
+++ b/der/CommoditiesDerivatives/CommoditiesContracts.rdf
@@ -1,61 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
+bu<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
+bu<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
-	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
-		<rdfs:label xml:lang="en">CommoditiesContracts</rdfs:label>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://www.w3.org/2004/02/skos/core"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-com-ctr;CommodityDerivativeContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-ctr;CommodityUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>&gt;commodity derivative contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-ctr;CommodityUnderlying">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>commodity underlying</rdfs:label>
-		<skos:definition xml:lang="en">The underlying of a Commodity Derivative, that is the commodity itself which underlies the contract.</skos:definition>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
+buxmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
+buxmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CommoditiesContracts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Core concepts for commodities based derivatives contracts and their underliers.</dct:abstract>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://www.w3.org/2004/02/skos/core"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-ctr;CommodityDerivativeContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-com-ctr;CommodityUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>&gt;commodity derivative contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-ctr;CommodityUnderlying">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>commodity underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The underlying of a Commodity Derivative, that is the commodity itself which underlies the contract.</skos:definition>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/CommoditiesDerivatives/CommoditiesDelivery.rdf
+++ b/der/CommoditiesDerivatives/CommoditiesDelivery.rdf
@@ -1,139 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-com-del "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/">
-	<!ENTITY fibo-der-com-fwd "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/">
-	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-	<!ENTITY fibo-fnd-plcx-sit "https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-com-del "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/">
+bu<!ENTITY fibo-der-com-fwd "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/">
+bu<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bu<!ENTITY fibo-fnd-plcx-sit "https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"
-	xmlns:fibo-der-com-del="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"
-	xmlns:fibo-der-com-fwd="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/"
-	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-fnd-plcx-sit="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/">
-		<rdfs:label xml:lang="en">CommoditiesDelivery</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;AgriculturalProductsDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
-		<rdfs:label xml:lang="en">agricultural products delivery</rdfs:label>
-		<skos:definition xml:lang="en">Delivery of any agricultural produce.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;BaseMetalsDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
-		<rdfs:label xml:lang="en">base metals delivery</rdfs:label>
-		<skos:definition xml:lang="en">Delivery of base metals.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;BullionPhysicalDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
-		<rdfs:label xml:lang="en">bullion physical delivery</rdfs:label>
-		<skos:definition xml:lang="en">Delivery of any precious metal.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;BullionTypeSelection">
-		<rdfs:label xml:lang="en">BullionTypeSelection</rdfs:label>
-		<skos:definition xml:lang="en">A type of bullion i.e. a metal which will be defined as a bullion commodity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;CommodityContractCashCloseout">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityForwardDelivery"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;CashCloseout"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;closedOutBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodity contract cash closeout</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;CommodityForwardDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-		<rdfs:label xml:lang="en">commodity forward delivery</rdfs:label>
-		<skos:definition xml:lang="en">The agreed forward delivery of a commodity or cash equivalent.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;CommodityPhysicalDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityForwardDelivery"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-com-del;deliverTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodity physical delivery</rdfs:label>
-		<skos:definition xml:lang="en">The physical delivery of some commodity at some agreed point in the future.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Would be entered into by bullion houses and the like - people who specialze in commodities. They would have facilities for physical delivery of their primary commodities. THere are very different terms for delivery of these different kinds of commodity.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;EnergyFlowsDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-del;EnergyPhysicalDelivery"/>
-		<rdfs:label xml:lang="en">energy flows delivery</rdfs:label>
-		<skos:definition xml:lang="en">Financial Transmission Rights.</skos:definition>
-		<skos:editorialNote xml:lang="en">This may or may not fit into the definition of a kid of delivery of the commodity.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;EnergyPhysicalDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
-		<rdfs:label xml:lang="en">energy physical delivery</rdfs:label>
-		<skos:definition xml:lang="en">Delivery of oil, gas and electricity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;GasDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-del;EnergyPhysicalDelivery"/>
-		<rdfs:label xml:lang="en">gas delivery</rdfs:label>
-		<skos:definition xml:lang="en">Delivery of fuel gas.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-del;OilDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-del;EnergyPhysicalDelivery"/>
-		<rdfs:label xml:lang="en">oil delivery</rdfs:label>
-		<skos:definition xml:lang="en">Delivery of oil.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-del;bullionType">
-		<rdfs:label xml:lang="en">is delivery of bullion type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-del;BullionPhysicalDelivery"/>
-		<rdfs:range rdf:resource="&fibo-der-com-del;BullionTypeSelection"/>
-		<skos:definition xml:lang="en">The type of bullion i.e. the metal which this bullion commodity is (Gold, Silver etc.).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-del;deliverTo">
-		<rdfs:label xml:lang="en">deliver to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-del;totalPhysicalQuantity">
-		<rdfs:label xml:lang="en">total physical quantity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-del;BullionPhysicalDelivery"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The amount of the bullion to be delivered, expressed in the specified units.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-com-del="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"
+buxmlns:fibo-der-com-fwd="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/"
+buxmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
+buxmlns:fibo-fnd-plcx-sit="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CommoditiesDelivery</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Methods by which the commodities in the Commodities ontology may be delivered, for those commodities ontologies that specify a deliverable underlier.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;AgriculturalProductsDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agricultural products delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery of any agricultural produce.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;BaseMetalsDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">base metals delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery of base metals.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;BullionPhysicalDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bullion physical delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery of any precious metal.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;BullionTypeSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BullionTypeSelection</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A type of bullion i.e. a metal which will be defined as a bullion commodity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;CommodityContractCashCloseout">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityForwardDelivery"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;CashCloseout"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;closedOutBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity contract cash closeout</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;CommodityForwardDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity forward delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The agreed forward delivery of a commodity or cash equivalent.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;CommodityPhysicalDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityForwardDelivery"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-com-del;deliverTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity physical delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The physical delivery of some commodity at some agreed point in the future.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Would be entered into by bullion houses and the like - people who specialze in commodities. They would have facilities for physical delivery of their primary commodities. THere are very different terms for delivery of these different kinds of commodity.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;EnergyFlowsDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-del;EnergyPhysicalDelivery"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">energy flows delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Financial Transmission Rights.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This may or may not fit into the definition of a kid of delivery of the commodity.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;EnergyPhysicalDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">energy physical delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery of oil, gas and electricity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;GasDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-del;EnergyPhysicalDelivery"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gas delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery of fuel gas.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-del;OilDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-del;EnergyPhysicalDelivery"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">oil delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery of oil.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-del;bullionType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is delivery of bullion type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-del;BullionPhysicalDelivery"/>
+bubu<rdfs:range rdf:resource="&fibo-der-com-del;BullionTypeSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of bullion i.e. the metal which this bullion commodity is (Gold, Silver etc.).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-del;deliverTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deliver to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-del;CommodityPhysicalDelivery"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-del;totalPhysicalQuantity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">total physical quantity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-del;BullionPhysicalDelivery"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of the bullion to be delivered, expressed in the specified units.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/CommoditiesDerivatives/CommodityForwards.rdf
+++ b/der/CommoditiesDerivatives/CommodityForwards.rdf
@@ -1,107 +1,110 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
-	<!ENTITY fibo-der-com-del "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/">
-	<!ENTITY fibo-der-com-fwd "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/">
-	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
+bu<!ENTITY fibo-der-com-del "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/">
+bu<!ENTITY fibo-der-com-fwd "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/">
+bu<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/"
-	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
-	xmlns:fibo-der-com-del="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"
-	xmlns:fibo-der-com-fwd="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/"
-	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/">
-		<rdfs:label xml:lang="en">CommodityForwards</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-com-fwd;CashSettledForwardContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-com-fwd;hasCalculationAgent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardCalculationAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash settled forward contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-fwd;CommodityForwardCalculationAgent">
-		<rdfs:label xml:lang="en">commodity forward calculation agent</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-fwd;CommodityForwardContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:label xml:lang="en">commodity forward contract</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML Definition (unusable): Defines a commodity forward product.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-fwd;CommodityForwardTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-del;CommodityForwardDelivery"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodity forward transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-fwd;cashSettled">
-		<rdfs:label xml:lang="en">cash settled</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The contract is settled for cash i.e. closed out against a similar but reverse contact.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-fwd;hasCalculationAgent">
-		<rdfs:label xml:lang="en">has calculation agent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-fwd;CashSettledForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-com-fwd;CommodityForwardCalculationAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-fwd;referenceRate">
-		<rdfs:label xml:lang="en">reference rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Is actually a price of something.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
+buxmlns:fibo-der-com-del="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"
+buxmlns:fibo-der-com-fwd="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/"
+buxmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CommodityForwards</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Forward contracts with a commodity underlier, along with the corresponding transactions, including cash settled contracts.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesDelivery/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityForwards/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-fwd;CashSettledForwardContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-com-fwd;hasCalculationAgent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardCalculationAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash settled forward contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-fwd;CommodityForwardCalculationAgent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity forward calculation agent</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-fwd;CommodityForwardContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity forward contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpML Definition (unusable): Defines a commodity forward product.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-fwd;CommodityForwardTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;side.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-com-del;CommodityForwardDelivery"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity forward transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-fwd;cashSettled">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash settled</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The contract is settled for cash i.e. closed out against a similar but reverse contact.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-fwd;hasCalculationAgent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has calculation agent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-fwd;CashSettledForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-com-fwd;CommodityForwardCalculationAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-fwd;referenceRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Is actually a price of something.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/CommoditiesDerivatives/CommodityOptions.rdf
+++ b/der/CommoditiesDerivatives/CommodityOptions.rdf
@@ -1,55 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
-	<!ENTITY fibo-der-com-opt "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityOptions/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
+bu<!ENTITY fibo-der-com-opt "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityOptions/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityOptions/"
-	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
-	xmlns:fibo-der-com-opt="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityOptions/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityOptions/">
-		<rdfs:label xml:lang="en">CommodityOptions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityOptions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-com-opt;CommodityOTCOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-opt;CommodityOTCOptionTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodity o t c option contract</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML Definition (unusable): Defines a commodity option product.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-opt;CommodityOTCOptionTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-		<rdfs:label xml:lang="en">commodity o t c option transaction</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
+buxmlns:fibo-der-com-opt="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityOptions/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityOptions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CommodityOptions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Over the counter options contracts with a commodity underlier, along with the corresponding transactions.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommodityOptions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-opt;CommodityOTCOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-com-opt;CommodityOTCOptionTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity o t c option contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpML Definition (unusable): Defines a commodity option product.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-opt;CommodityOTCOptionTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity o t c option transaction</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/CommoditiesDerivatives/CommoditySpots.rdf
+++ b/der/CommoditiesDerivatives/CommoditySpots.rdf
@@ -1,68 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
-	<!ENTITY fibo-der-com-sp "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySpots/">
-	<!ENTITY fibo-der-der-sp "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
+bu<!ENTITY fibo-der-com-sp "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySpots/">
+bu<!ENTITY fibo-der-der-sp "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/">
+bu<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySpots/"
-	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
-	xmlns:fibo-der-com-sp="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySpots/"
-	xmlns:fibo-der-der-sp="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySpots/">
-		<rdfs:label xml:lang="en">CommoditySpots</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySpots/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-com-sp;CommoditiesSpotContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-com-sp;transacts"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodities spot contract</rdfs:label>
-		<skos:definition xml:lang="en">The contract defined for or implied in a Commodities spot transaction.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-sp;CommoditiesSpotTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-sp;hasImpliedContract"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-sp;CommoditiesSpotContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodities spot transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-com-sp;transacts">
-		<rdfs:label xml:lang="en">transacts</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-com-sp;CommoditiesSpotContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
+buxmlns:fibo-der-com-sp="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySpots/"
+buxmlns:fibo-der-der-sp="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"
+buxmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySpots/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CommoditySpots</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Spot transactions on commodities, along with their corresponding or implied contracts. These are not a derivative but rather define the basic kind of spot transaction for the commodities themselves in the spot market.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySpots/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-sp;CommoditiesSpotContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-com-sp;transacts"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodities spot contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The contract defined for or implied in a Commodities spot transaction.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-sp;CommoditiesSpotTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-sp;hasImpliedContract"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-com-sp;CommoditiesSpotContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodities spot transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-com-sp;transacts">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transacts</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-com-sp;CommoditiesSpotContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/CommoditiesDerivatives/CommoditySwaps.rdf
+++ b/der/CommoditiesDerivatives/CommoditySwaps.rdf
@@ -1,70 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
-	<!ENTITY fibo-der-com-sw "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySwaps/">
-	<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
+bu<!ENTITY fibo-der-com-sw "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySwaps/">
+bu<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySwaps/"
-	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
-	xmlns:fibo-der-com-sw="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySwaps/"
-	xmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySwaps/">
-		<rdfs:label xml:lang="en">CommoditySwaps</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySwaps/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-com-sw;CommodityReturnLeg">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReferenceAsset"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-ctr;CommodityUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodity return leg</rdfs:label>
-		<skos:definition xml:lang="en">Return on the value of an underlying commodity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The cash flows from a commodity may be negative as you have a cost from holding the commodity but there are no interim cash flows, so it equates to a negative interest rate. So a commodity swap is like a TRS in that it is based the return on the increase in value.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-sw;CommoditySwapContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
-		<rdfs:label xml:lang="en">commodity swap contract</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML Definition (unusable): Defines a commodity swap product.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-com-sw;CommoditySwapTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;ReturnSwapTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReturnLeg"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-sw;CommodityReturnLeg"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodity swap transaction</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
+buxmlns:fibo-der-com-sw="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySwaps/"
+buxmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySwaps/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CommoditySwaps</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Swap contracts and their corresponding transactions where one leg is the return on some commodity.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditySwaps/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-sw;CommodityReturnLeg">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReferenceAsset"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-com-ctr;CommodityUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity return leg</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Return on the value of an underlying commodity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The cash flows from a commodity may be negative as you have a cost from holding the commodity but there are no interim cash flows, so it equates to a negative interest rate. So a commodity swap is like a TRS in that it is based the return on the increase in value.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-sw;CommoditySwapContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity swap contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpML Definition (unusable): Defines a commodity swap product.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-com-sw;CommoditySwapTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;ReturnSwapTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReturnLeg"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-com-sw;CommodityReturnLeg"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity swap transaction</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/der/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -1,1025 +1,1028 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/">
-	<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/">
+bu<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"
-	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"
-	xmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/">
-		<rdfs:label xml:lang="en">CreditDefaultSwaps</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<rdfs:Datatype rdf:about="&xsd;string">
-	</rdfs:Datatype>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifiesDealer"/>
-				<owl:allValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCashSettlementDealer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s cash settlement</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementDealer">
-		<rdfs:label xml:lang="en">c d s cash settlement dealer</rdfs:label>
-		<skos:definition xml:lang="en">A party from whom quotations are obtained by the calculation agent on the reference obligation for purposes of cash settlement of a CDS.</skos:definition>
-		<skos:editorialNote xml:lang="en">ACTION not sure if this is a distinct party or specification of an existing party in a wider process. Assume the latter - so define where and what.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementQuotationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">c d s cash settlement quotation method</rdfs:label>
-		<skos:definition xml:lang="en">The specification of the type of quotation rate to be obtained from each cash settlement reference bank. Further notes: For example, Bid, Offer or Mid-market. FpML Definition: The specification of the type of quotation rate to be obtained from each cash settlement reference bank.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementValuationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">c d s cash settlement valuation method</rdfs:label>
-		<skos:definition xml:lang="en">The defined methodology for determining the final price of the reference obligation for purposes of cash settlement. FpML: The ISDA defined methodology for determining the final price of the reference obligation for purposes of cash settlement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliveryCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
-		<rdfs:label xml:lang="en">c d s contingent delivery commitment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliverySide">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;definedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s contingent delivery side</rdfs:label>
-		<skos:definition xml:lang="en">The settlement of a CDS deal in the event that the events specified in the Contingent Leg of the deal take place.</skos:definition>
-		<skos:editorialNote xml:lang="en">Need to establish whether this is the delivery side or the settlement side of the Contingent transaction. The label Settlement seems to be misapplied. Deifnition Origin:SMER</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliveryTerms">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-dbx;equatesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s contingent delivery terms</rdfs:label>
-		<skos:definition xml:lang="en">The settlement of a CDS deal in the event that the events specified in the Contingent Leg of the deal take place.</skos:definition>
-		<skos:editorialNote xml:lang="en">Need to establish whether this is the delivery side or the settlement side of the Contingent transaction. The label Settlement seems to be misapplied. Deifnition Origin:SMER</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentSettlementCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
-		<rdfs:label xml:lang="en">c d s contingent settlement commitment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasDeliverySide"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSettlementSide"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentTransactionSettlement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSubject"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s contingent transaction</rdfs:label>
-		<skos:definition xml:lang="en">The transaction which takes place in the event that the specified Credit Event in a Credit default Swap takes place. Deifnition Origin:SMER</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentTransactionSettlement">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-dbx;equatesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentSettlementCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s contingent transaction settlement</rdfs:label>
-		<skos:definition xml:lang="en">Settlement for the transaction agreed in the CDS, which takes place if the Credit Event takes place. This is the payment as agreed by the Protection Seller, who becomes the buyer of the Deliverable Obligation. Deifnition Origin:SMER</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCreditEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;notifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;pertainsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s credit event</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCreditEventReference">
-		<rdfs:label xml:lang="en">c d s credit event reference</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSFeeLegStream">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;singlePayment"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;definesPeriodicPayments"/>
-				<owl:onClass rdf:resource="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;initialPayment"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;protectionSellerPayment"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;initialPoints"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;marketFixedRate"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s fee leg stream</rdfs:label>
-		<skos:definition xml:lang="en">Terms defining the fee leg in a CDS contract</skos:definition>
-		<skos:editorialNote xml:lang="en">Review session notes: See &quot;Fee Payment Leg&quot; for notes on this structure. Now separated the Leg (as a side of the transaction) and the formal terms for payment of the CDS fee, as a set of Contract Terms.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSFeePaymentCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;definedAs.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s fee payment commitment</rdfs:label>
-		<skos:definition xml:lang="en">The commitment in a Credit Default Swap, to pay the fee or fees for the credit protection.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is embodied in a Fee Leg.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSFeePaymentScheduleSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-		<rdfs:label xml:lang="en">c d s fee payment schedule specification</rdfs:label>
-		<skos:definition xml:lang="en">A schedule expressing payment events and dates.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSParty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ContingentTransactionParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s party</rdfs:label>
-		<skos:definition xml:lang="en">Either party to a Credit Default Swap contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This term identifies either party to the CDS contract (the protection seller and the protection buyer). Party roles such as &quot;Notification Party&quot; may be defined as one or the other or both CDS party.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">c d s periodic payment schedule</rdfs:label>
-		<skos:definition xml:lang="en">The schedule of fixed amounts to be paid on specified payment dates.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The amount can be specified in terms of a known currency amount or as an amount calculated on a formula basis by reference to a per annum fixed rate. The applicable business day convention and business day for adjusting any fixed rate payer payment date if it would otherwise fall on a day that is not a business day are to be specified. Review notes: Note that both of the above possibilities refer to the amount, not the determination of dates. It is assumed that this is always a specification of how to determine the dates (a schedule specification) and not an explicit list of dates and amounts on each date. If the latter is applicable, a term for this needs to be added as a type of &quot;Explicit Schedule&quot;.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CDSPhysicalSettlement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;mayRequire"/>
-				<owl:onClass rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d s physical settlement</rdfs:label>
-		<skos:definition xml:lang="en">Physical settlement is where you deliver the reference obligation (e.g.a bond) itself. Deifnition Origin:SMER</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentLeg">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
-		<rdfs:label xml:lang="en">contingent leg</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentTransactionCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">contingent transaction commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment which is agreed in advance but which only comes into force on the occurrence of some pre-agreed event.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ContingentTransactionParty">
-		<rdfs:label xml:lang="en">contingent transaction party</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditBasketReferenceConstituent">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/BasketConstituent"/>
-		<rdfs:label xml:lang="en">credit basket reference constituent</rdfs:label>
-		<skos:definition xml:lang="en">A constituent of the credit basket.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This amounts to a legal entity which is the reference entity and a security issued by that entity, as a means of measuring the credit performance of that legal entity.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwapContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
-				<owl:onClass rdf:resource="&fibo-der-cr-cds;ProtectionBuyer"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
-				<owl:onClass rdf:resource="&fibo-der-cr-cds;ProtectionSeller"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;establishes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ProtectionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasReferenceObligation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ProtectionSeller"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap contract</rdfs:label>
-		<skos:definition xml:lang="en">In a credit default swap one party (the protection seller) agrees to compensate another party (the protection buyer) if a specified company or Sovereign (the reference entity) experiences a credit event, indicating it is or may be unable to service its debts. The protection seller is typically paid a fee and/or premium, expressed as an annualized percent of the notional in basis points, regularly over the life of the transaction or otherwise as agreed by the parties.</skos:definition>
-		<skos:editorialNote xml:lang="en">Earlier draft definition: A swap instrument in which one party underwrites the risk of credit default of the other party or of an identified third party.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwapTransaction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasFeeLeg"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;FeePaymentLeg"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit default swap transaction</rdfs:label>
-		<skos:definition xml:lang="en">The transaction in which one party pay a fee or fees for credit protection and another commits to enter into the contingent transaction if the credit event takes place.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is embodied in a Fee Leg.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditDerivativeContract">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditEventUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit derivative contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditEventNotice">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Notice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;describes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;servedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit event notice</rdfs:label>
-		<skos:definition xml:lang="en">An irrevocable written or verbal notice that describes a credit event that has occurred.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A specified condition to settlement. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice. FpML full definition: &apos;A specified condition to settlement. An irrevocable written or verbal notice that describes a credit event that has occurred. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditEventUnderlying">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit event underlying</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;definedAs.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit protection commitment</rdfs:label>
-		<skos:definition xml:lang="en">The commitment in a Credit Defualt Swap, to protect against specified credit events.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Terms are defined as &quot;Contingent Leg&quot;; in FpML these are defined as &quot;Protection Terms&quot;. They are terms of the CDS contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionContingentLegTerms">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifies.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifies.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifiesObligation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit protection contingent leg terms</rdfs:label>
-		<skos:definition xml:lang="en">The leg of the swap which represents the credit protection.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review notes 31 March: For a protection leg the commitment is a conditional commitment to pay out in the event of the credit event. Typically this would be a default. Contingent Leg is another name for this, because it is contingent on the credit event. Contents: 1. The payment to be made in the event of the credit event occurring 2. the Credit Event itself. This is called the calculation amount as it is the notional amount minus the recovery, to get a final calculation amount. There is a formula behind this. The Calculation Amount is how the calculation is driven not what the actual payment amount is. Do we model the formula? Depends whether there is physical or cash settlement. Modeler notes: FpML terms for &quot;CDS Protection Terms&quot; are equivalent to this structure. Formal Definition for CDS Protection Terms: The legal terms relevant to defining the applicable floating rate payer calculation amount, credit events and associated conditions to settlement, and reference obligations. FpML: &apos;This element contains all the terms relevant to defining the applicable floating rate payer calculation amount, credit events and associated conditions to settlement, and reference obligations.&apos; Deifnition Origin:SMER</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;mayBe"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">deliverable obligation</rdfs:label>
-		<skos:definition xml:lang="en">An asset which is to be delivered as settlement of a CDS deal.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If the RO is a bond, the DO may be a different bond. Detailed Review Notes: Would see this more often in less deep markets. If it is a Loan, the DO may be assigment of a loan. FpML Full Definition: &apos;This element contains all the ISDA terms relevant to defining the deliverable obligations.&apos; Deifnition Origin:SMER</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligationBuyer">
-		<rdfs:label xml:lang="en">deliverable obligation buyer</rdfs:label>
-		<skos:definition xml:lang="en">The party which is obligated to purchase the Deliverable Obligation in the event that the CDS Contingent Transaction takes place. Deifnition Origin:SMER</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligationSeller">
-		<rdfs:label xml:lang="en">deliverable obligation seller</rdfs:label>
-		<skos:definition xml:lang="en">The party which is obligated to sell the Deliverable Obligation in the event that the CDS Contingent Transaction takes place. Deifnition Origin:SMER</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;EscrowAgent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">escrow agent</rdfs:label>
-		<skos:definition xml:lang="en">An agent which acts in escrow for the delivery of some Deliverable Obligation in the context of some CDS contract.</skos:definition>
-		<skos:editorialNote xml:lang="en">Identified at SME Review as being one possible mechanism which may be used in some cases, and specified as such in the CDS contract, for delivery of the Deliverable Obligation. Deifnition Origin:SMER</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;FeePaymentLeg">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;embodiesCDSFeePaymentCommitment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fee payment leg</rdfs:label>
-		<skos:definition xml:lang="en">The fee leg in a CDS contract</skos:definition>
-		<skos:editorialNote xml:lang="en">Review session notes: Q: whether this is any different to a regular Payment Leg. Answers: This is the &quot;other&quot; side of the swap from credit protection, i.e. the payment side. You are going to pay a set of fixed payments in return for a payment that occurs in the event of the credit event. So this is not incorrect but not a useful name for it. Swap is swap of a set of payments that equates the credit margin in return for the payments that apply in the case of the credit event. Conclusions: A good name for it might be the Credit Margin, at least from the point of view of the protection buyer, as this is the margin they are paying for the credit protection.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;LocallyDefinedCreditBasket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/Basket"/>
-		<rdfs:label xml:lang="en">locally defined credit basket</rdfs:label>
-		<skos:definition xml:lang="en">A basket of securities and/or reference entities monitored for credit purposes.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This would be the underlying of a non single-name Credit Default Swap. Review session notes: Basket is not just a basket of securities but a basket of securities and/or reference entities. The basket has terms about the nth entity to default and so on. So it works like a locally defined credit index, which (we assume) works in a similar way. Modeling note: Credit Index now modeled using information from OTPP, where each constituent is one Reference Entity and one corresponding instrument. Assume this arrangement works the same way. Modeled accordingly. See Indices and Indicators section for equivalent terms for published Credit Index.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;NotifyingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-cr-cds;identiy"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionBuyer">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionSeller">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">notifying party</rdfs:label>
-		<skos:definition xml:lang="en">The party which is able to issue formal notices indicating that a Credit Event has taken place, by means of a credit event notice.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If more than one party is referenced as being the notifying party (in the CDS contract) then either party may notify the other of a credit event occurring. That is, this party may be either party to the CDS Contract. ISDA 2003 Term: Notifying Party. FpML Full Definition: &apos;Pointer style references to a party identifier defined elsewhere in the document. The notifying party is the party that notifies the other party when a credit event has occurred by means of a credit event notice. If more than one party is referenced as being the notifying party then either party may notify the other of a credit event occurring. ISDA 2003 Term: Notifying Party.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ObligationAcceleration">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-		<rdfs:label xml:lang="en">obligation acceleration</rdfs:label>
-		<skos:definition xml:lang="en">One or more of the obligations have been declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Preferred by the market over Obligation Default, because more definitive and encompasses the definition of Obligation Default - this is more favorable to the Seller. Subject to the default requirement amount. This is a Credit Event. ISDA 2003 Term: Obligation Acceleration. FpML full definition: &apos;A credit event. One or more of the obligations have been declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay (preferred by the market over Obligation Default, because more definitive and encompasses the definition of Obligation Default - this is more favorable to the Seller). Subject to the default requirement amount. ISDA 2003 Term: Obligation Acceleration.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ObligationDefault">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-		<rdfs:label xml:lang="en">obligation default</rdfs:label>
-		<skos:definition xml:lang="en">One or more of the obligations have become capable of being declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a Credit Event. ISDA 2003 Term: Obligation Default. FpML full definition: &apos;A credit event. One or more of the obligations have become capable of being declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay. ISDA 2003 Term: Obligation Default.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ProtectionBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">protection buyer</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-cr-cds;ProtectionSeller"/>
-		<skos:definition xml:lang="en">The party which buys protection against a default on the Reference Obligation, from the Protection Seller.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ProtectionSeller">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">protection seller</rdfs:label>
-		<skos:definition xml:lang="en">The party which sells protection against a default on the Reference Obligation, to the Protection Buyer. This party commits to purchase the Refernce Obligation or some agreed alternative (the Deliverable Obligation), or settle for an equivalent amount in cash, in the event that the Credit Event defined in the contract takes place.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ReferenceEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
-		<rdfs:label xml:lang="en">c d s reference entity</rdfs:label>
-		<skos:definition xml:lang="en">The legal entity on which the protection buyer is buying or selling protection and any successor that assumes all or substantially all of its contractual and other obligations. This is the legal entity to which a Credit Event refers, if the event is defined in relation to some legal entity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML additional notes: It is vital to use the correct legal name of the entity and to be careful not to choose a subsidiary if you really want to trade protection on a parent company. Please note, Reference Entities cannot be senior or subordinated. It is the obligations of the Reference Entities that can be senior or subordinated. ISDA 2003 Term: Reference Entity&apos; Although the CDS is made out with reference to some security (issued by some party) or some loan to some party, the underlying purpose of the CDS is to protect that instrument in the event of some Credit Event that is to do with the issuing (debtor) party itself. Credit Events are therefore defined in relation to the Legal Entity and not in relation to the Security itself. FpML Definition: &apos;The corporate or sovereign entity on which you are buying or selling protection and any successor that assumes all or substantially all of its contractual and other obligations. It is vital to use the correct legal name of the entity and to be careful not to choose a subsidiary if you really want to trade protection on a parent company. Please note, Reference Entities cannot be senior or subordinated. It is the obligations of the Reference Entities that can be senior or subordinated. ISDA 2003 Term: Reference Entity&apos; Deifnition Origin:FpML adapted</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-cr-cds;ReferenceObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:label xml:lang="en">c d s reference obligation</rdfs:label>
-		<skos:definition xml:lang="en">The underlying obligation against which the CDS provides credit protection. The Reference Obligation is a financial instrument that is either issued or guaranteed by the reference entity. It serves to clarify the precise reference entity protection is being offered upon, and its legal position with regard to other related firms (parents/subsidiaries).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML adds &quot;Furthermore the Reference Obligation is ALWAYS deliverable and establishes the Pari Passu ranking (as the deliverable bonds must rank equal to the reference&quot; however this is not borne out in all cases (sometimes the Deliverable Obligation is NOT the Reference Obligation. This term is what we are referrring to when we refer to the credit event. This is what you are referencing to determine whether or not a default has occurred. Note: Loans as Reference Obligation: If the Ref Ob is a loan you can&apos;t establish that a default event has occurred but would have to specify some other event that can be obvserved to objectively determine that there has been a default. For example, you might have a loan for a company but monitor a bond issued by that company. If the bond defaults, the deliverable obligation may be the loan or some cash settlement based on the value of that loan (more typically). Detailed Review Notes: Q: Where does it go from here: thing or event? A: Commonly refers to an instrument, i.e. &quot;This is the instrument we are looking at; if this instrument defaults then we are going to pay out on the protection leg. FpML Full Definition: &apos;The underlying obligations of the reference entity on which you are buying or selling protection. The credit events Failure to Pay, Obligation Acceleration, Obligation Default, Restructuring, Repudiation/Moratorium are defined with respect to these obligations. ISDA 2003 Term:&apos; Also FpML referenceObligtion choice entry: &apos;The Reference Obligation is a financial instrument that is either issued or guaranteed by the reference entity. It serves to clarify the precise reference entity protection is being offered upon, and its legal position with regard to other related firms (parents/subsidiaries). Furthermore the Reference Obligation is ALWAYS deliverable and establishes the Pari Passu ranking (as the deliverable bonds must rank equal to the reference obligation). ISDA 2003 Term: Reference Obligation&apos; Deifnition Origin:FpML adapted</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;accruedInterestApplicable">
-		<rdfs:label xml:lang="en">accrued interest applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether accrued interest is included.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;additionalTerm">
-		<rdfs:label xml:lang="en">additional term</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Information conveying additional contractual terms for the contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;calculationAmount">
-		<rdfs:label xml:lang="en">calculation amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The notional amount of protection coverage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;cashSettlementBusinessDays">
-		<rdfs:label xml:lang="en">cash settlement business days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of business days used in the determination of the cash settlement payment date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;defaultRequirement">
-		<rdfs:label xml:lang="en">default requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;ObligationAcceleration"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The threshold for Obligation Acceleration</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;defaultRequirement.1">
-		<rdfs:label xml:lang="en">default requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;ObligationDefault"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The threshold for Obligation Default</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs">
-		<rdfs:label xml:lang="en">defined as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs.1">
-		<rdfs:label xml:lang="en">defined as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs.2">
-		<rdfs:label xml:lang="en">defined as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definesPeriodicPayments">
-		<rdfs:label xml:lang="en">defines periodic payments</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;dependentOn">
-		<rdfs:label xml:lang="en">dependent on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;describes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">describes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditEventNotice"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;effectiveDate">
-		<rdfs:label xml:lang="en">effective date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The effective starting date of the credit protection defined in the contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;embodies">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;embodiesCDSFeePaymentCommitment">
-		<rdfs:label xml:lang="en">embodies c d s fee payment commitment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;FeePaymentLeg"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;escrowApplicable">
-		<rdfs:label xml:lang="en">escrow applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether physical settlement must take place through the use of an escrow agent.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;establishes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;floatingAmountEvent">
-		<rdfs:label xml:lang="en">floating amount event</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">Events which... [definition needed, the FpML text doesn&apos;t define it]</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasBuyer">
-		<rdfs:label xml:lang="en">has buyer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasDeliverySide">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;hasPerspective"/>
-		<rdfs:label xml:lang="en">has delivery side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasFeeLeg">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
-		<rdfs:label xml:lang="en">has fee leg</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;FeePaymentLeg"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasReferenceObligation">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-		<rdfs:label xml:lang="en">has reference obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSeller">
-		<rdfs:label xml:lang="en">has seller</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSettlementSide">
-		<rdfs:label xml:lang="en">has settlement side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentTransactionSettlement"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSubject">
-		<rdfs:label xml:lang="en">has subject</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;holds">
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;identity">
-		<rdfs:label xml:lang="en">c d s underlying identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditEventUnderlying"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;identiy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">notifying party has identiy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionBuyer">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionSeller">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;initialPayment">
-		<rdfs:label xml:lang="en">initial payment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A single fixed payment that is payable by the payer to the receiver on the initial payment date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;initialPoints">
-		<rdfs:label xml:lang="en">initial points</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The up-front points expressed as a percentage of the notional.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;marketFixedRate">
-		<rdfs:label xml:lang="en">market fixed rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The credit spread (&quot;fair value&quot;) at which the trade was executed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;mayBe">
-		<rdfs:label xml:lang="en">may be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;mayRequire">
-		<rdfs:label xml:lang="en">may require</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;minimumQuotationAmount">
-		<rdfs:label xml:lang="en">minimum quotation amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The minimum intended threshold amount of outstanding principal balance of the reference obligation for which the quote should be obtained.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;modifiedEquityDelivery">
-		<rdfs:label xml:lang="en">modified equity delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">no-one knows what this means. Equity? It is not considered a default if the coupon on a Preferred Share is not paid. There are provisions in preference shares, since a company may be legally restrited from paying dividends other than from its reserves (e.g. in Aus law) so therefore this can&apos;t be a default. FpML: &apos;Value of this element set to \&apos;true\&apos; indicates that modified equity delivery is applicable.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;notifiedBy">
-		<rdfs:label xml:lang="en">notified by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;notionalAmount">
-		<rdfs:label xml:lang="en">notional amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The notional amount is the price at which the protection seller agrees to buy the bond in the event of a default.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;paymentDelay">
-		<rdfs:label xml:lang="en">payment delay</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether payment delays are applicable to the fixed Amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;pertainsTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-temx-cre;pertainsTo"/>
-		<rdfs:label xml:lang="en">pertains to by reference</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;physicalSettlementPeriod">
-		<rdfs:label xml:lang="en">physical settlement period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<skos:definition xml:lang="en">The number of business days used in the determination of the physical settlement date. Further Notes The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply then it should be flagged that &quot;Business Days Not Specified&quot;. If a specified number of business days are to apply these should be specified. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified. ISDA 2003 Term: Physical Settlement Period Note that although this is described as a period, it is not a period of time from one date/time to another, but a duration i.e. a length of time (in business days). FpML: &apos;The number of business days used in the determination of the physical settlement date. The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply the businessDaysNotSpecified element should be included. If a specified number of business days are to apply these should be specified in the businessDays element. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified in the maximumBusinessDays element. ISDA 2003 Term: Physical Settlement Period&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;protectionSellerPayment">
-		<rdfs:label xml:lang="en">protection seller payment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A payment on a CDS trade where there is a payment from Seller to Buyer.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;quotationAmount">
-		<rdfs:label xml:lang="en">quotation amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">An amount quoted, which is either an upper limit to the outstanding principal balance of the reference obligation for which the quote should be obtained, or the floating rate payer calculation amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;quotationMethod">
-		<rdfs:label xml:lang="en">quotation method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementQuotationMethod"/>
-		<skos:definition xml:lang="en">The type of price quotations to be requested from dealers when determining the market value of the reference obligation for purposes of cash settlement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;quotationStyle">
-		<rdfs:label xml:lang="en">quotation style</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">The type of quotation that was used between the trading desks in setting up the deal.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;scheduledTerminationDate">
-		<rdfs:label xml:lang="en">scheduled termination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date at which the contract for credit protection is due to expire as agreed by both parties.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;servedBy">
-		<rdfs:label xml:lang="en">served by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditEventNotice"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;settlementCurrency">
-		<rdfs:label xml:lang="en">settlement currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the deal is to be settled.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;singlePayment">
-		<rdfs:label xml:lang="en">single payment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A single fixed amount that is payable by the buyer to the seller on the fixed rate payer payment date. The fixed amount to be paid is specified in terms of a known currency amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;sixtyBusinessDaySettlementCap">
-		<rdfs:label xml:lang="en">sixty business day settlement cap</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the legal terms set forth in the following language are deemed part of the confirmation (the section references are to the 2003 ISDA Credit Derivatives Definitions): &apos;Notwithstanding Section 1.7 or any provisions of Sections 9.9 or 9.10 to the contrary, but without prejudice to Section 9.3 and (where applicable) Sections 9.4, 9.5 and 9.6, if the Termination Date has not occurred on or prior to the date that is 60 Business Days following the Physical Settlement Date, such 60th Business Day shall be deemed to be the Termination Date with respect to this Transaction except in relation to any portion of the Transaction (an &quot;Affected Portion&quot;) in respect of which: (1) a valid notice of Buy-in Price has been delivered that is effective fewer than three Business Days prior to such 60th Business Day, in which case the Termination Date for that Affected Portion shall be the third Business Day following the date on which such notice is effective; or (2) Buyer has purchased but not Delivered Deliverable Obligations validly specified by Seller pursuant to Section 9.10(b), in which case the Termination Date for that Affected Portion shall be the tenth Business Day following the date on which Seller validly specified such Deliverable Obligations to Buyer.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifies">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifies.1">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifies.2">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifiesDealer">
-		<rdfs:label xml:lang="en">specifies dealer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementDealer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifiesObligation">
-		<rdfs:label xml:lang="en">specifies obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;substitution">
-		<rdfs:label xml:lang="en">substitution</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether it is possible to substitute other obligations in place of the specified Deliverable Obligation.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationDate">
-		<rdfs:label xml:lang="en">valuation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date (however specified) after conditions to settlement have been satisfied, when the calculation agent obtains a price quotation on the Reference Obligation for purposes of cash settlement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationMethod">
-		<rdfs:label xml:lang="en">valuation method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementValuationMethod"/>
-		<skos:definition xml:lang="en">The methodology for determining the final price of the reference obligation for purposes of cash settlement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationTime">
-		<rdfs:label xml:lang="en">valuation time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TimeOfDay"/>
-		<skos:definition xml:lang="en">The time of day in the specified business center when the calculation agent seeks quotations for an amount of the reference obligation for purposes of cash settlement.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"
+buxmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CreditDefaultSwaps</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">A transaction and contract in which one leg is the conditional commitment to pay out on some debt in the event that a pre-defined credit event takes place. The contract may make reference to a specific debt instrument or loan, or take effect in the event of one of a range of events that happen to the business entity that is the debtor in that debt. Includes terms for different kinds of settlement arrangement. Note that these are a swap in name only, since under normal conditions there is only one stream of payment, the fee payment leg.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<rdfs:Datatype rdf:about="&xsd;string">
+bu</rdfs:Datatype>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifiesDealer"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCashSettlementDealer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s cash settlement</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementDealer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s cash settlement dealer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party from whom quotations are obtained by the calculation agent on the reference obligation for purposes of cash settlement of a CDS.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">ACTION not sure if this is a distinct party or specification of an existing party in a wider process. Assume the latter - so define where and what.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementQuotationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s cash settlement quotation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of the type of quotation rate to be obtained from each cash settlement reference bank. Further notes: For example, Bid, Offer or Mid-market. FpML Definition: The specification of the type of quotation rate to be obtained from each cash settlement reference bank.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSCashSettlementValuationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s cash settlement valuation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The defined methodology for determining the final price of the reference obligation for purposes of cash settlement. FpML: The ISDA defined methodology for determining the final price of the reference obligation for purposes of cash settlement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliveryCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s contingent delivery commitment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliverySide">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;definedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s contingent delivery side</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The settlement of a CDS deal in the event that the events specified in the Contingent Leg of the deal take place.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Need to establish whether this is the delivery side or the settlement side of the Contingent transaction. The label Settlement seems to be misapplied. Deifnition Origin:SMER</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentDeliveryTerms">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-dbx;equatesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s contingent delivery terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The settlement of a CDS deal in the event that the events specified in the Contingent Leg of the deal take place.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Need to establish whether this is the delivery side or the settlement side of the Contingent transaction. The label Settlement seems to be misapplied. Deifnition Origin:SMER</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentSettlementCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s contingent settlement commitment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasDeliverySide"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSettlementSide"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentTransactionSettlement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSubject"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s contingent transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The transaction which takes place in the event that the specified Credit Event in a Credit default Swap takes place. Deifnition Origin:SMER</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSContingentTransactionSettlement">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-dbx;equatesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentSettlementCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s contingent transaction settlement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Settlement for the transaction agreed in the CDS, which takes place if the Credit Event takes place. This is the payment as agreed by the Protection Seller, who becomes the buyer of the Deliverable Obligation. Deifnition Origin:SMER</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSCreditEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;notifiedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;pertainsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s credit event</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSCreditEventReference">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s credit event reference</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSFeeLegStream">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;singlePayment"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;definesPeriodicPayments"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;initialPayment"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;protectionSellerPayment"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;initialPoints"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;marketFixedRate"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s fee leg stream</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms defining the fee leg in a CDS contract</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review session notes: See &quot;Fee Payment Leg&quot; for notes on this structure. Now separated the Leg (as a side of the transaction) and the formal terms for payment of the CDS fee, as a set of Contract Terms.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSFeePaymentCommitment">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;definedAs.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s fee payment commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The commitment in a Credit Default Swap, to pay the fee or fees for the credit protection.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is embodied in a Fee Leg.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSFeePaymentScheduleSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s fee payment schedule specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A schedule expressing payment events and dates.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSParty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ContingentTransactionParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Either party to a Credit Default Swap contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This term identifies either party to the CDS contract (the protection seller and the protection buyer). Party roles such as &quot;Notification Party&quot; may be defined as one or the other or both CDS party.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s periodic payment schedule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The schedule of fixed amounts to be paid on specified payment dates.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The amount can be specified in terms of a known currency amount or as an amount calculated on a formula basis by reference to a per annum fixed rate. The applicable business day convention and business day for adjusting any fixed rate payer payment date if it would otherwise fall on a day that is not a business day are to be specified. Review notes: Note that both of the above possibilities refer to the amount, not the determination of dates. It is assumed that this is always a specification of how to determine the dates (a schedule specification) and not an explicit list of dates and amounts on each date. If the latter is applicable, a term for this needs to be added as a type of &quot;Explicit Schedule&quot;.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CDSPhysicalSettlement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;mayRequire"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s physical settlement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Physical settlement is where you deliver the reference obligation (e.g.a bond) itself. Deifnition Origin:SMER</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;ContingentLeg">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contingent leg</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;ContingentTransactionCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contingent transaction commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment which is agreed in advance but which only comes into force on the occurrence of some pre-agreed event.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;ContingentTransactionParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contingent transaction party</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CreditBasketReferenceConstituent">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/BasketConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit basket reference constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A constituent of the credit basket.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This amounts to a legal entity which is the reference entity and a security issued by that entity, as a means of measuring the credit performance of that legal entity.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwapContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CreditDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-cr-cds;ProtectionBuyer"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-cr-cds;ProtectionSeller"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;establishes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasBuyer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ProtectionBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasReferenceObligation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasSeller"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ProtectionSeller"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit default swap contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">In a credit default swap one party (the protection seller) agrees to compensate another party (the protection buyer) if a specified company or Sovereign (the reference entity) experiences a credit event, indicating it is or may be unable to service its debts. The protection seller is typically paid a fee and/or premium, expressed as an annualized percent of the notional in basis points, regularly over the life of the transaction or otherwise as agreed by the parties.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Earlier draft definition: A swap instrument in which one party underwrites the risk of credit default of the other party or of an identified third party.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CreditDefaultSwapTransaction">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;hasFeeLeg"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;FeePaymentLeg"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit default swap transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The transaction in which one party pay a fee or fees for credit protection and another commits to enter into the contingent transaction if the credit event takes place.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is embodied in a Fee Leg.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CreditDerivativeContract">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditEventUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit derivative contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CreditEventNotice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Notice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;describes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;servedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit event notice</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An irrevocable written or verbal notice that describes a credit event that has occurred.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A specified condition to settlement. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice. FpML full definition: &apos;A specified condition to settlement. An irrevocable written or verbal notice that describes a credit event that has occurred. The notice is sent from the notifying party (either the buyer or the seller) to the counterparty. It provides information relevant to determining that a credit event has occurred. This is typically accompanied by Publicly Available Information. ISDA 2003 Term: Credit Event Notice.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CreditEventUnderlying">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit event underlying</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionCommitment">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;definedAs.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit protection commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The commitment in a Credit Defualt Swap, to protect against specified credit events.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Terms are defined as &quot;Contingent Leg&quot;; in FpML these are defined as &quot;Protection Terms&quot;. They are terms of the CDS contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;CreditProtectionContingentLegTerms">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifies.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifies.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;specifiesObligation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit protection contingent leg terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The leg of the swap which represents the credit protection.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review notes 31 March: For a protection leg the commitment is a conditional commitment to pay out in the event of the credit event. Typically this would be a default. Contingent Leg is another name for this, because it is contingent on the credit event. Contents: 1. The payment to be made in the event of the credit event occurring 2. the Credit Event itself. This is called the calculation amount as it is the notional amount minus the recovery, to get a final calculation amount. There is a formula behind this. The Calculation Amount is how the calculation is driven not what the actual payment amount is. Do we model the formula? Depends whether there is physical or cash settlement. Modeler notes: FpML terms for &quot;CDS Protection Terms&quot; are equivalent to this structure. Formal Definition for CDS Protection Terms: The legal terms relevant to defining the applicable floating rate payer calculation amount, credit events and associated conditions to settlement, and reference obligations. FpML: &apos;This element contains all the terms relevant to defining the applicable floating rate payer calculation amount, credit events and associated conditions to settlement, and reference obligations.&apos; Deifnition Origin:SMER</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;mayBe"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deliverable obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An asset which is to be delivered as settlement of a CDS deal.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">If the RO is a bond, the DO may be a different bond. Detailed Review Notes: Would see this more often in less deep markets. If it is a Loan, the DO may be assigment of a loan. FpML Full Definition: &apos;This element contains all the ISDA terms relevant to defining the deliverable obligations.&apos; Deifnition Origin:SMER</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligationBuyer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deliverable obligation buyer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is obligated to purchase the Deliverable Obligation in the event that the CDS Contingent Transaction takes place. Deifnition Origin:SMER</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;DeliverableObligationSeller">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deliverable obligation seller</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is obligated to sell the Deliverable Obligation in the event that the CDS Contingent Transaction takes place. Deifnition Origin:SMER</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;EscrowAgent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">escrow agent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An agent which acts in escrow for the delivery of some Deliverable Obligation in the context of some CDS contract.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Identified at SME Review as being one possible mechanism which may be used in some cases, and specified as such in the CDS contract, for delivery of the Deliverable Obligation. Deifnition Origin:SMER</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;FeePaymentLeg">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;embodiesCDSFeePaymentCommitment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fee payment leg</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The fee leg in a CDS contract</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review session notes: Q: whether this is any different to a regular Payment Leg. Answers: This is the &quot;other&quot; side of the swap from credit protection, i.e. the payment side. You are going to pay a set of fixed payments in return for a payment that occurs in the event of the credit event. So this is not incorrect but not a useful name for it. Swap is swap of a set of payments that equates the credit margin in return for the payments that apply in the case of the credit event. Conclusions: A good name for it might be the Credit Margin, at least from the point of view of the protection buyer, as this is the margin they are paying for the credit protection.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;LocallyDefinedCreditBasket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/Basket"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">locally defined credit basket</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A basket of securities and/or reference entities monitored for credit purposes.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This would be the underlying of a non single-name Credit Default Swap. Review session notes: Basket is not just a basket of securities but a basket of securities and/or reference entities. The basket has terms about the nth entity to default and so on. So it works like a locally defined credit index, which (we assume) works in a similar way. Modeling note: Credit Index now modeled using information from OTPP, where each constituent is one Reference Entity and one corresponding instrument. Assume this arrangement works the same way. Modeled accordingly. See Indices and Indicators section for equivalent terms for published Credit Index.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;NotifyingParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-cr-cds;identiy"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionBuyer">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionSeller">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notifying party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is able to issue formal notices indicating that a Credit Event has taken place, by means of a credit event notice.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">If more than one party is referenced as being the notifying party (in the CDS contract) then either party may notify the other of a credit event occurring. That is, this party may be either party to the CDS Contract. ISDA 2003 Term: Notifying Party. FpML Full Definition: &apos;Pointer style references to a party identifier defined elsewhere in the document. The notifying party is the party that notifies the other party when a credit event has occurred by means of a credit event notice. If more than one party is referenced as being the notifying party then either party may notify the other of a credit event occurring. ISDA 2003 Term: Notifying Party.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;ObligationAcceleration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obligation acceleration</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One or more of the obligations have been declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Preferred by the market over Obligation Default, because more definitive and encompasses the definition of Obligation Default - this is more favorable to the Seller. Subject to the default requirement amount. This is a Credit Event. ISDA 2003 Term: Obligation Acceleration. FpML full definition: &apos;A credit event. One or more of the obligations have been declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay (preferred by the market over Obligation Default, because more definitive and encompasses the definition of Obligation Default - this is more favorable to the Seller). Subject to the default requirement amount. ISDA 2003 Term: Obligation Acceleration.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;ObligationDefault">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obligation default</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One or more of the obligations have become capable of being declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a Credit Event. ISDA 2003 Term: Obligation Default. FpML full definition: &apos;A credit event. One or more of the obligations have become capable of being declared due and payable before they would otherwise have been due and payable as a result of, or on the basis of, the occurrence of a default, event of default or other similar condition or event other than failure to pay. ISDA 2003 Term: Obligation Default.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;ProtectionBuyer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">protection buyer</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-cr-cds;ProtectionSeller"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which buys protection against a default on the Reference Obligation, from the Protection Seller.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;ProtectionSeller">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">protection seller</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which sells protection against a default on the Reference Obligation, to the Protection Buyer. This party commits to purchase the Refernce Obligation or some agreed alternative (the Deliverable Obligation), or settle for an equivalent amount in cash, in the event that the Credit Event defined in the contract takes place.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;ReferenceEntity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s reference entity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The legal entity on which the protection buyer is buying or selling protection and any successor that assumes all or substantially all of its contractual and other obligations. This is the legal entity to which a Credit Event refers, if the event is defined in relation to some legal entity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">FpML additional notes: It is vital to use the correct legal name of the entity and to be careful not to choose a subsidiary if you really want to trade protection on a parent company. Please note, Reference Entities cannot be senior or subordinated. It is the obligations of the Reference Entities that can be senior or subordinated. ISDA 2003 Term: Reference Entity&apos; Although the CDS is made out with reference to some security (issued by some party) or some loan to some party, the underlying purpose of the CDS is to protect that instrument in the event of some Credit Event that is to do with the issuing (debtor) party itself. Credit Events are therefore defined in relation to the Legal Entity and not in relation to the Security itself. FpML Definition: &apos;The corporate or sovereign entity on which you are buying or selling protection and any successor that assumes all or substantially all of its contractual and other obligations. It is vital to use the correct legal name of the entity and to be careful not to choose a subsidiary if you really want to trade protection on a parent company. Please note, Reference Entities cannot be senior or subordinated. It is the obligations of the Reference Entities that can be senior or subordinated. ISDA 2003 Term: Reference Entity&apos; Deifnition Origin:FpML adapted</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-cr-cds;ReferenceObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s reference obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The underlying obligation against which the CDS provides credit protection. The Reference Obligation is a financial instrument that is either issued or guaranteed by the reference entity. It serves to clarify the precise reference entity protection is being offered upon, and its legal position with regard to other related firms (parents/subsidiaries).</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">FpML adds &quot;Furthermore the Reference Obligation is ALWAYS deliverable and establishes the Pari Passu ranking (as the deliverable bonds must rank equal to the reference&quot; however this is not borne out in all cases (sometimes the Deliverable Obligation is NOT the Reference Obligation. This term is what we are referrring to when we refer to the credit event. This is what you are referencing to determine whether or not a default has occurred. Note: Loans as Reference Obligation: If the Ref Ob is a loan you can&apos;t establish that a default event has occurred but would have to specify some other event that can be obvserved to objectively determine that there has been a default. For example, you might have a loan for a company but monitor a bond issued by that company. If the bond defaults, the deliverable obligation may be the loan or some cash settlement based on the value of that loan (more typically). Detailed Review Notes: Q: Where does it go from here: thing or event? A: Commonly refers to an instrument, i.e. &quot;This is the instrument we are looking at; if this instrument defaults then we are going to pay out on the protection leg. FpML Full Definition: &apos;The underlying obligations of the reference entity on which you are buying or selling protection. The credit events Failure to Pay, Obligation Acceleration, Obligation Default, Restructuring, Repudiation/Moratorium are defined with respect to these obligations. ISDA 2003 Term:&apos; Also FpML referenceObligtion choice entry: &apos;The Reference Obligation is a financial instrument that is either issued or guaranteed by the reference entity. It serves to clarify the precise reference entity protection is being offered upon, and its legal position with regard to other related firms (parents/subsidiaries). Furthermore the Reference Obligation is ALWAYS deliverable and establishes the Pari Passu ranking (as the deliverable bonds must rank equal to the reference obligation). ISDA 2003 Term: Reference Obligation&apos; Deifnition Origin:FpML adapted</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;accruedInterestApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accrued interest applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether accrued interest is included.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;additionalTerm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">additional term</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information conveying additional contractual terms for the contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;calculationAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calculation amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The notional amount of protection coverage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;cashSettlementBusinessDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash settlement business days</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of business days used in the determination of the cash settlement payment date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;defaultRequirement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default requirement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;ObligationAcceleration"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The threshold for Obligation Acceleration</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;defaultRequirement.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default requirement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;ObligationDefault"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The threshold for Obligation Default</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentDeliveryTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definedAs.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;definesPeriodicPayments">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines periodic payments</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSPeriodicPaymentSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;dependentOn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dependent on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;describes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">describes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditEventNotice"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;effectiveDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effective date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The effective starting date of the credit protection defined in the contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;embodies">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;embodiesCDSFeePaymentCommitment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies c d s fee payment commitment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;FeePaymentLeg"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSFeePaymentCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;escrowApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">escrow applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether physical settlement must take place through the use of an escrow agent.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;establishes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;ContingentTransactionCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;floatingAmountEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floating amount event</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
+bubu<rdfs:range rdf:resource="&xsd;string"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Events which... [definition needed, the FpML text doesn&apos;t define it]</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasBuyer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has buyer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligationBuyer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasDeliverySide">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;hasPerspective"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has delivery side</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentDeliverySide"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasFeeLeg">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has fee leg</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;FeePaymentLeg"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasReferenceObligation">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has reference obligation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSeller">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has seller</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligationSeller"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSettlementSide">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has settlement side</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentTransactionSettlement"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;hasSubject">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has subject</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;holds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;identity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d s underlying identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditEventUnderlying"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;identiy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notifying party has identiy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionBuyer">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-der-cr-cds;ProtectionSeller">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;initialPayment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">initial payment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A single fixed payment that is payable by the payer to the receiver on the initial payment date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;initialPoints">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">initial points</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The up-front points expressed as a percentage of the notional.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;marketFixedRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market fixed rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The credit spread (&quot;fair value&quot;) at which the trade was executed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;mayBe">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;mayRequire">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may require</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;EscrowAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;minimumQuotationAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum quotation amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The minimum intended threshold amount of outstanding principal balance of the reference obligation for which the quote should be obtained.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;modifiedEquityDelivery">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">modified equity delivery</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">no-one knows what this means. Equity? It is not considered a default if the coupon on a Preferred Share is not paid. There are provisions in preference shares, since a company may be legally restrited from paying dividends other than from its reserves (e.g. in Aus law) so therefore this can&apos;t be a default. FpML: &apos;Value of this element set to \&apos;true\&apos; indicates that modified equity delivery is applicable.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;notifiedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notified by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;notionalAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notional amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The notional amount is the price at which the protection seller agrees to buy the bond in the event of a default.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;paymentDelay">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment delay</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether payment delays are applicable to the fixed Amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;pertainsTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-temx-cre;pertainsTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pertains to by reference</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;physicalSettlementPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">physical settlement period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of business days used in the determination of the physical settlement date. Further Notes The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply then it should be flagged that &quot;Business Days Not Specified&quot;. If a specified number of business days are to apply these should be specified. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified. ISDA 2003 Term: Physical Settlement Period Note that although this is described as a period, it is not a period of time from one date/time to another, but a duration i.e. a length of time (in business days). FpML: &apos;The number of business days used in the determination of the physical settlement date. The physical settlement date is this number of business days after all applicable conditions to settlement are satisfied. If a number of business days is not specified fallback provisions apply for determining the number of business days. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply the businessDaysNotSpecified element should be included. If a specified number of business days are to apply these should be specified in the businessDays element. If Section 8.5/8.6 of the 1999/2003 ISDA Definitions are to apply but capped at a maximum number of business days then the maximum number should be specified in the maximumBusinessDays element. ISDA 2003 Term: Physical Settlement Period&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;protectionSellerPayment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">protection seller payment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A payment on a CDS trade where there is a payment from Seller to Buyer.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;quotationAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quotation amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An amount quoted, which is either an upper limit to the outstanding principal balance of the reference obligation for which the quote should be obtained, or the floating rate payer calculation amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;quotationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quotation method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementQuotationMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of price quotations to be requested from dealers when determining the market value of the reference obligation for purposes of cash settlement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-cr-cds;quotationStyle">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quotation style</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bubu<rdfs:range rdf:resource="&xsd;string"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of quotation that was used between the trading desks in setting up the deal.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;scheduledTerminationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheduled termination date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the contract for credit protection is due to expire as agreed by both parties.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;servedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">served by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditEventNotice"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;NotifyingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;settlementCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which the deal is to be settled.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;singlePayment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">single payment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSFeeLegStream"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A single fixed amount that is payable by the buyer to the seller on the fixed rate payer payment date. The fixed amount to be paid is specified in terms of a known currency amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;sixtyBusinessDaySettlementCap">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sixty business day settlement cap</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the legal terms set forth in the following language are deemed part of the confirmation (the section references are to the 2003 ISDA Credit Derivatives Definitions): &apos;Notwithstanding Section 1.7 or any provisions of Sections 9.9 or 9.10 to the contrary, but without prejudice to Section 9.3 and (where applicable) Sections 9.4, 9.5 and 9.6, if the Termination Date has not occurred on or prior to the date that is 60 Business Days following the Physical Settlement Date, such 60th Business Day shall be deemed to be the Termination Date with respect to this Transaction except in relation to any portion of the Transaction (an &quot;Affected Portion&quot;) in respect of which: (1) a valid notice of Buy-in Price has been delivered that is effective fewer than three Business Days prior to such 60th Business Day, in which case the Termination Date for that Affected Portion shall be the third Business Day following the date on which such notice is effective; or (2) Buyer has purchased but not Delivered Deliverable Obligations validly specified by Seller pursuant to Section 9.10(b), in which case the Termination Date for that Affected Portion shall be the tenth Business Day following the date on which Seller validly specified such Deliverable Obligations to Buyer.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSPhysicalSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;DeliverableObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifies.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSContingentTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifies.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifiesDealer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies dealer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementDealer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;specifiesObligation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies obligation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditProtectionContingentLegTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;substitution">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">substitution</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether it is possible to substitute other obligations in place of the specified Deliverable Obligation.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date (however specified) after conditions to settlement have been satisfied, when the calculation agent obtains a price quotation on the Reference Obligation for purposes of cash settlement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCashSettlementValuationMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The methodology for determining the final price of the reference obligation for purposes of cash settlement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;valuationTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCashSettlement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TimeOfDay"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The time of day in the specified business center when the calculation agent seeks quotations for an amount of the reference obligation for purposes of cash settlement.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/DerivativesContracts/ExerciseConventions.rdf
+++ b/der/DerivativesContracts/ExerciseConventions.rdf
@@ -1,147 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-pub-stdi "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-pub-stdi "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
-	xmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-pub-stdi="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
-		<rdfs:label xml:lang="en">ExerciseConventions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-der-ex;AmericanExerciseConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-		<rdfs:label xml:lang="en">american exercise convention</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-ex;BermudaExerciseConvention"/>
-		<owl:disjointWith rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
-		<skos:definition xml:lang="en">A feature of an option that stipulates that the option can be exercised anytime within the specified date window.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-ex;AsianExerciseCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWriterCommitment"/>
-		<rdfs:label xml:lang="en">asian exercise commitment</rdfs:label>
-		<skos:definition xml:lang="en">Commitment to pay out on an option on the basis of a rolling average strike, which the other party may or may not choose to exercise against.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Definition of Asian Exercise Convention: Exercise convention whereby exercise tracks an underlying on a defined time period, anchored to a given time. The Asian Exercise Convention takes the European Date Exercise Convention but commits to a strike which is determined according to an average (or rolling average) value.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-ex;AsianExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-ex;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;AsianExerciseCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-ex;specifiesExerciseDateConvention"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">asian exercise terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing the exercise of an Asian Option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-ex;BermudaExerciseConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-ex;exerciseWindow.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bermuda exercise convention</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
-		<skos:definition xml:lang="en">A feature of an option that states it can be exercised at different times during the life of the option. The various times set for exercise are written within the option and allow for flexibility for both the writer and holder of the option.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The Bermuda option is named as such because its exercise dates are more flexible than European options and less flexible than American options. Thus, it is in the middle, just like Bermuda is between Europe and America. Bermuda options are also referred to as Mid-Atlantic, Quasi American, or Semi-American options.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-ex;CanaryExerciseConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;BermudaExerciseConvention"/>
-		<rdfs:label xml:lang="en">canary exercise convention</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-ex;EuropeanExerciseConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-		<rdfs:label xml:lang="en">european exercise convention</rdfs:label>
-		<skos:definition xml:lang="en">A feature of an option that stipulates that the option may only be exercised a stated Exercise Date. Therefore, there can be no early assignment with this type of option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-ex;ExerciseDatesConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-stdi;EDMCouncilConvention"/>
-		<rdfs:label xml:lang="en">exercise dates convention</rdfs:label>
-		<skos:definition xml:lang="en">The date terms determining when the holder or future holder of an option can implement the rights defined in the option.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note: this convention applies to all forms of embedded option and option instruments.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-ex;exerciseDate">
-		<rdfs:label xml:lang="en">exercise date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date of exercise (expiry)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-ex;exerciseDeterminationPeriod">
-		<rdfs:label xml:lang="en">exercise determination period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-ex;AsianExerciseCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The period during which the value of the underlying is measured in order to determine when the option may be exercised. The actual exercise date is the final day of the Exercise Period.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-ex;exerciseWindow">
-		<rdfs:label xml:lang="en">exercise window</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-ex;AmericanExerciseConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The window during which the Exercise can take place.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-ex;exerciseWindow.1">
-		<rdfs:label xml:lang="en">exercise window</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-ex;BermudaExerciseConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">Each time window during which the Exercise can take place.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-ex;setsOut">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-ex;AsianExerciseTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-ex;AsianExerciseCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-ex;specifiesExerciseDateConvention">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;optionExerciseTermsSpecifies"/>
-		<rdfs:label xml:lang="en">specifies exercise date convention</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-ex;AsianExerciseTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-pub-stdi="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ExerciseConventions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology sets out the various types of exercise convention (American, European, Bermuda and others). These are distinguished in terms of the time points or windows in which an option or an embedded option in a security may be exercised. Note this ontology is also referred to in the debt securities models.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-ex;AmericanExerciseConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">american exercise convention</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-ex;BermudaExerciseConvention"/>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A feature of an option that stipulates that the option can be exercised anytime within the specified date window.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-ex;AsianExerciseCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWriterCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asian exercise commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Commitment to pay out on an option on the basis of a rolling average strike, which the other party may or may not choose to exercise against.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Definition of Asian Exercise Convention: Exercise convention whereby exercise tracks an underlying on a defined time period, anchored to a given time. The Asian Exercise Convention takes the European Date Exercise Convention but commits to a strike which is determined according to an average (or rolling average) value.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-ex;AsianExerciseTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-ex;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;AsianExerciseCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-ex;specifiesExerciseDateConvention"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asian exercise terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms governing the exercise of an Asian Option.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-ex;BermudaExerciseConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-ex;exerciseWindow.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bermuda exercise convention</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A feature of an option that states it can be exercised at different times during the life of the option. The various times set for exercise are written within the option and allow for flexibility for both the writer and holder of the option.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The Bermuda option is named as such because its exercise dates are more flexible than European options and less flexible than American options. Thus, it is in the middle, just like Bermuda is between Europe and America. Bermuda options are also referred to as Mid-Atlantic, Quasi American, or Semi-American options.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-ex;CanaryExerciseConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;BermudaExerciseConvention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">canary exercise convention</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-ex;EuropeanExerciseConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">european exercise convention</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A feature of an option that stipulates that the option may only be exercised a stated Exercise Date. Therefore, there can be no early assignment with this type of option.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-ex;ExerciseDatesConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-stdi;EDMCouncilConvention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercise dates convention</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date terms determining when the holder or future holder of an option can implement the rights defined in the option.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note: this convention applies to all forms of embedded option and option instruments.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-ex;exerciseDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercise date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date of exercise (expiry)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-ex;exerciseDeterminationPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercise determination period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-ex;AsianExerciseCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period during which the value of the underlying is measured in order to determine when the option may be exercised. The actual exercise date is the final day of the Exercise Period.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-ex;exerciseWindow">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercise window</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-ex;AmericanExerciseConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The window during which the Exercise can take place.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-ex;exerciseWindow.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercise window</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-ex;BermudaExerciseConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Each time window during which the Exercise can take place.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-ex;setsOut">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-ex;AsianExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-ex;AsianExerciseCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-ex;specifiesExerciseDateConvention">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;optionExerciseTermsSpecifies"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies exercise date convention</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-ex;AsianExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/DerivativesContracts/Forwards.rdf
+++ b/der/DerivativesContracts/Forwards.rdf
@@ -1,521 +1,524 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-		<rdfs:label xml:lang="en">Forwards</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;CalculationAgent">
-		<rdfs:label xml:lang="en">calculation agent</rdfs:label>
-		<skos:definition xml:lang="en">The entity which carries out the valuation of an underlying asset, or from which the valuation of the underlying is to be taken.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;CashCloseout">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;closedOutBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash closeout</rdfs:label>
-		<skos:definition xml:lang="en">Closeout of the contract in the form of the cash equivalent of the asset or commodity rather than the underlying asset or commodity itself.</skos:definition>
-		<skos:editorialNote xml:lang="en">Various SME REview notes from OTC sessions: This is where you go into the market and buy the offsetting contract. Exchange Traded: Standard process for exchange traded: if you have an open contract you close out the contract by taking the reverse contract, then present those contracts to the clearing house to be closed out. What clearing house? What is the relationship between the two partie sand the clearing house. That&apos;s for futures. What about OTC? Does this exist? Closeout does exist for OTC. For OTC. Terms of contract are that they are cash settled. Except maybe gold.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;CloseTime">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
-		<rdfs:label xml:lang="en">close time</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;DerivativesCloseTime">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
-		<rdfs:label xml:lang="en">derivatives close time</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;allowsForOptionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">forward cash conditional delivery commitment</rdfs:label>
-		<skos:definition xml:lang="en">Commitment to deliver agreed amountof cash in the event that the option is exercised.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashDelivery">
-		<rdfs:label xml:lang="en">forward cash delivery</rdfs:label>
-		<skos:definition xml:lang="en">&apos;This is the first of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashDeliveryCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;commitsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">forward cash delivery commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to deliver a cash amount at an agreed date in the future.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Not the earliest possible date as in a Spot. FpML exchangedCurrency1 referred to as a &quot;Currency Stream&quot; &apos;This is the first of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashSettlementCommitment">
-		<rdfs:label xml:lang="en">forward cash settlement commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to settle a cash amount at an agreed date in the future.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note the earliest possible date as in a Spot. FpML exchangedCurrency2 referred to as a &quot;Currency Stream&quot; &apos;This is the second of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashSettlementTermsSet">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">forward cash settlement terms set</rdfs:label>
-		<skos:definition xml:lang="en">&apos;This is the second of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasValuationTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">forward contract</rdfs:label>
-		<skos:definition xml:lang="en">A cash market transaction in which a seller agrees to deliver a specific cash commodity to a buyer at some point in the future.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Unlike futures contracts (which occur through a clearing firm), forward contracts are privately negotiated and are not standardized. Further, the two parties must bear each other&apos;s credit risk, which is not the case with a futures contract. Also, since the contracts are not exchange traded, there is no marking to market requirement, which allows a buyer to avoid almost all capital outflow initially (though some counterparties might set collateral requirements). Given the lack of standardization in these contracts, there is very little scope for a secondary market in forwards. The price specified in a forward contract for a specific commodity. The forward price makes the forward contract have no value when the contract is written. However, if the value of the underlying commodity changes, the value of the forward contract becomes positive or negative, depending on the position held. Forwards are priced in a manner similar to futures. Like in the case of a futures contract, the first step in pricing a forward is to add the spot price to the cost of carry (interest forgone, convenience yield, storage costs and interest/dividend received on the underlying). Unlike a futures contract though, the price may also include a premium for counterparty credit risk, and the fact that there is not daily marking to market process to minimize default risk. If there is no allowance for these credit risks, then the forward price will equal the futures price.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardContractBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
-		<rdfs:label xml:lang="en">forward contract buyer</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardContractSeller">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<rdfs:label xml:lang="en">forward contract seller</rdfs:label>
-		<skos:definition xml:lang="en">A seller of the underlying instrument in a Forward contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardDeliveryCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;commitsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;madeBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionUnderlyingSeller"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">forward delivery commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to deliver something at some time or under some terms in the future.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In an Option, there is still a commitment on one side to deliver in the event that the other side chooses to exercise the option.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardDeliveryTermsSet">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-dbx;equatesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">forward delivery terms set</rdfs:label>
-		<skos:definition xml:lang="en">The delivery of something in the future, at an agreed date or dates and under agreed terms.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardTransaction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">forward transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction in which one party commits at the present to delivery of something in the future.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardValuationTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasValuationTiming"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-der-fwd;MasterConfirmationValuationTimeTermsSet">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-der-fwd;ValuationTimeType">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;TimeOfDay">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;valuationDate"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">forward valuation terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms for valuation of underlying(s) for a Forward Contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;MasterConfirmationValuationTimeTermsSet">
-		<rdfs:label xml:lang="en">master confirmation valuation time terms set</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms specifying the time for Valuation of Equity Underlying.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note this is referred to in the selection list for times of day at which valuation can occur, as &quot;As Specified in Master Confirmation&quot;. Since that is not a time of day, Master confirmation is added here. Presumably the Master Confirmation (contract / covering agreement) has other terms. REVIEW</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;OSP">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
-		<rdfs:label xml:lang="en">o s p</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;OpenTime">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
-		<rdfs:label xml:lang="en">open time</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;UnderlyingValuation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;undertakenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;CalculationAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">underlying valuation</rdfs:label>
-		<skos:definition xml:lang="en">The act of valuation of the underlying on some OTC Derivative.</skos:definition>
-		<skos:editorialNote xml:lang="en">Abstracted from FpML term for calculation Agent and Valuation terms as referred to in Equity Forward and presumably other derivatives also.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ValuationTimeType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
-		<rdfs:label xml:lang="en">valuation time type</rdfs:label>
-		<skos:definition xml:lang="en">The time of day at which the calculation agent values the underlying, for example the official closing time of the exchange.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;XETRA">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
-		<rdfs:label xml:lang="en">x e t r a</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;allowsForOptionOf">
-		<rdfs:label xml:lang="en">allows for option of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;cashDelivery">
-		<rdfs:label xml:lang="en">cash delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;CashCloseout"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;cashDelivery.1">
-		<rdfs:label xml:lang="en">cash delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;closedOutBy">
-		<rdfs:label xml:lang="en">closed out by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;CashCloseout"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;commitsTo">
-		<rdfs:label xml:lang="en">commits to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;contractSize">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The deliverable quantity of goods or commodities underlying futures, forward and option contracts.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;deliveryAmount">
-		<rdfs:label xml:lang="en">delivery amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;deliveryDate">
-		<rdfs:label xml:lang="en">delivery date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-		<skos:definition xml:lang="en">FpML = valueDate Definition for &apos;valueDate&apos; in FpML &apos;The date on which both currencies traded will settle.&apos; Definition for &apos;currency1ValueDate&apos; in FpML &apos;The date on which the currency1 amount will be settled. To be used in a split value date scenario.&apos; Notes 20 Jan: single value date scenario adds nothing to the model. The &quot;split value date&quot; is when Payment Date and SettlementDate are different; otherwise they are the same. We don&apos;t need to model this.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;deliveryDate.1">
-		<rdfs:label xml:lang="en">delivery date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;embodies">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;establishes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;establishes.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;forwardPrice">
-		<rdfs:label xml:lang="en">forward price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The forward price of the underlying.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasBuyer">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-		<rdfs:label xml:lang="en">has buyer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasSeller">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
-		<rdfs:label xml:lang="en">has seller</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasValuationTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has valuation terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasValuationTimeOfDay">
-		<rdfs:label xml:lang="en">has valuation time of day</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;MasterConfirmationValuationTimeTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TimeOfDay"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasValuationTiming">
-		<rdfs:label xml:lang="en">has valuation timing</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-der-fwd;MasterConfirmationValuationTimeTermsSet">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-der-fwd;ValuationTimeType">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;TimeOfDay">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;maturityDate">
-		<rdfs:label xml:lang="en">maturity date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<skos:definition xml:lang="en">The date at which the buyer must take delivery of the underlier. Also the date the contract ends between both parties.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;paymentFeeType">
-		<rdfs:label xml:lang="en">payment fee type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The type of fee or additional payment, e.g. brokerage, upfront fee etc.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;paymentType">
-		<rdfs:label xml:lang="en">payment type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-		<skos:definition xml:lang="en">&apos;A classification of the type of fee or additional payment, e.g. brokerage, upfront fee etc. FpML does not define domain values for this element.&apos;</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;settlementAmount">
-		<rdfs:label xml:lang="en">settlement amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;settlementDate">
-		<rdfs:label xml:lang="en">settlement date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-		<skos:definition xml:lang="en">FpML = valueDate Definition for &apos;valueDate&apos; in FpML &apos;The date on which both currencies traded will settle.&apos; Definition for &apos;currency2ValueDate&apos; in FpML &apos;The date on which the currency2 amount will be settled. To be used in a split value date scenario.&apos; Notes 20 Jan: This is the scenario where &quot;t&quot; for one leg is different to &quot;t&quot; for the other leg.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;side">
-		<rdfs:label xml:lang="en">side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;side.1">
-		<rdfs:label xml:lang="en">side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;specifies">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;undertakenBy">
-		<rdfs:label xml:lang="en">undertaken by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;CalculationAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;valuationDate">
-		<rdfs:label xml:lang="en">valuation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;valuationTime">
-		<rdfs:label xml:lang="en">valuation time</rdfs:label>
-	</owl:DatatypeProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Forwards</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts defining a derivative contract in which one side represents a commitment to sell or purchase the underlier at a defined price at a given time in the future.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;CalculationAgent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calculation agent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity which carries out the valuation of an underlying asset, or from which the valuation of the underlying is to be taken.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;CashCloseout">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;closedOutBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash closeout</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Closeout of the contract in the form of the cash equivalent of the asset or commodity rather than the underlying asset or commodity itself.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Various SME REview notes from OTC sessions: This is where you go into the market and buy the offsetting contract. Exchange Traded: Standard process for exchange traded: if you have an open contract you close out the contract by taking the reverse contract, then present those contracts to the clearing house to be closed out. What clearing house? What is the relationship between the two partie sand the clearing house. That&apos;s for futures. What about OTC? Does this exist? Closeout does exist for OTC. For OTC. Terms of contract are that they are cash settled. Except maybe gold.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;CloseTime">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">close time</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;DerivativesCloseTime">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives close time</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;allowsForOptionOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward cash conditional delivery commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Commitment to deliver agreed amountof cash in the event that the option is exercised.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashDelivery">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward cash delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&apos;This is the first of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashDeliveryCommitment">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;commitsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward cash delivery commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment to deliver a cash amount at an agreed date in the future.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Not the earliest possible date as in a Spot. FpML exchangedCurrency1 referred to as a &quot;Currency Stream&quot; &apos;This is the first of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashSettlementCommitment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward cash settlement commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment to settle a cash amount at an agreed date in the future.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note the earliest possible date as in a Spot. FpML exchangedCurrency2 referred to as a &quot;Currency Stream&quot; &apos;This is the second of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashSettlementTermsSet">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward cash settlement terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&apos;This is the second of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasSeller"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasValuationTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;side"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;side.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A cash market transaction in which a seller agrees to deliver a specific cash commodity to a buyer at some point in the future.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Unlike futures contracts (which occur through a clearing firm), forward contracts are privately negotiated and are not standardized. Further, the two parties must bear each other&apos;s credit risk, which is not the case with a futures contract. Also, since the contracts are not exchange traded, there is no marking to market requirement, which allows a buyer to avoid almost all capital outflow initially (though some counterparties might set collateral requirements). Given the lack of standardization in these contracts, there is very little scope for a secondary market in forwards. The price specified in a forward contract for a specific commodity. The forward price makes the forward contract have no value when the contract is written. However, if the value of the underlying commodity changes, the value of the forward contract becomes positive or negative, depending on the position held. Forwards are priced in a manner similar to futures. Like in the case of a futures contract, the first step in pricing a forward is to add the spot price to the cost of carry (interest forgone, convenience yield, storage costs and interest/dividend received on the underlying). Unlike a futures contract though, the price may also include a premium for counterparty credit risk, and the fact that there is not daily marking to market process to minimize default risk. If there is no allowance for these credit risks, then the forward price will equal the futures price.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardContractBuyer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward contract buyer</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardContractSeller">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward contract seller</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A seller of the underlying instrument in a Forward contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardDeliveryCommitment">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;commitsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;madeBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionUnderlyingSeller"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward delivery commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment to deliver something at some time or under some terms in the future.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In an Option, there is still a commitment on one side to deliver in the event that the other side chooses to exercise the option.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardDeliveryTermsSet">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-dbx;equatesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward delivery terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The delivery of something in the future, at an agreed date or dates and under agreed terms.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardTransaction">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction in which one party commits at the present to delivery of something in the future.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ForwardValuationTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasValuationTiming"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-der-fwd;MasterConfirmationValuationTimeTermsSet">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-der-fwd;ValuationTimeType">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;TimeOfDay">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;valuationDate"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward valuation terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for valuation of underlying(s) for a Forward Contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;MasterConfirmationValuationTimeTermsSet">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">master confirmation valuation time terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal terms specifying the time for Valuation of Equity Underlying.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note this is referred to in the selection list for times of day at which valuation can occur, as &quot;As Specified in Master Confirmation&quot;. Since that is not a time of day, Master confirmation is added here. Presumably the Master Confirmation (contract / covering agreement) has other terms. REVIEW</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;OSP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o s p</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;OpenTime">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">open time</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;UnderlyingValuation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;undertakenBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;CalculationAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying valuation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The act of valuation of the underlying on some OTC Derivative.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Abstracted from FpML term for calculation Agent and Valuation terms as referred to in Equity Forward and presumably other derivatives also.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;ValuationTimeType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation time type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The time of day at which the calculation agent values the underlying, for example the official closing time of the exchange.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-fwd;XETRA">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ValuationTimeType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">x e t r a</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;allowsForOptionOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allows for option of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;cashDelivery">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash delivery</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;CashCloseout"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;cashDelivery.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash delivery</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;closedOutBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">closed out by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;CashCloseout"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;commitsTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commits to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;contractSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The deliverable quantity of goods or commodities underlying futures, forward and option contracts.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;deliveryAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delivery amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;deliveryDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delivery date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">FpML = valueDate Definition for &apos;valueDate&apos; in FpML &apos;The date on which both currencies traded will settle.&apos; Definition for &apos;currency1ValueDate&apos; in FpML &apos;The date on which the currency1 amount will be settled. To be used in a split value date scenario.&apos; Notes 20 Jan: single value date scenario adds nothing to the model. The &quot;split value date&quot; is when Payment Date and SettlementDate are different; otherwise they are the same. We don&apos;t need to model this.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;deliveryDate.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delivery date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;embodies">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;establishes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;establishes.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;forwardPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The forward price of the underlying.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasBuyer">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has buyer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasSeller">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has seller</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasValuationTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has valuation terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasValuationTimeOfDay">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has valuation time of day</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;MasterConfirmationValuationTimeTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TimeOfDay"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasValuationTiming">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has valuation timing</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-der-der-fwd;MasterConfirmationValuationTimeTermsSet">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-der-der-fwd;ValuationTimeType">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;TimeOfDay">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;maturityDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the buyer must take delivery of the underlier. Also the date the contract ends between both parties.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;paymentFeeType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment fee type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of fee or additional payment, e.g. brokerage, upfront fee etc.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;paymentType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&apos;A classification of the type of fee or additional payment, e.g. brokerage, upfront fee etc. FpML does not define domain values for this element.&apos;</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;settlementAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;settlementDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">FpML = valueDate Definition for &apos;valueDate&apos; in FpML &apos;The date on which both currencies traded will settle.&apos; Definition for &apos;currency2ValueDate&apos; in FpML &apos;The date on which the currency2 amount will be settled. To be used in a split value date scenario.&apos; Notes 20 Jan: This is the scenario where &quot;t&quot; for one leg is different to &quot;t&quot; for the other leg.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;side">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">side</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;side.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">side</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;specifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;undertakenBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">undertaken by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;CalculationAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;valuationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;valuationTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation time</rdfs:label>
+bu</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/der/DerivativesContracts/OptionContractsOnFutures.rdf
+++ b/der/DerivativesContracts/OptionContractsOnFutures.rdf
@@ -1,72 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-cof "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/OptionContractsOnFutures/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-cof "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/OptionContractsOnFutures/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/OptionContractsOnFutures/"
-	xmlns:fibo-der-der-cof="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/OptionContractsOnFutures/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/OptionContractsOnFutures/">
-		<rdfs:label xml:lang="en">OptionContractsOnFutures</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/OptionContractsOnFutures/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-der-cof;FuturesContractUnderlying">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-cof;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures contract underlying</rdfs:label>
-		<skos:definition xml:lang="en">An underlying which is a futures contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">(not an underlying OF a future instrument)</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-cof;OTCContractOnFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-cof;hasUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-cof;FuturesContractUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c contract on future</rdfs:label>
-		<skos:definition xml:lang="en">An option contract with an underlying futures contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-cof;hasUnderlying">
-		<rdfs:label xml:lang="en">has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-cof;OTCContractOnFuture"/>
-		<rdfs:range rdf:resource="&fibo-der-der-cof;FuturesContractUnderlying"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-cof;identity">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-cof;FuturesContractUnderlying"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-cof="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/OptionContractsOnFutures/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/OptionContractsOnFutures/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">OptionContractsOnFutures</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Over the counter option contracts giving the holder to purchase or sell a given futures contract at the allowed times.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/OptionContractsOnFutures/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-cof;FuturesContractUnderlying">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-cof;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures contract underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An underlying which is a futures contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">(not an underlying OF a future instrument)</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-cof;OTCContractOnFuture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-cof;hasUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-cof;FuturesContractUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c contract on future</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option contract with an underlying futures contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-cof;hasUnderlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-cof;OTCContractOnFuture"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-cof;FuturesContractUnderlying"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-cof;identity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-cof;FuturesContractUnderlying"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/DerivativesContracts/Options.rdf
+++ b/der/DerivativesContracts/Options.rdf
@@ -1,1442 +1,1445 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
-	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-etd-eto "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
-	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegistrationAuthorities/">
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
+bu<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-etd-eto "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
+bu<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegistrationAuthorities/">
+bu<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
-	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-etd-eto="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
-	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegistrationAuthorities/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-		<rdfs:label xml:lang="en">Options</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegistrationAuthorities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;AbsolutePriceStrikeSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikePriceSpecification"/>
-		<rdfs:label xml:lang="en">absolute price strike specification</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
-		<skos:definition xml:lang="en">Expression of the strike price as an absolute monetary price at which the option is to be struck.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;AssetMaximumOrMinimumPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
-		<rdfs:label xml:lang="en">asset maximum or minimum payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to pay out on the maximum or minimum of a set of assets. Further Notes Maximum of n Assets This rainbow is similar to the best of n assets plus cash we referred to in part a, with the exception that no cash payoff is possible and there is a strike price for this type of option. The payoff of a call and put are given as: Rainbow-Call = max[0, max(S1, S2) - X] Rainbow-Put = max[0, X - max(S1, S2)] Minimum of n Assets The counterpart to a maximum of n assets, this rainbow pays out the value of the underperformer of the n assets. The payoff for minimum of 2 asset rainbow calls and puts are given as: Rainbow-Call = max[0, mainS1, S2) - X] Rainbow-Put = max[0, X - min(S1, S2)]</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;AssetOrNothingPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;BinaryPayoutCommitment"/>
-		<rdfs:label xml:lang="en">asset or nothing payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;CashOrNothingPayoutCommitment"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;BestOfAssetsPlusCashPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PayoffAssetsList"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">best of assets plus cash payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to pay out on the best of a number of assets, plus cash.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This type of rainbow effectively has n + 1 payoff possibilities. If we consider a 2 asset &quot;best of plus cash&quot;, the payoff at expiry is a choice between Asset 1, Asset 2, or the predetermined cash amount. There is no strike price and the payoff is given as: Rainbow = max(S1, S2, Cash;T)</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;BetterOrWorseOfAssetsPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;references"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PayoffAssetsList"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">better or worse of assets payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to pay out on the best or worst of a number of assets.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Better of n Assets This type of rainbow is similar to the best of n assets plus cash but with the exception that there is no possible cash payoff, and X is set to 0. With this in mind, a better of 2 assets rainbow is essentially a two-asset call option, with a payoff being: Rainbow = max[0, max(S1, S2)] Worse of n Assets Essentially the opposite to the better of n assets, with the payoff being on the asset with the lower value. We can give the payoff for this option on 2 assets as: Rainbow = max[0, min(S1, S2)]</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;BinaryPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">binary payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;CalculatedPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">calculated payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;LinearPayoutCommitment"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;CallOptionBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-		<rdfs:label xml:lang="en">call option buyer</rdfs:label>
-		<skos:definition xml:lang="en">The Party which is the buyer of the Call Option. This party has the option but not the obligation to transact as the Buyer of the Option Underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;CallOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;CallOptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;CallOptionType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;CallOptionWritingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">call option contract</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;ChooserOptionContract"/>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;PutOptionContract"/>
-		<skos:definition xml:lang="en">Contracts between a buyer and a seller giving the buyer (holder) the right, but not the obligation, to buy the assets specified at a fixed price or formula, on or before a specified date. The seller of the call option assumes the obligation of delivering the assets specified should the buyer exercise his option.</skos:definition>
-		<skos:editorialNote xml:lang="en">ISO FIBIM has same (ISO CFI-derived) written definition for the &quot;Call&quot; selection entry in the selection list &quot;OptionTypeCode&quot;. Additional modeling Dec 2010: this is now deprecated for the former OTC Call Option. Combine the definition and consnsus from here, and the Simple Fact, befpre de;eting. the formerly OTC term has the required relationship facts.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;CallOptionType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionType"/>
-		<rdfs:label xml:lang="en">call option type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;CallOptionWritingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-		<rdfs:label xml:lang="en">call option writing party</rdfs:label>
-		<skos:definition xml:lang="en">The Party which is the writer of the Call Option. This party has the obligation to transact as the Seller of the Option Underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;CashOrNothingPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;BinaryPayoutCommitment"/>
-		<rdfs:label xml:lang="en">cash or nothing payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to pay out on a binary option, as cash or nothing.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;ChooserOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-der-opt;OptionCallTransaction">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-der-opt;OptionPutTransaction">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionTypeElectionDate"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">chooser option contract</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;PutOptionContract"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;ConditionalPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">conditional payout commitment</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;LinearPayoutCommitment"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;DefinedConditionsPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">defined conditions payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment which is only made when certain defined conditions are met. Further notes: Like all contractual commitments, the details of the commitment (and in this case, the conditions) are defined in the corresponding Contractual Terms. These set out what the commitment is and what the conditions are under which it is to be met. Term introduced in order to support digital and other exotic options. Note this is similar to but distinct from commitments where the specific nature of the commitment (typically a cashflow) is defined by resolving some mathematical formula i.e. where the commitment to do something is not conditional but the precise monetary amounts (payment, settlement) are.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;EarlyExerciseCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWriterCommitment"/>
-		<rdfs:label xml:lang="en">early exercise commitment</rdfs:label>
-		<skos:definition xml:lang="en">The commitment to exercise the option ahead of the expiry date under given conditions as laid out in the Barrier Feature terms of the Option contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;FixedLookbackStrikeFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikeFormula"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExpression"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fixed lookback strike formula</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackFormulaExpression"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;subtracts"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;subtractsFrom"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedStrikeAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fixed lookback strike formula expression</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;FixedLookbackStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fixed lookback strike terms</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeTerms"/>
-		<skos:definition xml:lang="en">Strike terms which reflect the difference between a running maximum value of the observable during the lookback period, and the pre-agreed strike. The agreed settlement is based on the difference between these. Further Notes This is only settled in cash and the strike is predetermined at payoff and the payoff is the max diff between the optimal price and the strike price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;FixedStrikeAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
-		<rdfs:label xml:lang="en">fixed strike amount</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;FixedStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;includesSpecificationTerm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;StrikePriceSpecification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fixed strike terms</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;ResetableStrikeTerms"/>
-		<skos:definition xml:lang="en">Contractual terms setting out a fixed, pre-agreed price or level at which the option is to be struck.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is similar to the FpML term for Strike, but there are two other types of Strike specification - look back and reset. FpML strike: &apos;Defines whether it is a price or level at which the option has been, or will be, struck.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;FloatingLookbackFormulaExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackFormulaExpression"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;subtracts.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;subtractsFrom.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableFinalValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">floating lookback formula expression</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;FloatingLookbackStrikeFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikeFormula"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExpression.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">floating lookback strike formula</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;FloatingLookbackStrikeSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">floating lookback strike schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;FloatingLookbackStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFormula.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">floating lookback strike terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;KnockIn">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionFeature"/>
-		<rdfs:label xml:lang="en">knock in</rdfs:label>
-		<skos:definition xml:lang="en">An option which comes into existence if the knock-in event happens. It works exactly the reverse of a knock-out. In a knock-in, an option comes into existence if a certain level is hit.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;KnockOut">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionFeature"/>
-		<rdfs:label xml:lang="en">knock out</rdfs:label>
-		<skos:definition xml:lang="en">An option which ceases to exist if the knock-out event occurs. A knock out happens when a particular level is hit (like the Swiss franc touching the level of 1.10 against the dollar), when the option ceases to exist.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;LinearPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-		<rdfs:label xml:lang="en">linear payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">The commitment to pay out on a straight vanilla option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;LinearPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;LinearPayoutCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">linear payout terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing the payment commitment on a vanilla option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;LookbackFormulaExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
-		<rdfs:label xml:lang="en">lookback formula expression</rdfs:label>
-		<skos:definition xml:lang="en">An expression of a lookback formula</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;LookbackObservableValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;PastValue"/>
-		<rdfs:label xml:lang="en">lookback observable value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;LookbackObservableValueAtMaturity">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackObservableValue"/>
-		<rdfs:label xml:lang="en">lookback observable value at maturity</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;LookbackObservableValueDuringLookbackPeriod">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackObservableValue"/>
-		<rdfs:label xml:lang="en">lookback observable value during lookback period</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;LookbackStrikeObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-dbx;ObservableUnderlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">lookback strike observable</rdfs:label>
-		<skos:definition xml:lang="en">The agreed parameter which is used in the formula for fixed OR floating lookback.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;LookbackStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">lookback strike terms</rdfs:label>
-		<skos:definition xml:lang="en">Strike terms in which the value of some observed variable (the underlying) is looked back at during some period, typically a period ending in the maturity of the Option, and the payoff is determined by comparing the agreed strike with the value of this variable.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The payoff may either be the difference between a fixed, pre-agreed Strike Price and the observable, or the difference between the best or worst valuable of the observable and the value of that same observable at maturity of the contract (these are the Fixed and Floating lookback terms respectively). This (per review at Nordea) is not mutually exclusive with the terms for Fixed Strike and Resettable Strike, that is, either of those kinds of strike terms may apply, and Lookback strike terms may also apply.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OTCOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:label xml:lang="en">o t c option contract</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<skos:definition xml:lang="en">Exotic options traded on the over-the-counter market, where participants can choose the characteristics of the options traded.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The flexibility of these options is attractive to many. With OTC options, both hedgers and speculators can benefit from avoiding the restrictions that normal standardized exchanges place on options. The flexibility allows participants to achieve their desired position more precisely and cost effectively. Review note (13 Jan 2010 or earlier): optional delivery dates where there&apos;s a right to change e.g. extend or shorten the delivery period. Part of the terms. For instance time options.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;ObservableBestValue">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;LookbackObservableValueDuringLookbackPeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;isOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;LookbackStrikeObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">observable best value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;ObservableFinalValue">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;LookbackObservableValueAtMaturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">observable final value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionBarrierFeatureEvent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasDirection"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;UpOrDown"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;relatesTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option barrier feature event</rdfs:label>
-		<skos:definition xml:lang="en">An event which defines when an option feature comes into effect.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionBarrierFeatureTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;EarlyExerciseCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionFeature"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option barrier feature terms</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms setting out when and under what circumstances the option contract is deemed to be in force. This takes the form of an event and the relationship between the event and the applicability of the option.</skos:definition>
-		<skos:editorialNote xml:lang="en">After some research it was determined that the nature of the thing normally called &quot;Feature&quot; in an option is a contractual term defining when and under what circumstances the option itself is deemed be in force. In other words this is a set of contractual terms. Option features in this sense are &quot;Knock In&quot; or &quot;Knock Out&quot;, each relating to a market event (usually a price reaching a given level). A third feature, &quot;Knock In Knock Out&quot; is really two of these and is represented as such in the Option terms i.e. there may be two of this Option Feature Terms term. The term &quot;Barrier Option&quot; applies to both of these, i.e. Knock In and Knock Out are types of Barrier Option. An option contract may or may not have a barrier option. If it does not, none of this applies. Others: knock in a knock out, knock in a digitale, if it exceeds one barrier you get a call; for another you get a put, and so on.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionBinaryPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;BinaryPayoutCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option binary payout terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing a binary payout commitment.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
-		<rdfs:label xml:lang="en">option buyer</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionBuyerCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;madeBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionUnderlyingBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option buyer commitment</rdfs:label>
-		<skos:definition xml:lang="en">Commitments, if any, on the part of the holder (buyer) of the Option.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Obligations incude: Obligation to inform the seller by a certain time if the holder wishes to exercise. Once the instrument is exercised there are separate obligations in settlement as part of that transactions; that is not covered here. If you want to exercise you have to do it in a certain way - review whether any of this is contractually defined as obligations on the part of the holder.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionCallTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;makes"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;receives"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option call transaction</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
-		<skos:definition xml:lang="en">A transaction which is defined in an options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase of the underlying or some cash equivalent thereof, as defined in the option contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Purchase is by the option beneficiary (holder).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionConditionalPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option conditional payout terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing a conditional payment commitment on an option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionExerciseTimeTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;optionExerciseTermsSpecifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option exercise time terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionFeature">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">option feature</rdfs:label>
-		<skos:definition xml:lang="en">Types of feature for an option. This itemizes whether the option comes into force (Knock In) or ceases being in force (Knock Out) when the stated event occurs.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
-		<rdfs:label xml:lang="en">option party</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPayoutCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWriterCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;enteredIntoBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option payout commitment</rdfs:label>
-		<skos:definition xml:lang="en">Commitment by the issuer to pay out on an option should the holder choose to exercise this.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This commitment is set out in formal Exercise Terms.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPayoutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ParametricCashflowTerms"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option payout terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing the payout on an option. These formally define the commitment(s) entered into by the writing party to the option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremium">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;expressedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPayer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPaymentDate"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasReceiver"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PremiumReceiver"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option premium</rdfs:label>
-		<skos:definition xml:lang="en">The amount paid for an option.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review notes (Equity Options): This is just the price. not specific to Equities Options. See Pricing for Exchange Traded Derivatives where we already have similar terms. In forward Fx, premium relates to whether or not the price of the forward is greater or less than the price of the PSpo. In Bonds, whether or not the capital price is more or less than face value (see Bonds Proicing model). In THIS context: the money you pay for the option. FpML: A type used to describe the amount paid for an equity option.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumExpression">
-		<rdfs:label xml:lang="en">option premium expression</rdfs:label>
-		<skos:definition xml:lang="en">The formal expression of the Option Premium.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a choice between expressing amount of premium paid as either price per option, or percentage of notional amount. FpML: &apos;Choice between expressing amount of premium paid as either price per option, or percentage of notional amount.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumFixed">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumVariability"/>
-		<rdfs:label xml:lang="en">option premium fixed</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumPaymentArrangement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">option premium payment arrangement</rdfs:label>
-		<skos:definition xml:lang="en">Premium Type for Forward Start Equity Options.</skos:definition>
-		<skos:editorialNote xml:lang="en">This was originally a selectable list called option premium type selection (option premium type in data models). Note against that element is given below, based on which this has been implemented as two sets of classes (both characterized as kinds of method). 
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
+buxmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-etd-eto="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
+buxmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegistrationAuthorities/"
+buxmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Options</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts common to all option contracts and their corresponding transactions. An option gives one party (the holder) the right to purchase or sell the underlying commodity at a given time or times in the future (as determined by the exercise convention), if they choose to do so. Includes option features, these being definitions of how the option comes into or ceases being in force when a given event occurs along with a range of other variations.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegistrationAuthorities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;AbsolutePriceStrikeSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikePriceSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">absolute price strike specification</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Expression of the strike price as an absolute monetary price at which the option is to be struck.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;AssetMaximumOrMinimumPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset maximum or minimum payout commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment to pay out on the maximum or minimum of a set of assets. Further Notes Maximum of n Assets This rainbow is similar to the best of n assets plus cash we referred to in part a, with the exception that no cash payoff is possible and there is a strike price for this type of option. The payoff of a call and put are given as: Rainbow-Call = max[0, max(S1, S2) - X] Rainbow-Put = max[0, X - max(S1, S2)] Minimum of n Assets The counterpart to a maximum of n assets, this rainbow pays out the value of the underperformer of the n assets. The payoff for minimum of 2 asset rainbow calls and puts are given as: Rainbow-Call = max[0, mainS1, S2) - X] Rainbow-Put = max[0, X - min(S1, S2)]</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;AssetOrNothingPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;BinaryPayoutCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset or nothing payout commitment</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;CashOrNothingPayoutCommitment"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;BestOfAssetsPlusCashPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PayoffAssetsList"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">best of assets plus cash payout commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment to pay out on the best of a number of assets, plus cash.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This type of rainbow effectively has n + 1 payoff possibilities. If we consider a 2 asset &quot;best of plus cash&quot;, the payoff at expiry is a choice between Asset 1, Asset 2, or the predetermined cash amount. There is no strike price and the payoff is given as: Rainbow = max(S1, S2, Cash;T)</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;BetterOrWorseOfAssetsPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;references"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PayoffAssetsList"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">better or worse of assets payout commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment to pay out on the best or worst of a number of assets.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Better of n Assets This type of rainbow is similar to the best of n assets plus cash but with the exception that there is no possible cash payoff, and X is set to 0. With this in mind, a better of 2 assets rainbow is essentially a two-asset call option, with a payoff being: Rainbow = max[0, max(S1, S2)] Worse of n Assets Essentially the opposite to the better of n assets, with the payoff being on the asset with the lower value. We can give the payoff for this option on 2 assets as: Rainbow = max[0, min(S1, S2)]</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;BinaryPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">binary payout commitment</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;CalculatedPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calculated payout commitment</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;LinearPayoutCommitment"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;CallOptionBuyer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call option buyer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Party which is the buyer of the Call Option. This party has the option but not the obligation to transact as the Buyer of the Option Underlying.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;CallOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;CallOptionBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;CallOptionType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;CallOptionWritingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call option contract</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;ChooserOptionContract"/>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;PutOptionContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contracts between a buyer and a seller giving the buyer (holder) the right, but not the obligation, to buy the assets specified at a fixed price or formula, on or before a specified date. The seller of the call option assumes the obligation of delivering the assets specified should the buyer exercise his option.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">ISO FIBIM has same (ISO CFI-derived) written definition for the &quot;Call&quot; selection entry in the selection list &quot;OptionTypeCode&quot;. Additional modeling Dec 2010: this is now deprecated for the former OTC Call Option. Combine the definition and consnsus from here, and the Simple Fact, befpre de;eting. the formerly OTC term has the required relationship facts.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;CallOptionType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call option type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;CallOptionWritingParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call option writing party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Party which is the writer of the Call Option. This party has the obligation to transact as the Seller of the Option Underlying.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;CashOrNothingPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;BinaryPayoutCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash or nothing payout commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment to pay out on a binary option, as cash or nothing.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;ChooserOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-der-opt;OptionCallTransaction">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-der-opt;OptionPutTransaction">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionTypeElectionDate"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">chooser option contract</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;PutOptionContract"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;ConditionalPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conditional payout commitment</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;LinearPayoutCommitment"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;DefinedConditionsPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined conditions payout commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment which is only made when certain defined conditions are met. Further notes: Like all contractual commitments, the details of the commitment (and in this case, the conditions) are defined in the corresponding Contractual Terms. These set out what the commitment is and what the conditions are under which it is to be met. Term introduced in order to support digital and other exotic options. Note this is similar to but distinct from commitments where the specific nature of the commitment (typically a cashflow) is defined by resolving some mathematical formula i.e. where the commitment to do something is not conditional but the precise monetary amounts (payment, settlement) are.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;EarlyExerciseCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWriterCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">early exercise commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The commitment to exercise the option ahead of the expiry date under given conditions as laid out in the Barrier Feature terms of the Option contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;FixedLookbackStrikeFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikeFormula"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExpression"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed lookback strike formula</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackFormulaExpression"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;subtracts"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;subtractsFrom"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedStrikeAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed lookback strike formula expression</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;FixedLookbackStrikeTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFormula"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed lookback strike terms</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Strike terms which reflect the difference between a running maximum value of the observable during the lookback period, and the pre-agreed strike. The agreed settlement is based on the difference between these. Further Notes This is only settled in cash and the strike is predetermined at payoff and the payoff is the max diff between the optimal price and the strike price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;FixedStrikeAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed strike amount</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;FixedStrikeTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;includesSpecificationTerm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;StrikePriceSpecification"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed strike terms</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;ResetableStrikeTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms setting out a fixed, pre-agreed price or level at which the option is to be struck.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is similar to the FpML term for Strike, but there are two other types of Strike specification - look back and reset. FpML strike: &apos;Defines whether it is a price or level at which the option has been, or will be, struck.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;FloatingLookbackFormulaExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackFormulaExpression"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;subtracts.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;subtractsFrom.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ObservableFinalValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floating lookback formula expression</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;FloatingLookbackStrikeFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikeFormula"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasExpression.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floating lookback strike formula</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;FloatingLookbackStrikeSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floating lookback strike schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;FloatingLookbackStrikeTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFormula.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floating lookback strike terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;KnockIn">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionFeature"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">knock in</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option which comes into existence if the knock-in event happens. It works exactly the reverse of a knock-out. In a knock-in, an option comes into existence if a certain level is hit.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;KnockOut">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionFeature"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">knock out</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option which ceases to exist if the knock-out event occurs. A knock out happens when a particular level is hit (like the Swiss franc touching the level of 1.10 against the dollar), when the option ceases to exist.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;LinearPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">linear payout commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The commitment to pay out on a straight vanilla option.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;LinearPayoutTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;LinearPayoutCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">linear payout terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms governing the payment commitment on a vanilla option.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;LookbackFormulaExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lookback formula expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An expression of a lookback formula</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;LookbackObservableValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;PastValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lookback observable value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;LookbackObservableValueAtMaturity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackObservableValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lookback observable value at maturity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;LookbackObservableValueDuringLookbackPeriod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;LookbackObservableValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lookback observable value during lookback period</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;LookbackStrikeObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-dbx;ObservableUnderlier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lookback strike observable</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The agreed parameter which is used in the formula for fixed OR floating lookback.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;LookbackStrikeTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSchedule"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lookback strike terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Strike terms in which the value of some observed variable (the underlying) is looked back at during some period, typically a period ending in the maturity of the Option, and the payoff is determined by comparing the agreed strike with the value of this variable.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The payoff may either be the difference between a fixed, pre-agreed Strike Price and the observable, or the difference between the best or worst valuable of the observable and the value of that same observable at maturity of the contract (these are the Fixed and Floating lookback terms respectively). This (per review at Nordea) is not mutually exclusive with the terms for Fixed Strike and Resettable Strike, that is, either of those kinds of strike terms may apply, and Lookback strike terms may also apply.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OTCOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c option contract</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Exotic options traded on the over-the-counter market, where participants can choose the characteristics of the options traded.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The flexibility of these options is attractive to many. With OTC options, both hedgers and speculators can benefit from avoiding the restrictions that normal standardized exchanges place on options. The flexibility allows participants to achieve their desired position more precisely and cost effectively. Review note (13 Jan 2010 or earlier): optional delivery dates where there&apos;s a right to change e.g. extend or shorten the delivery period. Part of the terms. For instance time options.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;ObservableBestValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;LookbackObservableValueDuringLookbackPeriod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;isOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;LookbackStrikeObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">observable best value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;ObservableFinalValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;LookbackObservableValueAtMaturity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">observable final value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionBarrierFeatureEvent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasDirection"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;UpOrDown"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;relatesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option barrier feature event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event which defines when an option feature comes into effect.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionBarrierFeatureTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;EarlyExerciseCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionFeature"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option barrier feature terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal terms setting out when and under what circumstances the option contract is deemed to be in force. This takes the form of an event and the relationship between the event and the applicability of the option.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">After some research it was determined that the nature of the thing normally called &quot;Feature&quot; in an option is a contractual term defining when and under what circumstances the option itself is deemed be in force. In other words this is a set of contractual terms. Option features in this sense are &quot;Knock In&quot; or &quot;Knock Out&quot;, each relating to a market event (usually a price reaching a given level). A third feature, &quot;Knock In Knock Out&quot; is really two of these and is represented as such in the Option terms i.e. there may be two of this Option Feature Terms term. The term &quot;Barrier Option&quot; applies to both of these, i.e. Knock In and Knock Out are types of Barrier Option. An option contract may or may not have a barrier option. If it does not, none of this applies. Others: knock in a knock out, knock in a digitale, if it exceeds one barrier you get a call; for another you get a put, and so on.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionBinaryPayoutTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;BinaryPayoutCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option binary payout terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms governing a binary payout commitment.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionBuyer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option buyer</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionBuyerCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;madeBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionUnderlyingBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option buyer commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Commitments, if any, on the part of the holder (buyer) of the Option.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Obligations incude: Obligation to inform the seller by a certain time if the holder wishes to exercise. Once the instrument is exercised there are separate obligations in settlement as part of that transactions; that is not covered here. If you want to exercise you have to do it in a certain way - review whether any of this is contractually defined as obligations on the part of the holder.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionCallTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;makes"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;receives"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option call transaction</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction which is defined in an options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase of the underlying or some cash equivalent thereof, as defined in the option contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Purchase is by the option beneficiary (holder).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionConditionalPayoutTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;ConditionalPayoutCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option conditional payout terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms governing a conditional payment commitment on an option.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionExerciseTimeTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;optionExerciseTermsSpecifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option exercise time terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionFeature">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option feature</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Types of feature for an option. This itemizes whether the option comes into force (Knock In) or ceases being in force (Knock Out) when the stated event occurs.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option party</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPayoutCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWriterCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;enteredIntoBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option payout commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Commitment by the issuer to pay out on an option should the holder choose to exercise this.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This commitment is set out in formal Exercise Terms.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPayoutTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ParametricCashflowTerms"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option payout terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms governing the payout on an option. These formally define the commitment(s) entered into by the writing party to the option.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPremium">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;expressedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPayer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPaymentDate"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasReceiver"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PremiumReceiver"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option premium</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount paid for an option.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review notes (Equity Options): This is just the price. not specific to Equities Options. See Pricing for Exchange Traded Derivatives where we already have similar terms. In forward Fx, premium relates to whether or not the price of the forward is greater or less than the price of the PSpo. In Bonds, whether or not the capital price is more or less than face value (see Bonds Proicing model). In THIS context: the money you pay for the option. FpML: A type used to describe the amount paid for an equity option.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumExpression">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option premium expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formal expression of the Option Premium.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a choice between expressing amount of premium paid as either price per option, or percentage of notional amount. FpML: &apos;Choice between expressing amount of premium paid as either price per option, or percentage of notional amount.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumFixed">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumVariability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option premium fixed</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumPaymentArrangement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option premium payment arrangement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Premium Type for Forward Start Equity Options.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This was originally a selectable list called option premium type selection (option premium type in data models). Note against that element is given below, based on which this has been implemented as two sets of classes (both characterized as kinds of method). 
 
 Earlier SME Review note:
 Further notes: REVIEW THIS - there appear to be two separate semantics in this list; are they mutually exclusive? Answers: You can pay the premium up front or in arrears (pre v pos tpaid) or you can pay it at any agreed time (indeed the time is already defined as terms see Payment Date), so this simply reflects that. Then there are other types of &quot;Participating OptionS&quot; where the anmount you pay depends on something else - so you don&apos;t pay the Premium up front. If it ends up outt of the money then you don&apos;t have to pay as much. So this is &quot;Variable&quot; premium. The alternative to this is &quot;Fixed&quot;. If it&apos;s prepaid it&apos;s firxed If it&apos;s post paid it can bt variable or fixed. SO these are two facts. FpML: Premium Type for Forward Start Equity Option</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumPreOrPostType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPaymentArrangement"/>
-		<rdfs:label xml:lang="en">option premium pre or post type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumVariability">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPaymentArrangement"/>
-		<rdfs:label xml:lang="en">option premium variability</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumVariable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumVariability"/>
-		<rdfs:label xml:lang="en">option premium variable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionPutTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;makes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;receives.1"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option put transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionStrikeResetSchedule">
-		<rdfs:label xml:lang="en">option strike reset schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
-		<rdfs:label xml:lang="en">option strike terms</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms setting out the price or level at which the option is to be struck. FpML strike: &apos;Defines whether it is a price or level at which the option has been, or will be, struck.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-		<rdfs:label xml:lang="en">option contract terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionTransactionParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-		<rdfs:label xml:lang="en">option transaction party</rdfs:label>
-		<skos:definition xml:lang="en">The party to an Option transaction.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is identified as also being a party to the contract that underlies that transaction. Definition OriginLSR Draft</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">option type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionTypeSelection">
-		<rdfs:label xml:lang="en">OptionTypeSelection</rdfs:label>
-		<skos:definition xml:lang="en">Whether it is a call option (right to purchase a specific underlying asset) or a put option (right to sell a specific underlying asset).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionUnderlyingBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTransactionParty"/>
-		<rdfs:label xml:lang="en">option underlying buyer</rdfs:label>
-		<skos:definition xml:lang="en">The buyer of the underlying in an Option Transaction.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the party which buys the underlying in the event that the transaction goes ahead.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionUnderlyingSeller">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTransactionParty"/>
-		<rdfs:label xml:lang="en">option underlying seller</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionValuationTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasValuationDate"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option valuation terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionWriterCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">option writer commitment</rdfs:label>
-		<skos:definition xml:lang="en">Commitment on the part of the writer (issuing party) of the Option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionWritingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<rdfs:label xml:lang="en">option writing party</rdfs:label>
-		<skos:definition xml:lang="en">The writing party of an OTC Option, i.e. the seller of a contract. This is the party that grants the rights defined by this instrument and in return receives a payment for it.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See 2000 ISDA definitions Article 11.1 (a). In the case of an option, these rights are the rights to buy or sell the instrument at the stated terms. FpML: &apos;A reference to the party that sells (&quot;writes&quot;) this instrument, i.e. that grants the rights defined by this instrument and in return receives a payment for it. See 2000 ISDA definitions Article 11.1 (a). In the case of FRAs this is the floating rate payer.&apos; Seller; Also known as Short Side.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;OptionalUnderlyingTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;hasTransactionParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionTransactionParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">optional underlying transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction which is defined in an options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase or sale of the deliverable underlying as defined in the option contract, or some cash equivalent thereof. Further notes: This is not any different from any other kind of derivatives transaction. The Transaction is still defined as the purchase and sale of the underlying even if it is cash settled. It is defined as the swap of the fixed price for the current market price. Would define a reference price for the current market price if it&apos;s not a physical settlement. Would for example define the use of a calculation agent. Scenarios: 1. Agree to cash settle even though the underlying is a deliverable 2. Agree to settle cash because it&apos;s difficult to get hold of the underlying 3. The underlying is by its nature not deliverable 4. Fx where the deliverable is a currency to cash delivery is synonymous with delivery of the underlying asset, so the underlying observable and the underlying deliverable are the same actual thing. How this is modeled: Cash &quot;Settlement&quot; (means cash delivery) is where you take cash instad of delivery of the underlying deliverable. Whatever is going to be delivered there is going to be a reverse transaction at the going market rate. That also covers the use of an index or basket as the underlying. Examples of this: IR Swap - not an Option.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PayoffAssetsList">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
-		<rdfs:label xml:lang="en">payoff assets list</rdfs:label>
-		<skos:definition xml:lang="en">The list of n assets which are used to determine a best or worst value in determining conditinal payoff commitments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PayoffCommitmentReferenceAsset">
-		<rdfs:label xml:lang="en">payoff commitment reference asset</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PercentageStrikePriceSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikePriceSpecification"/>
-		<rdfs:label xml:lang="en">percentage strike price specification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PostpaidPremiumType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPreOrPostType"/>
-		<rdfs:label xml:lang="en">postpaid premium type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PremiumPayer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;isUsually"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">premium payer</rdfs:label>
-		<skos:definition xml:lang="en">The party responsible for making the payment of an Equity Option Premium.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review 17 Feb: Not clear whether this can ever go the other way. Is it possible to create an option where you pay as well as delive rthe option? See for example Zero Cost Options. It may be that this is in FpML simply because the original model wanted ot be explicit a bout who paid what, just to avoid any confusion perhaps. Legally: you are buying the rights and obligations in the Option... FpML: &apos;A reference to the party responsible for making the payments defined by this structure.&apos;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PremiumPercentageOfNotionalExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
-		<rdfs:label xml:lang="en">premium percentage of notional expression</rdfs:label>
-		<skos:definition xml:lang="en">The expression of the premium as a percentage of the notional value of the transaction.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A percentage of 5% would be expressed as 5%. Note that FpML recasts the percentage as a fractional amount. FpML: &apos;The amount of premium to be paid expressed as a percentage of the notional value of the transaction. A percentage of 5% would be expressed as 0.05.&apos; note that in OTC markets the options are traded on volatility which ultimately calculkates to a premium. This allows for prices to be made generically.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PremiumPricePerOptionExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
-		<rdfs:label xml:lang="en">premium price per option expression</rdfs:label>
-		<skos:definition xml:lang="en">The expression of the premium as a function of the number of options.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Specifically this is expressed as a monetary amount, where that monetary amount is the amount per option. FpML: &apos;The amount of premium to be paid expressed as a function of the number of options.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PremiumReceiver">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
-		<rdfs:label xml:lang="en">premium receiver</rdfs:label>
-		<skos:definition xml:lang="en">The party that receives the payments of an Equity Option Premium. FpML: &apos;A reference to the party that receives the payments corresponding to this structure.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PrepaidPremiumType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPreOrPostType"/>
-		<rdfs:label xml:lang="en">prepaid premium type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PutOptionBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-		<rdfs:label xml:lang="en">put option buyer</rdfs:label>
-		<skos:definition xml:lang="en">The Party which is the buyer of the Put Option. This party has the option but not the obligation to transact as the Seller of the Option Underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PutOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PutOptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PutOptionType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PutOptionWritingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">put option contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PutOptionType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionType"/>
-		<rdfs:label xml:lang="en">put option type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;PutOptionWritingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-		<rdfs:label xml:lang="en">put option writing party</rdfs:label>
-		<skos:definition xml:lang="en">The Party which is the writer of the Put Option. This party has the obligation to transact as the Buyer of the Option Underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;ResetableStrikeTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasResetSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionStrikeResetSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">resetable strike terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;SecuritiesTransactionOption">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualOption"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;accruesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;isRightTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities transaction option</rdfs:label>
-		<skos:definition xml:lang="en">The option itself, that is the right but not the obligation to proceed with a transaction at some time in the future under terms defined in the option contract. This option is held and exercised by the party to the contract which is defined as the option holder or option buyer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;StrikeFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CashflowFormula"/>
-		<rdfs:label xml:lang="en">strike formula</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;StrikePriceSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;PriceSpecification"/>
-		<rdfs:label xml:lang="en">strike price specification</rdfs:label>
-		<skos:definition xml:lang="en">The strike price for the option is the agreed price for the transaction if this takes place. Applies to all options types. Action: Make sure that&apos;s there for all Options types.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;UnderlyingOnOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/Basket">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-pas-pas;NegotiableCommodity">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">underlying on option</rdfs:label>
-		<skos:definition xml:lang="en">The instrument or parameter, or combinations thereof, that are used as the basis for the Option Instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;UpOrDown">
-		<rdfs:label xml:lang="en">up or down</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-opt;VariablePremiumDeterminationFormula">
-		<rdfs:label xml:lang="en">variable premium determination formula</rdfs:label>
-		<skos:definition xml:lang="en">Formula for agreed determination of the variable premium.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can be defined just as text. One could extend this but there is not need to at this point.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;accruesTo">
-		<rdfs:label xml:lang="en">accrues to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;definesOptional">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-sec;governs"/>
-		<rdfs:label xml:lang="en">defines optional</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;effectiveDate">
-		<rdfs:label xml:lang="en">effective date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The effective date for the option, that is the date from which the derivative contract is valid,</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;enteredIntoBy">
-		<rdfs:label xml:lang="en">entered into by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;expressedAs">
-		<rdfs:label xml:lang="en">expressed as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;fixedStrikeAmount">
-		<rdfs:label xml:lang="en">fixed strike amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedStrikeAmount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasBuyer">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-		<rdfs:label xml:lang="en">has buyer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasDirection">
-		<rdfs:label xml:lang="en">has direction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;UpOrDown"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExpression">
-		<rdfs:label xml:lang="en">has expression</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormula"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExpression.1">
-		<rdfs:label xml:lang="en">has expression</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeFormula"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFeature">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has feature</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFormula">
-		<rdfs:label xml:lang="en">has formula</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFormula.1">
-		<rdfs:label xml:lang="en">has formula</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionType">
-		<rdfs:label xml:lang="en">has option type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionType"/>
-		<skos:definition xml:lang="en">Whether it is a call option (right to purchase a specific underlying asset) or a put option (right to sell a specific underlying asset)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionTypeElectionDate">
-		<rdfs:label xml:lang="en">has option type election date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;ChooserOptionContract"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-		<skos:definition xml:lang="en">The date on which the holder of the Chooser option contract determines a choice of either a Call or a Put,</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML: &apos;Date where the holder of a Chooser option contract determines a choice of either a Call or a Put&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPayer">
-		<rdfs:label xml:lang="en">has payer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPaymentDate">
-		<rdfs:label xml:lang="en">has payment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-		<skos:definition xml:lang="en">The payment date for the Option Premium.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can be expressed as either an adjustable or relative date. FpML: &apos;The payment date, which can be expressed as either an adjustable or relative date.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPremium">
-		<rdfs:label xml:lang="en">has premium</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPremiumType">
-		<rdfs:label xml:lang="en">has premium type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPremiumPaymentArrangement"/>
-		<skos:definition xml:lang="en">The type of premium payment. FpML: &apos;Premium type for a forward starting equity option.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasReceiver">
-		<rdfs:label xml:lang="en">has receiver</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;PremiumReceiver"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasResetSchedule">
-		<rdfs:label xml:lang="en">has reset schedule</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;ResetableStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionStrikeResetSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasSchedule">
-		<rdfs:label xml:lang="en">has schedule</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasSeller">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
-		<rdfs:label xml:lang="en">has seller</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasStrikeTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has strike terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasValuationDate">
-		<rdfs:label xml:lang="en">has valuation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionValuationTerms"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasValuationTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has valuation terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionValuationTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;identity">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;LookbackStrikeObservable"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;identity.1">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;LookbackObservableValueDuringLookbackPeriod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;identity.2">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;ObservableFinalValue"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;LookbackObservableValueAtMaturity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;identity.3">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-derx-dbx;underlierHasIdentity"/>
-		<rdfs:label xml:lang="en">option underlying identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;includesSpecificationTerm">
-		<rdfs:label xml:lang="en">includes specification term</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;StrikePriceSpecification"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;isOf">
-		<rdfs:label xml:lang="en">is of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;LookbackStrikeObservable"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;isRightTo">
-		<rdfs:label xml:lang="en">is right to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;isUsually">
-		<rdfs:label xml:lang="en">is usually</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;lookbackPeriod">
-		<rdfs:label xml:lang="en">lookback period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The period in which the strike</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;makes">
-		<rdfs:label xml:lang="en">makes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;makes.1">
-		<rdfs:label xml:lang="en">makes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;numberOfOptions">
-		<rdfs:label xml:lang="en">number of options</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The price per asset, index or basket observed on the trade or effective date. FpML: &apos;The price per asset, index or basket observed on the trade or effective date.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;optionExerciseTermsSpecifies">
-		<rdfs:label xml:lang="en">option exercise terms specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;paymentAmount">
-		<rdfs:label xml:lang="en">payment amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The monetary amount paid as the Premium.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;percentageOfNotional">
-		<rdfs:label xml:lang="en">percentage of notional</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;PremiumPercentageOfNotionalExpression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The amount of premium to be paid expressed as a percentage of the notional value of the transaction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;pricePerOption">
-		<rdfs:label xml:lang="en">price per option</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;PremiumPricePerOptionExpression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount of premium to be paid expressed as a monetary amount to be paid per option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;receives">
-		<rdfs:label xml:lang="en">receives</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;receives.1">
-		<rdfs:label xml:lang="en">receives</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;references">
-		<rdfs:label xml:lang="en">references</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;BetterOrWorseOfAssetsPayoutCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;PayoffAssetsList"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;setsOut">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;setsOutContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;setsOut.1">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;EarlyExerciseCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;strikeCurrency">
-		<rdfs:label xml:lang="en">strike currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the option strike is specified or denominated.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;strikeDeterminationDate">
-		<rdfs:label xml:lang="en">strike determination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedStrikeTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date on which the strike is determined,</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;strikePriceAbsoluteAmount">
-		<rdfs:label xml:lang="en">strike price absolute amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;AbsolutePriceStrikeSpecification"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The absolute monetary price at which the option has been struck.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;strikePricePercentage">
-		<rdfs:label xml:lang="en">strike price percentage</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The price or level expressed as a percentage of the forward starting spot price.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtracts">
-		<rdfs:label xml:lang="en">subtracts</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtracts.1">
-		<rdfs:label xml:lang="en">subtracts</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtractsFrom">
-		<rdfs:label xml:lang="en">subtracts from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;FixedStrikeAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtractsFrom.1">
-		<rdfs:label xml:lang="en">subtracts from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;ObservableFinalValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;threshold">
-		<rdfs:label xml:lang="en">threshold</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureEvent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The price or other variable (as a number) which has to be met for the event to be deemed to have occurred.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-fbc-fi-fi;Option">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFeature"/>
-				<owl:onClass rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPremium"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPremium"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasStrikeTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasValuationTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionValuationTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option contract</rdfs:label>
-		<skos:definition xml:lang="en">A financial derivative which represents a contract sold by one party (option writer) to another party (option holder). The contract offers the buyer the right, but not the obligation, to buy (call) or sell (put) a security or other financial asset at an agreed-upon price (the strike price) during a certain period of time or on a specific date (exercise date).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Options may be created Over the Counter, or through an Exchange (in which case the Option Holder may transfer the Option to another party).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumPreOrPostType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPaymentArrangement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option premium pre or post type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumVariability">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPaymentArrangement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option premium variability</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPremiumVariable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumVariability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option premium variable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionPutTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;makes.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;receives.1"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option put transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionStrikeResetSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option strike reset schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionStrikeTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option strike terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms setting out the price or level at which the option is to be struck. FpML strike: &apos;Defines whether it is a price or level at which the option has been, or will be, struck.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option contract terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionTransactionParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option transaction party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party to an Option transaction.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is identified as also being a party to the contract that underlies that transaction. Definition OriginLSR Draft</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionTypeSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">OptionTypeSelection</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether it is a call option (right to purchase a specific underlying asset) or a put option (right to sell a specific underlying asset).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionUnderlyingBuyer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTransactionParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option underlying buyer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The buyer of the underlying in an Option Transaction.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the party which buys the underlying in the event that the transaction goes ahead.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionUnderlyingSeller">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTransactionParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option underlying seller</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionValuationTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasValuationDate"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option valuation terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionWriterCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option writer commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Commitment on the part of the writer (issuing party) of the Option.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionWritingParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option writing party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The writing party of an OTC Option, i.e. the seller of a contract. This is the party that grants the rights defined by this instrument and in return receives a payment for it.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">See 2000 ISDA definitions Article 11.1 (a). In the case of an option, these rights are the rights to buy or sell the instrument at the stated terms. FpML: &apos;A reference to the party that sells (&quot;writes&quot;) this instrument, i.e. that grants the rights defined by this instrument and in return receives a payment for it. See 2000 ISDA definitions Article 11.1 (a). In the case of FRAs this is the floating rate payer.&apos; Seller; Also known as Short Side.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;OptionalUnderlyingTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;hasTransactionParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionTransactionParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">optional underlying transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction which is defined in an options contract and which may or may not take place, at the discretion of the holder of the option. If it does take place, this will be a transaction for the purchase or sale of the deliverable underlying as defined in the option contract, or some cash equivalent thereof. Further notes: This is not any different from any other kind of derivatives transaction. The Transaction is still defined as the purchase and sale of the underlying even if it is cash settled. It is defined as the swap of the fixed price for the current market price. Would define a reference price for the current market price if it&apos;s not a physical settlement. Would for example define the use of a calculation agent. Scenarios: 1. Agree to cash settle even though the underlying is a deliverable 2. Agree to settle cash because it&apos;s difficult to get hold of the underlying 3. The underlying is by its nature not deliverable 4. Fx where the deliverable is a currency to cash delivery is synonymous with delivery of the underlying asset, so the underlying observable and the underlying deliverable are the same actual thing. How this is modeled: Cash &quot;Settlement&quot; (means cash delivery) is where you take cash instad of delivery of the underlying deliverable. Whatever is going to be delivered there is going to be a reverse transaction at the going market rate. That also covers the use of an index or basket as the underlying. Examples of this: IR Swap - not an Option.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PayoffAssetsList">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payoff assets list</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The list of n assets which are used to determine a best or worst value in determining conditinal payoff commitments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PayoffCommitmentReferenceAsset">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payoff commitment reference asset</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PercentageStrikePriceSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;StrikePriceSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage strike price specification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PostpaidPremiumType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPreOrPostType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">postpaid premium type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PremiumPayer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;isUsually"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">premium payer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party responsible for making the payment of an Equity Option Premium.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review 17 Feb: Not clear whether this can ever go the other way. Is it possible to create an option where you pay as well as delive rthe option? See for example Zero Cost Options. It may be that this is in FpML simply because the original model wanted ot be explicit a bout who paid what, just to avoid any confusion perhaps. Legally: you are buying the rights and obligations in the Option... FpML: &apos;A reference to the party responsible for making the payments defined by this structure.&apos;</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PremiumPercentageOfNotionalExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">premium percentage of notional expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The expression of the premium as a percentage of the notional value of the transaction.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A percentage of 5% would be expressed as 5%. Note that FpML recasts the percentage as a fractional amount. FpML: &apos;The amount of premium to be paid expressed as a percentage of the notional value of the transaction. A percentage of 5% would be expressed as 0.05.&apos; note that in OTC markets the options are traded on volatility which ultimately calculkates to a premium. This allows for prices to be made generically.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PremiumPricePerOptionExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">premium price per option expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The expression of the premium as a function of the number of options.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Specifically this is expressed as a monetary amount, where that monetary amount is the amount per option. FpML: &apos;The amount of premium to be paid expressed as a function of the number of options.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PremiumReceiver">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">premium receiver</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party that receives the payments of an Equity Option Premium. FpML: &apos;A reference to the party that receives the payments corresponding to this structure.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PrepaidPremiumType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionPremiumPreOrPostType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prepaid premium type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PutOptionBuyer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">put option buyer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Party which is the buyer of the Put Option. This party has the option but not the obligation to transact as the Seller of the Option Underlying.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PutOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PutOptionBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasOptionType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PutOptionType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PutOptionWritingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">put option contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PutOptionType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">put option type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;PutOptionWritingParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">put option writing party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Party which is the writer of the Put Option. This party has the obligation to transact as the Buyer of the Option Underlying.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;ResetableStrikeTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasResetSchedule"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionStrikeResetSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">resetable strike terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;SecuritiesTransactionOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualOption"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;accruesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;isRightTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities transaction option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The option itself, that is the right but not the obligation to proceed with a transaction at some time in the future under terms defined in the option contract. This option is held and exercised by the party to the contract which is defined as the option holder or option buyer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;StrikeFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CashflowFormula"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike formula</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;StrikePriceSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;PriceSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike price specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The strike price for the option is the agreed price for the transaction if this takes place. Applies to all options types. Action: Make sure that&apos;s there for all Options types.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;UnderlyingOnOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/Basket">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fbc-fi-fi;FinancialInstrument">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-pas-pas;NegotiableCommodity">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying on option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The instrument or parameter, or combinations thereof, that are used as the basis for the Option Instrument.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;UpOrDown">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">up or down</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-opt;VariablePremiumDeterminationFormula">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">variable premium determination formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formula for agreed determination of the variable premium.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This can be defined just as text. One could extend this but there is not need to at this point.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;accruesTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accrues to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;definesOptional">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-sec;governs"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines optional</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;effectiveDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effective date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The effective date for the option, that is the date from which the derivative contract is valid,</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;enteredIntoBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">entered into by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;expressedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expressed as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPremiumExpression"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;fixedStrikeAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed strike amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedStrikeAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasBuyer">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has buyer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasDirection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has direction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;UpOrDown"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExpression">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has expression</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormula"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasExpression.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has expression</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeFormula"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFeature">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has feature</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFormula">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has formula</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormula"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasFormula.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has formula</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeFormula"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has option type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionType"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether it is a call option (right to purchase a specific underlying asset) or a put option (right to sell a specific underlying asset)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasOptionTypeElectionDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has option type election date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;ChooserOptionContract"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date on which the holder of the Chooser option contract determines a choice of either a Call or a Put,</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">FpML: &apos;Date where the holder of a Chooser option contract determines a choice of either a Call or a Put&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPayer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has payer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPaymentDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has payment date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The payment date for the Option Premium.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This can be expressed as either an adjustable or relative date. FpML: &apos;The payment date, which can be expressed as either an adjustable or relative date.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPremium">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has premium</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasPremiumType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has premium type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPremiumPaymentArrangement"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of premium payment. FpML: &apos;Premium type for a forward starting equity option.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasReceiver">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has receiver</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;PremiumReceiver"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasResetSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has reset schedule</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;ResetableStrikeTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionStrikeResetSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has schedule</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;FloatingLookbackStrikeSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasSeller">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has seller</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasStrikeTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has strike terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasValuationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has valuation date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionValuationTerms"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;hasValuationTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has valuation terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionValuationTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;identity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;LookbackStrikeObservable"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;identity.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;LookbackObservableValueDuringLookbackPeriod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;identity.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;ObservableFinalValue"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;LookbackObservableValueAtMaturity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;identity.3">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-derx-dbx;underlierHasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option underlying identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;includesSpecificationTerm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes specification term</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedStrikeTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;StrikePriceSpecification"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;isOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;LookbackStrikeObservable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;isRightTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is right to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;isUsually">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is usually</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;PremiumPayer"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;lookbackPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lookback period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;LookbackStrikeTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period in which the strike</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;makes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">makes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;makes.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">makes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;numberOfOptions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of options</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price per asset, index or basket observed on the trade or effective date. FpML: &apos;The price per asset, index or basket observed on the trade or effective date.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;optionExerciseTermsSpecifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option exercise terms specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;paymentAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The monetary amount paid as the Premium.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;percentageOfNotional">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage of notional</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;PremiumPercentageOfNotionalExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of premium to be paid expressed as a percentage of the notional value of the transaction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;pricePerOption">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price per option</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;PremiumPricePerOptionExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of premium to be paid expressed as a monetary amount to be paid per option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;receives">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">receives</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;receives.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">receives</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;references">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">references</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;BetterOrWorseOfAssetsPayoutCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;PayoffAssetsList"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;setsOut">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;setsOutContractualEconomicCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPayoutTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionPayoutCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;setsOut.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;EarlyExerciseCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;strikeCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which the option strike is specified or denominated.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;strikeDeterminationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike determination date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedStrikeTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date on which the strike is determined,</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;strikePriceAbsoluteAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike price absolute amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;AbsolutePriceStrikeSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The absolute monetary price at which the option has been struck.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;strikePricePercentage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike price percentage</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price or level expressed as a percentage of the forward starting spot price.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtracts">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subtracts</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtracts.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subtracts</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;ObservableBestValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtractsFrom">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subtracts from</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FixedLookbackStrikeFormulaExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;FixedStrikeAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;subtractsFrom.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subtracts from</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;FloatingLookbackFormulaExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;ObservableFinalValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-opt;threshold">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">threshold</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price or other variable (as a number) which has to be met for the event to be deemed to have occurred.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-fi-fi;Option">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasFeature"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasBuyer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasPremium"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionPremium"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasSeller"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasStrikeTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionStrikeTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasValuationTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;OptionValuationTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;SecuritiesTransactionOption"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A financial derivative which represents a contract sold by one party (option writer) to another party (option holder). The contract offers the buyer the right, but not the obligation, to buy (call) or sell (put) a security or other financial asset at an agreed-upon price (the strike price) during a certain period of time or on a specific date (exercise date).</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Options may be created Over the Counter, or through an Exchange (in which case the Option Holder may transfer the Option to another party).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/DerivativesContracts/ReturnSwaps.rdf
+++ b/der/DerivativesContracts/ReturnSwaps.rdf
@@ -1,142 +1,145 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-der-rsw "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
-		<rdfs:label xml:lang="en">ReturnSwaps</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-der-rsw;AssetDerivativeContract">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">asset derivative contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-rsw;AssetReturnCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-rsw;definedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">asset return commitment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-rsw;AssetReturnStream">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReferenceAsset"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">asset return stream</rdfs:label>
-		<skos:definition xml:lang="en">A leg in which the returns on an asset are paid.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This does not refer to the return to the holder, but to the return on an underlying asset. This may be just the dividend / interest amounts on the underlying, or it may also include the increase / decrease in value of the underlying (Total Return). 10 Mar: Not used for Interest Rate Swaps. Return Leg is the non cash leg of a swap that has a cash leg. This leg type has nothing to do with Statistical leg types. A return for one negotiator is payment for the other. FpML: Return amounts of the return type swap.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-rsw;ReturnLeg">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-rsw;embodiesAssetReturnCommitment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-rsw;AssetReturnCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">return leg</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-rsw;ReturnSwapContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
-		<rdfs:label xml:lang="en">return swap contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-rsw;ReturnSwapTransaction">
-		<rdfs:label xml:lang="en">return swap transaction</rdfs:label>
-		<skos:definition xml:lang="en">The transaction of a total Return Swap. This is the transaction in which the return on some asset is exchanged for some agreed payment or series of payments.</skos:definition>
-		<skos:editorialNote xml:lang="en">17 March review session notes: This is about the return you get not about what kinds of legs it has. Talk about return as a payoff. Then kinds of return are kinds of payoff e.g. total return. Return of a portfiolo, a single asset, or an index as per other note.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-rsw;SimpleReturnStream">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
-		<rdfs:label xml:lang="en">simple return stream</rdfs:label>
-		<skos:definition xml:lang="en">A leg defining the returns on an underlying instrument, namely the interest payments on a debt instrument or the dividends on an equity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Does not include the appreciation on the price of the asset.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-rsw;TotalReturnSwapContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;ReturnSwapContract"/>
-		<rdfs:label xml:lang="en">total return swap contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;definedAs">
-		<rdfs:label xml:lang="en">defined as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-rsw;AssetReturnCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;embodiesAssetReturnCommitment">
-		<rdfs:label xml:lang="en">embodies asset return commitment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-rsw;ReturnLeg"/>
-		<rdfs:range rdf:resource="&fibo-der-der-rsw;AssetReturnCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;hasFundingLeg">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
-		<rdfs:label xml:lang="en">has funding leg</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-rsw;ReturnSwapTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;hasReferenceAsset">
-		<rdfs:label xml:lang="en">has reference asset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
-		<rdfs:range rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;hasReturnLeg">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
-		<rdfs:label xml:lang="en">has return leg</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-rsw;ReturnSwapTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-rsw;ReturnLeg"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-rsw;rateOfReturn">
-		<rdfs:label xml:lang="en">rate of return</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
-		<skos:definition xml:lang="en">The terms of the initial price of the return type swap and of the subsequent valuations of the underlyer.</skos:definition>
-	</owl:DatatypeProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-der-rsw="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ReturnSwaps</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Swap transactions and their corresponding contract, in which one leg provides a return on some asset. There are different kinds of asset return stream including simple and total returns. These terms are common to the different kinds of asset return swap (equity asset return swaps and bond swaps).</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ReturnSwaps/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-rsw;AssetDerivativeContract">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset derivative contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-rsw;AssetReturnCommitment">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-rsw;definedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset return commitment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-rsw;AssetReturnStream">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-rsw;hasReferenceAsset"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset return stream</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A leg in which the returns on an asset are paid.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This does not refer to the return to the holder, but to the return on an underlying asset. This may be just the dividend / interest amounts on the underlying, or it may also include the increase / decrease in value of the underlying (Total Return). 10 Mar: Not used for Interest Rate Swaps. Return Leg is the non cash leg of a swap that has a cash leg. This leg type has nothing to do with Statistical leg types. A return for one negotiator is payment for the other. FpML: Return amounts of the return type swap.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-rsw;ReturnLeg">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-rsw;embodiesAssetReturnCommitment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-rsw;AssetReturnCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">return leg</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-rsw;ReturnSwapContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">return swap contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-rsw;ReturnSwapTransaction">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">return swap transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The transaction of a total Return Swap. This is the transaction in which the return on some asset is exchanged for some agreed payment or series of payments.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">17 March review session notes: This is about the return you get not about what kinds of legs it has. Talk about return as a payoff. Then kinds of return are kinds of payoff e.g. total return. Return of a portfiolo, a single asset, or an index as per other note.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-rsw;SimpleReturnStream">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">simple return stream</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A leg defining the returns on an underlying instrument, namely the interest payments on a debt instrument or the dividends on an equity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Does not include the appreciation on the price of the asset.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-rsw;TotalReturnSwapContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;ReturnSwapContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">total return swap contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;definedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-rsw;AssetReturnCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;embodiesAssetReturnCommitment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies asset return commitment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-rsw;ReturnLeg"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-rsw;AssetReturnCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;hasFundingLeg">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has funding leg</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-rsw;ReturnSwapTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;hasReferenceAsset">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has reference asset</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ass-ass;AssetUnderlier"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-rsw;hasReturnLeg">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has return leg</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-rsw;ReturnSwapTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-rsw;ReturnLeg"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-der-rsw;rateOfReturn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rate of return</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-rsw;AssetReturnStream"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The terms of the initial price of the return type swap and of the subsequent valuations of the underlyer.</skos:definition>
+bu</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/der/DerivativesContracts/Spots.rdf
+++ b/der/DerivativesContracts/Spots.rdf
@@ -1,203 +1,206 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-sp "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/">
-	<!ENTITY fibo-der-fx-sp "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-sp "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/">
+bu<!ENTITY fibo-der-fx-sp "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"
-	xmlns:fibo-der-der-sp="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"
-	xmlns:fibo-der-fx-sp="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/">
-		<rdfs:label xml:lang="en">Spots</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<rdfs:Datatype rdf:about="&xsd;string">
-	</rdfs:Datatype>
-	
-	<owl:Class rdf:about="&fibo-der-der-sp;SpotCashSettlementTerms">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-sp;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotSettlementCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-sp;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-sp;payer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotPayer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-sp;receiver"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotReceiver"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">spot cash settlement terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-sp;SpotContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
-		<rdfs:label xml:lang="en">spot contract</rdfs:label>
-		<skos:definition xml:lang="en">A contract relating to a transaction which is for immediate settlement. Further notes: A spot transaction simply means a transaction in which some goods or currency are exchanged for some other goods or currency, with no future delivery provision. A Spot contract is the usually unwritten contract which by definition underlies that kind of transaction. Spot means for immediate settlement. Immediate here means the minimum number of days that are possible. This includes general retail transactions as well as the specialixed types of spot transactiojn foud in the financial services and treasury trading contexts, such as Fx Spots (a sub type of this) and commodity spot transactions. However the settlement date is still some time in the future. Also given different time zones, the settlement would be at some time in the future anyway Formerly a financial e.g. currency Spot would have been 2 (working) days settlement for example. Canadian v USD would be 1 day. Follows a settlement convention from the relevant market. Action: Add reference to Settlement Convention for the given market.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-sp;SpotDelivery">
-		<rdfs:label xml:lang="en">spot delivery</rdfs:label>
-		<skos:definition xml:lang="en">Delivery of some agreed item in the present or at some agreed but imediate settlement date.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-sp;SpotPayer">
-		<rdfs:label xml:lang="en">spot payer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-sp;SpotReceiver">
-		<rdfs:label xml:lang="en">spot receiver</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-sp;SpotSettlementCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-sp;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SettlementConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">spot settlement commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment for settlement at the earliest possible trading date, in accordance with the applicable settlement convention.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-sp;SpotTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-sp;hasImpliedContract"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;subject"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">spot transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;embodies">
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
-		<owl:inverseOf rdf:resource="&fibo-der-fx-sp;commitsTo"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;establishes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-sp;SpotSettlementCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;hasImpliedContract">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
-		<rdfs:label xml:lang="en">has implied contract</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-sp;SpotContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;payer">
-		<rdfs:label xml:lang="en">payer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-sp;SpotPayer"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-sp;paymentType">
-		<rdfs:label xml:lang="en">payment type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">FpML = paymentType &apos;A classification of the type of fee or additional payment, e.g. brokerage, upfront fee etc. FpML does not define domain values for this element.&apos;</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;receiver">
-		<rdfs:label xml:lang="en">receiver</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-sp;SpotReceiver"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;refersTo">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotSettlementCommitment"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-sec;SettlementConvention"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;settlementAmount">
-		<rdfs:label xml:lang="en">settlement amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;settlementDate">
-		<rdfs:label xml:lang="en">settlement date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">&apos;The date on which both currencies traded will settle.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;settlementInformation">
-		<rdfs:label xml:lang="en">settlement information</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">FpML settlementInformation (in payment) &apos;The information required to settle a currency payment that results from a trade.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-sp;spotPrice">
-		<rdfs:label xml:lang="en">spot price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotDelivery"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-sp="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"
+buxmlns:fibo-der-fx-sp="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Spots</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Spot transactions, along with their corresponding or implied contracts. These are not a derivative but rather define simple transactions that are immediately settled by both sides, for a given kind of asset or commodity. These are the concepts common to other variants of spot such as commodities spots.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<rdfs:Datatype rdf:about="&xsd;string">
+bu</rdfs:Datatype>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-sp;SpotCashSettlementTerms">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-sp;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotSettlementCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-sp;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-sp;payer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotPayer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-sp;receiver"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotReceiver"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spot cash settlement terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-sp;SpotContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spot contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A contract relating to a transaction which is for immediate settlement. Further notes: A spot transaction simply means a transaction in which some goods or currency are exchanged for some other goods or currency, with no future delivery provision. A Spot contract is the usually unwritten contract which by definition underlies that kind of transaction. Spot means for immediate settlement. Immediate here means the minimum number of days that are possible. This includes general retail transactions as well as the specialixed types of spot transactiojn foud in the financial services and treasury trading contexts, such as Fx Spots (a sub type of this) and commodity spot transactions. However the settlement date is still some time in the future. Also given different time zones, the settlement would be at some time in the future anyway Formerly a financial e.g. currency Spot would have been 2 (working) days settlement for example. Canadian v USD would be 1 day. Follows a settlement convention from the relevant market. Action: Add reference to Settlement Convention for the given market.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-sp;SpotDelivery">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spot delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery of some agreed item in the present or at some agreed but imediate settlement date.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-sp;SpotPayer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spot payer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-sp;SpotReceiver">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spot receiver</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-sp;SpotSettlementCommitment">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-sp;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SettlementConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spot settlement commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment for settlement at the earliest possible trading date, in accordance with the applicable settlement convention.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-sp;SpotTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-sp;hasImpliedContract"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;subject"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spot transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;embodies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
+bubu<owl:inverseOf rdf:resource="&fibo-der-fx-sp;commitsTo"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;establishes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-sp;SpotSettlementCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;hasImpliedContract">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has implied contract</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-sp;SpotContract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;payer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-sp;SpotPayer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-der-sp;paymentType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bubu<rdfs:range rdf:resource="&xsd;string"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">FpML = paymentType &apos;A classification of the type of fee or additional payment, e.g. brokerage, upfront fee etc. FpML does not define domain values for this element.&apos;</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;receiver">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">receiver</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-sp;SpotReceiver"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;refersTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotSettlementCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-sec;SettlementConvention"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;settlementAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;settlementDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&apos;The date on which both currencies traded will settle.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;settlementInformation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement information</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">FpML settlementInformation (in payment) &apos;The information required to settle a currency payment that results from a trade.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-sp;spotPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spot price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-sp;SpotDelivery"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/DerivativesContracts/Swaptions.rdf
+++ b/der/DerivativesContracts/Swaptions.rdf
@@ -1,134 +1,137 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-spn "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaptions/">
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-spn "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaptions/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaptions/"
-	xmlns:fibo-der-der-spn="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaptions/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaptions/">
-		<rdfs:label xml:lang="en">Swaptions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaptions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-der-spn;LegalSwapOption">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualOption"/>
-		<rdfs:label xml:lang="en">legal swap option</rdfs:label>
-		<skos:definition xml:lang="en">The option, that is the right but not the obligation, to enter into a Swap transaction at some time in the future under terms defined in the Swaption contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-spn;SwaptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-spn;hasExerciseProcedure"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-spn;SwaptionExerciseProcedrure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-spn;hasPremium"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-spn;SwaptionPremium"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-spn;LegalSwapOption"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">swaption contract</rdfs:label>
-		<skos:definition xml:lang="en">Option taken on interest rate swaps. These are FX interest rate option.</skos:definition>
-		<skos:editorialNote xml:lang="en">This definition is specific to IR Swaps. Are there other sorts? Can we have a more general definition? FpML: A swaption product definition.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-spn;SwaptionExerciseProcedrure">
-		<rdfs:label xml:lang="en">swaption exercise procedrure</rdfs:label>
-		<skos:definition xml:lang="en">Procedure for the exercise of the Swaption.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FpML: &apos;A set of parameters defining procedures associated with the exercise.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-spn;SwaptionPremium">
-		<rdfs:label xml:lang="en">swaption premium</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-spn;SwaptionTransaction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-spn;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-spn;SwaptionContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">swaption transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-spn;embodies">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-spn;SwaptionContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-spn;hasExerciseProcedure">
-		<rdfs:label xml:lang="en">has exercise procedure</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-spn;SwaptionExerciseProcedrure"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-spn;hasPremium">
-		<rdfs:label xml:lang="en">has premium</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-spn;SwaptionPremium"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-spn;isRightTo">
-		<rdfs:label xml:lang="en">is right to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-spn;LegalSwapOption"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-spn;paymentDate">
-		<rdfs:label xml:lang="en">payment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-spn;premiumAmount">
-		<rdfs:label xml:lang="en">premium amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionPremium"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-spn="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaptions/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaptions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Swaptions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Contracts and their corresponding transactions, structured like a swap except that one of the legs is optional on the part of the leg payer rather than being an unconditional commitment to make that payment. The optional leg is therefore structure very like an option contract. Unlike an option, the other side is not a one-off fee to enter into the contract but a commitment to make a pre-defined series of payments.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaptions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-spn;LegalSwapOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualOption"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal swap option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The option, that is the right but not the obligation, to enter into a Swap transaction at some time in the future under terms defined in the Swaption contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-spn;SwaptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-spn;hasExerciseProcedure"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-spn;SwaptionExerciseProcedrure"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-spn;hasPremium"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-spn;SwaptionPremium"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-spn;LegalSwapOption"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">swaption contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Option taken on interest rate swaps. These are FX interest rate option.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This definition is specific to IR Swaps. Are there other sorts? Can we have a more general definition? FpML: A swaption product definition.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-spn;SwaptionExerciseProcedrure">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">swaption exercise procedrure</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Procedure for the exercise of the Swaption.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">FpML: &apos;A set of parameters defining procedures associated with the exercise.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-spn;SwaptionPremium">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">swaption premium</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-der-spn;SwaptionTransaction">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-spn;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-spn;SwaptionContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">swaption transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-spn;embodies">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-spn;SwaptionContract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-spn;hasExerciseProcedure">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has exercise procedure</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-spn;SwaptionExerciseProcedrure"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-spn;hasPremium">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has premium</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-spn;SwaptionPremium"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-spn;isRightTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is right to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-spn;LegalSwapOption"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-spn;paymentDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionPremium"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-der-spn;premiumAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">premium amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-spn;SwaptionPremium"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/DerivativesContractsExt/DerivativesBasicsExt.rdf
+++ b/der/DerivativesContractsExt/DerivativesBasicsExt.rdf
@@ -1,128 +1,131 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
-		<rdfs:label xml:lang="en">DerivativesBasicsExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/DerivativeContractParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransactionParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-dbx;hasDerivativePartyIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/ObservableValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-dbx;DeliverableUnderlier">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:label xml:lang="en">deliverable underlier</rdfs:label>
-		<skos:definition xml:lang="en">The Underlying of a Derivatives Contract, which may also be delivered on exercise or expiry of that contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-dbx;ObservableUnderlier">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:label xml:lang="en">observable underlier</rdfs:label>
-		<skos:definition xml:lang="en">An underlying observable which is in numeric form and does not represent a deliverable asset.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Derivatives which are based on an observable underlying are settled in some way other than by delivery of the underlying, since the underlying is not in the nature of something that can be delivered.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-dbx;equatesTo">
-		<rdfs:label xml:lang="en">equates to</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-dbx;hasDerivativePartyIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">has derivative party identity</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/DerivativeContractParty"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-dbx;underlierHasIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">underlier has identity</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/Basket">
-					</rdf:Description>
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument">
-					</rdf:Description>
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-pas-pas;NegotiableCommodity">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
-				<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/DerivativeContractParty"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DerivativesBasicsExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional basic terms about derivatives contracts. These include distinctions between kinds of underlie (deliverable versus observable) along with the ability to characterize derivatives according the identity relatojnship to the kind of thing that is the underlie, where the Release models currently have only a restriction on a more general property.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/DerivativeContractParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransactionParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-dbx;hasDerivativePartyIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/ObservableValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-dbx;DeliverableUnderlier">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deliverable underlier</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Underlying of a Derivatives Contract, which may also be delivered on exercise or expiry of that contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-dbx;ObservableUnderlier">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">observable underlier</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An underlying observable which is in numeric form and does not represent a deliverable asset.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Derivatives which are based on an observable underlying are settled in some way other than by delivery of the underlying, since the underlying is not in the nature of something that can be delivered.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-dbx;equatesTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equates to</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-dbx;hasDerivativePartyIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has derivative party identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/DerivativeContractParty"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-dbx;underlierHasIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlier has identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/Basket">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-pas-pas;NegotiableCommodity">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
+bubububu<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/DerivativeContractParty"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/DerivativesContractsExt/DerivativesClassificationFacets.rdf
+++ b/der/DerivativesContractsExt/DerivativesClassificationFacets.rdf
@@ -1,38 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY core "http://www.w3.org/2004/02/skos/core/">
-	<!ENTITY fibo-der-derx-facx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesClassificationFacets/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY core "http://www.w3.org/2004/02/skos/core/">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-derx-facx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesClassificationFacets/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesClassificationFacets/"
-	xmlns:core="http://www.w3.org/2004/02/skos/core/"
-	xmlns:fibo-der-derx-facx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesClassificationFacets/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesClassificationFacets/">
-		<rdfs:label xml:lang="en">DerivativesClassificationFacets</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesClassificationFacets/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-derx-facx;AssetTypeFacet">
-		<rdfs:label xml:lang="en">asset type facet</rdfs:label>
-		<skos:definition xml:lang="en">Types od Derivatives contract classlfied by their underlying asset type.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-facx;ContractStructureFacet">
-		<rdfs:label xml:lang="en">contract structure facet</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:core="http://www.w3.org/2004/02/skos/core/"
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-derx-facx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesClassificationFacets/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesClassificationFacets/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DerivativesClassificationFacets</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology contains only identification of the different classification facets by which derivatives are classified elsewhere in the model.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesClassificationFacets/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-facx;AssetTypeFacet">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset type facet</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Types od Derivatives contract classlfied by their underlying asset type.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-facx;ContractStructureFacet">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract structure facet</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/DerivativesContractsExt/OTCDerivativeMasterAgreements.rdf
+++ b/der/DerivativesContractsExt/OTCDerivativeMasterAgreements.rdf
@@ -1,749 +1,752 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-derx-ma "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
-	<!ENTITY fibo-fnd-agrx-ele "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-txnx "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-derx-ma "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
+bu<!ENTITY fibo-fnd-agrx-ele "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-txnx "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/"
-	xmlns:fibo-der-der-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-derx-ma="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
-	xmlns:fibo-fnd-agrx-ele="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-txnx="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/">
-		<rdfs:label xml:lang="en">OTCDerivativeMasterAgreements</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;CreditEventsDescriptiveTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;contractuallyDefines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit events descriptive terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms describing Credit Events and defining what these are for the purposes of this Agreement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;CreditSupportAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;hasBeneficiary"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;CreditSupportBeneficiary"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;hasProvider"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;CreditSupportProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit support agreement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;CreditSupportBeneficiary">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
-		<rdfs:label xml:lang="en">credit support beneficiary</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;CreditSupportDefaultEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;isFailureInForceOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;CreditSupportAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit support default event</rdfs:label>
-		<skos:definition xml:lang="en">Failure of some Credit Support Agreement.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Per ISDA Master Agreement exmple, this may take one of the following forms (there may be others not in this example): - Failure to comply with some obligation under the Credit Support Agreement (after a suitable grace period has elapsed) - Expiration or Termination of Credit Support Agreement while it is still needed for the transactions it covers (i.e. not normal termination); - Disavowal or repudiation of the Credit Suport Agreement by one or other party to it. Note that these three all relate to the state of the Credit Support Agreement, and have the effect that the Credit Support Agreement is no longer in effect, during a time when there is some Transaction in play which was intended to be covered by that Agreement. ISDA original terms from Master Agreement example, in full: Credit Support Default. (1) Failure by the party or any Credit Support Provider of such party to comply with or perform any agreement or obligation to be complied with or performed by it in accordance with any Credit Support Document if such failure is continuing after any applicable grace period has elapsed; (2) the expiration or termination of such Credit Support Document or the failing or ceasing of such Credit Support Document to be in full force and effect for the purpose of this Agreement (in either case other than in accordance with its terms) prior to the satisfaction of all obligations of such party under each Transaction to which such Credit Support Document relates without the written consent of the other party; or (3) the party or such Credit Support Provider disaffirms, disclaims, repudiates or rejects, in whole or in part, or challenges the validity of, such Credit Support Document Definition Agreement: SR Draft. Details from ISDA above.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;CreditSupportProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<rdfs:label xml:lang="en">credit support provider</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;CrossDefaultProvisions">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment"/>
-		<rdfs:label xml:lang="en">cross default provisions</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;CurrencySpecificationTerm">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
-		<rdfs:label xml:lang="en">currency specification term</rdfs:label>
-		<skos:definition xml:lang="en">Term defining the currency or currencies for payments.</skos:definition>
-		<skos:editorialNote xml:lang="en">is found in general terms in example Master Agreement.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;DefaultInterestObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
-		<rdfs:label xml:lang="en">default interest obligation</rdfs:label>
-		<skos:definition xml:lang="en">Obligation in respect of defaults in the performance of any payment obligation.</skos:definition>
-		<skos:example xml:lang="en">Example text: Default Interest; Other Amounts. Prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party that defaults in the performance of any payment obligation will, to the extent permitted by law and subject to Section 6(c), be required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment, at the Default Rate. Such interest will be calculated on the basis of daily compounding and the actual number of days elapsed. If, prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party defaults in the performance of any obligation required to be settled by delivery, it will compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement. &quot; Note that this last sentence relates to a separate Obligation, labeled as Other Amount Obligation.</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;DefaultingParty">
-		<rdfs:label xml:lang="en">defaulting party</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;DeliveryObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
-		<rdfs:label xml:lang="en">delivery obligation</rdfs:label>
-		<skos:definition xml:lang="en">Obligation to make deliveries on transactions transacted under the Master Agreement, as specified in any Confirmation made by that party.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This and the Payment Obligation may be set out in one clause of the Master Agreement. This is the clause which obligates the parties to make the payments or deliveries in accordance with those Confirmations, which are generally messages. May be subject to other provisions in the Master Agreement. Example text: &quot;Each party will make each payment or delivery specified in each Confirmation to be made by it, subject to the other provisions of this Agreement. &quot;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;EarlyTerminationDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;AgencyDeterminedDate"/>
-		<rdfs:label xml:lang="en">early termination date</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;EarlyTerminationDateDeterminingAgent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDeterminingAgent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;EarlyTerminationDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">early termination date determining agent</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;MasterAgreementAccountChangeNotificationObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;MasterAgreementChangeNotificationObligation"/>
-		<rdfs:label xml:lang="en">master agreement account change notification obligation</rdfs:label>
-		<skos:definition xml:lang="en">The obligtation to notify the counterparty to this agreement, of any changes in account details.</skos:definition>
-		<skos:example xml:lang="en">Example text: &quot;Either party may change its account for receiving a payment or delivery by giving notice to the other party at least five Local Business Days prior to the scheduled date for the payment or delivery to which such change applies unless such other party gives timely notice of a reasonable objection to such change.&quot; Note that the notice period is given as a fact about the general kind of obligation which is Master Agreement Change notification Obligation.</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;MasterAgreementChangeNotificationObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
-		<rdfs:label xml:lang="en">master agreement change notification obligation</rdfs:label>
-		<skos:definition xml:lang="en">The obligtaion to notify the counterparty to this agreement, of any changes in details.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">General term of which Change of Account is an example.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationProvisions"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">master agreement early termination provisions</rdfs:label>
-		<skos:definition xml:lang="en">Terms and Conditions around early termination of the Master Agreement.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Terms here include: Additional Terminaton Event Affected Parties</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;MasterAgreementObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualObligation"/>
-		<rdfs:label xml:lang="en">master agreement obligation</rdfs:label>
-		<skos:definition xml:lang="en">Obligation set out in some Master Agreement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;NettingTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;setsOut.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">netting terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out how Netting may or may not take place and the Obligations on each party in respect of that Netting.</skos:definition>
-		<skos:editorialNote xml:lang="en">These terms are set out as text in the Sample Master Agreement and may be difficult (and unproductive) to model). Here they are: Example Text: &quot;Netting. If on any date amounts would otherwise be payable:- (i) in the same currency; and (ii) in respect of the same Transaction, by each party to the other, then, on such date, each party’s obligation to make payment of any such amount will be automatically satisfied and discharged and, if the aggregate amount that would otherwise have been payable by one party exceeds the aggregate amount that would otherwise have been payable by the other party, replaced by an obligation upon the party by whom the larger aggregate amount would have been payable to pay to the other party the excess of the larger aggregate amount over the smaller aggregate amount. The parties may elect in respect of two or more Transactions that a net amount will be determined in respect of all amounts payable on the same date in the same currency in respect of such Transactions, regardless of whether such amounts are payable in respect of the same Transaction. The election may be made in the Schedule or a Confirmation by specifying that subparagraph (ii) above will not apply to the Transactions identified as being subject to the election, together with the starting date (in which case subparagraph (ii) above will not, or will cease to, apply to such Transactions from such date). This election may be made separately for different groups of Transactions and will apply separately to each pairing of Offices through which the parties make and receive payments or deliveries. &quot;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;NonDefaultingParty">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;actsAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;EarlyTerminationDateDeterminingAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">non defaulting party</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCDerivativeMasterAgreementRepresentation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;RepresentationsSection"/>
-		<rdfs:label xml:lang="en">o t c derivative master agreement representation</rdfs:label>
-		<skos:definition xml:lang="en">Representations by one or other party in the Master Agreement.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These typically include: Basic Representations - Status of the organization - Powers of the organization - Absence of conflicts - Existence of the relevant consents - Binding nature of the Agreement. Absence of default and similar events Absence of litigation Accuracy of information Tax representations (withholding; notifications) - Payer - Payee Representations as to the Credit Support Agreement Representations as to regulatory matters</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCDerivativeTransactionMasterAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-txnx;MasterAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;hasTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;hasProvisions"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationProvisions"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c derivative transaction master agreement</rdfs:label>
-		<skos:definition xml:lang="en">Master agreement covering over the counter derivatives transactions to be carried out between the parties to this contract.</skos:definition>
-		<skos:example xml:lang="en">Sample preamble to one of these: &quot;EXAMPLE BANK, a Michigan banking corporation and SAMPLECOMPANY US, INC. a Delaware corporation have entered and/or anticipate entering into one or more transactions (each a &quot;Transaction&quot;) that are or will be governed by this Master Agreement, which includes the schedule (the &quot;Schedule&quot;), and the documents and other confirming evidence (each a &quot;Confirmation&quot;) exchanged between the parties confirming those Transactions. &quot;</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;MasterAgreementObligation"/>
-		<rdfs:label xml:lang="en">o t c derivatives master agreement obligation</rdfs:label>
-		<skos:definition xml:lang="en">Obligation set out in some OTC Derivatives Master Agreement.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This will typically include obligations to make payments according to confirmations, details of how deliveries are to be made etc. There are exceptions set out to some of these obligations.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementAgreementsTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment"/>
-		<rdfs:label xml:lang="en">o t c master agreement agreements terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out specific Agreements between the parties, that is specific things they agree to do or allow.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These include (per example Master Agreement from ISDA/FpML): - Furnish specified information - Maintain authorizations - Comply with laws - Tax agreement (agree to make notice of non compliances) - Payment of Stamp Tax There may be other similar Agreement types specific to given contexts. Note also that a common super-class of this Terms Set has not been modeled at this time, but there are probably common Agreements type terms that are common to many or most contract contexts.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ConditionsPrecedent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ctrx;varies"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-derx-ma;DeliveryObligation">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-derx-ma;PaymentObligation">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c master agreement conditions precedent</rdfs:label>
-		<skos:definition xml:lang="en">Conditions precedent on payment or delivery on a transaction transacted under this Master Agreement.</skos:definition>
-		<skos:example xml:lang="en">Example text: &quot;Each obligation of each party under Section 2(a)(i) is subject to (1) the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, (2) the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated and (3) each other applicable condition precedent specified in this Agreement. &quot; In the above, the Obligations defined under Section 2(a)(i) of the Master Agrement is the obligation to make each payment or delivery defined in a Confirmation for a transaction carried out under this Master Agreement.</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label xml:lang="en">o t c master agreement contractual commitment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-		<rdfs:label xml:lang="en">o t c master agreement early termination right</rdfs:label>
-		<skos:definition xml:lang="en">Right or one or other party to the Master Agreement to termination the Agreement early.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This generally arises from some Default Event on the part of the other party.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementElement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:label xml:lang="en">o t c master agreement element</rdfs:label>
-		<skos:definition xml:lang="en">Terms specific to a Master Agreement governing transactions of Over the Counter derivatives between parties.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is included so that all OTC Master Agreement Contract Terms Sets may be included under this one set. Terms are also described as specializations of the sorts of terms that they are (e.g. conditions Precedent, Commitments Terms and so on).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementObligationsTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;setsOut.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c master agreement obligations terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out the obligations on one or other party to the agreement.</skos:definition>
-		<skos:editorialNote xml:lang="en">The obligations are modeled in detail as Obligations. There is little merit in setting out the terms themselves as a model of textual elements - these terms are bext understood in relation to the Obligations which they represent, which are modeled in detail.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingDefaultEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;invokedInEventOf.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;NonDefaultingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;specifies.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;DefaultingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c master agreement right to termination following default event</rdfs:label>
-		<skos:definition xml:lang="en">The Right to Terminate the Master Agreement Following an Event of Default.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a right which may be invoked by either party to the Master Agreement; in so doing they acome the &quot;Non Defaulting Party&quot; with respect to this Right. ISDA Definition in full: Right to Terminate Following Event of Default. If at any time an Event of Default with respect to a party (the &quot;Defaulting Party&quot;) has occurred and is then continuing, the other party (the &quot;Non-defaulting Party&quot;) may, by not more than 20 days notice to the Defaulting Party specifying the relevant Event of Default, designate a day not earlier than the day such notice is effective as an Early Termination Date in respect of all outstanding Transactions. If, however, &quot;Automatic Early Termination&quot; is specified in the Schedule as applying to a party, then an Early Termination Date in respect of all outstanding Transactions will occur immediately upon the occurrence with respect to such party of an Event of Default specified in Section 5(a)(vii)(1), (3), (5), (6) or, to the extent analogous thereto, (8), and as of the time immediately preceding the institution of the relevant proceeding or the presentation of the relevant petition upon the occurrence with respect to such party of an Event of Default specified in Section 5(a)(vii)(4) or, to the extent analogous thereto, (8).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingTerminationEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;invokedInEventOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c master agreement right to termination following termination event</rdfs:label>
-		<skos:definition xml:lang="en">The Right to Terminate the Agreement Following some Termination Event.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin xml:lang="en">This specifies an event which is predefined in the Agreement as constituting a Termination Event, with the effect that this right (tro termination) is invoked by the occurrence of that event. That is the assumption modeled here. ISDA Master Agreement example text in full: Right to Terminate Following Termination Event. (i) Notice. If a Termination Event occurs, an Affected Party will, promptly upon becoming aware of it, notify the other party, specifying the nature of that Termination Event and each Affected Transaction and will also give such other information about that Termination Event as the other party may reasonably require. (ii) Transfer to Avoid Termination Event. If either an Illegality under Section 5(b)(i)(1) or a Tax Event occurs and there is only one Affected Party, or if a Tax Event Upon Merger occurs and the Burdened Party is the Affected Party, the Affected Party will, as a condition to its right to designate an Early Termination Date under Section 6(b)(iv), use all reasonable efforts (which will not require such party to incur a loss, excluding immaterial, incidental expenses) to transfer within 20 days after it gives notice under Section 6(b)(i) all its rights and obligations under this Agreement in respect of the Affected Transactions to another of its Offices or Affiliates so that such Termination Event ceases to exist. If the Affected Party is not able to make such a transfer it will give notice to the other party to that effect within such 20 day period, whereupon the other party may effect such a transfer within 30 days after the notice is given under Section 6(b)(i). Any such transfer by a party under this Section 6(b)(ii) will be subject to and conditional upon the prior written consent of the other party, which consent will not be withheld if such other party&amp;rsquo;s policies in effect at such time would permit it to enter into transactions with the transferee on the terms proposed. (iii) Two Affected Parties. If an Illegality under Section 5(b)(i)(1) or a Tax Event occurs and there are two Affected Parties, each party will use all reasonable efforts to reach agreement within 30 days after notice thereof is given under Section 6(b)(i) on action to avoid that Termination Event. (iv) Right to Terminate. If:- (1) a transfer under Section 6(b)(ii) or an agreement under Section 6(b)(iii), as the case may be, has not been effected with respect to all Affected Transactions within 30 days after an Affected Party gives notice under Section 6(b)(i); or (2) an Illegality under Section 5(b)(i)(2), a Credit Event Upon Merger or an Additional Termination Event occurs, or a Tax Event Upon Merger occurs and the Burdened Party is not the Affected Party, either party in the case of an Illegality, the Burdened Party in the case of a Tax Event Upon Merger, any Affected Party in the case of a Tax Event or an Additional Termination Event if there is more than one Affected Party, or the party which is not the Affected Party in the case of a Credit Event Upon Merger or an Additional Termination Event if there is only one Affected Party may, by not more than 20 days notice to the other party and provided that the relevant Termination Event is then continuing, designate a day not earlier than the day such notice is effective as an Early Termination Date in respect of all Affected Transactions.</fibo-fnd-utl-av:definitionOrigin>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent">
-		<rdfs:label xml:lang="en">o t c master agreement termination event</rdfs:label>
-		<skos:definition xml:lang="en">&quot;Termination Event&quot; means an Illegality, a Tax Event or a Tax Event Upon Merger or, if specified to be applicable, a Credit Event Upon Merger or an Additional Termination Event.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementTerminationProvisions">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;TerminationProvisions"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;describesTreatmentOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c master agreement termination provisions</rdfs:label>
-		<skos:definition xml:lang="en">Termination provisions in the OTC Derivatives Master Agreement, setting out the conditions, consequences etc. of termination of the Agreement.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Early Termination is a specific set of terms within this, that are specific to this kind of Master Agreement.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;ObligationInRespectOfNetting">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-derx-ma;mayBeVariedByOne"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-bsc;OTCTransactionConfirmation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">obligation in respect of netting</rdfs:label>
-		<skos:definition xml:lang="en">Some obligation on one or other party in respect of any netting up of amounts due under a combination of transactions transacted under this Master Agreement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;OtherAmountsObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
-		<rdfs:label xml:lang="en">other amounts obligation</rdfs:label>
-		<skos:definition xml:lang="en">Obligation in regard to other defaults on obligations. Example Contract Text: &quot;If, prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party defaults in the performance of any obligation required to be settled by delivery, it will compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement. &quot;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;PaymentObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
-		<rdfs:label xml:lang="en">payment obligation</rdfs:label>
-		<skos:definition xml:lang="en">Obligation to make payments on transactions transacted under the Master Agreement, as specified in any Confirmation made by that party.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This and the Delivery Obligation may be set out in one clause of the Master Agreement. This is the clause which obligates the parties to make the payments or deliveries in accordance with those Confirmations, which are generally messages. May be subject to other provisions in the Master Agreement. Example text: &quot;Each party will make each payment or delivery specified in each Confirmation to be made by it, subject to the other provisions of this Agreement. &quot; Additional terms in the clause which follows the above, deal with more specific terms about payments.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;PaymentObligationAsDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
-		<rdfs:label xml:lang="en">payment obligation as delivery</rdfs:label>
-		<skos:definition xml:lang="en">Obligation for payment in settlement of a transaction when this payment takes the form of delivery of some payment in kind.</skos:definition>
-		<skos:example xml:lang="en">Sample text: &quot;... Where settlement is by delivery (that is, other than by payment), such delivery will be made for receipt on the due date in the manner customary for the relevant obligation unless otherwise specified in the relevant Confirmation or elsewhere in this Agreement. &quot;</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">payment place specification method</rdfs:label>
-		<skos:definition xml:lang="en">Selection of possible places to be specified for the payments in a Master Agreement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;PaymentPlaceSpecifiedEitherInMasterAgreementOrConfirmation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod"/>
-		<rdfs:label xml:lang="en">payment place specified either in master agreement or confirmation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;PaymentPlaceSpecifiedInConfirmationMessage">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod"/>
-		<rdfs:label xml:lang="en">payment place specified in confirmation message</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;PaymentPlaceSpecifiedInMasterAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod"/>
-		<rdfs:label xml:lang="en">payment place specified in master agreement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;TaxWithholdingGrossupObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;TaxWithholdingObligation"/>
-		<rdfs:label xml:lang="en">tax withholding grossup obligation</rdfs:label>
-		<skos:definition xml:lang="en">Grossup Obligations in respect of Tax, that is an obligation to deduct or withhold tax in respect of payments made under transactions governed by the Master Agreement.</skos:definition>
-		<skos:example xml:lang="en">Example Text Gross-Up. All payments under this Agreement will be made without any deduction or withholding for or on account of any Tax unless such deduction or withholding is required by any applicable law, as modified by the practice of any relevant governmental revenue authority, then in effect. If a party is so required to deduct or withhold, then that party (&quot;X&quot;) will:- (1) promptly notify the other party (&quot;Y&quot;) of such requirement; (2) pay to the relevant authorities the full amount required to be deducted or withheld (including the full amount required to be deducted or withheld from any additional amount paid by X to Y under this Section 2(d)) promptly upon the earlier of determining that such deduction or withholding is required or receiving notice that such amount has been assessed against Y; (3) promptly forward to Y an official receipt (or a certified copy), or other documentation reasonably acceptable to Y, evidencing such payment to such authorities; and (4) if such Tax is an Indemnifiable Tax, pay to Y, in addition to the payment to which Y is otherwise entitled under this Agreement, such additional amount as is necessary to ensure that the net amount actually received by Y (free and clear of Indemnifiable Taxes, whether assessed against X or Y) will equal the full amount Y would have received had no such deduction or withholding been required. However, X will not be required to pay any additional amount to Y to the extent that it would not be required to be paid but for:- (A) the failure by Y to comply with or perform any agreement contained in Section 4(a)(i), 4(a)(iii) or 4(d); or (B) the failure of a representation made by Y pursuant to Section 3(f) to be accurate and true unless such failure would not have occurred but for (I) any action taken by a taxing authority, or brought in a court of competent jurisdiction, on or after the date on which a Transaction is entered into (regardless of whether such action is taken or brought with respect to a party to this Agreement) or (II) a Change in Tax Law.</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;TaxWithholdingLiability">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;TaxWithholdingObligation"/>
-		<rdfs:label xml:lang="en">tax withholding liability</rdfs:label>
-		<skos:definition xml:lang="en">Obligation in respect of liability for tax. This defines whether or not the party which is required to deduct some tax payment and does not do so, is then entitled to receive the funds from the other party in the event that a liability for this tax is later assessed against the first party.</skos:definition>
-		<skos:example xml:lang="en">Example text: Liability. If:- (1) X is required by any applicable law, as modified by the practice of any relevant governmental revenue authority, to make any deduction or withholding in respect of which X would not be required to pay an additional amount to Y under Section 2(d)(i)(4); (2) X does not so deduct or withhold; and (3) a liability resulting from such Tax is assessed directly against X, then, except to the extent Y has satisfied or then satisfies the liability resulting from such Tax, Y will promptly pay to X the amount of such liability (including any related liability for interest, but including any related liability for penalties only if Y has failed to comply with or perform any agreement contained in Section 4(a)(i), 4(a)(iii) or 4(d)).</skos:example>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-derx-ma;TaxWithholdingObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
-		<rdfs:label xml:lang="en">tax withholding obligation</rdfs:label>
-		<skos:definition xml:lang="en">An obligation with regard to the payment of taxes.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;actsAs">
-		<rdfs:label xml:lang="en">acts as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;NonDefaultingParty"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;EarlyTerminationDateDeterminingAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;automaticNettingApplicable">
-		<rdfs:label xml:lang="en">automatic netting applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;NettingTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether netting takes place automatically in respect of one transaction. Example text: &quot;If on any date amounts would otherwise be payable:- (i) in the same currency; and (ii) in respect of the same Transaction, by each party to the other, then, on such date, each party’s obligation to make payment of any such amount will be automatically satisfied and discharged and, if the aggregate amount that would otherwise have been payable by one party exceeds the aggregate amount that would otherwise have been payable by the other party, replaced by an obligation upon the party by whom the larger aggregate amount would have been payable to pay to the other party the excess of the larger aggregate amount over the smaller aggregate amount. &quot;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;changeOfAccountDetailsAllowed">
-		<rdfs:label xml:lang="en">change of account details allowed</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementAccountChangeNotificationObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the account details may be varied for individual transactions transacted under this Master Agreement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;compensateOtherParty">
-		<rdfs:label xml:lang="en">compensate other party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OtherAmountsObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not, under the stated circumstances, if a party defaults in the performance of any obligation required to be settled by delivery, it is obliged to compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;contractuallyDefines">
-		<rdfs:label xml:lang="en">contractually defines</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;CreditEventsDescriptiveTerms"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;crossTransactionNettingElection">
-		<rdfs:label xml:lang="en">cross transaction netting election</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;NettingTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether either party may elect to carry out netting in respect of two or more transactions carried out under this Master Agreement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-derx-ma;currencySpecificMethods">
-		<rdfs:label xml:lang="en">currency specific methods</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
-		<skos:definition xml:lang="en">Payment is to be in the manner customary for the currency in question. Example text: &quot;... in the manner customary for payments in the required currency.&quot; It is not clear what if anything the alternative would be. Included as a &quot;yes/no&quot; term for completeness.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;defaultInterestApplicable">
-		<rdfs:label xml:lang="en">default interest applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;DefaultInterestObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether a party that defaults in the performance of any payment obligation will, to the extent permitted by law and this agreement be required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;defaultInterestCompoundingBasis">
-		<rdfs:label xml:lang="en">default interest compounding basis</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;DefaultInterestObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The basis upon which default interest is to be calculated, as a period of time (e.g. daily).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;describesTreatmentOf">
-		<rdfs:label xml:lang="en">describes treatment of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationProvisions"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;dischargedByNetting">
-		<rdfs:label xml:lang="en">discharged by netting</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The obligations for payment by either party is automatically discharged or satisfied in the event of other amounts being due on the same day and in the same currency. The Obligation in question is ether discharged completely or replaced with an obligation in respect of the outstanding difference, on the part of whichever party has a greater amount due to the other (a positive amount after netting) for that transaction on that date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;effectOfDesignation">
-		<rdfs:label xml:lang="en">effect of designation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Description of the effect of designation of this right.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;forward">
-		<rdfs:label xml:lang="en">forward</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingGrossupObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">If a party is required to deduct or withhold tax, whether that party is to promptly forward to the other party an official receipt (or a certified copy), or other documentation reasonably acceptable to that party, evidencing such payment to such authorities.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;freelyTransferableFunds">
-		<rdfs:label xml:lang="en">freely transferable funds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;hasBeneficiary">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-		<rdfs:label xml:lang="en">has beneficiary</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;CreditSupportAgreement"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;CreditSupportBeneficiary"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;hasProvider">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
-		<rdfs:label xml:lang="en">has provider</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;CreditSupportAgreement"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;CreditSupportProvider"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;hasTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCDerivativeTransactionMasterAgreement"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;inDefault">
-		<rdfs:label xml:lang="en">in default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The condition that some default has occurred in respect to the other party. Further notes: Conditions precedent typically include that no default has occurred, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;includesPenaltyPayments">
-		<rdfs:label xml:lang="en">includes penalty payments</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingLiability"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether liability on the part of the counterparty (the party which is not assessed as being liable for the relevant tax) includes liability for penalties in respect of the late or non payment of that tax by the party so assessed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;invokedInEventOf">
-		<rdfs:label xml:lang="en">invoked in event of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingTerminationEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;invokedInEventOf.1">
-		<rdfs:label xml:lang="en">invoked in event of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;isFailureInForceOf">
-		<rdfs:label xml:lang="en">is failure in force of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;CreditSupportDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;CreditSupportAgreement"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;makeUpForIndemnifiable">
-		<rdfs:label xml:lang="en">make up for indemnifiable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingGrossupObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">If a party (&quot;X&quot;) is required to deduct or withhold tax, and if such Tax is an Indemnifiable Tax, whether X is to pay to the other party (&quot;Y&quot;), in addition to the payment to which Y is otherwise entitled under this Agreement, such additional amount as is necessary to ensure that the net amount actually received by Y (free and clear of Indemnifiable Taxes, whether assessed against X or Y) will equal the full amount Y would have received had no such deduction or withholding been required. However, X will not be required to pay any additional amount to Y to the extent that it would not be required to be paid but for:- (A) the failure by Y to comply with or perform any agreement contained in the provisions for furnishing specified information in this agreement; or (B) the failure of a representation made by Y pursuant to the Representation Section of the agreement to be accurate and true unless such failure would not have occurred but for (I) any action taken by a taxing authority, or brought in a court of competent jurisdiction, on or after the date on which a Transaction is entered into (regardless of whether such action is taken or brought with respect to a party to this Agreement) or (II) a Change in Tax Law. Further notes: The above is all definitional of this term.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;masterAgreementCurrency">
-		<rdfs:label xml:lang="en">master agreement currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;CurrencySpecificationTerm"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency for payments under this Master Agreement. ISDA Master Agreement example text: Payment in the Contractual Currency. Each payment under this Agreement will be made in the relevant currency specified in this Agreement for that payment (the &quot;Contractual Currency&quot;). To the extent permitted by applicable law, any obligation to make payments under this Agreement in the Contractual Currency will not be discharged or satisfied by any tender in any currency other than the Contractual Currency, except to the extent such tender results in the actual receipt by the party to which payment is owed, acting in a reasonable manner and in good faith in converting the currency so tendered into the Contractual Currency, of the full amount in the Contractual Currency of all amounts payable in respect of this Agreement. If for any reason the amount in the Contractual Currency so received falls short of the amount in the Contractual Currency payable in respect of this Agreement, the party required to make the payment will, to the extent permitted by applicable law, immediately pay such additional amount in the Contractual Currency as may be necessary to compensate for the shortfall. If for any reason the amount in the Contractual Currency so received exceeds the amount in the Contractual Currency payable in respect of this Agreement, the party receiving the payment will refund promptly the amount of such excess.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;mayBeVariedByOne">
-		<rdfs:label xml:lang="en">may be varied by one</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
-		<rdfs:range rdf:resource="&fibo-der-der-bsc;OTCTransactionConfirmation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;mayVary">
-		<rdfs:label xml:lang="en">may vary</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-bsc;OTCTransactionConfirmation"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
-		<owl:inverseOf rdf:resource="&fibo-der-derx-ma;mayBeVariedByOne"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;notify">
-		<rdfs:label xml:lang="en">notify</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingGrossupObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">If a party is required to deduct or withhold tax, whether obligation is to promptly notify the other party of Tax Withholding Grossup requirement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;ongoingDefault">
-		<rdfs:label xml:lang="en">ongoing default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The condition that some default or potential default is ongoing in respect to the other party. Further notes: Conditions precedent typically include that no default is ongoing, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;pay">
-		<rdfs:label xml:lang="en">pay</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingGrossupObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">If a party &quot;X&quot; is required to deduct or withhold tax, whether Obligation is to pay to the relevant authorities the full amount required to be deducted or withheld (including the full amount required to be deducted or withheld from any additional amount paid by X to Y under this obligation promptly upon the earlier of determining that such deduction or withholding is required or receiving notice that such amount has been assessed against Y;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;payableByCounterparty">
-		<rdfs:label xml:lang="en">payable by counterparty</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingLiability"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the counterparty is obliged to promptly pay to the party which is assessed as being liable for the relevant tax, the amount of such liability.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;paymentDateCalculationRequirement">
-		<rdfs:label xml:lang="en">payment date calculation requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Provisions for calculation of Payment dates in the event of this Early Termination.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;paymentInKindDeliveryObligation">
-		<rdfs:label xml:lang="en">payment in kind delivery obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligationAsDelivery"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Precise description of the form in which payment is to be made when payment is in kind.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;paymentPlaceSpecification">
-		<rdfs:label xml:lang="en">payment place specification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod"/>
-		<skos:definition xml:lang="en">The place for payments specified in this Master Agreement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;potentialDefault">
-		<rdfs:label xml:lang="en">potential default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The condition that some potential default has occurred in respect to the other party. Further notes: Conditions precedent typically include that no potential default has occurred, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;requiredDaysNotice">
-		<rdfs:label xml:lang="en">required days notice</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementChangeNotificationObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of days notice to be given for a change in the given kinds of details.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;setsOut">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;setsOut.1">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;NettingTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;setsOut.2">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementObligationsTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;specifiedIndebtedness">
-		<rdfs:label xml:lang="en">specified indebtedness</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;CrossDefaultProvisions"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Any obligation (whether present or future, contingent or otherwise, as principal or surety or otherwise) in respect of borrowed money. May not include obligations in respect of deposits received in the ordinary course of a party’s banking business. FpML: In Schedule: &quot;Specified Indebtedness&quot; will have the meaning specified in Section 14 except that such term shall not include obligations in respect of deposits received in the ordinary course of a party’s banking business. Section 14: &quot;Specified Indebtedness&quot; means, subject to the Schedule, any obligation (whether present or future, contingent or otherwise, as principal or surety or otherwise) in respect of borrowed money. Modeling note: Could extend this to have a yes/no option on the exclusion described in the Schedule to the sample Master Agreement</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;specifies">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;NonDefaultingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;specifies.1">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-der-derx-ma;DefaultingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;statementCalculationRequirements">
-		<rdfs:label xml:lang="en">statement calculation requirements</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Provisions for calculation of statements and statement amounts in the event of this Early Termination.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;subjectToOtherProvisions">
-		<rdfs:label xml:lang="en">subject to other provisions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;DeliveryObligation"/>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether this Obligation is subject to other provisions in the Master Agreement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;thresholdAmount">
-		<rdfs:label xml:lang="en">threshold amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;CrossDefaultProvisions"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;transactionEarlyTerminationDate">
-		<rdfs:label xml:lang="en">transaction early termination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The condition that some early termination date as been defined in respect to the transaction carried out under this Master Agreement. Further notes: note that this is in respect of a specific transaction transacted under the Master Agreement, so that the condition precedent for the obligation in respect of that specific transaction, is that this early transaction termation has not taken place in respect of this same transaction. Conditions precedent typically include this is not the case, so this is typically or always &quot;no&quot;. Sample text: &quot;the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated.&quot;</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-derx-ma="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
+buxmlns:fibo-fnd-agrx-ele="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-txnx="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">OTCDerivativeMasterAgreements</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Terms that make up the OTC Derivatives Master agreement as defined in the ISDA literature. This is an experimental ontology and needs considerable re-work if it is to be considered for release.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;CreditEventsDescriptiveTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;contractuallyDefines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit events descriptive terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms describing Credit Events and defining what these are for the purposes of this Agreement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;CreditSupportAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;hasBeneficiary"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;CreditSupportBeneficiary"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;hasProvider"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;CreditSupportProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit support agreement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;CreditSupportBeneficiary">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit support beneficiary</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;CreditSupportDefaultEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;isFailureInForceOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;CreditSupportAgreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit support default event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Failure of some Credit Support Agreement.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Per ISDA Master Agreement exmple, this may take one of the following forms (there may be others not in this example): - Failure to comply with some obligation under the Credit Support Agreement (after a suitable grace period has elapsed) - Expiration or Termination of Credit Support Agreement while it is still needed for the transactions it covers (i.e. not normal termination); - Disavowal or repudiation of the Credit Suport Agreement by one or other party to it. Note that these three all relate to the state of the Credit Support Agreement, and have the effect that the Credit Support Agreement is no longer in effect, during a time when there is some Transaction in play which was intended to be covered by that Agreement. ISDA original terms from Master Agreement example, in full: Credit Support Default. (1) Failure by the party or any Credit Support Provider of such party to comply with or perform any agreement or obligation to be complied with or performed by it in accordance with any Credit Support Document if such failure is continuing after any applicable grace period has elapsed; (2) the expiration or termination of such Credit Support Document or the failing or ceasing of such Credit Support Document to be in full force and effect for the purpose of this Agreement (in either case other than in accordance with its terms) prior to the satisfaction of all obligations of such party under each Transaction to which such Credit Support Document relates without the written consent of the other party; or (3) the party or such Credit Support Provider disaffirms, disclaims, repudiates or rejects, in whole or in part, or challenges the validity of, such Credit Support Document Definition Agreement: SR Draft. Details from ISDA above.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;CreditSupportProvider">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit support provider</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;CrossDefaultProvisions">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cross default provisions</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;CurrencySpecificationTerm">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">currency specification term</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Term defining the currency or currencies for payments.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">is found in general terms in example Master Agreement.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;DefaultInterestObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default interest obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Obligation in respect of defaults in the performance of any payment obligation.</skos:definition>
+bubu<skos:example rdf:datatype="&rdf;langString" xml:lang="en">Example text: Default Interest; Other Amounts. Prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party that defaults in the performance of any payment obligation will, to the extent permitted by law and subject to Section 6(c), be required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment, at the Default Rate. Such interest will be calculated on the basis of daily compounding and the actual number of days elapsed. If, prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party defaults in the performance of any obligation required to be settled by delivery, it will compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement. &quot; Note that this last sentence relates to a separate Obligation, labeled as Other Amount Obligation.</skos:example>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;DefaultingParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defaulting party</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;DeliveryObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delivery obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Obligation to make deliveries on transactions transacted under the Master Agreement, as specified in any Confirmation made by that party.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This and the Payment Obligation may be set out in one clause of the Master Agreement. This is the clause which obligates the parties to make the payments or deliveries in accordance with those Confirmations, which are generally messages. May be subject to other provisions in the Master Agreement. Example text: &quot;Each party will make each payment or delivery specified in each Confirmation to be made by it, subject to the other provisions of this Agreement. &quot;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;EarlyTerminationDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;AgencyDeterminedDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">early termination date</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;EarlyTerminationDateDeterminingAgent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDeterminingAgent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;EarlyTerminationDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">early termination date determining agent</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;MasterAgreementAccountChangeNotificationObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;MasterAgreementChangeNotificationObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">master agreement account change notification obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The obligtation to notify the counterparty to this agreement, of any changes in account details.</skos:definition>
+bubu<skos:example rdf:datatype="&rdf;langString" xml:lang="en">Example text: &quot;Either party may change its account for receiving a payment or delivery by giving notice to the other party at least five Local Business Days prior to the scheduled date for the payment or delivery to which such change applies unless such other party gives timely notice of a reasonable objection to such change.&quot; Note that the notice period is given as a fact about the general kind of obligation which is Master Agreement Change notification Obligation.</skos:example>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;MasterAgreementChangeNotificationObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">master agreement change notification obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The obligtaion to notify the counterparty to this agreement, of any changes in details.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">General term of which Change of Account is an example.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationProvisions"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">master agreement early termination provisions</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms and Conditions around early termination of the Master Agreement.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Terms here include: Additional Terminaton Event Affected Parties</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;MasterAgreementObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">master agreement obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Obligation set out in some Master Agreement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;NettingTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;setsOut.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">netting terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out how Netting may or may not take place and the Obligations on each party in respect of that Netting.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">These terms are set out as text in the Sample Master Agreement and may be difficult (and unproductive) to model). Here they are: Example Text: &quot;Netting. If on any date amounts would otherwise be payable:- (i) in the same currency; and (ii) in respect of the same Transaction, by each party to the other, then, on such date, each party’s obligation to make payment of any such amount will be automatically satisfied and discharged and, if the aggregate amount that would otherwise have been payable by one party exceeds the aggregate amount that would otherwise have been payable by the other party, replaced by an obligation upon the party by whom the larger aggregate amount would have been payable to pay to the other party the excess of the larger aggregate amount over the smaller aggregate amount. The parties may elect in respect of two or more Transactions that a net amount will be determined in respect of all amounts payable on the same date in the same currency in respect of such Transactions, regardless of whether such amounts are payable in respect of the same Transaction. The election may be made in the Schedule or a Confirmation by specifying that subparagraph (ii) above will not apply to the Transactions identified as being subject to the election, together with the starting date (in which case subparagraph (ii) above will not, or will cease to, apply to such Transactions from such date). This election may be made separately for different groups of Transactions and will apply separately to each pairing of Offices through which the parties make and receive payments or deliveries. &quot;</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;NonDefaultingParty">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;actsAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;EarlyTerminationDateDeterminingAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non defaulting party</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCDerivativeMasterAgreementRepresentation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;RepresentationsSection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c derivative master agreement representation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Representations by one or other party in the Master Agreement.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These typically include: Basic Representations - Status of the organization - Powers of the organization - Absence of conflicts - Existence of the relevant consents - Binding nature of the Agreement. Absence of default and similar events Absence of litigation Accuracy of information Tax representations (withholding; notifications) - Payer - Payee Representations as to the Credit Support Agreement Representations as to regulatory matters</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCDerivativeTransactionMasterAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-txnx;MasterAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;hasTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;hasProvisions"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationProvisions"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c derivative transaction master agreement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Master agreement covering over the counter derivatives transactions to be carried out between the parties to this contract.</skos:definition>
+bubu<skos:example rdf:datatype="&rdf;langString" xml:lang="en">Sample preamble to one of these: &quot;EXAMPLE BANK, a Michigan banking corporation and SAMPLECOMPANY US, INC. a Delaware corporation have entered and/or anticipate entering into one or more transactions (each a &quot;Transaction&quot;) that are or will be governed by this Master Agreement, which includes the schedule (the &quot;Schedule&quot;), and the documents and other confirming evidence (each a &quot;Confirmation&quot;) exchanged between the parties confirming those Transactions. &quot;</skos:example>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;MasterAgreementObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c derivatives master agreement obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Obligation set out in some OTC Derivatives Master Agreement.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This will typically include obligations to make payments according to confirmations, details of how deliveries are to be made etc. There are exceptions set out to some of these obligations.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementAgreementsTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement agreements terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out specific Agreements between the parties, that is specific things they agree to do or allow.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These include (per example Master Agreement from ISDA/FpML): - Furnish specified information - Maintain authorizations - Comply with laws - Tax agreement (agree to make notice of non compliances) - Payment of Stamp Tax There may be other similar Agreement types specific to given contexts. Note also that a common super-class of this Terms Set has not been modeled at this time, but there are probably common Agreements type terms that are common to many or most contract contexts.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ConditionsPrecedent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ctrx;varies"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-derx-ma;DeliveryObligation">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-derx-ma;PaymentObligation">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement conditions precedent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Conditions precedent on payment or delivery on a transaction transacted under this Master Agreement.</skos:definition>
+bubu<skos:example rdf:datatype="&rdf;langString" xml:lang="en">Example text: &quot;Each obligation of each party under Section 2(a)(i) is subject to (1) the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, (2) the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated and (3) each other applicable condition precedent specified in this Agreement. &quot; In the above, the Obligations defined under Section 2(a)(i) of the Master Agrement is the obligation to make each payment or delivery defined in a Confirmation for a transaction carried out under this Master Agreement.</skos:example>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement contractual commitment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement early termination right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Right or one or other party to the Master Agreement to termination the Agreement early.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This generally arises from some Default Event on the part of the other party.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementElement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement element</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms specific to a Master Agreement governing transactions of Over the Counter derivatives between parties.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is included so that all OTC Master Agreement Contract Terms Sets may be included under this one set. Terms are also described as specializations of the sorts of terms that they are (e.g. conditions Precedent, Commitments Terms and so on).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementObligationsTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementContractualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;setsOut.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement obligations terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out the obligations on one or other party to the agreement.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The obligations are modeled in detail as Obligations. There is little merit in setting out the terms themselves as a model of textual elements - these terms are bext understood in relation to the Obligations which they represent, which are modeled in detail.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingDefaultEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;invokedInEventOf.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;NonDefaultingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;specifies.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;DefaultingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement right to termination following default event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Right to Terminate the Master Agreement Following an Event of Default.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a right which may be invoked by either party to the Master Agreement; in so doing they acome the &quot;Non Defaulting Party&quot; with respect to this Right. ISDA Definition in full: Right to Terminate Following Event of Default. If at any time an Event of Default with respect to a party (the &quot;Defaulting Party&quot;) has occurred and is then continuing, the other party (the &quot;Non-defaulting Party&quot;) may, by not more than 20 days notice to the Defaulting Party specifying the relevant Event of Default, designate a day not earlier than the day such notice is effective as an Early Termination Date in respect of all outstanding Transactions. If, however, &quot;Automatic Early Termination&quot; is specified in the Schedule as applying to a party, then an Early Termination Date in respect of all outstanding Transactions will occur immediately upon the occurrence with respect to such party of an Event of Default specified in Section 5(a)(vii)(1), (3), (5), (6) or, to the extent analogous thereto, (8), and as of the time immediately preceding the institution of the relevant proceeding or the presentation of the relevant petition upon the occurrence with respect to such party of an Event of Default specified in Section 5(a)(vii)(4) or, to the extent analogous thereto, (8).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingTerminationEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;invokedInEventOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement right to termination following termination event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Right to Terminate the Agreement Following some Termination Event.</skos:definition>
+bubu<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&rdf;langString" xml:lang="en">This specifies an event which is predefined in the Agreement as constituting a Termination Event, with the effect that this right (tro termination) is invoked by the occurrence of that event. That is the assumption modeled here. ISDA Master Agreement example text in full: Right to Terminate Following Termination Event. (i) Notice. If a Termination Event occurs, an Affected Party will, promptly upon becoming aware of it, notify the other party, specifying the nature of that Termination Event and each Affected Transaction and will also give such other information about that Termination Event as the other party may reasonably require. (ii) Transfer to Avoid Termination Event. If either an Illegality under Section 5(b)(i)(1) or a Tax Event occurs and there is only one Affected Party, or if a Tax Event Upon Merger occurs and the Burdened Party is the Affected Party, the Affected Party will, as a condition to its right to designate an Early Termination Date under Section 6(b)(iv), use all reasonable efforts (which will not require such party to incur a loss, excluding immaterial, incidental expenses) to transfer within 20 days after it gives notice under Section 6(b)(i) all its rights and obligations under this Agreement in respect of the Affected Transactions to another of its Offices or Affiliates so that such Termination Event ceases to exist. If the Affected Party is not able to make such a transfer it will give notice to the other party to that effect within such 20 day period, whereupon the other party may effect such a transfer within 30 days after the notice is given under Section 6(b)(i). Any such transfer by a party under this Section 6(b)(ii) will be subject to and conditional upon the prior written consent of the other party, which consent will not be withheld if such other party&amp;rsquo;s policies in effect at such time would permit it to enter into transactions with the transferee on the terms proposed. (iii) Two Affected Parties. If an Illegality under Section 5(b)(i)(1) or a Tax Event occurs and there are two Affected Parties, each party will use all reasonable efforts to reach agreement within 30 days after notice thereof is given under Section 6(b)(i) on action to avoid that Termination Event. (iv) Right to Terminate. If:- (1) a transfer under Section 6(b)(ii) or an agreement under Section 6(b)(iii), as the case may be, has not been effected with respect to all Affected Transactions within 30 days after an Affected Party gives notice under Section 6(b)(i); or (2) an Illegality under Section 5(b)(i)(2), a Credit Event Upon Merger or an Additional Termination Event occurs, or a Tax Event Upon Merger occurs and the Burdened Party is not the Affected Party, either party in the case of an Illegality, the Burdened Party in the case of a Tax Event Upon Merger, any Affected Party in the case of a Tax Event or an Additional Termination Event if there is more than one Affected Party, or the party which is not the Affected Party in the case of a Credit Event Upon Merger or an Additional Termination Event if there is only one Affected Party may, by not more than 20 days notice to the other party and provided that the relevant Termination Event is then continuing, designate a day not earlier than the day such notice is effective as an Early Termination Date in respect of all Affected Transactions.</fibo-fnd-utl-av:definitionOrigin>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement termination event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&quot;Termination Event&quot; means an Illegality, a Tax Event or a Tax Event Upon Merger or, if specified to be applicable, a Credit Event Upon Merger or an Additional Termination Event.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OTCMasterAgreementTerminationProvisions">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;TerminationProvisions"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;describesTreatmentOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c master agreement termination provisions</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Termination provisions in the OTC Derivatives Master Agreement, setting out the conditions, consequences etc. of termination of the Agreement.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Early Termination is a specific set of terms within this, that are specific to this kind of Master Agreement.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;ObligationInRespectOfNetting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-derx-ma;mayBeVariedByOne"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-bsc;OTCTransactionConfirmation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obligation in respect of netting</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some obligation on one or other party in respect of any netting up of amounts due under a combination of transactions transacted under this Master Agreement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;OtherAmountsObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">other amounts obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Obligation in regard to other defaults on obligations. Example Contract Text: &quot;If, prior to the occurrence or effective designation of an Early Termination Date in respect of the relevant Transaction, a party defaults in the performance of any obligation required to be settled by delivery, it will compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement. &quot;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;PaymentObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Obligation to make payments on transactions transacted under the Master Agreement, as specified in any Confirmation made by that party.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This and the Delivery Obligation may be set out in one clause of the Master Agreement. This is the clause which obligates the parties to make the payments or deliveries in accordance with those Confirmations, which are generally messages. May be subject to other provisions in the Master Agreement. Example text: &quot;Each party will make each payment or delivery specified in each Confirmation to be made by it, subject to the other provisions of this Agreement. &quot; Additional terms in the clause which follows the above, deal with more specific terms about payments.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;PaymentObligationAsDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment obligation as delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Obligation for payment in settlement of a transaction when this payment takes the form of delivery of some payment in kind.</skos:definition>
+bubu<skos:example rdf:datatype="&rdf;langString" xml:lang="en">Sample text: &quot;... Where settlement is by delivery (that is, other than by payment), such delivery will be made for receipt on the due date in the manner customary for the relevant obligation unless otherwise specified in the relevant Confirmation or elsewhere in this Agreement. &quot;</skos:example>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment place specification method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Selection of possible places to be specified for the payments in a Master Agreement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;PaymentPlaceSpecifiedEitherInMasterAgreementOrConfirmation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment place specified either in master agreement or confirmation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;PaymentPlaceSpecifiedInConfirmationMessage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment place specified in confirmation message</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;PaymentPlaceSpecifiedInMasterAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment place specified in master agreement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;TaxWithholdingGrossupObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;TaxWithholdingObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax withholding grossup obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Grossup Obligations in respect of Tax, that is an obligation to deduct or withhold tax in respect of payments made under transactions governed by the Master Agreement.</skos:definition>
+bubu<skos:example rdf:datatype="&rdf;langString" xml:lang="en">Example Text Gross-Up. All payments under this Agreement will be made without any deduction or withholding for or on account of any Tax unless such deduction or withholding is required by any applicable law, as modified by the practice of any relevant governmental revenue authority, then in effect. If a party is so required to deduct or withhold, then that party (&quot;X&quot;) will:- (1) promptly notify the other party (&quot;Y&quot;) of such requirement; (2) pay to the relevant authorities the full amount required to be deducted or withheld (including the full amount required to be deducted or withheld from any additional amount paid by X to Y under this Section 2(d)) promptly upon the earlier of determining that such deduction or withholding is required or receiving notice that such amount has been assessed against Y; (3) promptly forward to Y an official receipt (or a certified copy), or other documentation reasonably acceptable to Y, evidencing such payment to such authorities; and (4) if such Tax is an Indemnifiable Tax, pay to Y, in addition to the payment to which Y is otherwise entitled under this Agreement, such additional amount as is necessary to ensure that the net amount actually received by Y (free and clear of Indemnifiable Taxes, whether assessed against X or Y) will equal the full amount Y would have received had no such deduction or withholding been required. However, X will not be required to pay any additional amount to Y to the extent that it would not be required to be paid but for:- (A) the failure by Y to comply with or perform any agreement contained in Section 4(a)(i), 4(a)(iii) or 4(d); or (B) the failure of a representation made by Y pursuant to Section 3(f) to be accurate and true unless such failure would not have occurred but for (I) any action taken by a taxing authority, or brought in a court of competent jurisdiction, on or after the date on which a Transaction is entered into (regardless of whether such action is taken or brought with respect to a party to this Agreement) or (II) a Change in Tax Law.</skos:example>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;TaxWithholdingLiability">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;TaxWithholdingObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax withholding liability</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Obligation in respect of liability for tax. This defines whether or not the party which is required to deduct some tax payment and does not do so, is then entitled to receive the funds from the other party in the event that a liability for this tax is later assessed against the first party.</skos:definition>
+bubu<skos:example rdf:datatype="&rdf;langString" xml:lang="en">Example text: Liability. If:- (1) X is required by any applicable law, as modified by the practice of any relevant governmental revenue authority, to make any deduction or withholding in respect of which X would not be required to pay an additional amount to Y under Section 2(d)(i)(4); (2) X does not so deduct or withhold; and (3) a liability resulting from such Tax is assessed directly against X, then, except to the extent Y has satisfied or then satisfies the liability resulting from such Tax, Y will promptly pay to X the amount of such liability (including any related liability for interest, but including any related liability for penalties only if Y has failed to comply with or perform any agreement contained in Section 4(a)(i), 4(a)(iii) or 4(d)).</skos:example>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-derx-ma;TaxWithholdingObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax withholding obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An obligation with regard to the payment of taxes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;actsAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">acts as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;NonDefaultingParty"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;EarlyTerminationDateDeterminingAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;automaticNettingApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">automatic netting applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;NettingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether netting takes place automatically in respect of one transaction. Example text: &quot;If on any date amounts would otherwise be payable:- (i) in the same currency; and (ii) in respect of the same Transaction, by each party to the other, then, on such date, each party’s obligation to make payment of any such amount will be automatically satisfied and discharged and, if the aggregate amount that would otherwise have been payable by one party exceeds the aggregate amount that would otherwise have been payable by the other party, replaced by an obligation upon the party by whom the larger aggregate amount would have been payable to pay to the other party the excess of the larger aggregate amount over the smaller aggregate amount. &quot;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;changeOfAccountDetailsAllowed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">change of account details allowed</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementAccountChangeNotificationObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the account details may be varied for individual transactions transacted under this Master Agreement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;compensateOtherParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">compensate other party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OtherAmountsObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not, under the stated circumstances, if a party defaults in the performance of any obligation required to be settled by delivery, it is obliged to compensate the other party on demand if and to the extent provided for in the relevant Confirmation or elsewhere in this Agreement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;contractuallyDefines">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractually defines</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;CreditEventsDescriptiveTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;crossTransactionNettingElection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cross transaction netting election</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;NettingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether either party may elect to carry out netting in respect of two or more transactions carried out under this Master Agreement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-derx-ma;currencySpecificMethods">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">currency specific methods</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Payment is to be in the manner customary for the currency in question. Example text: &quot;... in the manner customary for payments in the required currency.&quot; It is not clear what if anything the alternative would be. Included as a &quot;yes/no&quot; term for completeness.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;defaultInterestApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default interest applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;DefaultInterestObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether a party that defaults in the performance of any payment obligation will, to the extent permitted by law and this agreement be required to pay interest (before as well as after judgment) on the overdue amount to the other party on demand in the same currency as such overdue amount, for the period from (and including) the original due date for payment to (but excluding) the date of actual payment.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;defaultInterestCompoundingBasis">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default interest compounding basis</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;DefaultInterestObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The basis upon which default interest is to be calculated, as a period of time (e.g. daily).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;describesTreatmentOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">describes treatment of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationProvisions"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;dischargedByNetting">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">discharged by netting</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The obligations for payment by either party is automatically discharged or satisfied in the event of other amounts being due on the same day and in the same currency. The Obligation in question is ether discharged completely or replaced with an obligation in respect of the outstanding difference, on the part of whichever party has a greater amount due to the other (a positive amount after netting) for that transaction on that date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;effectOfDesignation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effect of designation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Description of the effect of designation of this right.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;forward">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingGrossupObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">If a party is required to deduct or withhold tax, whether that party is to promptly forward to the other party an official receipt (or a certified copy), or other documentation reasonably acceptable to that party, evidencing such payment to such authorities.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;freelyTransferableFunds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">freely transferable funds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;hasBeneficiary">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has beneficiary</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;CreditSupportAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;CreditSupportBeneficiary"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;hasProvider">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has provider</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;CreditSupportAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;CreditSupportProvider"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;hasTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCDerivativeTransactionMasterAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementElement"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;inDefault">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in default</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The condition that some default has occurred in respect to the other party. Further notes: Conditions precedent typically include that no default has occurred, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;includesPenaltyPayments">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes penalty payments</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingLiability"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether liability on the part of the counterparty (the party which is not assessed as being liable for the relevant tax) includes liability for penalties in respect of the late or non payment of that tax by the party so assessed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;invokedInEventOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">invoked in event of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingTerminationEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementTerminationEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;invokedInEventOf.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">invoked in event of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingDefaultEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;isFailureInForceOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is failure in force of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;CreditSupportDefaultEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;CreditSupportAgreement"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;makeUpForIndemnifiable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">make up for indemnifiable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingGrossupObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">If a party (&quot;X&quot;) is required to deduct or withhold tax, and if such Tax is an Indemnifiable Tax, whether X is to pay to the other party (&quot;Y&quot;), in addition to the payment to which Y is otherwise entitled under this Agreement, such additional amount as is necessary to ensure that the net amount actually received by Y (free and clear of Indemnifiable Taxes, whether assessed against X or Y) will equal the full amount Y would have received had no such deduction or withholding been required. However, X will not be required to pay any additional amount to Y to the extent that it would not be required to be paid but for:- (A) the failure by Y to comply with or perform any agreement contained in the provisions for furnishing specified information in this agreement; or (B) the failure of a representation made by Y pursuant to the Representation Section of the agreement to be accurate and true unless such failure would not have occurred but for (I) any action taken by a taxing authority, or brought in a court of competent jurisdiction, on or after the date on which a Transaction is entered into (regardless of whether such action is taken or brought with respect to a party to this Agreement) or (II) a Change in Tax Law. Further notes: The above is all definitional of this term.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;masterAgreementCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">master agreement currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;CurrencySpecificationTerm"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency for payments under this Master Agreement. ISDA Master Agreement example text: Payment in the Contractual Currency. Each payment under this Agreement will be made in the relevant currency specified in this Agreement for that payment (the &quot;Contractual Currency&quot;). To the extent permitted by applicable law, any obligation to make payments under this Agreement in the Contractual Currency will not be discharged or satisfied by any tender in any currency other than the Contractual Currency, except to the extent such tender results in the actual receipt by the party to which payment is owed, acting in a reasonable manner and in good faith in converting the currency so tendered into the Contractual Currency, of the full amount in the Contractual Currency of all amounts payable in respect of this Agreement. If for any reason the amount in the Contractual Currency so received falls short of the amount in the Contractual Currency payable in respect of this Agreement, the party required to make the payment will, to the extent permitted by applicable law, immediately pay such additional amount in the Contractual Currency as may be necessary to compensate for the shortfall. If for any reason the amount in the Contractual Currency so received exceeds the amount in the Contractual Currency payable in respect of this Agreement, the party receiving the payment will refund promptly the amount of such excess.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;mayBeVariedByOne">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be varied by one</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-bsc;OTCTransactionConfirmation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;mayVary">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may vary</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-der-bsc;OTCTransactionConfirmation"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
+bubu<owl:inverseOf rdf:resource="&fibo-der-derx-ma;mayBeVariedByOne"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;notify">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notify</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingGrossupObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">If a party is required to deduct or withhold tax, whether obligation is to promptly notify the other party of Tax Withholding Grossup requirement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;ongoingDefault">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ongoing default</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The condition that some default or potential default is ongoing in respect to the other party. Further notes: Conditions precedent typically include that no default is ongoing, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;pay">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pay</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingGrossupObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">If a party &quot;X&quot; is required to deduct or withhold tax, whether Obligation is to pay to the relevant authorities the full amount required to be deducted or withheld (including the full amount required to be deducted or withheld from any additional amount paid by X to Y under this obligation promptly upon the earlier of determining that such deduction or withholding is required or receiving notice that such amount has been assessed against Y;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;payableByCounterparty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payable by counterparty</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;TaxWithholdingLiability"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the counterparty is obliged to promptly pay to the party which is assessed as being liable for the relevant tax, the amount of such liability.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;paymentDateCalculationRequirement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment date calculation requirement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Provisions for calculation of Payment dates in the event of this Early Termination.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;paymentInKindDeliveryObligation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment in kind delivery obligation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligationAsDelivery"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Precise description of the form in which payment is to be made when payment is in kind.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;paymentPlaceSpecification">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment place specification</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;PaymentPlaceSpecificationMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The place for payments specified in this Master Agreement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;potentialDefault">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">potential default</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The condition that some potential default has occurred in respect to the other party. Further notes: Conditions precedent typically include that no potential default has occurred, so this is typically or always &quot;no&quot;. Sample text (of which this term is a part): &quot; the condition precedent that no Event of Default or Potential Event of Default with respect to the other party has occurred and is continuing, &quot;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;requiredDaysNotice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">required days notice</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementChangeNotificationObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of days notice to be given for a change in the given kinds of details.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;setsOut">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementEarlyTerminationRight"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;setsOut.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;NettingTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;ObligationInRespectOfNetting"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;setsOut.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementObligationsTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;OTCDerivativesMasterAgreementObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;specifiedIndebtedness">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specified indebtedness</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;CrossDefaultProvisions"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any obligation (whether present or future, contingent or otherwise, as principal or surety or otherwise) in respect of borrowed money. May not include obligations in respect of deposits received in the ordinary course of a party’s banking business. FpML: In Schedule: &quot;Specified Indebtedness&quot; will have the meaning specified in Section 14 except that such term shall not include obligations in respect of deposits received in the ordinary course of a party’s banking business. Section 14: &quot;Specified Indebtedness&quot; means, subject to the Schedule, any obligation (whether present or future, contingent or otherwise, as principal or surety or otherwise) in respect of borrowed money. Modeling note: Could extend this to have a yes/no option on the exclusion described in the Schedule to the sample Master Agreement</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;specifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingDefaultEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;NonDefaultingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;specifies.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementRightToTerminationFollowingDefaultEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-der-derx-ma;DefaultingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;statementCalculationRequirements">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">statement calculation requirements</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;MasterAgreementEarlyTerminationProvisions"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Provisions for calculation of statements and statement amounts in the event of this Early Termination.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;subjectToOtherProvisions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subject to other provisions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;DeliveryObligation"/>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;PaymentObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether this Obligation is subject to other provisions in the Master Agreement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;thresholdAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">threshold amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;CrossDefaultProvisions"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-ma;transactionEarlyTerminationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction early termination date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-derx-ma;OTCMasterAgreementConditionsPrecedent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The condition that some early termination date as been defined in respect to the transaction carried out under this Master Agreement. Further notes: note that this is in respect of a specific transaction transacted under the Master Agreement, so that the condition precedent for the obligation in respect of that specific transaction, is that this early transaction termation has not taken place in respect of this same transaction. Conditions precedent typically include this is not the case, so this is typically or always &quot;no&quot;. Sample text: &quot;the condition precedent that no Early Termination Date in respect of the relevant Transaction has occurred or been effectively designated.&quot;</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/DerivativesContractsExt/SwapsExt.rdf
+++ b/der/DerivativesContractsExt/SwapsExt.rdf
@@ -1,50 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-derx-swx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-derx-swx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"
-	xmlns:fibo-der-derx-swx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/">
-		<rdfs:label xml:lang="en">SwapsExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-derx-swx;LegDefinedAs">
-		<rdfs:label xml:lang="en">leg defined as</rdfs:label>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/FloatingInterestRateLeg"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-derx-swx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SwapsExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional Swaps concepts that are not included in the Release models for Swaps. These are mainly properties relating to swap legs, parties and transaction concepts that are not included in the Release ontology for Swaps.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-derx-swx;LegDefinedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">leg defined as</rdfs:label>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/FloatingInterestRateLeg"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/ExchangeTradedDerivatives/DerivativesStandardizedTerms.rdf
+++ b/der/ExchangeTradedDerivatives/DerivativesStandardizedTerms.rdf
@@ -1,105 +1,108 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-etd-ostd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
-	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-etd-ostd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
+bu<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-der-etd-ostd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"
-	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-		<rdfs:label xml:lang="en">DerivativesStandardizedTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-etd-std;DerivativesClearing">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesListing"/>
-		<rdfs:label xml:lang="en">derivatives clearing</rdfs:label>
-		<skos:definition xml:lang="en">The service... This is correect - this role applies the same to Futures and Options contracts on derivatives exchanges. This is always on a Futures Exchange. There are similar terms / facilities for options traded on a Stock Exchange. Also American v European by implication of the nature of the underlying i.e. whether it&apos;s a stock or a futures contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-std;DerivativesExchange">
-		<rdfs:label xml:lang="en">derivatives exchange</rdfs:label>
-		<skos:definition xml:lang="en">Exchange where futures contracts and options on futures contracts are traded.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Exchanges may trade commodities, financial derivatives, or a combination of the two, as well as futures and options on indices and equity products.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-std;DerivativesListing">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/isProvidedBy"/>
-				<owl:allValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:allValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">derivatives listing</rdfs:label>
-		<skos:definition xml:lang="en">A listing of an instrument on a derivatives exchange. The listing is a product of the individual exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An exchange traded derivative is a product offered by the exchange, whereby the investor chooses to invest in that option and it then becomes a contract between them and the exchange. In this sense this is not the same as an Equity listing, and the facts about equities ot other exchange traded products listings do not apply to a derivatives listing. Update 24 Nov 2010: Later reviews (see notes elsewhere) don&apos;t support this description. In fact the contract is between investors (participants in the exchange).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-std;DerivativesPriceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;PriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">derivatives price determination method</rdfs:label>
-		<skos:definition xml:lang="en">Method by which prices are arrived at for derivatives securities (futures or options).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-std;ElectronicPriceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">electronic price determination method</rdfs:label>
-		<skos:definition xml:lang="en">Other price determination method. More information required.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-std;OpenOutcryPriceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">open outcry price determination method</rdfs:label>
-		<skos:definition xml:lang="en">Method of trading on a commodity exchange. The term derives from the fact that traders must shout out their buy or sell orders. When a trader shouts he wants to sell at a particular price and someone else shouts he wants to buy at that price the two traders have made a contract that will be recorded.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-std;evenLotSize">
-		<rdfs:label xml:lang="en">even lot size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Unit of trading in a commodity, established by an exchange, and to which official price quotations from that exchange apply.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-std;openOutcry">
-		<rdfs:label xml:lang="en">open outcry</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether trading on the exchange is by way of open outcry in the form of physical interaction between participants. No means that trading is carried out electronically.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-etd-ostd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"
+buxmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DerivativesStandardizedTerms</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Core concepts for standardized terms for exchange traded options and futures, that are common to both. Includes the definition of the derivatives exchange and the listing of a product on that exchange along with price determination methods.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-std;DerivativesClearing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesListing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives clearing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The service... This is correect - this role applies the same to Futures and Options contracts on derivatives exchanges. This is always on a Futures Exchange. There are similar terms / facilities for options traded on a Stock Exchange. Also American v European by implication of the nature of the underlying i.e. whether it&apos;s a stock or a futures contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives exchange</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Exchange where futures contracts and options on futures contracts are traded.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Exchanges may trade commodities, financial derivatives, or a combination of the two, as well as futures and options on indices and equity products.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-std;DerivativesListing">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/isProvidedBy"/>
+bubububu<owl:allValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:allValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A listing of an instrument on a derivatives exchange. The listing is a product of the individual exchange.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">An exchange traded derivative is a product offered by the exchange, whereby the investor chooses to invest in that option and it then becomes a contract between them and the exchange. In this sense this is not the same as an Equity listing, and the facts about equities ot other exchange traded products listings do not apply to a derivatives listing. Update 24 Nov 2010: Later reviews (see notes elsewhere) don&apos;t support this description. In fact the contract is between investors (participants in the exchange).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-std;DerivativesPriceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;PriceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives price determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Method by which prices are arrived at for derivatives securities (futures or options).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-std;ElectronicPriceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">electronic price determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Other price determination method. More information required.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-std;OpenOutcryPriceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">open outcry price determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Method of trading on a commodity exchange. The term derives from the fact that traders must shout out their buy or sell orders. When a trader shouts he wants to sell at a particular price and someone else shouts he wants to buy at that price the two traders have made a contract that will be recorded.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-std;evenLotSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">even lot size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Unit of trading in a commodity, established by an exchange, and to which official price quotations from that exchange apply.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-std;openOutcry">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">open outcry</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether trading on the exchange is by way of open outcry in the form of physical interaction between participants. No means that trading is carried out electronically.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
+++ b/der/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
@@ -1,732 +1,736 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
-	<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-etd-eto "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
-	<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
-	<!ENTITY fibo-der-etd-ostd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
-	<!ENTITY fibo-der-etd-oxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/">
-	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-	<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
-	<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
+bu<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-der-etd-eto "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
+bu<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
+bu<!ENTITY fibo-der-etd-ostd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
+bu<!ENTITY fibo-der-etd-oxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/">
+bu<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bu<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
+bu<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
+bu<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
-	xmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-etd-eto="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
-	xmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"
-	xmlns:fibo-der-etd-ostd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"
-	xmlns:fibo-der-etd-oxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/"
-	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"
-	xmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
-		<rdfs:label xml:lang="en">ExchangeTradedOptions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;BondOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;DebtDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;BondOptionUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond option</rdfs:label>
-		<skos:definition xml:lang="en">An option on a traded futures contract for a Bond. When exercised, the holder exercises the right to buy the future on a Bond, s/he does not exercise the right to buy a bond.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example an option on a Treasury Bill is an option on a T Bill Future, not on a T Bill itself. Hence these are defined as a kind of futures option.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;BondOptionUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
-		<rdfs:label xml:lang="en">bond option underlying</rdfs:label>
-		<skos:definition xml:lang="en">The underlying on a Bond Option, which is the corresponding Bond Future contract on the same exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the underlying in the sense that when the option is exercised the investor takes delivery of the corresponding futures contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;CommoditiesOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;CommoditiesOptionUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodities option</rdfs:label>
-		<skos:definition xml:lang="en">An option to buy or sell the future on some underlying commodity. The exercise is always to buy the underlying asset i.e. the future instrument NOT the underlying goods.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;CommoditiesOptionUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
-		<rdfs:label xml:lang="en">commodities option underlying</rdfs:label>
-		<skos:definition xml:lang="en">The underlying on a Commodities Option, which is the corresponding Commodity Future contract on the same exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the underlying in the sense that when the option is exercised the investor takes delivery of the corresponding futures contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;CurrencyOptionExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">currency option exercise terms set</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms defining when or under what circumstances an currency option is to be exercised.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Also includes terms defining delivery when the contract is exercised. Delivery for currency options is by way of cash.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;EquityIndexOptionUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.3"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;EquityReferenceIndex"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity index option underlying</rdfs:label>
-		<skos:definition xml:lang="en">The inderlying of the equity index option, which is a reference index consisting of shares.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review session note 16 Dec 2009: Nature of the &quot;Underlying&quot; as a class here: Somebody takes a defined Pf of those at that time. Modeling response: this describes a different sort of equity option, one based on a locally defined basket of equities. This has not been modeled. An equity index as defined here and in the Indices and Indicators part of the model is a published figure, out out by an index publisher. The composition of the basiet underkying that index is a matter for the publisher and not for the Options Contract. It sounds as though a locally defined basket may be used as another kind of Underlying, and may be loosely referred to as an index option, however that&apos;s not the term modeled here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;EquityOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;StockOptionExerciseTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity option</rdfs:label>
-		<skos:definition xml:lang="en">Equity options are the most common type of equity derivative. They provide the right, but not the obligation to trade a quantity of stock at a set price at a future time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;EquityOptionUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.3"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity option underlying</rdfs:label>
-		<skos:definition xml:lang="en">The equity security that must be delivered when the option contract is exercised.</skos:definition>
-		<skos:editorialNote xml:lang="en">From SME Review 16 Dec 2009: Equity Option uses consolidated market data feed for the price of the underlying. so this is specified by for instance the national market system that consolidates the market information, so everyone is looking at the same Last Trade information. See Equity diagram where we have &quot;Composite&quot; market consisting of a number of markets. The Equity is normally not traded on the options exchange. But they will still attach to a market even if it&apos;s not their own. Further research: national market systems (US, what about the rest?)</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;ExchangeTradedEquityIndexOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;IndexOptionExerciseTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;EquityIndexOptionUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exchange traded equity index option</rdfs:label>
-		<skos:definition xml:lang="en">Equity Index options offer the investor an opportunity to either capitalize on an expected market move or to protect holdings in the underlying instruments. The difference is that the underlying instruments are indexes.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These indexes can reflect the characteristics of either the broad equity market as a whole or specific industry sectors within the marketplace.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;ExchangeTradedOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasFeature"/>
-				<owl:onClass rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasContractDuration"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasCounterparty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasOptionGuarantor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionGuarantor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasPriceDeterminationMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasPrincipal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exchange traded option contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;ExchangeTradedOptionTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-		<rdfs:label xml:lang="en">exchange traded option transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;ForeignCurrencyOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;CurrencyOptionExerciseTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;FxOptionUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">foreign currency option</rdfs:label>
-		<skos:definition xml:lang="en">An option on a currency, based on the spot exchange rate of that currency to the currency of the security itself.</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition needed - this is just a place holder. Actually, this would also have a Currency Future as the Underlying Action: change this. Definition:Review</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;FutureOptionsExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;convention"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;AmericanExerciseConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">future options exercise terms set</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms defining when or under what circumstances an options instrument may be exercised.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Also includes terms defining delivery when the contract is exercised.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;FxOptionUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.3"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/CurrencySpotBuyRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx option underlying</rdfs:label>
-		<skos:definition xml:lang="en">The underlying of the foreign currency option is a currency spot rate.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;IROptionUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
-		<rdfs:label xml:lang="en">i r option underlying</rdfs:label>
-		<skos:definition xml:lang="en">The underlying on a Commodities Option, which is the corresponding Commodity Future contract on the same exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the underlying in the sense that when the option is exercised the investor takes delivery of the corresponding futures contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;IndexOptionExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">index option exercise terms set</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms defining when or under what circumstances an options instrument may be exercised.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Also includes terms defining delivery when the contract is exercised. Delivery for index options is by way of cash.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;InterestRateOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;IROptionUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">interest rate option</rdfs:label>
-		<skos:definition xml:lang="en">An option on some underlying interest rate. If the option is exercised, delivery is in the frorm of the corresponding interest rate future.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;LongTermEquityOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;EquityOption"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasContractDuration"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">long term equity option</rdfs:label>
-		<skos:definition xml:lang="en">An option whose contract expires at a date longer than one year. Also known as long-term equity anticipation securities (LEAPS). From Investopedia: These options are called long-term equity anticipation securities (LEAPS). By providing opportunities to control and manage risk or even to speculate, LEAPS are virtually identical to regular options. LEAPS, however, provide these opportunities for much longer periods of time. Although they are not available on all stocks, LEAPS are available on most widely held issues.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;NovatedOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;haPrincipal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">novated option contract</rdfs:label>
-		<skos:definition xml:lang="en">An Option Contract after the stage where a Derivatives Exchange has novated this contract and become the principal to it, for purposes of clearing and settlement. The Clearing House novates both contract. So when you are on the floor (as a Broker), you trade with another Broker. Then you take it to th eRing, and present it to the Ring. So you write a contract and give it to the ringleader, who then books it. So the party you dealt with deals with the exahcnge, and you deal with the exchange. THen there are two contracts for one deal. So the answer here is that there are two novated contracts for one Options deal. Difference: If not open outcry? In OO the deal is done and given to the ringleader, who represents the Cleaing house. When it&apos;s not open outcry, the clearing house gets the deal, books the deal, and margins it. So you don&apos;t know as much about the deal and process. This eliminiates stickiness of a market that has credit. Similar to what occurs in share markets, where clearing takes place, e.g. when someone defaults on delivery. Clearing House simply closes out the contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;NovatedOptionContractPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;identity.1"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">novated option contract principal</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;OptionContractOnFutures">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;FutureOptionsExerciseTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option contract on futures</rdfs:label>
-		<skos:definition xml:lang="en">Future options are the most common type of equity derivative. They provide the right, but not the obligation to trade a quantity of futures instruments at a set price at a future time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;OptionGuarantor">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantorHasIdentity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option guarantor</rdfs:label>
-		<skos:definition xml:lang="en">The Guarantor of an options security. This is the party that agreed to make good any losses incurred by the holder in the event of a default by the issuer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;OptionInstrumentExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;optionExerciseTermsHasConventionExerciseDateConvention"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option instrument exercise terms</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms defining when or under what circumstances an options instrument may be exercised.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Also includes terms defining delivery when the contract is exercised.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;OptionOnFuturesUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.3"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option on futures underlying</rdfs:label>
-		<skos:definition xml:lang="en">The underlying of a traded Futures Option, which is a traded Futures contract, generally on the same derivatives exchange.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review notes: This seems right. The underlying is the future contract because it&apos;s what&apos;s delivered when the option expires or is exercised.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;SingleStockOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;EquityOption"/>
-		<rdfs:label xml:lang="en">single stock option</rdfs:label>
-		<skos:definition xml:lang="en">Option instrument based on a single equity security (share) underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;StockOptionExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseConvention"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">stock option exercise terms set</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms defining when or under what circumstances a single stock options instrument may be exercised.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Delivery when the contract is exercised is by delivery of the underlying stock. ADD: Delivery dates, as being distinct from exercise dates.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;TradedOptionPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;isA"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">traded option principal</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
-		<skos:definition xml:lang="en">The principal to the Traded Option contract. THis is the party which gives the other party the right to take up the obligation, and which is obliged to honor that transaction if that option is taken up.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;TradedOptionsCounterparty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;isA.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">traded options counterparty</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;becomesPartOf">
-		<rdfs:label>becomes part of</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;contractSize">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of underlyers in this contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;convention">
-		<rdfs:label xml:lang="en">convention</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;FutureOptionsExerciseTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-ex;AmericanExerciseConvention"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;delivery">
-		<rdfs:label xml:lang="en">delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;expiry">
-		<rdfs:label xml:lang="en">expiry</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
-		<skos:definition xml:lang="en">Legal expiry of the Contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;haPrincipal">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-etd-eto;hasPrincipal"/>
-		<rdfs:label xml:lang="en">ha principal</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;NovatedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasContractDuration">
-		<rdfs:label xml:lang="en">has contract duration</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasCounterparty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;hasBuyer"/>
-		<rdfs:label xml:lang="en">has counterparty</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasExerciseConvention">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-etd-eto;optionExerciseTermsHasConventionExerciseDateConvention"/>
-		<rdfs:label xml:lang="en">has exercise convention</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;StockOptionExerciseTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasExerciseTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has exercise terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasFeature">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has feature</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasListing">
-		<rdfs:label xml:lang="en">has listing</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-oxc;OptionsListing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasOptionGuarantor">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;hasContractGuarantor"/>
-		<rdfs:label xml:lang="en">has option guarantor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;OptionGuarantor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasPriceDeterminationMethod">
-		<rdfs:label xml:lang="en">has price determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasPrincipal">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;hasSeller"/>
-		<rdfs:label xml:lang="en">has principal</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasUnderlying">
-		<rdfs:label xml:lang="en">has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;EquityOption"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;EquityOptionUnderlying"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;identity.1">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;isA">
-		<rdfs:label xml:lang="en">is a</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;isA.1">
-		<rdfs:label xml:lang="en">is a</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;minimumLotSize">
-		<rdfs:label xml:lang="en">minimum lot size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The minimum number of options contracts that may be traded at any one time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;optionExerciseTermsHasConventionExerciseDateConvention">
-		<rdfs:label xml:lang="en">option exercise terms has convention exercise date convention</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;optionType">
-		<rdfs:label xml:lang="en">option type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionTypeSelection"/>
-		<skos:definition xml:lang="en">Whether the option is a call or a put option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;relatesTo">
-		<rdfs:label xml:lang="en">relates to</rdfs:label>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;standardExerciseTermsHasExerciseConvention">
-		<rdfs:label>standard exercise terms has exercise convention</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikePrice">
-		<rdfs:label xml:lang="en">strike price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;CurrencyOptionExerciseTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<skos:definition xml:lang="en">Predetermined price at which the holder will have to buy or sell the underlying currency.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikePrice.1">
-		<rdfs:label xml:lang="en">strike price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;FutureOptionsExerciseTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<skos:definition xml:lang="en">Predetermined spread at which the holder will have to buy or sell the futures contract for the underlying.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikePrice.2">
-		<rdfs:label xml:lang="en">strike price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">Predetermined price or spread at which the holder will have to buy or sell the underlying</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikePrice.3">
-		<rdfs:label xml:lang="en">strike price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;StockOptionExerciseTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<skos:definition xml:lang="en">Predetermined price at which the holder will have to buy or sell the underlying instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikeSpread">
-		<rdfs:label xml:lang="en">strike spread</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;IndexOptionExerciseTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Predetermined spread at which the holder may exercise the contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;underlying">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedEquityIndexOption"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;EquityIndexOptionUnderlying"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;underlying.1">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;underlying.2">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-eto;ForeignCurrencyOption"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;FxOptionUnderlying"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
+buxmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-der-etd-eto="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
+buxmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"
+buxmlns:fibo-der-etd-ostd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"
+buxmlns:fibo-der-etd-oxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/"
+buxmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+buxmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
+buxmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"
+buxmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ExchangeTradedOptions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Option contracts offered on an options exchange. Includes a wide range of asset types (instruments, indices, foreign exchange, rates, commodities etc.) and the kinds of exchange traded option that are based on these.
+		Note that some of the contract types are named similarly to their OTC equivalents, such as bond option.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;BondOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;DebtDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;BondOptionUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option on a traded futures contract for a Bond. When exercised, the holder exercises the right to buy the future on a Bond, s/he does not exercise the right to buy a bond.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example an option on a Treasury Bill is an option on a T Bill Future, not on a T Bill itself. Hence these are defined as a kind of futures option.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;BondOptionUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond option underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The underlying on a Bond Option, which is the corresponding Bond Future contract on the same exchange.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the underlying in the sense that when the option is exercised the investor takes delivery of the corresponding futures contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;CommoditiesOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;CommoditiesOptionUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodities option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option to buy or sell the future on some underlying commodity. The exercise is always to buy the underlying asset i.e. the future instrument NOT the underlying goods.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;CommoditiesOptionUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodities option underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The underlying on a Commodities Option, which is the corresponding Commodity Future contract on the same exchange.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the underlying in the sense that when the option is exercised the investor takes delivery of the corresponding futures contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;CurrencyOptionExerciseTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">currency option exercise terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms defining when or under what circumstances an currency option is to be exercised.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Also includes terms defining delivery when the contract is exercised. Delivery for currency options is by way of cash.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;EquityIndexOptionUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.3"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;EquityReferenceIndex"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity index option underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The inderlying of the equity index option, which is a reference index consisting of shares.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review session note 16 Dec 2009: Nature of the &quot;Underlying&quot; as a class here: Somebody takes a defined Pf of those at that time. Modeling response: this describes a different sort of equity option, one based on a locally defined basket of equities. This has not been modeled. An equity index as defined here and in the Indices and Indicators part of the model is a published figure, out out by an index publisher. The composition of the basiet underkying that index is a matter for the publisher and not for the Options Contract. It sounds as though a locally defined basket may be used as another kind of Underlying, and may be loosely referred to as an index option, however that&apos;s not the term modeled here.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;EquityOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;StockOptionExerciseTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Equity options are the most common type of equity derivative. They provide the right, but not the obligation to trade a quantity of stock at a set price at a future time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;EquityOptionUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.3"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity option underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The equity security that must be delivered when the option contract is exercised.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From SME Review 16 Dec 2009: Equity Option uses consolidated market data feed for the price of the underlying. so this is specified by for instance the national market system that consolidates the market information, so everyone is looking at the same Last Trade information. See Equity diagram where we have &quot;Composite&quot; market consisting of a number of markets. The Equity is normally not traded on the options exchange. But they will still attach to a market even if it&apos;s not their own. Further research: national market systems (US, what about the rest?)</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;ExchangeTradedEquityIndexOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;IndexOptionExerciseTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;EquityIndexOptionUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange traded equity index option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Equity Index options offer the investor an opportunity to either capitalize on an expected market move or to protect holdings in the underlying instruments. The difference is that the underlying instruments are indexes.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These indexes can reflect the characteristics of either the broad equity market as a whole or specific industry sectors within the marketplace.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;ExchangeTradedOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasFeature"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;definesOptional"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasContractDuration"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasCounterparty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasOptionGuarantor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionGuarantor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasPriceDeterminationMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasPrincipal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange traded option contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;ExchangeTradedOptionTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange traded option transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;ForeignCurrencyOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;CurrencyOptionExerciseTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;FxOptionUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">foreign currency option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option on a currency, based on the spot exchange rate of that currency to the currency of the security itself.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Definition needed - this is just a place holder. Actually, this would also have a Currency Future as the Underlying Action: change this. Definition:Review</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;FutureOptionsExerciseTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;convention"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;AmericanExerciseConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">future options exercise terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms defining when or under what circumstances an options instrument may be exercised.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Also includes terms defining delivery when the contract is exercised.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;FxOptionUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.3"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/CurrencySpotBuyRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx option underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The underlying of the foreign currency option is a currency spot rate.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;IROptionUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i r option underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The underlying on a Commodities Option, which is the corresponding Commodity Future contract on the same exchange.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the underlying in the sense that when the option is exercised the investor takes delivery of the corresponding futures contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;IndexOptionExerciseTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index option exercise terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms defining when or under what circumstances an options instrument may be exercised.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Also includes terms defining delivery when the contract is exercised. Delivery for index options is by way of cash.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;InterestRateOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;IROptionUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option on some underlying interest rate. If the option is exercised, delivery is in the frorm of the corresponding interest rate future.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;LongTermEquityOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;EquityOption"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasContractDuration"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">long term equity option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option whose contract expires at a date longer than one year. Also known as long-term equity anticipation securities (LEAPS). From Investopedia: These options are called long-term equity anticipation securities (LEAPS). By providing opportunities to control and manage risk or even to speculate, LEAPS are virtually identical to regular options. LEAPS, however, provide these opportunities for much longer periods of time. Although they are not available on all stocks, LEAPS are available on most widely held issues.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;NovatedOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;haPrincipal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">novated option contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Option Contract after the stage where a Derivatives Exchange has novated this contract and become the principal to it, for purposes of clearing and settlement. The Clearing House novates both contract. So when you are on the floor (as a Broker), you trade with another Broker. Then you take it to th eRing, and present it to the Ring. So you write a contract and give it to the ringleader, who then books it. So the party you dealt with deals with the exahcnge, and you deal with the exchange. THen there are two contracts for one deal. So the answer here is that there are two novated contracts for one Options deal. Difference: If not open outcry? In OO the deal is done and given to the ringleader, who represents the Cleaing house. When it&apos;s not open outcry, the clearing house gets the deal, books the deal, and margins it. So you don&apos;t know as much about the deal and process. This eliminiates stickiness of a market that has credit. Similar to what occurs in share markets, where clearing takes place, e.g. when someone defaults on delivery. Clearing House simply closes out the contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;NovatedOptionContractPrincipal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;identity.1"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">novated option contract principal</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;OptionContractOnFutures">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;FutureOptionsExerciseTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;underlying.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option contract on futures</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Future options are the most common type of equity derivative. They provide the right, but not the obligation to trade a quantity of futures instruments at a set price at a future time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;OptionGuarantor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantorHasIdentity"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option guarantor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Guarantor of an options security. This is the party that agreed to make good any losses incurred by the holder in the event of a default by the issuer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;OptionInstrumentExerciseTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;optionExerciseTermsHasConventionExerciseDateConvention"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option instrument exercise terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms defining when or under what circumstances an options instrument may be exercised.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Also includes terms defining delivery when the contract is exercised.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;OptionOnFuturesUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;UnderlyingOnOption"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;identity.3"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option on futures underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The underlying of a traded Futures Option, which is a traded Futures contract, generally on the same derivatives exchange.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review notes: This seems right. The underlying is the future contract because it&apos;s what&apos;s delivered when the option expires or is exercised.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;SingleStockOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;EquityOption"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">single stock option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Option instrument based on a single equity security (share) underlying.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;StockOptionExerciseTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;hasExerciseConvention"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stock option exercise terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms defining when or under what circumstances a single stock options instrument may be exercised.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Delivery when the contract is exercised is by delivery of the underlying stock. ADD: Delivery dates, as being distinct from exercise dates.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;TradedOptionPrincipal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;isA"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded option principal</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The principal to the Traded Option contract. THis is the party which gives the other party the right to take up the obligation, and which is obliged to honor that transaction if that option is taken up.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-eto;TradedOptionsCounterparty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;isA.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded options counterparty</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;becomesPartOf">
+bubu<rdfs:label>becomes part of</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;contractSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of underlyers in this contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;convention">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convention</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;FutureOptionsExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-ex;AmericanExerciseConvention"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;delivery">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delivery</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;expiry">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expiry</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Legal expiry of the Contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;haPrincipal">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-etd-eto;hasPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ha principal</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;NovatedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasContractDuration">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has contract duration</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasCounterparty">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;hasBuyer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has counterparty</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasExerciseConvention">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-etd-eto;optionExerciseTermsHasConventionExerciseDateConvention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has exercise convention</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;StockOptionExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasExerciseTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has exercise terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasFeature">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has feature</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasListing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has listing</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-oxc;OptionsListing"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasOptionGuarantor">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;hasContractGuarantor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has option guarantor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;OptionGuarantor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasPriceDeterminationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has price determination method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasPrincipal">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-der-opt;hasSeller"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has principal</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;hasUnderlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;EquityOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;EquityOptionUnderlying"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;identity.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;isA">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is a</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;TradedOptionPrincipal"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;isA.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is a</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;minimumLotSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum lot size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The minimum number of options contracts that may be traded at any one time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;optionExerciseTermsHasConventionExerciseDateConvention">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option exercise terms has convention exercise date convention</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;optionType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionTypeSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the option is a call or a put option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;relatesTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates to</rdfs:label>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;standardExerciseTermsHasExerciseConvention">
+bubu<rdfs:label>standard exercise terms has exercise convention</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikePrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;CurrencyOptionExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Predetermined price at which the holder will have to buy or sell the underlying currency.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikePrice.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;FutureOptionsExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Predetermined spread at which the holder will have to buy or sell the futures contract for the underlying.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikePrice.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Predetermined price or spread at which the holder will have to buy or sell the underlying</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikePrice.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;StockOptionExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Predetermined price at which the holder will have to buy or sell the underlying instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;strikeSpread">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike spread</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;IndexOptionExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Predetermined spread at which the holder may exercise the contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;underlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ExchangeTradedEquityIndexOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;EquityIndexOptionUnderlying"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;underlying.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;OptionOnFuturesUnderlying"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-eto;underlying.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-eto;ForeignCurrencyOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;FxOptionUnderlying"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/ExchangeTradedDerivatives/Futures.rdf
+++ b/der/ExchangeTradedDerivatives/Futures.rdf
@@ -1,431 +1,435 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
-	<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
-	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-	<!ENTITY fibo-der-etd-fstd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/">
-	<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
-	<!ENTITY fibo-der-etd-fxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/">
-	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-	<!ENTITY fibo-sec-dbt-mm-trd "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ass-ass "https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/">
+bu<!ENTITY fibo-der-com-ctr "https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/">
+bu<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bu<!ENTITY fibo-der-etd-fstd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/">
+bu<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
+bu<!ENTITY fibo-der-etd-fxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/">
+bu<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bu<!ENTITY fibo-sec-dbt-mm-trd "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"
-	xmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
-	xmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
-	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-der-etd-fstd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"
-	xmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"
-	xmlns:fibo-der-etd-fxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"
-	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:fibo-sec-dbt-mm-trd="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
-		<rdfs:label xml:lang="en">Futures</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;BondFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFuture"/>
-		<rdfs:label xml:lang="en">bond future</rdfs:label>
-		<skos:definition xml:lang="en">A future instrument where the underlying is a bond.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;BondFutureUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.4"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond future underlying</rdfs:label>
-		<skos:definition xml:lang="en">The Bond which is the underlying instrument of a Bond Future contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;CommodityFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:label xml:lang="en">commodity future</rdfs:label>
-		<skos:definition xml:lang="en">A futures contract tied to the movement of a particular commodity. This enables contract buyers to buy a specific amount of a commodity at a specific price on a particular date in the future.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The price of the contract is determined using the &quot;Open Outcry&quot; system on the floor of a commodity exchange such as the Chicago Board of Trade or the Commodity Exchange in New York. There are commodity futures contracts based on meats such as cattle and pork bellies; grains such as corn, oats, soybeans and wheat; metals such as gold, silver and platinum; and energy products such as heating oil, natural gas and crude oil.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;EquityFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
-		<rdfs:label xml:lang="en">equity future</rdfs:label>
-		<skos:definition xml:lang="en">A Futures instrument which is based on an equity security or securities, specifically a publicly issued and traded share.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;EquityFutureShareUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity future share underlying</rdfs:label>
-		<skos:definition xml:lang="en">A share which is the underlying of an Equities Future contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FinancialFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:label xml:lang="en">financial future</rdfs:label>
-		<skos:definition xml:lang="en">A futures contract based on a financial instrument.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically a financial futures contract is based on an underlying debt instrument. Examples of instruments underlying financial futures contracts include Treasury bills, Treasury notes, Government National Mortgage Association (Ginnie Mae) pass-throughs, foreign currencies, and certificates of deposit. Such contracts usually move under the influence of interest rates. As rates rise, contracts fall in value; as rates fall, contracts gain in value. Trading in these contracts is governed in the U.S. by the federal Commodities Futures Trading Commission. Traders use these futures to speculate on the direction of interest rates. Financial institutions use them to hedge financial portfolios against adverse fluctuations in interest rates.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FutureInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;hasProvider"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FuturesTradingAccountProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;hasSettlementArrangement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;pricingDeterminedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/hasAccountHolder"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/FuturesTradingAccountHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">future instrument</rdfs:label>
-		<skos:definition xml:lang="en">Agreement to buy or sell a specific amount of a commodity, a currency or a financial instrument at a particular price on a stipulated future date. A futures contract obligates the buyer to purchase the underlying commodity, currency or financial instrument and the seller to sell it unless the contract is sold to another before settlement date which may happen if a trader waits to take a profit or cut a loss. Further notes: This contrasts with options trading in which the option buyer may choose whether or not to exercise the option by the exercise date. Unlike options, futures convey an obligation to buy. The risk to the holder is unlimited, and because the payoff pattern is symmetrical, the risk to the seller is unlimited as well. Dollars lost and gained by each party on a futures contract are equal and opposite. In other words, futures trading is a zero-sum game. Futures contracts are forward contracts, meaning they represent a pledge to make a certain transaction at a future date. The exchange of assets occurs on the date specified in the contract. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearinghouses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check. Definition origin: Barrons, adapted by EDMC SMER.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FuturesCommodityUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures commodity underlying</rdfs:label>
-		<skos:definition xml:lang="en">A negotiable commodity as the underlying of a Futures contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FuturesIndexUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.2"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures index underlying</rdfs:label>
-		<skos:definition xml:lang="en">An economic rate which is the underlying of a Futures contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FuturesTradingAccountProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.3"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures trading account provider</rdfs:label>
-		<skos:definition xml:lang="en">The party which is the principal of the Futures contract. This is the party that sets the terms of the contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This party is by definition a futures trading exchange or derivatives exchange.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FuturesTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
-		<rdfs:label xml:lang="en">futures transaction</rdfs:label>
-		<skos:definition xml:lang="en">A forward settlement transaction which is defined by the Futures market in which they are traded.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is a specialization of the Forward Transaction, which is distinguished by specific rules around for example novation. These are Market rules. So OTC v Futures are distinguished as markets where transactions occur. Action: Define &quot;OTC Market&quot; and &quot;Futures Market&quot; as types of the existing term &quot;Market&quot;. In some futures markets the line between notional physical is graded as some markets which were Open Outcry (physical place) become Notional Place.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;IndexFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
-		<rdfs:label xml:lang="en">index future</rdfs:label>
-		<skos:definition xml:lang="en">A futures contract on a stock or financial index. For each index there may be a different multiple for determining the price of the futures contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;InterestRateFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
-		<rdfs:label xml:lang="en">interest rate future</rdfs:label>
-		<skos:definition xml:lang="en">An Interest Rate Future is a futures contract with an interest-bearing instrument as the underlying asset.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.4"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">interest rate future debt underlying</rdfs:label>
-		<skos:definition xml:lang="en">The debt instrument which is the underlying of an Interest Rate Future contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;MoneyMarketFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFuture"/>
-		<rdfs:label xml:lang="en">money market future</rdfs:label>
-		<skos:definition xml:lang="en">A future instrument where the underlying is a money market instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;MoneyMarketFutureUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.4"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">money market future underlying</rdfs:label>
-		<skos:definition xml:lang="en">The money market instrument which is the underlying of a Money Market Futures contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;UnderlyingOnFuture">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:label xml:lang="en">underlying on future</rdfs:label>
-		<skos:definition xml:lang="en">The item (commodity, reference, index, instrument etc.) that determines the value of the Futures contract and in most cases forms the deliverable when the contract expires.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;contractSize">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The deliverable quantity of goods or commodities underlying the futures contract. This is denominated as a multiple of the lot size in the case of a commodity future. For financial futures this is the number of units of the underlying security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;contractValue">
-		<rdfs:label xml:lang="en">contract value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The deliverable value of goods, instruments or commodities underlying the futures contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;conversionFactor">
-		<rdfs:label xml:lang="en">conversion factor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;BondFuture"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The conversion factor is the price of the delivered bond/note ($1 par value) to yield a fixed rate. The conversion factor is used to calculate a final delivery price.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;firstDeliveryDate">
-		<rdfs:label xml:lang="en">first delivery date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The start date of the range of dates by which the underlying for a futures contract must be delivered in order for the terms of the contract to be fulfilled.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;firstNoticeDate">
-		<rdfs:label xml:lang="en">first notice date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The first date at which a delivery notice can be issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasListing">
-		<rdfs:label xml:lang="en">has listing</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasProvider">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
-		<rdfs:label xml:lang="en">has provider</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-fut;FuturesTradingAccountProvider"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasSettlementArrangement">
-		<rdfs:label xml:lang="en">has settlement arrangement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
-		<skos:definition xml:lang="en">The action by which an underlying commodity, security, cash value, or delivery instrument covering a contract is tendered and received by the contract holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This determines what is delivered to the holder when the future is exercised.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;EquityFutureShareUnderlying"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity.1">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FuturesCommodityUnderlying"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity.2">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">index underlying identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FuturesIndexUnderlying"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity.3">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FuturesTradingAccountProvider"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity.4">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lastDeliveryDate">
-		<rdfs:label xml:lang="en">last delivery date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The last date in the range of dates by which the underlying for a futures contract must be delivered in order for the terms of the contract to be fulfilled.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lastNoticeDate">
-		<rdfs:label xml:lang="en">last notice date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The last date at which a delivery notice can be issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lotSize">
-		<rdfs:label xml:lang="en">lot size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;CommodityFuture"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">How many of the underlying commodity can be sold. The groupings of certain units of measure in the underlying commodity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;maturity">
-		<rdfs:label xml:lang="en">maturity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date at which the security settlement must occur. It is the end of the life of the future contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;multiple">
-		<rdfs:label xml:lang="en">multiple</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;IndexFuture"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The multiple for determining the price of the futures contract in relation to the underlying index rate.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;notionalAmount">
-		<rdfs:label xml:lang="en">notional amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;CommodityFuture"/>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;EquityFuture"/>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;InterestRateFuture"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The total value of a leveraged position&apos;s assets.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;pricingDeterminedBy">
-		<rdfs:label xml:lang="en">pricing determined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;securityDescription">
-		<rdfs:label xml:lang="en">security description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The name of the security that uniquely identifies it amongst all other securities.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;tickSize">
-		<rdfs:label xml:lang="en">tick size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The minimum value of the upward or downward movement of the price of the contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;tickValue">
-		<rdfs:label xml:lang="en">tick value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The minimum value of the upward or downward movement of the contract. This is the contract size multiplied by the tick size.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;unitOfTrading">
-		<rdfs:label xml:lang="en">unit of trading</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">How many of the underlying securities can be sold.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/FuturesTradingAccountHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ass-ass="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"
+buxmlns:fibo-der-com-ctr="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"
+buxmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
+buxmlns:fibo-der-etd-fstd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"
+buxmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"
+buxmlns:fibo-der-etd-fxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"
+buxmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
+buxmlns:fibo-sec-dbt-mm-trd="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Futures</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Futures are functionally the same as forwards on the over the counter market, but are marketed via futures exchanges. Includes a wide range of asset types (instruments, indices, foreign exchange, rates, commodities etc.) and the kinds of futures that are based on these.
+		Note that some of the contract types are named similarly to their OTC equivalents, such as bond option.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;BondFuture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFuture"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond future</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A future instrument where the underlying is a bond.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;BondFutureUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.4"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond future underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Bond which is the underlying instrument of a Bond Future contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;CommodityFuture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity future</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A futures contract tied to the movement of a particular commodity. This enables contract buyers to buy a specific amount of a commodity at a specific price on a particular date in the future.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The price of the contract is determined using the &quot;Open Outcry&quot; system on the floor of a commodity exchange such as the Chicago Board of Trade or the Commodity Exchange in New York. There are commodity futures contracts based on meats such as cattle and pork bellies; grains such as corn, oats, soybeans and wheat; metals such as gold, silver and platinum; and energy products such as heating oil, natural gas and crude oil.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;EquityFuture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity future</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Futures instrument which is based on an equity security or securities, specifically a publicly issued and traded share.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;EquityFutureShareUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity future share underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A share which is the underlying of an Equities Future contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;FinancialFuture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial future</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A futures contract based on a financial instrument.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Typically a financial futures contract is based on an underlying debt instrument. Examples of instruments underlying financial futures contracts include Treasury bills, Treasury notes, Government National Mortgage Association (Ginnie Mae) pass-throughs, foreign currencies, and certificates of deposit. Such contracts usually move under the influence of interest rates. As rates rise, contracts fall in value; as rates fall, contracts gain in value. Trading in these contracts is governed in the U.S. by the federal Commodities Futures Trading Commission. Traders use these futures to speculate on the direction of interest rates. Financial institutions use them to hedge financial portfolios against adverse fluctuations in interest rates.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;FutureInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fut;hasProvider"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FuturesTradingAccountProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fut;hasSettlementArrangement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fut;pricingDeterminedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/hasAccountHolder"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/FuturesTradingAccountHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">future instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Agreement to buy or sell a specific amount of a commodity, a currency or a financial instrument at a particular price on a stipulated future date. A futures contract obligates the buyer to purchase the underlying commodity, currency or financial instrument and the seller to sell it unless the contract is sold to another before settlement date which may happen if a trader waits to take a profit or cut a loss. Further notes: This contrasts with options trading in which the option buyer may choose whether or not to exercise the option by the exercise date. Unlike options, futures convey an obligation to buy. The risk to the holder is unlimited, and because the payoff pattern is symmetrical, the risk to the seller is unlimited as well. Dollars lost and gained by each party on a futures contract are equal and opposite. In other words, futures trading is a zero-sum game. Futures contracts are forward contracts, meaning they represent a pledge to make a certain transaction at a future date. The exchange of assets occurs on the date specified in the contract. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearinghouses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check. Definition origin: Barrons, adapted by EDMC SMER.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;FuturesCommodityUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures commodity underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A negotiable commodity as the underlying of a Futures contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;FuturesIndexUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.2"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures index underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An economic rate which is the underlying of a Futures contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;FuturesTradingAccountProvider">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.3"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures trading account provider</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is the principal of the Futures contract. This is the party that sets the terms of the contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This party is by definition a futures trading exchange or derivatives exchange.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;FuturesTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A forward settlement transaction which is defined by the Futures market in which they are traded.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is a specialization of the Forward Transaction, which is distinguished by specific rules around for example novation. These are Market rules. So OTC v Futures are distinguished as markets where transactions occur. Action: Define &quot;OTC Market&quot; and &quot;Futures Market&quot; as types of the existing term &quot;Market&quot;. In some futures markets the line between notional physical is graded as some markets which were Open Outcry (physical place) become Notional Place.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;IndexFuture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index future</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A futures contract on a stock or financial index. For each index there may be a different multiple for determining the price of the futures contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;InterestRateFuture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate future</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Interest Rate Future is a futures contract with an interest-bearing instrument as the underlying asset.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;UnderlyingOnFuture"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.4"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate future debt underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The debt instrument which is the underlying of an Interest Rate Future contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;MoneyMarketFuture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFuture"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">money market future</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A future instrument where the underlying is a money market instrument.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;MoneyMarketFutureUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fut;identity.4"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDebtInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">money market future underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The money market instrument which is the underlying of a Money Market Futures contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fut;UnderlyingOnFuture">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying on future</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The item (commodity, reference, index, instrument etc.) that determines the value of the Futures contract and in most cases forms the deliverable when the contract expires.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;contractSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The deliverable quantity of goods or commodities underlying the futures contract. This is denominated as a multiple of the lot size in the case of a commodity future. For financial futures this is the number of units of the underlying security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;contractValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The deliverable value of goods, instruments or commodities underlying the futures contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;conversionFactor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conversion factor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;BondFuture"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The conversion factor is the price of the delivered bond/note ($1 par value) to yield a fixed rate. The conversion factor is used to calculate a final delivery price.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;firstDeliveryDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first delivery date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The start date of the range of dates by which the underlying for a futures contract must be delivered in order for the terms of the contract to be fulfilled.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;firstNoticeDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first notice date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The first date at which a delivery notice can be issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasListing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has listing</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasProvider">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has provider</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-fut;FuturesTradingAccountProvider"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasSettlementArrangement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has settlement arrangement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The action by which an underlying commodity, security, cash value, or delivery instrument covering a contract is tendered and received by the contract holder.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This determines what is delivered to the holder when the future is exercised.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;EquityFutureShareUnderlying"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FuturesCommodityUnderlying"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity.2">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index underlying identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FuturesIndexUnderlying"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FuturesTradingAccountProvider"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;identity.4">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lastDeliveryDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">last delivery date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The last date in the range of dates by which the underlying for a futures contract must be delivered in order for the terms of the contract to be fulfilled.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lastNoticeDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">last notice date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The last date at which a delivery notice can be issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lotSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lot size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;CommodityFuture"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How many of the underlying commodity can be sold. The groupings of certain units of measure in the underlying commodity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;maturity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the security settlement must occur. It is the end of the life of the future contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;multiple">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiple</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;IndexFuture"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The multiple for determining the price of the futures contract in relation to the underlying index rate.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;notionalAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notional amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;CommodityFuture"/>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;EquityFuture"/>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;InterestRateFuture"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The total value of a leveraged position&apos;s assets.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;pricingDeterminedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pricing determined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;securityDescription">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The name of the security that uniquely identifies it amongst all other securities.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;tickSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tick size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The minimum value of the upward or downward movement of the price of the contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;tickValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tick value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The minimum value of the upward or downward movement of the contract. This is the contract size multiplied by the tick size.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;unitOfTrading">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unit of trading</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How many of the underlying securities can be sold.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/FuturesTradingAccountHolder">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/ExchangeTradedDerivatives/FuturesExchanges.rdf
+++ b/der/ExchangeTradedDerivatives/FuturesExchanges.rdf
@@ -1,121 +1,124 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-etd-fstd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/">
-	<!ENTITY fibo-der-etd-fxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/">
-	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-etd-fstd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/">
+bu<!ENTITY fibo-der-etd-fxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/">
+bu<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"
-	xmlns:fibo-der-etd-fstd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"
-	xmlns:fibo-der-etd-fxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"
-	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/">
-		<rdfs:label xml:lang="en">FuturesExchanges</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fxc;FuturesListing">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesListing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fxc;marginCall"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fxc;marginProvision"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures listing</rdfs:label>
-		<skos:definition xml:lang="en">A listing of a futures instrument on a derivatives exchange.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fxc;StandardizedFuturesListingTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fxc;becomeFeaturesOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fxc;definedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized futures listing terms set</rdfs:label>
-		<skos:definition xml:lang="en">Standard terms set out by the exchange which will apply to any listing of a futures contract on this exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Individual listings will take on these standard terms but they are not contractual terms of the futures contract, they are facts about that listing on that exchange.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;becomeFeaturesOf">
-		<rdfs:label xml:lang="en">become features of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fxc;StandardizedFuturesListingTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;definedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-		<rdfs:label xml:lang="en">defined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fxc;StandardizedFuturesListingTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;marginCall">
-		<rdfs:label xml:lang="en">has margin call</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">A broker&apos;s demand on an investor using margin to deposit additional money or securities so that the margin account is brought up to the minimum maintenance margin. This is sometimes called a &apos;fed call&apos; or &apos;maintenance call&apos;.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;marginCallApplicable">
-		<rdfs:label xml:lang="en">margin call applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fxc;StandardizedFuturesListingTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not a Margin Call may be applicable to the listing.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;marginProvision">
-		<rdfs:label xml:lang="en">has margin provision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">An amount necessary to cover the purchase of the underlying security since delivery is mandatory, be it physical or cash. Failing to provide a sufficient provision will result in a margin call.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;specifiesDeliveryMethod">
-		<rdfs:label xml:lang="en">specifies delivery method</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
-		<skos:definition xml:lang="en">Type of delivery for contracts. This determines what is delivered to the holder when the future is exercised.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-etd-fstd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"
+buxmlns:fibo-der-etd-fxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"
+buxmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FuturesExchanges</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts relating to the listing of futures contracts on a derivatives exchange.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fxc;FuturesListing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesListing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fxc;marginCall"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fxc;marginProvision"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A listing of a futures instrument on a derivatives exchange.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fxc;StandardizedFuturesListingTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fxc;becomeFeaturesOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fxc;definedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standardized futures listing terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Standard terms set out by the exchange which will apply to any listing of a futures contract on this exchange.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Individual listings will take on these standard terms but they are not contractual terms of the futures contract, they are facts about that listing on that exchange.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;becomeFeaturesOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">become features of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fxc;StandardizedFuturesListingTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;definedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fxc;StandardizedFuturesListingTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;marginCall">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has margin call</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A broker&apos;s demand on an investor using margin to deposit additional money or securities so that the margin account is brought up to the minimum maintenance margin. This is sometimes called a &apos;fed call&apos; or &apos;maintenance call&apos;.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;marginCallApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">margin call applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fxc;StandardizedFuturesListingTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not a Margin Call may be applicable to the listing.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;marginProvision">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has margin provision</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fxc;FuturesListing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An amount necessary to cover the purchase of the underlying security since delivery is mandatory, be it physical or cash. Failing to provide a sufficient provision will result in a margin call.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fxc;specifiesDeliveryMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies delivery method</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Type of delivery for contracts. This determines what is delivered to the holder when the future is exercised.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/ExchangeTradedDerivatives/FuturesStandardizedTerms.rdf
+++ b/der/ExchangeTradedDerivatives/FuturesStandardizedTerms.rdf
@@ -1,245 +1,248 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-etd-fstd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/">
-	<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
-	<!ENTITY fibo-der-etd-fxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/">
-	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-etd-fstd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/">
+bu<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/">
+bu<!ENTITY fibo-der-etd-fxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/">
+bu<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"
-	xmlns:fibo-der-etd-fstd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"
-	xmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"
-	xmlns:fibo-der-etd-fxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"
-	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/">
-		<rdfs:label xml:lang="en">FuturesStandardizedTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;BondFutureStandardizedTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;InterestRateFutureStandardizedTermsSet"/>
-		<rdfs:label xml:lang="en">bond future standardized terms set</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for bond futures contracts, as set out by the derivatives exchange. Bond Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;DerivativesDeliveryCash">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
-		<rdfs:label xml:lang="en">derivatives delivery cash</rdfs:label>
-		<skos:definition xml:lang="en">Cash settlement involves paying the difference between the futures price and the spot price of the underlying asset</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A settlement method used in certain future and option contracts whereby, upon expiry or exercise, the seller of the financial instrument does not deliver the actual but transfers the associated cash position. For sellers not wishing to take actual possession of the underlying cash commodity, cash settlement is a more convenient method of transacting futures and options contracts. For example, the purchaser of a cotton future that is cash settled, rather than being required to take ownership of physical bundles of cotton, pays the difference between the spot price of cotton and the futures price.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;DerivativesDeliveryPhysical">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
-		<rdfs:label xml:lang="en">derivatives delivery physical</rdfs:label>
-		<skos:definition xml:lang="en">Delivery means physically delivering the underlying asset on the agreed date. Term in an options or futures contract which requires the actual underlying asset to be delivered upon the specified delivery date, rather than being traded out with offsetting contracts.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If you sell a gold futures contract of say 1 kilogram then you will have to give real gold to the buyer on the mutually agreed date. Most derivatives are not actually exercised, but are traded out before their delivery date. However, physical delivery still occurs with some trades: it is most common with commodities, but can also occur with other financial instruments.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;DerivativesDeliverySquaringOff">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
-		<rdfs:label xml:lang="en">derivatives delivery squaring off</rdfs:label>
-		<skos:definition xml:lang="en">Squaring off means taking a position opposite your initial one. For example, you square off the purchase of a gold futures contract by selling the identical contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;DerivativesDeliveryType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DeliveryMethod"/>
-		<rdfs:label xml:lang="en">derivatives delivery type</rdfs:label>
-		<skos:definition xml:lang="en">Type of delivery for a traded futures or options contract; the way in which a contract is settled in the event of expiry or exercise.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">What&apos;s expected is the delivery of the commodity but in most cases that is not the case there is some other form of settlement, i.e. there is some exit strategy on the expiration of the future. There are 3 ways: squaring off, delivery and cash settlement (difference between future price and spot of underlying asset).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;EquityFutureStandardizedTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet"/>
-		<rdfs:label xml:lang="en">equity future standardized terms set</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for equity futures contracts, as set out by the derivatives exchange. Equity Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fstd;becomesTermsOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial future standardized terms set</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for financial futures contracts, as set out by the derivatives exchange. Financial Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;IndexFutureStandardizedTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet"/>
-		<rdfs:label xml:lang="en">index future standardized terms set</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for index futures contracts, as set out by the derivatives exchange. Index Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;InterestRateFutureStandardizedTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet"/>
-		<rdfs:label xml:lang="en">interest rate future standardized terms set</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for interest rate futures contracts, as set out by the derivatives exchange. Interest Rate Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;MoneyMarketFutureStandardizedTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;InterestRateFutureStandardizedTermsSet"/>
-		<rdfs:label xml:lang="en">money market future standardized terms set</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for money market futures contracts, as set out by the derivatives exchange. Money Market Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;StandardizedCommodityFutureTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fstd;becomesTermsOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;CommodityFuture"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized commodity future terms set</rdfs:label>
-		<skos:definition xml:lang="en">Standard terms for a commodity futures contract, determined in advance by the exchange. These will become terms of an individual futures contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These may be varied or overridden for individual contracts.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fstd;StandardizedFuturesTerms">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/StandardizedTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fxc;specifiesDeliveryMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fstd;becomesTermsOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fstd;definedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fstd;pricingToBeDeterminedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized futures terms</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for futures contracts, as set out by the derivatives exchange. Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Standard symbology for the commodities are standardized by the exchanges as part of their standard contracts, for example trading in standard bushels, commonly defined kinds of oil and so on. These give the units in which lot sizes are described and defined.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;becomesTermsOf">
-		<rdfs:label xml:lang="en">becomes terms of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;contractSize">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;EquityFutureStandardizedTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of share units underlying the futures contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;contractSize.1">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The deliverable quantity of goods or commodities underlying the futures contract. This is denominated as a multiple of the lot size in the case of a commodity future. For financial futures this is the number of units of the underlying security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;conversionFactor">
-		<rdfs:label xml:lang="en">conversion factor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;BondFutureStandardizedTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The conversion factor is the price of the delivered bond/note ($1 par value) to yield a fixed rate. The conversion factor is used to calculate a final delivery price.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;definedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-		<rdfs:label xml:lang="en">defined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;lotSize">
-		<rdfs:label xml:lang="en">lot size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedCommodityFutureTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">How many of the underlying commodity can be sold. The groupings of certain units of measure in the underlying commodity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;multiple">
-		<rdfs:label xml:lang="en">multiple</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;IndexFutureStandardizedTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The multiple for determining the price of the futures contract in relation to the underlying index rate.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;pricingToBeDeterminedBy">
-		<rdfs:label xml:lang="en">pricing to be determined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;tickSize">
-		<rdfs:label xml:lang="en">tick size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The minimum value of the upward or downward movement of the price of the contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;tickValue">
-		<rdfs:label xml:lang="en">tick value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The minimum value of the upward or downward movement of the contract. This is the contract size multiplied by the tick size.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;unitOfMeasure">
-		<rdfs:label xml:lang="en">unit of measure</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedCommodityFutureTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The unit in which the underlying commodity is to be measured.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;unitOfTrading">
-		<rdfs:label xml:lang="en">unit of trading</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The pre-determined unit in which financial futures will be traded on this exchange.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-etd-fstd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"
+buxmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"
+buxmlns:fibo-der-etd-fxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"
+buxmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FuturesStandardizedTerms</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Standard contractual terms for potential future contracts that an investor may enter into with the derivatives exchange. Includes terms specific to different types of future contract and different available delivery arrangements.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesExchanges/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;BondFutureStandardizedTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;InterestRateFutureStandardizedTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond future standardized terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of standard terms for bond futures contracts, as set out by the derivatives exchange. Bond Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;DerivativesDeliveryCash">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives delivery cash</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Cash settlement involves paying the difference between the futures price and the spot price of the underlying asset</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A settlement method used in certain future and option contracts whereby, upon expiry or exercise, the seller of the financial instrument does not deliver the actual but transfers the associated cash position. For sellers not wishing to take actual possession of the underlying cash commodity, cash settlement is a more convenient method of transacting futures and options contracts. For example, the purchaser of a cotton future that is cash settled, rather than being required to take ownership of physical bundles of cotton, pays the difference between the spot price of cotton and the futures price.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;DerivativesDeliveryPhysical">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives delivery physical</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery means physically delivering the underlying asset on the agreed date. Term in an options or futures contract which requires the actual underlying asset to be delivered upon the specified delivery date, rather than being traded out with offsetting contracts.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">If you sell a gold futures contract of say 1 kilogram then you will have to give real gold to the buyer on the mutually agreed date. Most derivatives are not actually exercised, but are traded out before their delivery date. However, physical delivery still occurs with some trades: it is most common with commodities, but can also occur with other financial instruments.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;DerivativesDeliverySquaringOff">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives delivery squaring off</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Squaring off means taking a position opposite your initial one. For example, you square off the purchase of a gold futures contract by selling the identical contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;DerivativesDeliveryType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DeliveryMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives delivery type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Type of delivery for a traded futures or options contract; the way in which a contract is settled in the event of expiry or exercise.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">What&apos;s expected is the delivery of the commodity but in most cases that is not the case there is some other form of settlement, i.e. there is some exit strategy on the expiration of the future. There are 3 ways: squaring off, delivery and cash settlement (difference between future price and spot of underlying asset).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;EquityFutureStandardizedTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity future standardized terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of standard terms for equity futures contracts, as set out by the derivatives exchange. Equity Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fstd;becomesTermsOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial future standardized terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of standard terms for financial futures contracts, as set out by the derivatives exchange. Financial Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;IndexFutureStandardizedTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index future standardized terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of standard terms for index futures contracts, as set out by the derivatives exchange. Index Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;InterestRateFutureStandardizedTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate future standardized terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of standard terms for interest rate futures contracts, as set out by the derivatives exchange. Interest Rate Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;MoneyMarketFutureStandardizedTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;InterestRateFutureStandardizedTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">money market future standardized terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of standard terms for money market futures contracts, as set out by the derivatives exchange. Money Market Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;StandardizedCommodityFutureTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fstd;becomesTermsOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;CommodityFuture"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standardized commodity future terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Standard terms for a commodity futures contract, determined in advance by the exchange. These will become terms of an individual futures contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These may be varied or overridden for individual contracts.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-fstd;StandardizedFuturesTerms">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/StandardizedTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fxc;specifiesDeliveryMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fstd;DerivativesDeliveryType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fstd;becomesTermsOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fstd;definedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-fstd;pricingToBeDeterminedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standardized futures terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of standard terms for futures contracts, as set out by the derivatives exchange. Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Standard symbology for the commodities are standardized by the exchanges as part of their standard contracts, for example trading in standard bushels, commonly defined kinds of oil and so on. These give the units in which lot sizes are described and defined.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;becomesTermsOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes terms of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;contractSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;EquityFutureStandardizedTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of share units underlying the futures contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;contractSize.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The deliverable quantity of goods or commodities underlying the futures contract. This is denominated as a multiple of the lot size in the case of a commodity future. For financial futures this is the number of units of the underlying security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;conversionFactor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conversion factor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;BondFutureStandardizedTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The conversion factor is the price of the delivered bond/note ($1 par value) to yield a fixed rate. The conversion factor is used to calculate a final delivery price.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;definedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;lotSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lot size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedCommodityFutureTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How many of the underlying commodity can be sold. The groupings of certain units of measure in the underlying commodity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;multiple">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiple</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;IndexFutureStandardizedTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The multiple for determining the price of the futures contract in relation to the underlying index rate.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;pricingToBeDeterminedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pricing to be determined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;tickSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tick size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The minimum value of the upward or downward movement of the price of the contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;tickValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tick value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedFuturesTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The minimum value of the upward or downward movement of the contract. This is the contract size multiplied by the tick size.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;unitOfMeasure">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unit of measure</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;StandardizedCommodityFutureTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The unit in which the underlying commodity is to be measured.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-fstd;unitOfTrading">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unit of trading</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-fstd;FinancialFutureStandardizedTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The pre-determined unit in which financial futures will be traded on this exchange.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/ExchangeTradedDerivatives/OptionsExchanges.rdf
+++ b/der/ExchangeTradedDerivatives/OptionsExchanges.rdf
@@ -1,95 +1,98 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-etd-oxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/">
-	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-etd-oxc "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/">
+bu<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/"
-	xmlns:fibo-der-etd-oxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/"
-	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/">
-		<rdfs:label xml:lang="en">OptionsExchanges</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-etd-oxc;ClearingParticipant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
-		<rdfs:label xml:lang="en">clearing participant</rdfs:label>
-		<skos:definition xml:lang="en">People who are members of the exchange who are allowed to clear the trades. There are various categories of entities which are participating in this full process: FTrading Member Clearing Member Entity which does both for itself (not professionally carrying out the clearing for other</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-oxc;DerivativesBroker">
-		<rdfs:label xml:lang="en">derivatives broker</rdfs:label>
-		<skos:definition xml:lang="en">A party which is party to the transaction between entities which are not on the Derivatives Exchange. The Broker is then also a member of the Exchange (see Trading PArticipant), and in this context is the one who carries out the deals on the exchange, and who settles his margin daily. These may poarticipate in the OTC market also, where they just get a fee for introdiucing them. In formal exchanges, the Broker is doing th edeal, and the fact that the deal is passed on to others is a separate transaction, which they are also party to.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-oxc;MarginAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Account"/>
-		<rdfs:label xml:lang="en">margin account</rdfs:label>
-		<skos:definition xml:lang="en">Account held at a Derivatives Exchange by a participant in that exchange.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-oxc;OptionsExchangeParticipant">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">options exchange participant</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-oxc;OptionsListing">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesListing"/>
-		<rdfs:label xml:lang="en">options listing</rdfs:label>
-		<skos:definition xml:lang="en">A listing of an options instrument on a derivatives exchange. The listing is a product of the individual exchange.</skos:definition>
-		<skos:editorialNote xml:lang="en">This term sdoes not exist. If there was a listing of something that was an option, it would be a warrant. Review: We agreed to come back to this definition and verify whether it means the same as listing in the equities sense .</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-oxc;TradingParticipant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-oxc;OptionsExchangeParticipant"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-oxc;canBecome"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-oxc;ClearingParticipant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-oxc;mayBe"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-oxc;DerivativesBroker"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">trading participant</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-oxc;canBecome">
-		<rdfs:label xml:lang="en">can become</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-oxc;ClearingParticipant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-oxc;mayBe">
-		<rdfs:label xml:lang="en">may be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-oxc;DerivativesBroker"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-etd-oxc="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/"
+buxmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">OptionsExchanges</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts relating to the listing of futures contracts on a derivatives exchange along with the basic notion of a margin account on such an exchange.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsExchanges/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-oxc;ClearingParticipant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">clearing participant</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">People who are members of the exchange who are allowed to clear the trades. There are various categories of entities which are participating in this full process: FTrading Member Clearing Member Entity which does both for itself (not professionally carrying out the clearing for other</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-oxc;DerivativesBroker">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivatives broker</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which is party to the transaction between entities which are not on the Derivatives Exchange. The Broker is then also a member of the Exchange (see Trading PArticipant), and in this context is the one who carries out the deals on the exchange, and who settles his margin daily. These may poarticipate in the OTC market also, where they just get a fee for introdiucing them. In formal exchanges, the Broker is doing th edeal, and the fact that the deal is passed on to others is a separate transaction, which they are also party to.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-oxc;MarginAccount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">margin account</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Account held at a Derivatives Exchange by a participant in that exchange.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-oxc;OptionsExchangeParticipant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">options exchange participant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-oxc;OptionsListing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesListing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">options listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A listing of an options instrument on a derivatives exchange. The listing is a product of the individual exchange.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This term sdoes not exist. If there was a listing of something that was an option, it would be a warrant. Review: We agreed to come back to this definition and verify whether it means the same as listing in the equities sense .</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-oxc;TradingParticipant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-oxc;OptionsExchangeParticipant"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-oxc;canBecome"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-oxc;ClearingParticipant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-oxc;mayBe"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-oxc;DerivativesBroker"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading participant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-oxc;canBecome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">can become</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-oxc;ClearingParticipant"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-oxc;mayBe">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-oxc;TradingParticipant"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-oxc;DerivativesBroker"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/ExchangeTradedDerivatives/OptionsStandardizedTerms.rdf
+++ b/der/ExchangeTradedDerivatives/OptionsStandardizedTerms.rdf
@@ -1,256 +1,259 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-etd-eto "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
-	<!ENTITY fibo-der-etd-ostd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
-	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-der-etd-eto "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
+bu<!ENTITY fibo-der-etd-ostd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
+bu<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-etd-eto="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
-	xmlns:fibo-der-etd-ostd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"
-	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
-		<rdfs:label xml:lang="en">OptionsStandardizedTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:label xml:lang="en">options clearing entity</rdfs:label>
-		<skos:definition xml:lang="en">An entity which is responsible for clearing transactions for put and call options on common stocks and other equity issues, stock indexes, foreign currencies, interest rate composites and single-stock futures.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">e.g. Options Clearing Corporation (US). In Canada the equivalent is In the US, the Options Clearing Corporation defines defaults e.g. lot sizes. This applies to equity options, index options, flex options, yield based options and short dated options. It does not apply to other types of option. Its roles are: 1. Clearing 2. Advocate for sound business practice. Similar to regulator though not officially one. Has a role in risk management Full list from OCC website: OCC clears transactions for put and call options on common stocks and other equity issues, stock indexes, foreign currencies, interest rate composites and single-stock futures</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedCurrencyOptionTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ForeignCurrencyOption"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized currency option terms set</rdfs:label>
-		<skos:definition xml:lang="en">Standard terms for a currency optioon contract, determined in advance by the exchange. These will become terms of an individual currency option contract. These may be varied or overridden for individual contracts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedEquityOptionTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;EquityOption"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized equity option terms set</rdfs:label>
-		<skos:definition xml:lang="en">Standard terms for an equity option contract, determined in advance by the exchange. These will become terms of an individual equity option contract. These may be varied or overridden for individual contracts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;becomesPartOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-eto;standardExerciseTermsHasExerciseConvention"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-ostd;specifies"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized exercise terms set</rdfs:label>
-		<skos:definition xml:lang="en">Standard exercise terms for an option contract, determined in advance by the exchange. These will become exercise terms of an individual option contract. These may be varied or overridden for individual contracts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedFuturesOptionTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized futures option terms set</rdfs:label>
-		<skos:definition xml:lang="en">Standard terms for a futures options contract, determined in advance by the exchange. These will become terms of an individual futures option contract. These may be varied or overridden for individual contracts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedIndexOptionTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ExchangeTradedEquityIndexOption"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized index option terms set</rdfs:label>
-		<skos:definition xml:lang="en">Standard terms for an index option contract, determined in advance by the exchange. These will become terms of an individual index option contract. These may be varied or overridden for individual contracts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedOptionsTerms">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/StandardizedTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-ostd;includesFeature"/>
-				<owl:onClass rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-ostd;definedBy"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-ostd;pricingToBeDeterminedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized options terms</rdfs:label>
-		<skos:definition xml:lang="en">A standardized set of terms for an options contract. These are defined by a securities exchange or an options clearing entity. Options contracts issued by the exchange may embody these terms or have equivalent terms which override these.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;becomesTermsOf">
-		<rdfs:label xml:lang="en">becomes terms of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;contractSize">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedCurrencyOptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The number of units of the currency traded under one Futures Contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;contractSize.1">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedEquityOptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of shares traded under one Option Contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;contractSize.2">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedFuturesOptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of futures contracts traded under one Futures Option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;contractSize.3">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of underlyers to be in a contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;definedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-		<rdfs:label xml:lang="en">defined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;includesFeature">
-		<rdfs:label xml:lang="en">includes feature</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;indexMultiplier">
-		<rdfs:label xml:lang="en">index multiplier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedIndexOptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The multiple of the index traded under one Futures contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;optionType">
-		<rdfs:label xml:lang="en">option type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-der-opt;OptionTypeSelection"/>
-		<skos:definition xml:lang="en">Whether the option will be a call or a put option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;pricingToBeDeterminedBy">
-		<rdfs:label xml:lang="en">pricing to be determined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;specifies">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedExerciseTermsSet"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-der-etd-eto="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
+buxmlns:fibo-der-etd-ostd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"
+buxmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">OptionsStandardizedTerms</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Standard contractual terms for potential options contracts that an investor may enter into with the derivatives exchange. Includes terms specific to different types of option and different available exercise and delivery arrangements.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">options clearing entity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An entity which is responsible for clearing transactions for put and call options on common stocks and other equity issues, stock indexes, foreign currencies, interest rate composites and single-stock futures.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">e.g. Options Clearing Corporation (US). In Canada the equivalent is In the US, the Options Clearing Corporation defines defaults e.g. lot sizes. This applies to equity options, index options, flex options, yield based options and short dated options. It does not apply to other types of option. Its roles are: 1. Clearing 2. Advocate for sound business practice. Similar to regulator though not officially one. Has a role in risk management Full list from OCC website: OCC clears transactions for put and call options on common stocks and other equity issues, stock indexes, foreign currencies, interest rate composites and single-stock futures</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedCurrencyOptionTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ForeignCurrencyOption"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standardized currency option terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Standard terms for a currency optioon contract, determined in advance by the exchange. These will become terms of an individual currency option contract. These may be varied or overridden for individual contracts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedEquityOptionTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;EquityOption"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standardized equity option terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Standard terms for an equity option contract, determined in advance by the exchange. These will become terms of an individual equity option contract. These may be varied or overridden for individual contracts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedExerciseTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;becomesPartOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionInstrumentExerciseTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-eto;standardExerciseTermsHasExerciseConvention"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-ostd;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standardized exercise terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Standard exercise terms for an option contract, determined in advance by the exchange. These will become exercise terms of an individual option contract. These may be varied or overridden for individual contracts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedFuturesOptionTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;OptionContractOnFutures"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standardized futures option terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Standard terms for a futures options contract, determined in advance by the exchange. These will become terms of an individual futures option contract. These may be varied or overridden for individual contracts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedIndexOptionTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ExchangeTradedEquityIndexOption"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standardized index option terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Standard terms for an index option contract, determined in advance by the exchange. These will become terms of an individual index option contract. These may be varied or overridden for individual contracts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-ostd;StandardizedOptionsTerms">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/StandardizedTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-ostd;includesFeature"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-ostd;becomesTermsOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-ostd;definedBy"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-etd-ostd;pricingToBeDeterminedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standardized options terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A standardized set of terms for an options contract. These are defined by a securities exchange or an options clearing entity. Options contracts issued by the exchange may embody these terms or have equivalent terms which override these.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;becomesTermsOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes terms of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;contractSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedCurrencyOptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of units of the currency traded under one Futures Contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;contractSize.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedEquityOptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of shares traded under one Option Contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;contractSize.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedFuturesOptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of futures contracts traded under one Futures Option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;contractSize.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of underlyers to be in a contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;definedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;includesFeature">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes feature</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionBarrierFeatureTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;indexMultiplier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index multiplier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedIndexOptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The multiple of the index traded under one Futures contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;optionType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-opt;OptionTypeSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the option will be a call or a put option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;pricingToBeDeterminedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pricing to be determined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedOptionsTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-etd-ostd;specifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-ostd;StandardizedExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/FxDerivatives/FxContracts.rdf
+++ b/der/FxDerivatives/FxContracts.rdf
@@ -1,66 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
-		<rdfs:label xml:lang="en">FxContracts</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-fx-ctr;ExchangeRateUnderlying">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-ctr;identity"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/QuotedExchangeRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exchange rate underlying</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
-		<rdfs:label xml:lang="en">foreign exchange derivative contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-ctr;OTCFxProduct">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCProduct"/>
-		<rdfs:label xml:lang="en">o t c fx product</rdfs:label>
-		<skos:definition xml:lang="en">An OTC Product for foreign exchange, whereby two or more currencies are transacted.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Includes Fx spots, forwards, swaps and the like.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-ctr;identity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">underlying identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-ctr;ExchangeRateUnderlying"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/QuotedExchangeRate"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FxContracts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts common to foreign exchange derivatives (spots, forwards, options and swaps).</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-ctr;ExchangeRateUnderlying">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-ctr;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/QuotedExchangeRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange rate underlying</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">foreign exchange derivative contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-ctr;OTCFxProduct">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCProduct"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c fx product</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An OTC Product for foreign exchange, whereby two or more currencies are transacted.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Includes Fx spots, forwards, swaps and the like.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-ctr;identity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-ctr;ExchangeRateUnderlying"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/QuotedExchangeRate"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/FxDerivatives/FxForwards.rdf
+++ b/der/FxDerivatives/FxForwards.rdf
@@ -1,175 +1,178 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
-	<!ENTITY fibo-der-fx-fwd "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/">
-	<!ENTITY fibo-der-fx-sp "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
-	<!ENTITY fibo-der-fx-sw "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
+bu<!ENTITY fibo-der-fx-fwd "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/">
+bu<!ENTITY fibo-der-fx-sp "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
+bu<!ENTITY fibo-der-fx-sw "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/"
-	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
-	xmlns:fibo-der-fx-fwd="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/"
-	xmlns:fibo-der-fx-sp="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"
-	xmlns:fibo-der-fx-sw="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/">
-		<rdfs:label xml:lang="en">FxForwards</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-fx-fwd;FXForwardOutrightContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
-		<rdfs:label xml:lang="en">f x forward outright contract</rdfs:label>
-		<skos:definition xml:lang="en">A forward contract in the forex market that locks in the price at which an entity can buy or sell a currency on a future date. Also known as &quot;outright forward currency transaction&quot;, &quot;forward outright&quot; or &quot;FX forward&quot;.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In currency forward contracts, the contract holders are obligated to buy or sell the currency at a specified price, at a specified quantity and on a specified future date. These contracts cannot be transferred. Jan 10 Review Notes Outright Forward is the term for the professional markets. Spot + Swap where Swap is 2 simultaneous transactions.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-fwd;FxForwardContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx forward contract</rdfs:label>
-		<skos:definition xml:lang="en">A agreement to deliver and settle a given amount of currency in one currency, in exchange for a given amount in another currency, at an agreed date in the future and at an agreed rate of exchange.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-fwd;FxForwardOutright">
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;OTCFxProduct"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-fwd;hasPart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpot"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-fwd;hasPart.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-sw;FxSwap"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx forward outright</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-fwd;FxForwardTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-fwd;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-fwd;side"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-fwd;side.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx forward transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction in which cash is exchanged in two currencies at an agreed rate at an agreed date in the future.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;embodies">
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;exchangedCurrencyOne">
-		<rdfs:label xml:lang="en">exchanged currency one</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">FpML has a term exchangedCurrency1 but this refers to the currency flow not the currency as in USD, CDN etc. FpML definition for exchangedCurrency1: &apos;This is the first of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;exchangedCurrencyTwo">
-		<rdfs:label xml:lang="en">exchanged currency two</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;forwardRate">
-		<rdfs:label xml:lang="en">forward rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FXForwardOutrightContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The rate at which the seller currency is purchased in the buyer currency.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;fxForwardRate">
-		<rdfs:label xml:lang="en">fx forward rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">&apos;The rate of exchange between the two currencies.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;hasPart">
-		<rdfs:label xml:lang="en">has part</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardOutright"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpot"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;hasPart.1">
-		<rdfs:label xml:lang="en">has part</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardOutright"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-sw;FxSwap"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;side">
-		<rdfs:label xml:lang="en">side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;side.1">
-		<rdfs:label xml:lang="en">side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
+buxmlns:fibo-der-fx-fwd="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/"
+buxmlns:fibo-der-fx-sp="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"
+buxmlns:fibo-der-fx-sw="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FxForwards</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">A forward transaction and the corresponding or implied contract in which payment is made or received in the future based on the exchange rate between two currencies at that defined future date. Includes the notion of an Fx Forward Outright Contract.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-fwd;FXForwardOutrightContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">f x forward outright contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A forward contract in the forex market that locks in the price at which an entity can buy or sell a currency on a future date. Also known as &quot;outright forward currency transaction&quot;, &quot;forward outright&quot; or &quot;FX forward&quot;.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In currency forward contracts, the contract holders are obligated to buy or sell the currency at a specified price, at a specified quantity and on a specified future date. These contracts cannot be transferred. Jan 10 Review Notes Outright Forward is the term for the professional markets. Spot + Swap where Swap is 2 simultaneous transactions.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-fwd;FxForwardContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx forward contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A agreement to deliver and settle a given amount of currency in one currency, in exchange for a given amount in another currency, at an agreed date in the future and at an agreed rate of exchange.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-fwd;FxForwardOutright">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;OTCFxProduct"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-fwd;hasPart"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpot"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-fwd;hasPart.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-sw;FxSwap"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx forward outright</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-fwd;FxForwardTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-fwd;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-fwd;side"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-fwd;side.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx forward transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction in which cash is exchanged in two currencies at an agreed rate at an agreed date in the future.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;embodies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;exchangedCurrencyOne">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchanged currency one</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">FpML has a term exchangedCurrency1 but this refers to the currency flow not the currency as in USD, CDN etc. FpML definition for exchangedCurrency1: &apos;This is the first of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;exchangedCurrencyTwo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchanged currency two</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;forwardRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FXForwardOutrightContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rate at which the seller currency is purchased in the buyer currency.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;fxForwardRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx forward rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&apos;The rate of exchange between the two currencies.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;hasPart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has part</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardOutright"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpot"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;hasPart.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has part</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardOutright"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-sw;FxSwap"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;side">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">side</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;side.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">side</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/FxDerivatives/FxOptions.rdf
+++ b/der/FxDerivatives/FxOptions.rdf
@@ -1,261 +1,264 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
-	<!ENTITY fibo-der-fx-opt "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxOptions/">
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
+bu<!ENTITY fibo-der-fx-opt "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxOptions/">
+bu<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxOptions/"
-	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
-	xmlns:fibo-der-fx-opt="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxOptions/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxOptions/">
-		<rdfs:label xml:lang="en">Foreign Exchange (FX) Options</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxOptions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;CashCallOption">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-opt;allowsForOptionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash call option</rdfs:label>
-		<skos:definition xml:lang="en">Option to purchase cash at an agreed rate on an agreed date.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;CashPutOption">
-		<rdfs:label xml:lang="en">cash put option</rdfs:label>
-		<skos:definition xml:lang="en">Option to sell cash at an agreed rate on an agreed date.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In Fx Put and Call refer to the Dealt Ccy, ie. I will put the dealt Ccy&quot; o I will cal the Dealt ccy&quot;. The business does use the terms Put and Call. Put and Call are always from the PoV of the option beneficiary, always specifieds the side the bene will put or call. Have to know the Dealt Ccy and that it&apos;s to the Beneficiary not the granter of the option. The beneficiary gets to put the dealt ccy. Put X and Call Y in the same contract can also be stated in order to disambiguate, but you don&apos;t have to because the DC is already defined.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-opt;buyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-opt;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionSeller"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">foreign exchange (FX) option</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionBuyer">
-		<rdfs:label xml:lang="en">fx option buyer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionLeg">
-		<rdfs:label xml:lang="en">fx option leg</rdfs:label>
-		<skos:definition xml:lang="en">A standard FX OTC option (European or American) which may be a complete trade in its own right or part of a trade strategy. FpML A type that is used for describing a standard FX OTC option (European or American) which may be a complete trade in its own right or part of a trade strategy.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionPremium">
-		<rdfs:label xml:lang="en">fx option premium</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">FpML &apos;Premium amount or premium installment amount for an option.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionSeller">
-		<rdfs:label xml:lang="en">fx option seller</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-opt;buyerIsParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-opt;hasCorrespondingContract"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-opt;hasLeg"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionLeg"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-opt;seller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionSeller"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx option transaction</rdfs:label>
-		<skos:definition xml:lang="en">Define option as a wrapper. Done on a spot txn, but could logically be others. Adds the right whether or not to go into that.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;FxCallOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-opt;establishes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;CashCallOption"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-opt;establishes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx call option contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;FxPutOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
-		<rdfs:label xml:lang="en">fx put option contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;FxVolatilityOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
-		<rdfs:label xml:lang="en">fx volatility option</rdfs:label>
-		<skos:definition xml:lang="en">An option on the volatility of an FX rate. Further Note: Not found in FpML product definitions or taxonomy.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-opt;OTCCurrencyOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
-		<rdfs:label xml:lang="en">o t c currency option</rdfs:label>
-		<skos:definition xml:lang="en">A contract that grants the holder the right, but not the obligation, to buy or sell currency at a specified exchange rate during a specified period of time.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For this right, a premium is paid to the broker, which will vary depending on the number of contracts purchased. Currency options are one of the best ways for corporations or individuals to hedge against adverse movements in exchange rates. Investors can hedge against foreign currency risk by purchasing a currency option put or call. For example, assume that an investor believes that the USD/EUR rate is going to increase from 0.80 to 0.90 (meaning that it will become more expensive for a European investor to buy U.S dollars). In this case, the investor would want to buy a call option on USD/EUR so that he or she could stand to gain from an increase in the exchange rate (or the USD rise).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;allowsForOptionOf">
-		<rdfs:label xml:lang="en">allows for option of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;CashCallOption"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;buyer">
-		<rdfs:label xml:lang="en">buyer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionBuyer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;buyerIsParty">
-		<rdfs:label xml:lang="en">buyer is party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionBuyer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;buyingCurrency">
-		<rdfs:label xml:lang="en">buying currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;OTCCurrencyOption"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the option is bought.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;establishes">
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;FxCallOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-opt;CashCallOption"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;establishes.1">
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;FxCallOptionContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;expiry">
-		<rdfs:label xml:lang="en">expiry</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">FpML &apos;The date and time in a location of the option expiry. In the case of american options this is the latest possible expiry date and time.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;hasCorrespondingContract">
-		<rdfs:label xml:lang="en">has corresponding contract</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;hasLeg">
-		<rdfs:label xml:lang="en">has leg</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionLeg"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;hasSeller">
-		<rdfs:label xml:lang="en">has seller</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionSeller"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;seller">
-		<rdfs:label xml:lang="en">seller</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionSeller"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;sellingCurrency">
-		<rdfs:label xml:lang="en">selling currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;OTCCurrencyOption"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the Option is sold.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;strikeRate">
-		<rdfs:label xml:lang="en">strike rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
+buxmlns:fibo-der-fx-opt="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxOptions/"
+buxmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxOptions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Foreign Exchange (FX) Options</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Options where the option for the holder to call or put the option is based on a rate of exchange between two currencies at a time or times in the future.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxOptions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;CashCallOption">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-opt;allowsForOptionOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash call option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Option to purchase cash at an agreed rate on an agreed date.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;CashPutOption">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash put option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Option to sell cash at an agreed rate on an agreed date.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In Fx Put and Call refer to the Dealt Ccy, ie. I will put the dealt Ccy&quot; o I will cal the Dealt ccy&quot;. The business does use the terms Put and Call. Put and Call are always from the PoV of the option beneficiary, always specifieds the side the bene will put or call. Have to know the Dealt Ccy and that it&apos;s to the Beneficiary not the granter of the option. The beneficiary gets to put the dealt ccy. Put X and Call Y in the same contract can also be stated in order to disambiguate, but you don&apos;t have to because the DC is already defined.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-opt;buyer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-opt;hasSeller"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionSeller"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">foreign exchange (FX) option</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionBuyer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx option buyer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionLeg">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx option leg</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A standard FX OTC option (European or American) which may be a complete trade in its own right or part of a trade strategy. FpML A type that is used for describing a standard FX OTC option (European or American) which may be a complete trade in its own right or part of a trade strategy.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionPremium">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx option premium</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">FpML &apos;Premium amount or premium installment amount for an option.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionSeller">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx option seller</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;ForeignExchangeOptionTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionalUnderlyingTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-opt;buyerIsParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionBuyer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-opt;hasCorrespondingContract"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-opt;hasLeg"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionLeg"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-opt;seller"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionSeller"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx option transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Define option as a wrapper. Done on a spot txn, but could logically be others. Adds the right whether or not to go into that.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;FxCallOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-opt;establishes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-opt;CashCallOption"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-opt;establishes.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx call option contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;FxPutOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx put option contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;FxVolatilityOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx volatility option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option on the volatility of an FX rate. Further Note: Not found in FpML product definitions or taxonomy.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-opt;OTCCurrencyOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c currency option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A contract that grants the holder the right, but not the obligation, to buy or sell currency at a specified exchange rate during a specified period of time.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For this right, a premium is paid to the broker, which will vary depending on the number of contracts purchased. Currency options are one of the best ways for corporations or individuals to hedge against adverse movements in exchange rates. Investors can hedge against foreign currency risk by purchasing a currency option put or call. For example, assume that an investor believes that the USD/EUR rate is going to increase from 0.80 to 0.90 (meaning that it will become more expensive for a European investor to buy U.S dollars). In this case, the investor would want to buy a call option on USD/EUR so that he or she could stand to gain from an increase in the exchange rate (or the USD rise).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;allowsForOptionOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allows for option of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;CashCallOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;buyer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">buyer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionBuyer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;buyerIsParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">buyer is party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionBuyer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;buyingCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">buying currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;OTCCurrencyOption"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which the option is bought.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;establishes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;FxCallOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-opt;CashCallOption"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;establishes.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;FxCallOptionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;expiry">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expiry</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">FpML &apos;The date and time in a location of the option expiry. In the case of american options this is the latest possible expiry date and time.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;hasCorrespondingContract">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has corresponding contract</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;hasLeg">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has leg</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionLeg"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;hasSeller">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has seller</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionSeller"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;seller">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">seller</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-opt;ForeignExchangeOptionSeller"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;sellingCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">selling currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;OTCCurrencyOption"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which the Option is sold.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;strikeRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strike rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-opt;ForeignExchangeOption"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/FxDerivatives/FxSpots.rdf
+++ b/der/FxDerivatives/FxSpots.rdf
@@ -1,185 +1,188 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-sp "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/">
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
-	<!ENTITY fibo-der-fx-sp "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-sp "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
+bu<!ENTITY fibo-der-fx-sp "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"
-	xmlns:fibo-der-der-sp="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
-	xmlns:fibo-der-fx-sp="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
-		<rdfs:label xml:lang="en">FxSpots</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-fx-sp;FxSpot">
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;OTCFxProduct"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-sp;hasCorrespondingTransaction"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx spot</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-sp;FxSpotContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/CurrencySpotBuyRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-sp;establishes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-sp;establishes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx spot contract</rdfs:label>
-		<skos:definition xml:lang="en">The rate of a foreign-exchange contract for immediate delivery. Also known as &quot;benchmark rates&quot;, &quot;straightforward rates&quot; or &quot;outright rates&quot;, spot rates represent the price that a buyer expects to pay for a foreign currency in another currency.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Though the spot exchange rate is said to be settled immediately, the globally accepted settlement cycle for foreign-exchange contracts is two days. Foreign-exchange contracts are therefore settled on the second day after the day the deal is made.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-sp;FxSpotSettlementCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotSettlementCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-sp;commitsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx spot settlement commitment</rdfs:label>
-		<skos:definition xml:lang="en">no definition</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML exchangedCurrency2 referred to as a &quot;Currency Stream&quot;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-sp;FxSpotTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-sp;hasImpliedContract"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-sp;hasSide"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;DeliverCash"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-sp;hasSide"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;subject"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx spot transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;buyerCurrency">
-		<rdfs:label xml:lang="en">buyer currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The buyer&apos;s currency as specified in the contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;commitsTo">
-		<rdfs:label xml:lang="en">commits to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
-		<owl:inverseOf rdf:resource="&fibo-der-der-sp;embodies"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;establishes">
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;establishes.1">
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;fxSpotRate">
-		<rdfs:label xml:lang="en">fx spot rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">&apos;The rate of exchange between the two currencies.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;hasCorrespondingTransaction">
-		<rdfs:label xml:lang="en">has corresponding transaction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpot"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;hasSide">
-		<rdfs:label xml:lang="en">has side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;sellerCurrency">
-		<rdfs:label xml:lang="en">seller currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The seller&apos;s currency as specified in the contract.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-sp="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
+buxmlns:fibo-der-fx-sp="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FxSpots</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Simple transactions where an amount in one currency is exchanged for an amount in another currency, with settlement in the immediate future by both participants. This forms a point of reference for Fx forward and option transactions where the future or optional future transaction may be compared with the effects of completing that transaction in the present.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Spots/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-sp;FxSpot">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;OTCFxProduct"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-sp;hasCorrespondingTransaction"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx spot</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-sp;FxSpotContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/ForeignExchange/ForeignExchange/CurrencySpotBuyRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-sp;establishes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-sp;establishes.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx spot contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rate of a foreign-exchange contract for immediate delivery. Also known as &quot;benchmark rates&quot;, &quot;straightforward rates&quot; or &quot;outright rates&quot;, spot rates represent the price that a buyer expects to pay for a foreign currency in another currency.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Though the spot exchange rate is said to be settled immediately, the globally accepted settlement cycle for foreign-exchange contracts is two days. Foreign-exchange contracts are therefore settled on the second day after the day the deal is made.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-sp;FxSpotSettlementCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotSettlementCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-sp;commitsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx spot settlement commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">no definition</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpML exchangedCurrency2 referred to as a &quot;Currency Stream&quot;</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-sp;FxSpotTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-sp;SpotTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-sp;hasImpliedContract"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-sp;hasSide"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;DeliverCash"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-sp;hasSide"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;subject"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx spot transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;buyerCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">buyer currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The buyer&apos;s currency as specified in the contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;commitsTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commits to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-sp;SpotCashSettlementTerms"/>
+bubu<owl:inverseOf rdf:resource="&fibo-der-der-sp;embodies"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;establishes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;establishes.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpotSettlementCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;fxSpotRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx spot rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&apos;The rate of exchange between the two currencies.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;hasCorrespondingTransaction">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has corresponding transaction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpot"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;hasSide">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has side</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sp;sellerCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">seller currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sp;FxSpotContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seller&apos;s currency as specified in the contract.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/FxDerivatives/FxSwaps.rdf
+++ b/der/FxDerivatives/FxSwaps.rdf
@@ -1,86 +1,89 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
-	<!ENTITY fibo-der-fx-fwd "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/">
-	<!ENTITY fibo-der-fx-sp "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
-	<!ENTITY fibo-der-fx-sw "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
+bu<!ENTITY fibo-der-fx-fwd "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/">
+bu<!ENTITY fibo-der-fx-sp "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/">
+bu<!ENTITY fibo-der-fx-sw "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/"
-	xmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
-	xmlns:fibo-der-fx-fwd="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/"
-	xmlns:fibo-der-fx-sp="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"
-	xmlns:fibo-der-fx-sw="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/">
-		<rdfs:label xml:lang="en">FxSwaps</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-fx-sw;FxForwardForwardSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;OTCFxProduct"/>
-		<rdfs:label xml:lang="en">fx forward forward swap</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-sw;FxSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;OTCFxProduct"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-sw;hasCorrespondingForward"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-sw;hasCorrespondingSpot"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fx swap</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-fx-sw;FxSwapContract">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
-		<rdfs:label xml:lang="en">fx swap contract</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sw;embodies">
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sw;FxForwardForwardSwap"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sw;hasCorrespondingForward">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-fx-sp;hasCorrespondingTransaction"/>
-		<rdfs:label xml:lang="en">has corresponding forward</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sw;FxSwap"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-sw;hasCorrespondingSpot">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-fx-sp;hasCorrespondingTransaction"/>
-		<rdfs:label xml:lang="en">has corresponding spot</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-sw;FxSwap"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
+buxmlns:fibo-der-fx-fwd="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/"
+buxmlns:fibo-der-fx-sp="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"
+buxmlns:fibo-der-fx-sw="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FxSwaps</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Swap contracts in which one leg is based on the forward value of some currency exchange rate. These are defined in relation to the foreign exchange forward outright contract.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxForwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSpots/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxSwaps/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-sw;FxForwardForwardSwap">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;OTCFxProduct"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx forward forward swap</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-sw;FxSwap">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;OTCFxProduct"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-sw;hasCorrespondingForward"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-fx-sw;hasCorrespondingSpot"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx swap</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-fx-sw;FxSwapContract">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fx swap contract</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sw;embodies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sw;FxForwardForwardSwap"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sw;hasCorrespondingForward">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-fx-sp;hasCorrespondingTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has corresponding forward</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sw;FxSwap"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-fx-sw;hasCorrespondingSpot">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-fx-sp;hasCorrespondingTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has corresponding spot</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-fx-sw;FxSwap"/>
+bubu<rdfs:range rdf:resource="&fibo-der-fx-sp;FxSpotTransaction"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/OTCMiscContracts/ContractsForDifference.rdf
+++ b/der/OTCMiscContracts/ContractsForDifference.rdf
@@ -1,119 +1,122 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-misc-cfd "https://spec.edmcouncil.org/fibo/DER/OTCMiscContracts/ContractsForDifference/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-misc-cfd "https://spec.edmcouncil.org/fibo/DER/OTCMiscContracts/ContractsForDifference/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/OTCMiscContracts/ContractsForDifference/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-misc-cfd="https://spec.edmcouncil.org/fibo/DER/OTCMiscContracts/ContractsForDifference/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/OTCMiscContracts/ContractsForDifference/">
-		<rdfs:label xml:lang="en">ContractsForDifference</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/OTCMiscContracts/ContractsForDifference/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-misc-cfd;CFDCounterparty">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<rdfs:label xml:lang="en">c f d issuer</rdfs:label>
-		<skos:definition xml:lang="en">A party which issues or is the counterparty to a Contract For Difference.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-misc-cfd;CFDHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
-		<rdfs:label xml:lang="en">c f d holder</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-misc-cfd;ContractForDifference">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-misc-cfd;expiryDate"/>
-				<owl:onClass rdf:resource="&fibo-fnd-tim-tim;Date"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-misc-cfd;confersControlOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-misc-cfd;CFDHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-misc-cfd;CFDCounterparty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contract for difference</rdfs:label>
-		<skos:definition xml:lang="en">Cash settled contract where you buy or sell control of a particular asset such as USD. Further notes: You don&apos;t expect to deliver it, instead, at the end of the stated period you will take the current market value of the asset and pay the difference between the current market value and the value that you contracted for. Review session notes: Q: What are they? A: Cash settled contract where you buy or sell control of a particular asset such as USD. You don&apos;t expect to deliver it, instead, at the end of th estated period you will take the current market value of the asset and pay the difference between the current market value and the value that you contracted for. Just the same as a non deliverable forward. Differences: CFD are more a retail based product, they don&apos;t speciy a delivery date, they roll on a daily basis, the holder pays a margin but they don&apos;t determine the date where you have to settle. They rollover each day, but each day the holder has to provide a margin (and fees). Can roll along as long as you like, squaring up the current value and roll on for next day. No option to gake any value out of it. You can choose to terminate it, at which point youclear it at its current market value on that day and don&apos;t roll it over for the next. Developed to allow peopl ewho don&apos;t have the ability to hold the cash, to run a balance in a foreign ccy. What sort of assets? 1. Currency 2. No others known. Logically possible. Can be equity or anything. Q: What sort of facts apply: Delivery dates Quantities For non uniform assets: grades or qualities of those assets (e.g. oil0 Counterparties Earlier notes: Notes taken during Traded options SME Review: Traded in Australia and LSE. Presently these are predominantly OTC.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-misc-cfd;confersControlOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-		<rdfs:label xml:lang="en">confers control of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-misc-cfd;ContractForDifference"/>
-		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-misc-cfd;expiryDate">
-		<rdfs:label xml:lang="en">expiry date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-misc-cfd;ContractForDifference"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Date of expiry of the contract</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-misc-cfd;rollingFrequency">
-		<rdfs:label xml:lang="en">rolling frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-misc-cfd;ContractForDifference"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">In principle they can be rolled on any agreed basis. Usually no firm idea on when the parties want to settle, will hold untilo they feel like terminating, nbut there&apos;s no reason why this might not be made weekly or monthly.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-misc-cfd;terminationProvision">
-		<rdfs:label xml:lang="en">termination provision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-misc-cfd;ContractForDifference"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Possibles: Rolled daily Expires on some day If something new happens - provisions for the kinds of event that can lead to termination (as per most type of contract generally).</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-misc-cfd="https://spec.edmcouncil.org/fibo/DER/OTCMiscContracts/ContractsForDifference/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/OTCMiscContracts/ContractsForDifference/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ContractsForDifference</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">A contract which pays out based on the difference between the current market value and the value that the participant contracted for when the contract was initiated. Generally defined in terms of a currency asset, with the result that participants buy or sell control of that asset. These are usually carried forward on an ongoing basis rather than settled at a point in time.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/OTCMiscContracts/ContractsForDifference/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-misc-cfd;CFDCounterparty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c f d issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which issues or is the counterparty to a Contract For Difference.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-misc-cfd;CFDHolder">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeContractParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c f d holder</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-misc-cfd;ContractForDifference">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-misc-cfd;expiryDate"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-misc-cfd;confersControlOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-misc-cfd;CFDHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-misc-cfd;CFDCounterparty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract for difference</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Cash settled contract where you buy or sell control of a particular asset such as USD. Further notes: You don&apos;t expect to deliver it, instead, at the end of the stated period you will take the current market value of the asset and pay the difference between the current market value and the value that you contracted for. Review session notes: Q: What are they? A: Cash settled contract where you buy or sell control of a particular asset such as USD. You don&apos;t expect to deliver it, instead, at the end of th estated period you will take the current market value of the asset and pay the difference between the current market value and the value that you contracted for. Just the same as a non deliverable forward. Differences: CFD are more a retail based product, they don&apos;t speciy a delivery date, they roll on a daily basis, the holder pays a margin but they don&apos;t determine the date where you have to settle. They rollover each day, but each day the holder has to provide a margin (and fees). Can roll along as long as you like, squaring up the current value and roll on for next day. No option to gake any value out of it. You can choose to terminate it, at which point youclear it at its current market value on that day and don&apos;t roll it over for the next. Developed to allow peopl ewho don&apos;t have the ability to hold the cash, to run a balance in a foreign ccy. What sort of assets? 1. Currency 2. No others known. Logically possible. Can be equity or anything. Q: What sort of facts apply: Delivery dates Quantities For non uniform assets: grades or qualities of those assets (e.g. oil0 Counterparties Earlier notes: Notes taken during Traded options SME Review: Traded in Australia and LSE. Presently these are predominantly OTC.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-misc-cfd;confersControlOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers control of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-misc-cfd;ContractForDifference"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-misc-cfd;expiryDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expiry date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-misc-cfd;ContractForDifference"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date of expiry of the contract</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-misc-cfd;rollingFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rolling frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-misc-cfd;ContractForDifference"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">In principle they can be rolled on any agreed basis. Usually no firm idea on when the parties want to settle, will hold untilo they feel like terminating, nbut there&apos;s no reason why this might not be made weekly or monthly.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-misc-cfd;terminationProvision">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">termination provision</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-misc-cfd;ContractForDifference"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Possibles: Rolled daily Expires on some day If something new happens - provisions for the kinds of event that can lead to termination (as per most type of contract generally).</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/RateDerivatives/ForwardRateAgreements.rdf
+++ b/der/RateDerivatives/ForwardRateAgreements.rdf
@@ -1,39 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
-	<!ENTITY fibo-der-rat-fra "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/ForwardRateAgreements/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-fx-ctr "https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/">
+bu<!ENTITY fibo-der-rat-fra "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/ForwardRateAgreements/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/ForwardRateAgreements/"
-	xmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
-	xmlns:fibo-der-rat-fra="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/ForwardRateAgreements/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/ForwardRateAgreements/">
-		<rdfs:label xml:lang="en">ForwardRateAgreements</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/ForwardRateAgreements/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-rat-fra;ForwardRateAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
-		<rdfs:label xml:lang="en">forward rate agreement</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML: A type defining a Forward Rate Agreement (FRA) product. Clarified by Andrew Jacobs (Jan 2012): A FRA is an interest rate instrument with a single instrument. The interest rate is known at the start of the period. If it has changed at the end of the period, you settle for the difference.</skos:editorialNote>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-fx-ctr="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"
+buxmlns:fibo-der-rat-fra="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/ForwardRateAgreements/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/ForwardRateAgreements/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ForwardRateAgreements</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">A forward agreement in which the underlier is the interest rate of a single instrument. The interest rate is known at the start of the contract period and if it has changed at the end of that period the participants settle for the difference.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/FxDerivatives/FxContracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/ForwardRateAgreements/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-fra;ForwardRateAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">forward rate agreement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpML: A type defining a Forward Rate Agreement (FRA) product. Clarified by Andrew Jacobs (Jan 2012): A FRA is an interest rate instrument with a single instrument. The interest rate is known at the start of the period. If it has changed at the end of the period, you settle for the difference.</skos:editorialNote>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/RateDerivatives/IROptions.rdf
+++ b/der/RateDerivatives/IROptions.rdf
@@ -1,183 +1,186 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-rat-iro "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IROptions/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-rat-iro "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IROptions/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IROptions/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-rat-iro="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IROptions/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IROptions/">
-		<rdfs:label xml:lang="en">IROptions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IROptions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;CapDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;CapOrFloorDetermination"/>
-		<rdfs:label xml:lang="en">cap determination</rdfs:label>
-		<skos:definition xml:lang="en">The Strike rate is to be subtracted from the Observable rate on the reset date, to determine the settlement amount. This is incorrect. Cap applies to borrower. the Cap is the max amount I will pay to borrow. I take a capped rate. I am the buyer of the option. The market rate this time is higher than the capped rate. You as the seller of the option will pay me thedifference bwteen the capped rate and the market reate. If the market rate is lower than the capped rate no one pays anything because I will not exercise my right to that capped rate. So no money changes hands at settlement. Then: capped Loan: What I would be paying would be interest at the market rate if the market rate is lower, but if the market rate is higher then I would pay interest at the capped rate. This is the difference between a cap as a loan or as a cash settled thing. These represent different kinds of contract: Non loan one: Cap talks of settlement being difference between the market rate and the strike rate. This is cash settled. Name: &quot;Cap&quot; Loan one: Cap talks about a maximum interest rate payable by the holder, so the holder pays an amount each time, up to a maximum which is the Cap rate. Name: &quot;Capped Loan&quot; What manner of thin is this? A loan. Its ancestors are not OTC derivatives contracts thet are Loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;CapLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:label xml:lang="en">cap loan</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;CapOrFloorDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">cap or floor determination</rdfs:label>
-		<skos:definition xml:lang="en">Whether a given thing is treated as a Cap (something goes no higher than this amount) or as a Floor (something goes no lower than this).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;FloorDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;CapOrFloorDetermination"/>
-		<rdfs:label xml:lang="en">floor determination</rdfs:label>
-		<skos:definition xml:lang="en">The Observable rate is to be subtracted from the Strike rate on the reset date, to determine the settlement amount. Floor: I am an investor and I am specifying the minimum return I will get for that investment.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;FloorLoan">
-		<rdfs:label xml:lang="en">floor loan</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;InterestRateOptionStrikeTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;includesSpecificationTerm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">interest rate option strike terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms for the exercise of the Interest Rate Option.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Also terms for the exercise of each Caplet or Floorlet in an Option Strip. These are defined in terms fo a percentage rate which is the Strike rate.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;OTCInterestRateCapOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:label xml:lang="en">o t c interest rate cap option contract</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-rat-iro;OTCInterestRateFloorOptionContract"/>
-		<skos:definition xml:lang="en">A strip of options in which interest payable in each period is either the Observable (Underlying) rate or the Strike rate, at the holder&apos;s discretion, and in which the Strike rate represents a rate above which the holder can elect not to pay.</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition and editorial note against the property &apos;strike effect&apos; for this class (property is now a restriction): The Strike rate is to be subtracted from the Observable rate on the reset date, to determine the settlement amount. REVIEW SESSION NOTES: This is incorrect. Cap applies to borrower. the Cap is the max amount I will pay to borrow. I take a capped rate. I am the buyer of the option. The market rate this time is higher than the capped rate. You as the seller of the option will pay me thedifference bwteen the capped rate and the market reate. If the market rate is lower than the capped rate no one pays anything because I will not exercise my right to that capped rate. So no money changes hands at settlement. Then: capped Loan: What I would be paying would be interest at the market rate if the market rate is lower, but if the market rate is higher then I would pay interest at the capped rate. This is the difference between a cap as a loan or as a cash settled thing. These represent different kinds of contract: Non loan one: Cap talks of settlement being difference between the market rate and the strike rate. This is cash settled. Name: &quot;Cap&quot; Loan one: Cap talks about a maximum interest rate payable by the holder, so the holder pays an amount each time, up to a maximum which is the Cap rate. Name: &quot;Capped Loan&quot; What manner of thin is this? A loan. Its ancestors are not OTC derivatives contracts thet are Loan.</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The interest in each period is effectively capped by the Strike rate. That is, the rate of interest may not go above the Strike rate because the Holder is expected to exercise the option to take the Strike as the rate of interest instead.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;OTCInterestRateFloorOptionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rat-iro;hasStrikeEffect"/>
-				<owl:allValuesFrom rdf:resource="&fibo-der-rat-iro;FloorDetermination"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c interest rate floor option contract</rdfs:label>
-		<skos:editorialNote xml:lang="en">Definition and editorial note against the property &apos;strike effect&apos; for this class (property is now a restriction): The Observable rate is to be subtracted from the Strike rate on the reset date, to determine the settlement amount. Floor: I am an investor and I am specifying the minimum return I will get for that investment.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;OTCInterestRateOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-opt;hasStrikeTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rat-iro;InterestRateOptionStrikeTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c interest rate option</rdfs:label>
-		<skos:definition xml:lang="en">An option that tracks the cap and floor of an underlying interest rate.</skos:definition>
-		<skos:editorialNote xml:lang="en">No reason not to be a Cap or a floor. For example a Bond Option which also controls interest rate but it not referred to as an interest rate option (see Bond Options section). Also some IR Futures options (exchange traded) that are not. Also Swaption is a single option on a swap. Origin: SME Review comment during exchange traded options reviews: There are instruments that track the cap and floor of an underlying LIBOR, TIBOR rate. These are options. Term Origin; SME Review</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;OptionStripContract">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rat-iro;hasResetSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rat-iro;OptionStripResetSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option strip contract</rdfs:label>
-		<skos:definition xml:lang="en">A strip or sequential set of options with periodic reset dates, such that each period between resets behaves like an individual option (known as a Caplet or Floorlet).</skos:definition>
-		<skos:editorialNote xml:lang="en">The defining fact is that it is a set of sequential options. So in principal this is a strip of any kind of option. Can you strip forwards? In principal, but usually you would have a Commodity Swap which would be a strip of Forwards. Other strips? Don&apos;t always buy a string of caplets and floorlets but buy an individual cap or floor. for IR Options These are always Caps or Floors, that is the option settlement takes the form of the difference between the Strike rate and the designated underlying (observable) rate on the stated dates. Review notes: caps and floors are always strips, but there are strips for other assets as well. SO: There are strips besides Options; There are Option Strips besides IR (Cap and Floor) ones. See eg. in France where you may have a strip of options where the strike is set at each rollover. Details to come by email. In this case it would be an asset option, specifically Equity.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-iro;OptionStripResetSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">option strip reset schedule</rdfs:label>
-		<skos:definition xml:lang="en">Schedule of dates on which the Option Strip rate is determined and reset.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;exerciseDateOffset">
-		<rdfs:label xml:lang="en">exercise date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<skos:definition xml:lang="en">The period in days between the Reset Date and the date on which the Option may be exercised.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;hasResetSchedule">
-		<rdfs:label xml:lang="en">has reset schedule</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-der-rat-iro;OptionStripResetSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;hasStrikeEffect">
-		<rdfs:label xml:lang="en">has strike effect</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-der-rat-iro;CapOrFloorDetermination"/>
-		<skos:definition xml:lang="en">Whether the Strike rate is to be subtracted from the Observable rate on the reset date, or whether the Observable rate is to be subtracted from the Strike rate, to determine the settlement amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;interestAccrualDateOffset">
-		<rdfs:label xml:lang="en">interest accrual date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<skos:definition xml:lang="en">The period in days between each Reset Date and the commencement of accrual of interest for the next period.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;maturityDate">
-		<rdfs:label xml:lang="en">maturity date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date when the whole sequence of caps or floors expires.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;settlementDateOffset">
-		<rdfs:label xml:lang="en">settlement date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<skos:definition xml:lang="en">The period in days between each Reset Date and the corresponding Settlement Date.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-rat-iro="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IROptions/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IROptions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">IROptions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Options on interest rates. Incudes cap and floor determinations. Also includes the notion of an option strip, which is where each time the option expires it is carried forward to another similar or identical option contract.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IROptions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;CapDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;CapOrFloorDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cap determination</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Strike rate is to be subtracted from the Observable rate on the reset date, to determine the settlement amount. This is incorrect. Cap applies to borrower. the Cap is the max amount I will pay to borrow. I take a capped rate. I am the buyer of the option. The market rate this time is higher than the capped rate. You as the seller of the option will pay me thedifference bwteen the capped rate and the market reate. If the market rate is lower than the capped rate no one pays anything because I will not exercise my right to that capped rate. So no money changes hands at settlement. Then: capped Loan: What I would be paying would be interest at the market rate if the market rate is lower, but if the market rate is higher then I would pay interest at the capped rate. This is the difference between a cap as a loan or as a cash settled thing. These represent different kinds of contract: Non loan one: Cap talks of settlement being difference between the market rate and the strike rate. This is cash settled. Name: &quot;Cap&quot; Loan one: Cap talks about a maximum interest rate payable by the holder, so the holder pays an amount each time, up to a maximum which is the Cap rate. Name: &quot;Capped Loan&quot; What manner of thin is this? A loan. Its ancestors are not OTC derivatives contracts thet are Loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;CapLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cap loan</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;CapOrFloorDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cap or floor determination</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether a given thing is treated as a Cap (something goes no higher than this amount) or as a Floor (something goes no lower than this).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;FloorDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;CapOrFloorDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floor determination</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Observable rate is to be subtracted from the Strike rate on the reset date, to determine the settlement amount. Floor: I am an investor and I am specifying the minimum return I will get for that investment.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;FloorLoan">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floor loan</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;InterestRateOptionStrikeTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionExerciseTimeTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;includesSpecificationTerm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-opt;PercentageStrikePriceSpecification"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate option strike terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for the exercise of the Interest Rate Option.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Also terms for the exercise of each Caplet or Floorlet in an Option Strip. These are defined in terms fo a percentage rate which is the Strike rate.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;OTCInterestRateCapOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c interest rate cap option contract</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-rat-iro;OTCInterestRateFloorOptionContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A strip of options in which interest payable in each period is either the Observable (Underlying) rate or the Strike rate, at the holder&apos;s discretion, and in which the Strike rate represents a rate above which the holder can elect not to pay.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Definition and editorial note against the property &apos;strike effect&apos; for this class (property is now a restriction): The Strike rate is to be subtracted from the Observable rate on the reset date, to determine the settlement amount. REVIEW SESSION NOTES: This is incorrect. Cap applies to borrower. the Cap is the max amount I will pay to borrow. I take a capped rate. I am the buyer of the option. The market rate this time is higher than the capped rate. You as the seller of the option will pay me thedifference bwteen the capped rate and the market reate. If the market rate is lower than the capped rate no one pays anything because I will not exercise my right to that capped rate. So no money changes hands at settlement. Then: capped Loan: What I would be paying would be interest at the market rate if the market rate is lower, but if the market rate is higher then I would pay interest at the capped rate. This is the difference between a cap as a loan or as a cash settled thing. These represent different kinds of contract: Non loan one: Cap talks of settlement being difference between the market rate and the strike rate. This is cash settled. Name: &quot;Cap&quot; Loan one: Cap talks about a maximum interest rate payable by the holder, so the holder pays an amount each time, up to a maximum which is the Cap rate. Name: &quot;Capped Loan&quot; What manner of thin is this? A loan. Its ancestors are not OTC derivatives contracts thet are Loan.</skos:editorialNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The interest in each period is effectively capped by the Strike rate. That is, the rate of interest may not go above the Strike rate because the Holder is expected to exercise the option to take the Strike as the rate of interest instead.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;OTCInterestRateFloorOptionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rat-iro;hasStrikeEffect"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-der-rat-iro;FloorDetermination"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c interest rate floor option contract</rdfs:label>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Definition and editorial note against the property &apos;strike effect&apos; for this class (property is now a restriction): The Observable rate is to be subtracted from the Strike rate on the reset date, to determine the settlement amount. Floor: I am an investor and I am specifying the minimum return I will get for that investment.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;OTCInterestRateOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-der-opt;hasStrikeTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rat-iro;InterestRateOptionStrikeTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c interest rate option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option that tracks the cap and floor of an underlying interest rate.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">No reason not to be a Cap or a floor. For example a Bond Option which also controls interest rate but it not referred to as an interest rate option (see Bond Options section). Also some IR Futures options (exchange traded) that are not. Also Swaption is a single option on a swap. Origin: SME Review comment during exchange traded options reviews: There are instruments that track the cap and floor of an underlying LIBOR, TIBOR rate. These are options. Term Origin; SME Review</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;OptionStripContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rat-iro;hasResetSchedule"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rat-iro;OptionStripResetSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option strip contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A strip or sequential set of options with periodic reset dates, such that each period between resets behaves like an individual option (known as a Caplet or Floorlet).</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The defining fact is that it is a set of sequential options. So in principal this is a strip of any kind of option. Can you strip forwards? In principal, but usually you would have a Commodity Swap which would be a strip of Forwards. Other strips? Don&apos;t always buy a string of caplets and floorlets but buy an individual cap or floor. for IR Options These are always Caps or Floors, that is the option settlement takes the form of the difference between the Strike rate and the designated underlying (observable) rate on the stated dates. Review notes: caps and floors are always strips, but there are strips for other assets as well. SO: There are strips besides Options; There are Option Strips besides IR (Cap and Floor) ones. See eg. in France where you may have a strip of options where the strike is set at each rollover. Details to come by email. In this case it would be an asset option, specifically Equity.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-iro;OptionStripResetSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option strip reset schedule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Schedule of dates on which the Option Strip rate is determined and reset.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;exerciseDateOffset">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exercise date offset</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period in days between the Reset Date and the date on which the Option may be exercised.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;hasResetSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has reset schedule</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-rat-iro;OptionStripResetSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;hasStrikeEffect">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has strike effect</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-rat-iro;CapOrFloorDetermination"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Strike rate is to be subtracted from the Observable rate on the reset date, or whether the Observable rate is to be subtracted from the Strike rate, to determine the settlement amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;interestAccrualDateOffset">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest accrual date offset</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period in days between each Reset Date and the commencement of accrual of interest for the next period.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;maturityDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date when the whole sequence of caps or floors expires.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;settlementDateOffset">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement date offset</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period in days between each Reset Date and the corresponding Settlement Date.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/RateDerivatives/InflationSwaps.rdf
+++ b/der/RateDerivatives/InflationSwaps.rdf
@@ -1,139 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-rat-isw "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/InflationSwaps/">
-	<!ENTITY fibo-der-rat-rat "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-rat-isw "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/InflationSwaps/">
+bu<!ENTITY fibo-der-rat-rat "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/InflationSwaps/"
-	xmlns:fibo-der-rat-isw="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/InflationSwaps/"
-	xmlns:fibo-der-rat-rat="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/InflationSwaps/">
-		<rdfs:label xml:lang="en">InflationSwaps</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/InflationSwaps/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-rat-isw;InflationIndexFallBackBond">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rat-isw;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation index fall back bond</rdfs:label>
-		<skos:definition xml:lang="en">A fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8.</skos:definition>
-		<skos:editorialNote xml:lang="en">From FpML definition of &quot;Fallback Bond applicable&quot; related term: &apos;The applicability of a fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8. Omission of this element implies a value of true.&apos;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-isw;InflationIndexUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rat-rat;EconomicRateObservable"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rat-isw;specifies"/>
-				<owl:onClass rdf:resource="&fibo-der-rat-isw;InflationIndexFallBackBond"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation index underlying</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-isw;InflationLeg">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
-		<rdfs:label xml:lang="en">inflation leg</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-isw;InflationSwapContract">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rat-isw;underlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rat-isw;InflationIndexUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation swap contract</rdfs:label>
-		<skos:definition xml:lang="en">Draft definition: This is a swap instrument which makes reference to an inflation index.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It is also possible to make reference to an individual bond interest rate under some circumstances or instances. Not a specific schema in FpML. FpML details on fall-back bond (in definition for a yes/no field defining the presence of such a thing): &apos;The applicability of a fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8. Omission of this element imples a value of true.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rat-isw;InflationSwapTransaction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/FixedInterestRateLeg"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rat-isw;InflationLeg"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation swap transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction in which one leg is based on an inflation rate and the other leg is based on an interest rate (usually or always fixed interest).</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;fallbackBondApplicable">
-		<rdfs:label xml:lang="en">fallback bond applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The applicability of a fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8. Yes implies a value of true.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;identity">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationIndexFallBackBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;lag">
-		<rdfs:label xml:lang="en">lag</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationIndexUnderlying"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<skos:definition xml:lang="en">Details needed. Inserted per telecon (Derivatives PoC) from Andrew Jacobs. Identify the corresponding term in FpML and use that here.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;specifies">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationIndexUnderlying"/>
-		<rdfs:range rdf:resource="&fibo-der-rat-isw;InflationIndexFallBackBond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;underlying">
-		<rdfs:label xml:lang="en">underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationSwapContract"/>
-		<rdfs:range rdf:resource="&fibo-der-rat-isw;InflationIndexUnderlying"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-rat-isw="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/InflationSwaps/"
+buxmlns:fibo-der-rat-rat="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/InflationSwaps/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">InflationSwaps</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Swap contracts in which one leg is or represents an inflation index and the other is based on some interest rate, usually or always fixed. There is also sometimes a fall back bond that is referred to in certain circumstances.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/InflationSwaps/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-isw;InflationIndexFallBackBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rat-isw;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation index fall back bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From FpML definition of &quot;Fallback Bond applicable&quot; related term: &apos;The applicability of a fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8. Omission of this element implies a value of true.&apos;</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-isw;InflationIndexUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rat-rat;EconomicRateObservable"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rat-isw;specifies"/>
+bubububu<owl:onClass rdf:resource="&fibo-der-rat-isw;InflationIndexFallBackBond"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation index underlying</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-isw;InflationLeg">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/SwapLeg"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation leg</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-isw;InflationSwapContract">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/Swap"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rat-isw;underlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rat-isw;InflationIndexUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation swap contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Draft definition: This is a swap instrument which makes reference to an inflation index.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">It is also possible to make reference to an individual bond interest rate under some circumstances or instances. Not a specific schema in FpML. FpML details on fall-back bond (in definition for a yes/no field defining the presence of such a thing): &apos;The applicability of a fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8. Omission of this element imples a value of true.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-isw;InflationSwapTransaction">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/FixedInterestRateLeg"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rat-isw;InflationLeg"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation swap transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction in which one leg is based on an inflation rate and the other leg is based on an interest rate (usually or always fixed interest).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;fallbackBondApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fallback bond applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The applicability of a fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8. Yes implies a value of true.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;identity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationIndexFallBackBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;lag">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lag</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationIndexUnderlying"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Details needed. Inserted per telecon (Derivatives PoC) from Andrew Jacobs. Identify the corresponding term in FpML and use that here.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;specifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationIndexUnderlying"/>
+bubu<rdfs:range rdf:resource="&fibo-der-rat-isw;InflationIndexFallBackBond"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rat-isw;underlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rat-isw;InflationSwapContract"/>
+bubu<rdfs:range rdf:resource="&fibo-der-rat-isw;InflationIndexUnderlying"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/RateDerivatives/OTCIndexOptions.rdf
+++ b/der/RateDerivatives/OTCIndexOptions.rdf
@@ -1,39 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-rat-indo "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/OTCIndexOptions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/">
+bu<!ENTITY fibo-der-rat-indo "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/OTCIndexOptions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/OTCIndexOptions/"
-	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-rat-indo="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/OTCIndexOptions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/OTCIndexOptions/">
-		<rdfs:label xml:lang="en">OTCIndexOptions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/OTCIndexOptions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-rat-indo;OTCIndexOption">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
-		<rdfs:label xml:lang="en">o t c index option</rdfs:label>
-		<skos:definition xml:lang="en">An option whose underlying security is an index. If exercised, settlement is made by cash payment, since physical delivery is not possible.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Investors trading index options are essentially betting on the overall movement of the stock market as represented by a basket of stocks.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"
+buxmlns:fibo-der-rat-indo="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/OTCIndexOptions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/OTCIndexOptions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">OTCIndexOptions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Options whose underlying is an index. IF exercised, settlement is via cash payment.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Options/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/OTCIndexOptions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-rat-indo;OTCIndexOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c index option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option whose underlying security is an index. If exercised, settlement is made by cash payment, since physical delivery is not possible.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Investors trading index options are essentially betting on the overall movement of the stock market as represented by a basket of stocks.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/RateDerivatives/RateDerivatives.rdf
+++ b/der/RateDerivatives/RateDerivatives.rdf
@@ -1,159 +1,159 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/">
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/">
-	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/">
-	<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/">
-	<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/">
+bu<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/">
+bu<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/">
+bu<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/">
+bu<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/">
+bu<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"
-	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"
-	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"
-	xmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"
-	xmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/">
-		<rdfs:label>Rate Derivatives Ontology</rdfs:label>
-		<dct:license rdf:resource="&sm;MITLicense"/>
-		<sm:contentLanguage rdf:resource="http://www.omg.org/spec/ODM/"/>
-		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
-		<sm:copyright>Copyright (c) 2015-2017 EDM Council, Inc.
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"
+buxmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"
+buxmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"
+buxmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"
+buxmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"
+buxmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/">
+bubu<rdfs:label>Rate Derivatives Ontology</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Derivatives based on variation in some defined variable such as an economic rate, an interest rate or an index value.</dct:abstract>
+bubu<dct:license rdf:resource="&sm;MITLicense"/>
+bubu<sm:contentLanguage rdf:resource="http://www.omg.org/spec/ODM/"/>
+bubu<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
+bubu<sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/FBC/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/FND/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/IND/"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/SEC/"/>
-		<sm:fileAbbreviation>fibo-der-rtd-rtd</sm:fileAbbreviation>
-		<dct:abstract>This ontology defines ...</dct:abstract>
-		<sm:filename>RateDerivatives.rdf</sm:filename>
-		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/"/>
-		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/AboutRateDerivatives/"/>
-		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/FBC/AboutDER/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/20170201/RateDerivatives/RateDerivatives/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-rtd-rtd;EconomicRateObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;RateBasedObservable"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:onClass rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">economic rate observable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rtd-rtd;IndexDerivativeInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;RateBasedDerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-rtd;EconomicRateObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">index derivative instrument</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rtd-rtd;InterestRateDerivativeInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;RateBasedDerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-rtd;InterestRateObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">interest rate derivative instrument</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rtd-rtd;InterestRateObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;RateBasedObservable"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:onClass rdf:resource="&fibo-ind-ir-ir;ReferenceInterestRate"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">interest rate observable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rtd-rtd;RateBasedDerivativeInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-rtd;RateBasedObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>rate-based derivative instrument</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rtd-rtd;RateBasedObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;NonPhysicalUnderlier"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:onClass>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-sec-bsk;BasketOfIndices">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ind-ind;MarketRate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ei-ei;EconomicIndicator">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:onClass>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">rate based observable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-ei-ei;EconomicIndicator">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-ind-ind;MarketRate">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-sec-bsk;BasketOfIndices">
-	</owl:Class>
+bubu<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/FBC/"/>
+bubu<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/FND/"/>
+bubu<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/IND/"/>
+bubu<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/SEC/"/>
+bubu<sm:fileAbbreviation rdf:datatype="&xsd;string">fibo-der-rtd-rtd</sm:fileAbbreviation>
+bubu<sm:filename rdf:datatype="&xsd;string">RateDerivatives.rdf</sm:filename>
+bubu<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/AboutTheEDMC-FIBOFamily/"/>
+bubu<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/AboutRateDerivatives/"/>
+bubu<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/FBC/AboutDER/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/20170201/RateDerivatives/RateDerivatives/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-rtd-rtd;EconomicRateObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;RateBasedObservable"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:onClass rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic rate observable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rtd-rtd;IndexDerivativeInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;RateBasedDerivativeInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rtd-rtd;EconomicRateObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index derivative instrument</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rtd-rtd;InterestRateDerivativeInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;RateBasedDerivativeInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rtd-rtd;InterestRateObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate derivative instrument</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rtd-rtd;InterestRateObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rtd-rtd;RateBasedObservable"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:onClass rdf:resource="&fibo-ind-ir-ir;ReferenceInterestRate"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate observable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rtd-rtd;RateBasedDerivativeInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rtd-rtd;RateBasedObservable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>rate-based derivative instrument</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rtd-rtd;RateBasedObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;NonPhysicalUnderlier"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;ObservableValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:onClass>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-sec-sec-bsk;BasketOfIndices">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-ind-ind-ind;MarketRate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-ind-ei-ei;EconomicIndicator">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:onClass>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rate based observable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-ei-ei;EconomicIndicator">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-ind-ind;MarketRate">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-sec-bsk;BasketOfIndices">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/RateDerivativesExt/IRSwapTransactions.rdf
+++ b/der/RateDerivativesExt/IRSwapTransactions.rdf
@@ -1,64 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-ratx-irsx "https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/IRSwapTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-ratx-irsx "https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/IRSwapTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/IRSwapTransactions/"
-	xmlns:fibo-der-ratx-irsx="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/IRSwapTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/IRSwapTransactions/">
-		<rdfs:label xml:lang="en">IRSwapTransactions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/IRSwapTransactions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-ratx-irsx;BasisSwapTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ratx-irsx;IRSwapTransaction"/>
-		<rdfs:label xml:lang="en">basis swap transaction</rdfs:label>
-		<skos:definition xml:lang="en">A swap which exchanges cashflows based on two different interest rates.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Basis swap can be the same tenor but different indices e.g. 3 month LIBOR v 3 month TIBOR. Then the difference is not driven from a different interest rate period but from different markets, so I am swapping based on the difference in efficiency between the two markets. In cross ccy sense, would swap a Jap index for a US index. (is this a basis swap?) Protecting ourselves fom basis risk which is the difference in price between two markets. Review Conclusion: Basis swap is distinguished by being related to two markets. Floating Floating is also sometimes referred to as a Basis Swap as well though, but this is a different meaning (so we model it somewhere else). See also forward swap, as a means for controlling interest rate.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ratx-irsx;CurrencySwapTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ratx-irsx;IRSwapTransaction"/>
-		<rdfs:label xml:lang="en">currency swap transaction</rdfs:label>
-		<skos:definition xml:lang="en">A swap transaction in which the two streams of interest payments are in different currencies.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ratx-irsx;IRSwapTransaction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
-				<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/InterestRateSwapLeg"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">i r swap transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction in which one interest rate is exchanged for another.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is made up of two legs which are made of the same stuff as a Funding Leg. IR Swap can be floating floating or fixed floating. The most common single ccy swap is the ficed v floating swap. In IR Markets we are talking about borrowing, so the legs can be thought of as a borrowing leg and a lending leg. In Equities etc. the Cash Leg is typically funding because you are looking to control the purchase or value of a non cash asset this is not the case here with these IR Swaps. FpML - just &quot;Swap&quot;.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ratx-irsx;VanillaIRSwapTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ratx-irsx;IRSwapTransaction"/>
-		<rdfs:label xml:lang="en">vanilla i r swap transaction</rdfs:label>
-		<skos:definition xml:lang="en">An interest rate swap transaction in which fixed interest payments on the notional are exchanged for floating interest payments.</skos:definition>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-ratx-irsx="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/IRSwapTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/IRSwapTransactions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">IRSwapTransactions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Various kinds of interest rate swap transaction that may be entered into.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/SwapsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/IRSwapTransactions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-ratx-irsx;BasisSwapTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ratx-irsx;IRSwapTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">basis swap transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A swap which exchanges cashflows based on two different interest rates.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Basis swap can be the same tenor but different indices e.g. 3 month LIBOR v 3 month TIBOR. Then the difference is not driven from a different interest rate period but from different markets, so I am swapping based on the difference in efficiency between the two markets. In cross ccy sense, would swap a Jap index for a US index. (is this a basis swap?) Protecting ourselves fom basis risk which is the difference in price between two markets. Review Conclusion: Basis swap is distinguished by being related to two markets. Floating Floating is also sometimes referred to as a Basis Swap as well though, but this is a different meaning (so we model it somewhere else). See also forward swap, as a means for controlling interest rate.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ratx-irsx;CurrencySwapTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ratx-irsx;IRSwapTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">currency swap transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A swap transaction in which the two streams of interest payments are in different currencies.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ratx-irsx;IRSwapTransaction">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/hasTransactionLeg"/>
+bubububu<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/InterestRateSwapLeg"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i r swap transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction in which one interest rate is exchanged for another.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is made up of two legs which are made of the same stuff as a Funding Leg. IR Swap can be floating floating or fixed floating. The most common single ccy swap is the ficed v floating swap. In IR Markets we are talking about borrowing, so the legs can be thought of as a borrowing leg and a lending leg. In Equities etc. the Cash Leg is typically funding because you are looking to control the purchase or value of a non cash asset this is not the case here with these IR Swaps. FpML - just &quot;Swap&quot;.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ratx-irsx;VanillaIRSwapTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ratx-irsx;IRSwapTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">vanilla i r swap transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An interest rate swap transaction in which fixed interest payments on the notional are exchanged for floating interest payments.</skos:definition>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/der/RateDerivativesExt/RateDerivativesExt.rdf
+++ b/der/RateDerivativesExt/RateDerivativesExt.rdf
@@ -1,134 +1,137 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
-	<!ENTITY fibo-der-ratx-ratx "https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/RateDerivativesExt/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-derx-dbx "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/">
+bu<!ENTITY fibo-der-ratx-ratx "https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/RateDerivativesExt/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/RateDerivativesExt/"
-	xmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
-	xmlns:fibo-der-ratx-ratx="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/RateDerivativesExt/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/RateDerivativesExt/">
-		<rdfs:label xml:lang="en">RateDerivativesExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/RateDerivativesExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/EconomicRateObservable">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ratx-ratx;observableIdentity"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<owl:disjointWith rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateObservable"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/IndexDerivativeInstrument">
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateDerivativeInstrument">
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateObservable">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ratx-ratx;observableIdentity"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/RateBasedObservable">
-		<rdfs:subClassOf rdf:resource="&fibo-der-derx-dbx;ObservableUnderlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-ratx-ratx;observableIdentity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfIndices">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ratx-ratx;BondEquivalentYield">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ratx-ratx;InterestRateTreatment"/>
-		<rdfs:label xml:lang="en">bond equivalent yield</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ratx-ratx;InterestRateTreatment">
-		<rdfs:label xml:lang="en">interest rate treatment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-ratx-ratx;MoneyMarketYield">
-		<rdfs:subClassOf rdf:resource="&fibo-der-ratx-ratx;InterestRateTreatment"/>
-		<rdfs:label xml:lang="en">money market yield</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ratx-ratx;hasRateTreatment">
-		<rdfs:label xml:lang="en">has rate treatment</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateObservable"/>
-		<rdfs:range rdf:resource="&fibo-der-ratx-ratx;InterestRateTreatment"/>
-		<skos:definition xml:lang="en">The specification of any rate conversion which needs to be applied to the observed rate before being used in any calculations.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ratx-ratx;indexTenor">
-		<rdfs:label xml:lang="en">index tenor</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateObservable"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownDateDuration"/>
-		<skos:definition xml:lang="en">The tenor of the index, that is the length of time for which the index is quoted, e.g. 3 months, 6 months and so on.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-ratx-ratx;observableIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">observable identity</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/RateBasedObservable"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator">
-					</rdf:Description>
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate">
-					</rdf:Description>
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfIndices">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-derx-dbx="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"
+buxmlns:fibo-der-ratx-ratx="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/RateDerivativesExt/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/RateDerivativesExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">RateDerivativesExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Defines two kinds of interest rate treatment along with a common abstraction.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivativesExt/RateDerivativesExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/EconomicRateObservable">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ratx-ratx;observableIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<owl:disjointWith rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateObservable"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/IndexDerivativeInstrument">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateDerivativeInstrument">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateObservable">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ratx-ratx;observableIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/RateBasedObservable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-derx-dbx;ObservableUnderlier"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-ratx-ratx;observableIdentity"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfIndices">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ratx-ratx;BondEquivalentYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ratx-ratx;InterestRateTreatment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond equivalent yield</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ratx-ratx;InterestRateTreatment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate treatment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-ratx-ratx;MoneyMarketYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-ratx-ratx;InterestRateTreatment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">money market yield</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ratx-ratx;hasRateTreatment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has rate treatment</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateObservable"/>
+bubu<rdfs:range rdf:resource="&fibo-der-ratx-ratx;InterestRateTreatment"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of any rate conversion which needs to be applied to the observed rate before being used in any calculations.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ratx-ratx;indexTenor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index tenor</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/InterestRateObservable"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownDateDuration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The tenor of the index, that is the length of time for which the index is quoted, e.g. 3 months, 6 months and so on.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-ratx-ratx;observableIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">observable identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/DER/RateDerivatives/RateDerivatives/RateBasedObservable"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfIndices">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/der/RightsInstruments/RightsAndWarrants.rdf
+++ b/der/RightsInstruments/RightsAndWarrants.rdf
@@ -1,499 +1,502 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
-	<!ENTITY fibo-der-rgt-raw "https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
-	<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-secx-assx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
+bu<!ENTITY fibo-der-rgt-raw "https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
+bu<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-secx-assx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
-	xmlns:fibo-der-rgt-raw="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
-	xmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-secx-assx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/">
-		<rdfs:label xml:lang="en">RightsAndWarrants</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;AllotmentRight">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;numberOfSecuritiesDeterminedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;AllotmentRightFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">allotment right</rdfs:label>
-		<skos:definition xml:lang="en">Privileges allotted to existing security holders, entitling them to receive new securities free of charge.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;AllotmentRightFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:label xml:lang="en">allotment right formula</rdfs:label>
-		<skos:definition xml:lang="en">A formula used to calculate the number of securities for an Allotment Right, based on the number of these instruments that the holder holds. Conesnsus:Review</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;AllotmentRightHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;isByVirtueOfBeing"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">allotment right holder</rdfs:label>
-		<skos:definition xml:lang="en">The party which is the holder of an allotment right. This is identified as being a party which is also an existing holder of the security identified as the underlying security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;CommodityWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;Warrant"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;CommodityWarrantExerciseTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasWarrantUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodity warrant</rdfs:label>
-		<skos:definition xml:lang="en">A derivative based on commodities contracts traded on exchanges.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Example: Commodity Warrants Australia (CWA) is a locally owned outfit that has been in business for 18 months. It sells warrants based on 12 commodities and financial markets - crude oil, gold, silver, live cattle, corn, orange juice, soy, coffee, cocoa, the Dow Jones Industrial Average, the NASDAQ Composite Index and the S&amp;P 500 Index</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;CommodityWarrantExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commodity warrant exercise terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out how a commodity warrant may be exercised, including the form which delivery takes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;CompanyWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;Warrant"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;CompanyWarrantExerciseTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasWarrantUnderlying"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">company warrant</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-rgt-raw;CoveredWarrant"/>
-		<skos:definition xml:lang="en">Warrants which are issued by the issuer of the underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;CompanyWarrantExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;delivery"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">company warrant exercise terms set</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-rgt-raw;CoveredWarrantExerciseTerms"/>
-		<skos:definition xml:lang="en">Terms setting out how a company warrant or naked warrant may be exercised, including the form which delivery takes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;CoveredWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;Warrant"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;CoveredWarrantExerciseTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasWarrantUnderlying"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">covered warrant</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;CoveredWarrantExerciseTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;delivery"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">covered warrant exercise terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;EntitlementRightsInstrument">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:label xml:lang="en">entitlement rights instrument</rdfs:label>
-		<skos:definition xml:lang="en">A security giving the holder of that security the entitlement to purchase or sell back to the issuer new securities or some other commodity or instrument at a predetermined price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;ExchangeTradedWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;Warrant"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/ExchangeTradedSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasListing"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;WarrantListing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exchange traded warrant</rdfs:label>
-		<skos:definition xml:lang="en">A warrant which is traded on a securities exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be any kind of warrant except a (usually) Company Warrant. According to notes on Traditional Wwarrant: Warrants may be privately issued and may not necessarily be traded on an exchange. (Wikipedia)</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;PurchaseRight">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
-		<rdfs:label xml:lang="en">purchase right</rdfs:label>
-		<skos:definition xml:lang="en">Anti-takeover device that gives a prospective acquiree’s shareholders the right to buy usually shares of the firm or shares of anyone who acquires the firm at a deep discount to their fair market value.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The underlying is usually shares but this not necessarily the case. Also known as &quot;Poison Pill&quot;.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;StockholdersRightsInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;EntitlementRightsInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;givesTheRightToBuy"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-assx;hasHolder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">stockholders rights instrument</rdfs:label>
-		<skos:definition xml:lang="en">A security giving stockholders entitlement to purchase new securities issued by the corporation at a predetermined price (normally less than the current market price) in proportion to the number of securities already owned.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Stockholders may sell these to non stockholders if they wish. Rights are issued only for a short period of time, after which they expire.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
-		<rdfs:label xml:lang="en">stockholders rights instrument holder</rdfs:label>
-		<skos:definition xml:lang="en">A party which is the holder of a Stockholders Rights instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;StockholdersRightsInstrumentIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:label xml:lang="en">stockholders rights instrument issuer</rdfs:label>
-		<skos:definition xml:lang="en">The party which is the issuer of a Stockholders Rights instrument.</skos:definition>
-		<skos:editorialNote xml:lang="en">Specializes the term &quot;Issuer&quot; for different instrument classes; this specialization is not present in ISO FIBIM where the term is &quot;Issuer&quot; in each case.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;SubscriptionRight">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;givesRightToBuy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">subscription right</rdfs:label>
-		<skos:definition xml:lang="en">Privileges allotted to existing security holders, entitling them to subscribe to new securities at a price normally lower than the prevailing market price.</skos:definition>
-		<skos:editorialNote xml:lang="en">Why prevailing? It could be a new security of exactly the same class. Is this always new securities? Notes May 25: May be more an accounting or legal term for bonus issue, more accurate than scrip or bonus issue which reflects what happens in the books of the company. THis would mean that capitalization issue is seemingly synonymous with Bonus Issue / Scrip Issue (see moneytterms.co.uk which says that capitalization is less common but more correct, for scrip. &quot;The share capital on the balance sheet has to increate by the nominal value of the newly issued shares. This is balanced by an equal decrease in another part of hte shareholder&apos;s funds such as retained income of valuation reserves&quot;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;SubscriptionRightHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;isByVirtueOfBeing"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">subscription right holder</rdfs:label>
-		<skos:definition xml:lang="en">The party which is the holder of a subscription right. This is identified as being a party which is also an existing holder of the security identified as the underlying security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;ThirdPartyWarrantIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantIssuer"/>
-		<rdfs:label xml:lang="en">third party warrant issuer</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-rgt-raw;UnderlyingIssuer"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;TraditionalWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;CompanyWarrant"/>
-		<rdfs:label xml:lang="en">traditional warrant</rdfs:label>
-		<skos:definition xml:lang="en">Financial instruments which permit the holder to purchase or sell back to the issuer a specified amount of a share.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Warrants may be privately issued and may not necessarily be traded on an exchange. From Wikipedia: A warrant issued with a bond gives the holder the right to purchase equity shares issued by the company that issued the bond with the warrant.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;UnderlyingIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;identifiedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">underlying issuer</rdfs:label>
-		<skos:definition xml:lang="en">A party which is the issuer of a Covered Warrant. This party is by definition the issuer of the underlying securities.</skos:definition>
-		<skos:editorialNote xml:lang="en">Specializes the term &quot;Issuer&quot; for different instrument classes; this specialization is not present in ISO FIBIM where the term is &quot;Issuer&quot; in each case.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;Warrant">
-		<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;EntitlementRightsInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;WarrantIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasWarrantUnderlying"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">warrant</rdfs:label>
-		<skos:definition xml:lang="en">Financial instruments which permit the holder to purchase or sell back to the issuer a specified amount of a financial instrument, commodity, currency or other during a specified period at a specified price.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Warrants are for any kind of instrument. Warrants may be privately issued and may not necessarily be traded on an exchange.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;WarrantExerciseTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;delivery"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseConvention"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">warrant exercise terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out how a warrant instrument may be exercised. Further Notes Exercise terms as defined here also cover the automatic exercise of the warrant in the event of its expiry. These terms include the exercise style (FIBIM = OptionStyle type OptionStyleCode) and the delivery.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;WarrantIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:label xml:lang="en">warrant issuer</rdfs:label>
-		<skos:definition xml:lang="en">The issuer of a Warrant. This is defined in terms of what individual entity is the issuer and also what other roles they may or may not play for a specific type of warranty, specifically whether or not they are also the issuer of the underlying, if the underlying is a security.</skos:definition>
-		<skos:editorialNote xml:lang="en">Specializes the term &quot;Issuer&quot; for different instrument classes; this specialization is not present in ISO FIBIM where the term is &quot;Issuer&quot; in each case.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-rgt-raw;WarrantListing">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
-		<rdfs:label xml:lang="en">warrant listing</rdfs:label>
-		<skos:definition xml:lang="en">The listing of a warrant on a securities exchange. Action: confirm whether all the facts shown for listing of tradable securities generally, apply to the listing of a warrant. Also determine whether any of the terms in Listing need to be specialized or added to for Warrant Listing.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;delivery">
-		<rdfs:label xml:lang="en">delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-rgt-raw;expiryDate">
-		<rdfs:label xml:lang="en">expiry date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;EntitlementRightsInstrument"/>
-		<skos:definition xml:lang="en">Legal expiry of the Contract.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-rgt-raw;expiryDate.1">
-		<rdfs:label xml:lang="en">expiry date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
-		<skos:definition xml:lang="en">Expiry date of the warrant. This is the last date on which the holder may exercise the right to buy or sell back the underlying security.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;formulaText">
-		<rdfs:label xml:lang="en">formula text</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;AllotmentRightFormula"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The formula stated as text.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;givesRightToBuy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-der-rgt-raw;givesTheRightToBuy"/>
-		<rdfs:label xml:lang="en">gives right to buy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;SubscriptionRight"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;givesTheRightToBuy">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-		<rdfs:label xml:lang="en">gives the right to buy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;hasExerciseConvention">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isQualifiedBy"/>
-		<rdfs:label xml:lang="en">has exercise convention</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;hasExerciseTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has exercise terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
-		<rdfs:range rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;hasListing">
-		<rdfs:label xml:lang="en">has listing</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;ExchangeTradedWarrant"/>
-		<rdfs:range rdf:resource="&fibo-der-rgt-raw;WarrantListing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;hasWarrantUnderlying">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
-		<rdfs:label xml:lang="en">has warrant underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;identifiedAs">
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;UnderlyingIssuer"/>
-		<rdfs:range rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;isByVirtueOfBeing">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-ptyx;hasRelatedParty"/>
-		<rdfs:label xml:lang="en">is by virtue of being</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;numberOfSecurities">
-		<rdfs:label xml:lang="en">number of securities</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;AllotmentRight"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The number of securities based on the number of these instruments that the holder holds.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;numberOfSecuritiesDeterminedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">number of securities determined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;AllotmentRight"/>
-		<rdfs:range rdf:resource="&fibo-der-rgt-raw;AllotmentRightFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;oversubscribeOption">
-		<rdfs:label xml:lang="en">oversubscribe option</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Option whereby the holders of the rights instrument may get securities in the event that other right holders choose not to subscribe to theirs.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;perpetualMaturity">
-		<rdfs:label xml:lang="en">perpetual maturity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether this is a perpetual warrant, in other words it has no expiry date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;purchasePrice">
-		<rdfs:label xml:lang="en">purchase price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;PurchaseRight"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<skos:definition xml:lang="en">The price at which the holder of the Purchase Right may purchase the underlying security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;purchasePrice.1">
-		<rdfs:label xml:lang="en">purchase price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;SubscriptionRight"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<skos:definition xml:lang="en">The price at which the holder of the Subscription Right may purchase the underlying security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;putWarrant">
-		<rdfs:label xml:lang="en">put warrant</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">If Yes, this warrant gives the holder the right to sell the underlying security back to the issuer at a predetermined price; if No, the warrant gives the holder the right to purchase the instrument at the predetermined price (a call warrant).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;ratio">
-		<rdfs:label xml:lang="en">ratio</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;CompanyWarrant"/>
-		<rdfs:domain rdf:resource="&fibo-der-rgt-raw;CoveredWarrant"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The ratio of warrant units to underlying security units for delivery when the warrant is exercised.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
+buxmlns:fibo-der-rgt-raw="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
+buxmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-secx-assx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">RightsAndWarrants</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This covers a range of special contracts or arrangement with selected holders such as company participants. These include rights (privileges) extended to existing security holders to make new securities available to them at reduced prices or free, and warrants whereby the holder can purchase or sell back a given quantity of the instrument, commodity or currency during a specified period at a pre-defined price.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;AllotmentRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;numberOfSecuritiesDeterminedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;AllotmentRightFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allotment right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Privileges allotted to existing security holders, entitling them to receive new securities free of charge.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;AllotmentRightFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allotment right formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formula used to calculate the number of securities for an Allotment Right, based on the number of these instruments that the holder holds. Conesnsus:Review</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;AllotmentRightHolder">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;isByVirtueOfBeing"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allotment right holder</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is the holder of an allotment right. This is identified as being a party which is also an existing holder of the security identified as the underlying security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;CommodityWarrant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;Warrant"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;CommodityWarrantExerciseTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasWarrantUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity warrant</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A derivative based on commodities contracts traded on exchanges.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Example: Commodity Warrants Australia (CWA) is a locally owned outfit that has been in business for 18 months. It sells warrants based on 12 commodities and financial markets - crude oil, gold, silver, live cattle, corn, orange juice, soy, coffee, cocoa, the Dow Jones Industrial Average, the NASDAQ Composite Index and the S&amp;P 500 Index</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;CommodityWarrantExerciseTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;delivery"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity warrant exercise terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out how a commodity warrant may be exercised, including the form which delivery takes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;CompanyWarrant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;Warrant"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;CompanyWarrantExerciseTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasWarrantUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">company warrant</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-rgt-raw;CoveredWarrant"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Warrants which are issued by the issuer of the underlying.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;CompanyWarrantExerciseTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;delivery"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">company warrant exercise terms set</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-rgt-raw;CoveredWarrantExerciseTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out how a company warrant or naked warrant may be exercised, including the form which delivery takes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;CoveredWarrant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;Warrant"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;CoveredWarrantExerciseTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasWarrantUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">covered warrant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;CoveredWarrantExerciseTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;delivery"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">covered warrant exercise terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;EntitlementRightsInstrument">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">entitlement rights instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security giving the holder of that security the entitlement to purchase or sell back to the issuer new securities or some other commodity or instrument at a predetermined price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;ExchangeTradedWarrant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;Warrant"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/ExchangeTradedSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasListing"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;WarrantListing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange traded warrant</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A warrant which is traded on a securities exchange.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be any kind of warrant except a (usually) Company Warrant. According to notes on Traditional Wwarrant: Warrants may be privately issued and may not necessarily be traded on an exchange. (Wikipedia)</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;PurchaseRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Anti-takeover device that gives a prospective acquiree’s shareholders the right to buy usually shares of the firm or shares of anyone who acquires the firm at a deep discount to their fair market value.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The underlying is usually shares but this not necessarily the case. Also known as &quot;Poison Pill&quot;.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;StockholdersRightsInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;EntitlementRightsInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;givesTheRightToBuy"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-assx;hasHolder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stockholders rights instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security giving stockholders entitlement to purchase new securities issued by the corporation at a predetermined price (normally less than the current market price) in proportion to the number of securities already owned.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Stockholders may sell these to non stockholders if they wish. Rights are issued only for a short period of time, after which they expire.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stockholders rights instrument holder</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which is the holder of a Stockholders Rights instrument.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;StockholdersRightsInstrumentIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stockholders rights instrument issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is the issuer of a Stockholders Rights instrument.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Specializes the term &quot;Issuer&quot; for different instrument classes; this specialization is not present in ISO FIBIM where the term is &quot;Issuer&quot; in each case.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;SubscriptionRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;givesRightToBuy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscription right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Privileges allotted to existing security holders, entitling them to subscribe to new securities at a price normally lower than the prevailing market price.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Why prevailing? It could be a new security of exactly the same class. Is this always new securities? Notes May 25: May be more an accounting or legal term for bonus issue, more accurate than scrip or bonus issue which reflects what happens in the books of the company. THis would mean that capitalization issue is seemingly synonymous with Bonus Issue / Scrip Issue (see moneytterms.co.uk which says that capitalization is less common but more correct, for scrip. &quot;The share capital on the balance sheet has to increate by the nominal value of the newly issued shares. This is balanced by an equal decrease in another part of hte shareholder&apos;s funds such as retained income of valuation reserves&quot;</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;SubscriptionRightHolder">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;isByVirtueOfBeing"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subscription right holder</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is the holder of a subscription right. This is identified as being a party which is also an existing holder of the security identified as the underlying security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;ThirdPartyWarrantIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantIssuer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">third party warrant issuer</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-der-rgt-raw;UnderlyingIssuer"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;TraditionalWarrant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;CompanyWarrant"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traditional warrant</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Financial instruments which permit the holder to purchase or sell back to the issuer a specified amount of a share.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Warrants may be privately issued and may not necessarily be traded on an exchange. From Wikipedia: A warrant issued with a bond gives the holder the right to purchase equity shares issued by the company that issued the bond with the warrant.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;UnderlyingIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;WarrantIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;identifiedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which is the issuer of a Covered Warrant. This party is by definition the issuer of the underlying securities.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Specializes the term &quot;Issuer&quot; for different instrument classes; this specialization is not present in ISO FIBIM where the term is &quot;Issuer&quot; in each case.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;Warrant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-rgt-raw;EntitlementRightsInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;WarrantIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasWarrantUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">warrant</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Financial instruments which permit the holder to purchase or sell back to the issuer a specified amount of a financial instrument, commodity, currency or other during a specified period at a specified price.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Warrants are for any kind of instrument. Warrants may be privately issued and may not necessarily be traded on an exchange.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;WarrantExerciseTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;delivery"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-der-rgt-raw;hasExerciseConvention"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">warrant exercise terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out how a warrant instrument may be exercised. Further Notes Exercise terms as defined here also cover the automatic exercise of the warrant in the event of its expiry. These terms include the exercise style (FIBIM = OptionStyle type OptionStyleCode) and the delivery.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;WarrantIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">warrant issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer of a Warrant. This is defined in terms of what individual entity is the issuer and also what other roles they may or may not play for a specific type of warranty, specifically whether or not they are also the issuer of the underlying, if the underlying is a security.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Specializes the term &quot;Issuer&quot; for different instrument classes; this specialization is not present in ISO FIBIM where the term is &quot;Issuer&quot; in each case.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-der-rgt-raw;WarrantListing">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">warrant listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The listing of a warrant on a securities exchange. Action: confirm whether all the facts shown for listing of tradable securities generally, apply to the listing of a warrant. Also determine whether any of the terms in Listing need to be specialized or added to for Warrant Listing.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;delivery">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delivery</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-rgt-raw;expiryDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expiry date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;EntitlementRightsInstrument"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Legal expiry of the Contract.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-der-rgt-raw;expiryDate.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expiry date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Expiry date of the warrant. This is the last date on which the holder may exercise the right to buy or sell back the underlying security.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;formulaText">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formula text</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;AllotmentRightFormula"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formula stated as text.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;givesRightToBuy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-der-rgt-raw;givesTheRightToBuy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gives right to buy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;SubscriptionRight"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;givesTheRightToBuy">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gives the right to buy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;hasExerciseConvention">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isQualifiedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has exercise convention</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;hasExerciseTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has exercise terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
+bubu<rdfs:range rdf:resource="&fibo-der-rgt-raw;WarrantExerciseTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;hasListing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has listing</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;ExchangeTradedWarrant"/>
+bubu<rdfs:range rdf:resource="&fibo-der-rgt-raw;WarrantListing"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;hasWarrantUnderlying">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has warrant underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;identifiedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;UnderlyingIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;isByVirtueOfBeing">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-ptyx;hasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is by virtue of being</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrumentHolder"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;numberOfSecurities">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of securities</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;AllotmentRight"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of securities based on the number of these instruments that the holder holds.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;numberOfSecuritiesDeterminedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of securities determined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;AllotmentRight"/>
+bubu<rdfs:range rdf:resource="&fibo-der-rgt-raw;AllotmentRightFormula"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;oversubscribeOption">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">oversubscribe option</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;StockholdersRightsInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Option whereby the holders of the rights instrument may get securities in the event that other right holders choose not to subscribe to theirs.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;perpetualMaturity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">perpetual maturity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether this is a perpetual warrant, in other words it has no expiry date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;purchasePrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;PurchaseRight"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price at which the holder of the Purchase Right may purchase the underlying security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;purchasePrice.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;SubscriptionRight"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price at which the holder of the Subscription Right may purchase the underlying security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;putWarrant">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">put warrant</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;Warrant"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">If Yes, this warrant gives the holder the right to sell the underlying security back to the issuer at a predetermined price; if No, the warrant gives the holder the right to purchase the instrument at the predetermined price (a call warrant).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-der-rgt-raw;ratio">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ratio</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;CompanyWarrant"/>
+bubu<rdfs:domain rdf:resource="&fibo-der-rgt-raw;CoveredWarrant"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The ratio of warrant units to underlying security units for delivery when the warrant is exercised.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fbc/DebtAndEquities/CreditFacilities.rdf
+++ b/fbc/DebtAndEquities/CreditFacilities.rdf
@@ -1,274 +1,277 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fbc-dae-crf "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
-	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
-	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/FND/Places/Facilities/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fbc-dae-crf "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
+bu<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
+bu<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/FND/Places/Facilities/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"
-	xmlns:fibo-fbc-dae-crf="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"
-	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
-	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/FND/Places/Facilities/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
-		<rdfs:label xml:lang="en">CreditFacilities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Facilities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CommittedCreditFacility">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacility"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasNegotated"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;LendingCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">committed credit facility</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;UncommittedCreditFacility"/>
-		<skos:definition xml:lang="en">A credit facility which has been formally agreed between a potential lender and a potential borrower.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This represents a formal commitment from the potential lender. The commitment may also describe committed tranches of the Credit Facility set out for different purposes. This may have fees associated with it.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CommittedCreditFacilityTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacility"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-		<rdfs:label xml:lang="en">committed credit facility tranche</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;UncommittedCreditFacilityTranche"/>
-		<skos:definition xml:lang="en">A contractually committed line of credit which is issued as a revolving line of credit which can be drawn upon and has collateral</skos:definition>
-		<skos:definition xml:lang="en">A tranche of a credit facility which has been formally agreed between a potential lender and a potential borrower.</skos:definition>
-		<skos:editorialNote xml:lang="en">We now have it that all loans follow from a CommittedCredit Facility, but this may be transient. See notes on fees and Ts and Cs. See also FpML terms and elements on this. Apply to loan, draw-down generally (money market loan where we only see the actual lending). Is there also this feature in Money Markets, if you go straight to the market and they assess you on the spot? They have simply done the same kind of assessment. So maybe the concept of transient Cr facility tranche does not apply in that instance. There need be no firm commitment until the instrument is bought off you, at which point you have the capital. So this is where money markets and loans part company. Lending departments: create facility Money markets: deliver the money.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditAgreementTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label xml:lang="en">credit agremeent terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms relating to an agreement to extend some committed credit facility on the part of a potential lender to a potential borrower.</skos:definition>
-		<skos:editorialNote xml:lang="en">Includes terms for construction loans and other agreements which, while labeled as loans, are agreements to make loan advances at certain times and under certain conditions in the future. ACTIONS: Still need to connect these terms together in the overall model for Construction Loans and the rest. For now, added this term to take care of detail terms sets that are otherwise orphans. 14 July: What form does the set of terms of the commitment take? - will define a set of parameters or limits under which you are prepared to lend money. These may include: Pledges, negative pledges; pledge of security that is available to you if you lend the loan/ also restrictions on how frequently the tranche can be drawn down whether or under what conditions you can re-draw. These terms will determine the nature of the loan. so for example a student loan will have quite a restrictive facility. The facility probably on&apos;t just pay you money, it may for instance pay against a receipt for the fees, or may pay the institution directly. These terms are designed to control the credit risk that the lender (or ultimate lender) is going to take. Also you are charged for providing that facility - the bank, once it&apos;s made that commitment, will have had to set aside capital. They have no control of when you are going to draw down on that loan, so the bank has to ensure that when you do they don&apos;t exceed their capital requirements. There is a fee to cover this. Syndicated lending is more complex - there would be multiple lenders when the draw-down takes place - the potential lenders are numerous, and will be beyond the credit limits of any individual bank. these have agents, managers and so on, as well as the syndicate members who participate in the lending. Manager: does all the organization. calls people (lenders) together when the borrower makes a draw down, and distributes this. See Syndicate Loan diagram. This can be turned into multiple actual loans. There would be separate limits in these, based on currency, risk type and so on (as per Credit Facility generally). So one might use the borrowing for trade finance, revolving credit facility, straight draw-down, all specified in terms of the limits (maximum amounts that the lenders are prepared to give). A facility may also be a stand-by facility - one you may never want to draw down but need as protection.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditExtension">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Service"/>
-		<rdfs:label xml:lang="en">credit extension</rdfs:label>
-		<skos:definition xml:lang="en">A service whereby credit is extended from the service provider to some party i.e. a borrower.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacility">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-fac;Facility"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasTranche"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit facility</rdfs:label>
-		<skos:definition xml:lang="en">An option to borrow money. Defines the parameters in which you are able to draw down some amount as a loan, debt finance, or some other financial commitment.</skos:definition>
-		<skos:editorialNote xml:lang="en">There may also be min and max parcels of these. May also be fees for this facility. Review Questions and Discussion: QUESTION: Are there significant meaningful differences between retail and corporate? In the corporate world you may sit down and make an agreement between the lender and the potential borrower, to agreement. Corporate: Committed lending v Uncommitted lending. Sets limits what they are prepared to lend to a customer but don&apos;t make an agreement with the customer. Separately: May go into a &quot;Specified Commitment&quot; to make that lending. We say to the customer we are prepared to lend you x amount and of that, we will say, that eg 100M can be drawn down in this way, e.g as a direct loan, another 100M may be in terms of guarantees offered. May also put a lot of structure around how that may be drawn. Project financing / construction finance is where we have limits about this. You are constructing your own collateral in the construction. The collateral is an agreement where you may size these assets in the event of a default. Collateral may be associatedd irectly with the loan OR directly with the Facility. In the latter case you would not have to renegotiate collateral agreements every time you draw down on that loan. How this works: The Credit Facility in this latter case, is a bilateral contract: The lender is legally committing to be able to extend that amount of money. Borrower can borrow (or not) as and when they see fit. The lender has to then set aside capital for that money. It is now the borrower&apos;s right to determine when and how they draw this. So the central facility says we would do those loans - within the context for that facility. In retail:: there is no flexibility to negotiate, the Ts &amp; Cs are fairly standard. All the above concepts still exist in retail. So bank has limit they are prepared to lend that customer., determined in the context of the amount of collateral the retail customer can provide. Can still have construction loans in retail lending. See also syndicated loans. Set up with panel of potential vendors.</skos:editorialNote>
-		<skos:editorialNote xml:lang="en">We now have it that all loans follow from a CommittedCredit Facility, but this may be transient. See notes on fees and Ts and Cs. See also FpML terms and elements on this. Apply to loan, draw-down generally (money market loan where we only see the actual lending). Is there also this feature in Money Markets, if you go straight to the market and they assess you on the spot? They have simply done the same kind of assessment. So maybe the concept of transient Cr facility tranche does not apply in that instance. There need be no firm commitment until the instrument is bought off you, at which point you have the capital. So this is where money markets and loans part company. Lending departments: create facility Money markets: deliver the money.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;setsOutCommitmentTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacility"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditAgreementTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;LoanPrecedentConditions"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;mandates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;LendingCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit facility agreement</rdfs:label>
-		<skos:definition xml:lang="en">A formal contract in which a potential lender agrees to lend to a potential borrower under terms stated in this contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The agreement will usually also define tranches of the credit facility to which they are prepared to commit lending for specific purposes. Note that the existence of this formal agreement represents a fornal commmitment by the potential lender. This results in formal provisions needing to be made in terms of the lender&apos;s overall positions and exposures. See new notes in Credit Facility and elsewhere. These define the terms that belong in this box. Upper ontology: abstract so that every loan starts off as a credit facility. Then it should all fall into place.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityGuarantyTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasTranchePurpose"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTypeSelection"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit facility guaranty tranche</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;CreditFacilityLoanTranche"/>
-		<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;CreditFacilitySecuritiesTranche"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityLoanTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasTranchePurpose"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTypeSelection"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;issuedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit facility loan tranche</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;CreditFacilitySecuritiesTranche"/>
-		<skos:definition xml:lang="en">A tranche of a credit facility the purpose of which is a kind of Loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilitySecuritiesTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasTranchePurpose"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTypeSelection"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;issuedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gen;UnsubscribedDebt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit facility securities tranche</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacility"/>
-		<rdfs:label xml:lang="en">credit facility tranche</rdfs:label>
-		<skos:definition xml:lang="en">An individual tranche of the Credit Facility. This is the maximal amount of credit that can be extended to the potential borrower for the stated purpose.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The amount of each tranche of the credit facility sums to the total Credit Facility amount. Tranches of the Credit Facility each have a stated purpose. Credit Facility may includes provision of loans, of guarantees, credit finance and other things that can create a credit exposure. Scope of Credit Facility Tranches: Many tranches are for loans. For retail borrowers these would be the only types of tranche. For other types of potential borrowers e.g. corporates, other tranches of credit facility may include for securitized debt (where the potential borrower is a corporation), or for guaranty provision. (detailed note from SME Review 10 Feb 2011) Credit Facility may also have provision of guarantees, credit finance and other things that can create a credit exposure. These are all in the Credit Facility Tranche. Sets terms under which the lender may make a number of tns which may create the redit risk. The tranche may be the creation of the credit risk See also CDO, where the Pf is structured in a way that might then be subject to these considerations. Not the same meaning as Tranches in CDOs. (note ends) PoC (2010) notes (specific to Loan trahche) Note that since this time the scope of these has been extended since credit facility is also relevant to securitized debt, and other cretid exposures (guaranty etc.). The amount of each tranche, summed up. makes up the Credit Facillity amount. Each tranche has a loan type. One or more loans are issued against this transhe Against the loan will be one or more draw downs. Example: Take a tranche for Credit Line. This is $300K. against that $300K tranche, I issue a credit line loan of $200K . Against that loan of $200K I may draw $10K An amount you are good for under agreed termas and conditions. A credit line is not necessarily going to be drawn. Drawn is the Current debt obligation and may change from day to day. Simpler example: Construction Loan Credit Facility of $1M for this person Against a tranche of Construction Loan, I can have $300 tranche of credit facility. NOT A LOAN. Against that tranche of $300K I can create a loan (take a loan) for Construction, of $200K. That loan is also going to be advanced in several draw-downs. Once I complete the 1st phase of construction, for example at the start I get an initial 10$ for a draw of 15K, then after the 1st phase I get a draw of another 15% and so on. That is where debt and loan differ because the debt is what you are paying interest on (the outstanding balance) which reflects a cumulative sum of draw minus any principal repayments. The difference between these is to be explained at a future session. A given tranche will observe all of the requirements of a credit facility. It has additional requirements. So a Credit Facility has multiple tranches. It does not inherit Amount. Credit Facility Amounts are distinct from Tranche Amount. 14 July: Credit Faciliy versus Committed Credit Facility. Recall that a non committe credit facility implies no commitment on the part of the potential lender. Once they are committed to it, that&apos;s a contractual commitment. However, before they do that, they assess your credit (and/or collateral or other forms of interest). What happens as time goes along? There are Ts and Cs in the facility, including a termination date (and general temrination clauses). Are there general termination clauses for instance for changes to circumstances? there is an Evergreen concept, whereby the(potential) lender has the right to revise the Ts and Cs, and terminate the loan, on a given, pre-stated review date. So the Evergreen term has conditions about what happens to outstanding loans and so on. the bank will structure lending to be able to get out as required, for example the loan may not go on beyond the Evergreen review date. This is not hard and fast though - the proviedr of the facility manages this and decides accordingly. May noe be all that obvious to the borrower what happens. Meanwhile, with revolving facility there is by definitoin a review date. Modeling: Add these (Evergreen) etc. terms to the terms for the committed credit facility. There might be conditions in the lending agreement that say how we will handle that. Are there terms i nthe Loan contract itself that refer back tot hese? Yes. The Loan Documentation will reference the Credit Facility. Compare with ISDA Master Agreement. Are there also Termination clases based on default events? (as per ISDA MA)? Most likely. These will be defined in the loan agreement. The pre-agreed terms, these are the Conditions Precedent (see elsewhere in the model) The Conditions Precedent are those things that have ot happen before the loan comes into play, for example stumping up collaterial, setting up ESCROW accounts and that kind of thing, that have to happen before the FACILITY comes into existence. So there are Conditions Precedent to the Facility, and Conditions Presedent to the Loan. So for instance negative pledges etc. - during the life of the loan you would have to confirm that you are in compliance with the conditions in the NEgative Pledge agreement. These will be Conditions Subsequent. Are there &quot;Conditions Precedent&quot; to the loan itself? Seemingly not. The loan is committed. for a non committed Credit Facility (e.g. general loan, auto loan, mortgage, lent to individuals), there are no Conditions Precedent because the bank either agrees the loan or they do not. Even for a single up front loan, there is in principle a Credit Facility which is immediately drawn down. So during that initial (intra day) period of time, there is a committed credit facility. So there is always a committed Credit Facility even if it&apos;s only transient before it is drawn down. So Credit Facility may be committed or not. but all loan are drawn down from Committed Credit Facility, even if that commitment is only transient i.e. the loan is dranw down right away. In this case, the commitment is discharged right away as a draw down. So the existence of a fee, only applies to committed credit facility tranches which are not transient. The &quot;fees&quot; as such are embedded in the interest rate. Whatever costs are incurred are passed right through as interest rate. Whereas, with credit facilitie that exist for a time, there are additional costs, and these are passed on as fees. This is the logic of having &quot;undrawn fees&quot;. Example: Overdraft facility has a fee, which even if you don&apos;t use the overdraft, they charge you an undrawn fee. At the bank&apos;s discretion they might not charge fo rhtis, but recover the costs elsewhere. They may also have restrictions on whether you can have it there unused and so on. Modeling: Can construct almost any of these in whatever combination. So make sure that the model bears this out. So going into the Credit Facility is: - credit checking - Collateral - Security Interest as a general term these are, in common, all &quot;Credit Control&quot; or credit min=tigation features. Guaranties are another. CDS is also a form of guaranty, where someone guarantees that the other party will pay. Or it may take the form of some ownership transfer (?) Default: activates a Credit Support Agreement. Default event triggers the credit support agreement between the lender and the potential borrower (or a third party - see Guaranty), describing what the borrower (por other party) says the lender can do in the event of default. See Credit Support Agreements as a whole - we should model these. Also relates to the posting of collateral in OTC swaps and the like. This is also where central counterparties provide a mechanism for centralizing the risk of these. The central agency is holding the securities that each party has posted in their Master Agreement with the central counterparty (e.g. clearing house). Guaranties create contagion.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityTypeSelection">
-		<rdfs:label xml:lang="en">CreditFacilityTypeSelection</rdfs:label>
-		<skos:definition xml:lang="en">Types of purpose for which a credit facility tranche may be set up or may exist.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditExtension"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit provider</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;LendingCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label xml:lang="en">lending commitment</rdfs:label>
-		<skos:definition xml:lang="en">Some commitment to enter into some lending arrangement at some point in the future.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This commitment involves two (or more) parties: the party which makes a commitment to lend and the party or parties to which that commitment is made (and who thereby enjoy the corresponding right i.e. the expectation to be lent to under the terms defined in the or any contract which underpins and mechanizes this commitment).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;LoanPrecedentConditions">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditAgreementTerms"/>
-		<rdfs:label xml:lang="en">loan precedent conditions</rdfs:label>
-		<skos:definition xml:lang="en">Conditions which must be met before a loan may be approved.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;UncommittedCreditFacility">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacility"/>
-		<rdfs:label xml:lang="en">uncommitted credit facility</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-dae-crf;UncommittedCreditFacilityTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;UncommittedCreditFacility"/>
-		<rdfs:label xml:lang="en">uncommitted credit facility tranche</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;hasNegotated">
-		<rdfs:label xml:lang="en">has negotiated</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacility"/>
-		<rdfs:range rdf:resource="&fibo-fbc-dae-crf;LendingCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;hasTranche">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
-		<rdfs:label xml:lang="en">has tranche</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacility"/>
-		<rdfs:range rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;hasTranchePurpose">
-		<rdfs:label xml:lang="en">has tranche purpose</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-		<rdfs:range rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTypeSelection"/>
-		<skos:definition xml:lang="en">The purpose for which the Tranche may exist. Notes 10 Feb: Question: What about a website that offers facilities for multiple purposes? Sometimes facility and purpose are not kept distinct. Differences: Retail lending - as modeled here commercial lending - see notes Purpose - Specific lenders e.g. Sallie Mae: Is it a loan or a credit facility? Is it structured similar to Construction / project loan? May look like multiple loans but these are fungible so it looks like one loan? Semantically: Facility v Loan? Student loan: usually for no more than one year. Would have multiple loans, so e.g. 2 or 3 semesters. School sets up number of disbursements so that tan equal amount goes at the start of a given semestrer. Next year you apply again for the loan AND before that you reassess the credit worthiness, so this means you are applying for a new Credit Facility Tranche as defined here. Always treated as a separate loan. School also has to certify that loan. See status - schol status, grace period status. Defer, small fixed, etc. versus full P&amp;I which applies when they have left school May be 10 years or so. Would be separate loans, but pulled into one bull group, with one payment. May be a min payment amount to be applied abgainst each loan, say min $50 per payment, based upon the Program. Is the Program a facility?? Or should we regard it as a kind of pool of loans, with a single repayment schedule. Account? Consolidation. The individual doesn&apos;t have to see loads of statements.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;issuedAs">
-		<rdfs:label xml:lang="en">issued as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-		<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;Debt"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;setsOutCommitmentTo">
-		<rdfs:label xml:lang="en">sets out commitment to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacilityAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacility"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;trancheHasLoanPurpose">
-		<rdfs:label xml:lang="en">tranche has loan purpose</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacilityLoanTranche"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-crf;trancheLoanPurpose">
-		<rdfs:label xml:lang="en">tranche loan purpose</rdfs:label>
-	</owl:DatatypeProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fbc-dae-crf="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"
+buxmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"
+buxmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/FND/Places/Facilities/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CreditFacilities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts defining committed and uncommitted credit facilities. These are facilities extended by a bank to a potential borrower or debtor, forming the basis of many loan offerings.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Facilities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CommittedCreditFacility">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacility"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasNegotated"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;LendingCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">committed credit facility</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;UncommittedCreditFacility"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A credit facility which has been formally agreed between a potential lender and a potential borrower.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This represents a formal commitment from the potential lender. The commitment may also describe committed tranches of the Credit Facility set out for different purposes. This may have fees associated with it.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CommittedCreditFacilityTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacility"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">committed credit facility tranche</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;UncommittedCreditFacilityTranche"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A contractually committed line of credit which is issued as a revolving line of credit which can be drawn upon and has collateral</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A tranche of a credit facility which has been formally agreed between a potential lender and a potential borrower.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">We now have it that all loans follow from a CommittedCredit Facility, but this may be transient. See notes on fees and Ts and Cs. See also FpML terms and elements on this. Apply to loan, draw-down generally (money market loan where we only see the actual lending). Is there also this feature in Money Markets, if you go straight to the market and they assess you on the spot? They have simply done the same kind of assessment. So maybe the concept of transient Cr facility tranche does not apply in that instance. There need be no firm commitment until the instrument is bought off you, at which point you have the capital. So this is where money markets and loans part company. Lending departments: create facility Money markets: deliver the money.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditAgreementTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit agremeent terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms relating to an agreement to extend some committed credit facility on the part of a potential lender to a potential borrower.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Includes terms for construction loans and other agreements which, while labeled as loans, are agreements to make loan advances at certain times and under certain conditions in the future. ACTIONS: Still need to connect these terms together in the overall model for Construction Loans and the rest. For now, added this term to take care of detail terms sets that are otherwise orphans. 14 July: What form does the set of terms of the commitment take? - will define a set of parameters or limits under which you are prepared to lend money. These may include: Pledges, negative pledges; pledge of security that is available to you if you lend the loan/ also restrictions on how frequently the tranche can be drawn down whether or under what conditions you can re-draw. These terms will determine the nature of the loan. so for example a student loan will have quite a restrictive facility. The facility probably on&apos;t just pay you money, it may for instance pay against a receipt for the fees, or may pay the institution directly. These terms are designed to control the credit risk that the lender (or ultimate lender) is going to take. Also you are charged for providing that facility - the bank, once it&apos;s made that commitment, will have had to set aside capital. They have no control of when you are going to draw down on that loan, so the bank has to ensure that when you do they don&apos;t exceed their capital requirements. There is a fee to cover this. Syndicated lending is more complex - there would be multiple lenders when the draw-down takes place - the potential lenders are numerous, and will be beyond the credit limits of any individual bank. these have agents, managers and so on, as well as the syndicate members who participate in the lending. Manager: does all the organization. calls people (lenders) together when the borrower makes a draw down, and distributes this. See Syndicate Loan diagram. This can be turned into multiple actual loans. There would be separate limits in these, based on currency, risk type and so on (as per Credit Facility generally). So one might use the borrowing for trade finance, revolving credit facility, straight draw-down, all specified in terms of the limits (maximum amounts that the lenders are prepared to give). A facility may also be a stand-by facility - one you may never want to draw down but need as protection.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditExtension">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;Service"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit extension</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A service whereby credit is extended from the service provider to some party i.e. a borrower.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacility">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-fac;Facility"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasTranche"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit facility</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An option to borrow money. Defines the parameters in which you are able to draw down some amount as a loan, debt finance, or some other financial commitment.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">There may also be min and max parcels of these. May also be fees for this facility. Review Questions and Discussion: QUESTION: Are there significant meaningful differences between retail and corporate? In the corporate world you may sit down and make an agreement between the lender and the potential borrower, to agreement. Corporate: Committed lending v Uncommitted lending. Sets limits what they are prepared to lend to a customer but don&apos;t make an agreement with the customer. Separately: May go into a &quot;Specified Commitment&quot; to make that lending. We say to the customer we are prepared to lend you x amount and of that, we will say, that eg 100M can be drawn down in this way, e.g as a direct loan, another 100M may be in terms of guarantees offered. May also put a lot of structure around how that may be drawn. Project financing / construction finance is where we have limits about this. You are constructing your own collateral in the construction. The collateral is an agreement where you may size these assets in the event of a default. Collateral may be associatedd irectly with the loan OR directly with the Facility. In the latter case you would not have to renegotiate collateral agreements every time you draw down on that loan. How this works: The Credit Facility in this latter case, is a bilateral contract: The lender is legally committing to be able to extend that amount of money. Borrower can borrow (or not) as and when they see fit. The lender has to then set aside capital for that money. It is now the borrower&apos;s right to determine when and how they draw this. So the central facility says we would do those loans - within the context for that facility. In retail:: there is no flexibility to negotiate, the Ts &amp; Cs are fairly standard. All the above concepts still exist in retail. So bank has limit they are prepared to lend that customer., determined in the context of the amount of collateral the retail customer can provide. Can still have construction loans in retail lending. See also syndicated loans. Set up with panel of potential vendors.</skos:editorialNote>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">We now have it that all loans follow from a CommittedCredit Facility, but this may be transient. See notes on fees and Ts and Cs. See also FpML terms and elements on this. Apply to loan, draw-down generally (money market loan where we only see the actual lending). Is there also this feature in Money Markets, if you go straight to the market and they assess you on the spot? They have simply done the same kind of assessment. So maybe the concept of transient Cr facility tranche does not apply in that instance. There need be no firm commitment until the instrument is bought off you, at which point you have the capital. So this is where money markets and loans part company. Lending departments: create facility Money markets: deliver the money.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;setsOutCommitmentTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacility"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditAgreementTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;LoanPrecedentConditions"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;mandates"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;LendingCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit facility agreement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal contract in which a potential lender agrees to lend to a potential borrower under terms stated in this contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The agreement will usually also define tranches of the credit facility to which they are prepared to commit lending for specific purposes. Note that the existence of this formal agreement represents a fornal commmitment by the potential lender. This results in formal provisions needing to be made in terms of the lender&apos;s overall positions and exposures. See new notes in Credit Facility and elsewhere. These define the terms that belong in this box. Upper ontology: abstract so that every loan starts off as a credit facility. Then it should all fall into place.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityGuarantyTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasTranchePurpose"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTypeSelection"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit facility guaranty tranche</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;CreditFacilityLoanTranche"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;CreditFacilitySecuritiesTranche"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityLoanTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasTranchePurpose"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTypeSelection"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;issuedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit facility loan tranche</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fbc-dae-crf;CreditFacilitySecuritiesTranche"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A tranche of a credit facility the purpose of which is a kind of Loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilitySecuritiesTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;hasTranchePurpose"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTypeSelection"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;issuedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gen;UnsubscribedDebt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit facility securities tranche</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacility"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit facility tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An individual tranche of the Credit Facility. This is the maximal amount of credit that can be extended to the potential borrower for the stated purpose.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The amount of each tranche of the credit facility sums to the total Credit Facility amount. Tranches of the Credit Facility each have a stated purpose. Credit Facility may includes provision of loans, of guarantees, credit finance and other things that can create a credit exposure. Scope of Credit Facility Tranches: Many tranches are for loans. For retail borrowers these would be the only types of tranche. For other types of potential borrowers e.g. corporates, other tranches of credit facility may include for securitized debt (where the potential borrower is a corporation), or for guaranty provision. (detailed note from SME Review 10 Feb 2011) Credit Facility may also have provision of guarantees, credit finance and other things that can create a credit exposure. These are all in the Credit Facility Tranche. Sets terms under which the lender may make a number of tns which may create the redit risk. The tranche may be the creation of the credit risk See also CDO, where the Pf is structured in a way that might then be subject to these considerations. Not the same meaning as Tranches in CDOs. (note ends) PoC (2010) notes (specific to Loan trahche) Note that since this time the scope of these has been extended since credit facility is also relevant to securitized debt, and other cretid exposures (guaranty etc.). The amount of each tranche, summed up. makes up the Credit Facillity amount. Each tranche has a loan type. One or more loans are issued against this transhe Against the loan will be one or more draw downs. Example: Take a tranche for Credit Line. This is $300K. against that $300K tranche, I issue a credit line loan of $200K . Against that loan of $200K I may draw $10K An amount you are good for under agreed termas and conditions. A credit line is not necessarily going to be drawn. Drawn is the Current debt obligation and may change from day to day. Simpler example: Construction Loan Credit Facility of $1M for this person Against a tranche of Construction Loan, I can have $300 tranche of credit facility. NOT A LOAN. Against that tranche of $300K I can create a loan (take a loan) for Construction, of $200K. That loan is also going to be advanced in several draw-downs. Once I complete the 1st phase of construction, for example at the start I get an initial 10$ for a draw of 15K, then after the 1st phase I get a draw of another 15% and so on. That is where debt and loan differ because the debt is what you are paying interest on (the outstanding balance) which reflects a cumulative sum of draw minus any principal repayments. The difference between these is to be explained at a future session. A given tranche will observe all of the requirements of a credit facility. It has additional requirements. So a Credit Facility has multiple tranches. It does not inherit Amount. Credit Facility Amounts are distinct from Tranche Amount. 14 July: Credit Faciliy versus Committed Credit Facility. Recall that a non committe credit facility implies no commitment on the part of the potential lender. Once they are committed to it, that&apos;s a contractual commitment. However, before they do that, they assess your credit (and/or collateral or other forms of interest). What happens as time goes along? There are Ts and Cs in the facility, including a termination date (and general temrination clauses). Are there general termination clauses for instance for changes to circumstances? there is an Evergreen concept, whereby the(potential) lender has the right to revise the Ts and Cs, and terminate the loan, on a given, pre-stated review date. So the Evergreen term has conditions about what happens to outstanding loans and so on. the bank will structure lending to be able to get out as required, for example the loan may not go on beyond the Evergreen review date. This is not hard and fast though - the proviedr of the facility manages this and decides accordingly. May noe be all that obvious to the borrower what happens. Meanwhile, with revolving facility there is by definitoin a review date. Modeling: Add these (Evergreen) etc. terms to the terms for the committed credit facility. There might be conditions in the lending agreement that say how we will handle that. Are there terms i nthe Loan contract itself that refer back tot hese? Yes. The Loan Documentation will reference the Credit Facility. Compare with ISDA Master Agreement. Are there also Termination clases based on default events? (as per ISDA MA)? Most likely. These will be defined in the loan agreement. The pre-agreed terms, these are the Conditions Precedent (see elsewhere in the model) The Conditions Precedent are those things that have ot happen before the loan comes into play, for example stumping up collaterial, setting up ESCROW accounts and that kind of thing, that have to happen before the FACILITY comes into existence. So there are Conditions Precedent to the Facility, and Conditions Presedent to the Loan. So for instance negative pledges etc. - during the life of the loan you would have to confirm that you are in compliance with the conditions in the NEgative Pledge agreement. These will be Conditions Subsequent. Are there &quot;Conditions Precedent&quot; to the loan itself? Seemingly not. The loan is committed. for a non committed Credit Facility (e.g. general loan, auto loan, mortgage, lent to individuals), there are no Conditions Precedent because the bank either agrees the loan or they do not. Even for a single up front loan, there is in principle a Credit Facility which is immediately drawn down. So during that initial (intra day) period of time, there is a committed credit facility. So there is always a committed Credit Facility even if it&apos;s only transient before it is drawn down. So Credit Facility may be committed or not. but all loan are drawn down from Committed Credit Facility, even if that commitment is only transient i.e. the loan is dranw down right away. In this case, the commitment is discharged right away as a draw down. So the existence of a fee, only applies to committed credit facility tranches which are not transient. The &quot;fees&quot; as such are embedded in the interest rate. Whatever costs are incurred are passed right through as interest rate. Whereas, with credit facilitie that exist for a time, there are additional costs, and these are passed on as fees. This is the logic of having &quot;undrawn fees&quot;. Example: Overdraft facility has a fee, which even if you don&apos;t use the overdraft, they charge you an undrawn fee. At the bank&apos;s discretion they might not charge fo rhtis, but recover the costs elsewhere. They may also have restrictions on whether you can have it there unused and so on. Modeling: Can construct almost any of these in whatever combination. So make sure that the model bears this out. So going into the Credit Facility is: - credit checking - Collateral - Security Interest as a general term these are, in common, all &quot;Credit Control&quot; or credit min=tigation features. Guaranties are another. CDS is also a form of guaranty, where someone guarantees that the other party will pay. Or it may take the form of some ownership transfer (?) Default: activates a Credit Support Agreement. Default event triggers the credit support agreement between the lender and the potential borrower (or a third party - see Guaranty), describing what the borrower (por other party) says the lender can do in the event of default. See Credit Support Agreements as a whole - we should model these. Also relates to the posting of collateral in OTC swaps and the like. This is also where central counterparties provide a mechanism for centralizing the risk of these. The central agency is holding the securities that each party has posted in their Master Agreement with the central counterparty (e.g. clearing house). Guaranties create contagion.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditFacilityTypeSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CreditFacilityTypeSelection</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Types of purpose for which a credit facility tranche may be set up or may exist.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;CreditProvider">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;ServiceProvider"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;provides"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-crf;CreditExtension"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit provider</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;LendingCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lending commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some commitment to enter into some lending arrangement at some point in the future.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This commitment involves two (or more) parties: the party which makes a commitment to lend and the party or parties to which that commitment is made (and who thereby enjoy the corresponding right i.e. the expectation to be lent to under the terms defined in the or any contract which underpins and mechanizes this commitment).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;LoanPrecedentConditions">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditAgreementTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan precedent conditions</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Conditions which must be met before a loan may be approved.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;UncommittedCreditFacility">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacility"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">uncommitted credit facility</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fbc-dae-crf;UncommittedCreditFacilityTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;UncommittedCreditFacility"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">uncommitted credit facility tranche</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;hasNegotated">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has negotiated</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacility"/>
+bubu<rdfs:range rdf:resource="&fibo-fbc-dae-crf;LendingCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;hasTranche">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tranche</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacility"/>
+bubu<rdfs:range rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;hasTranchePurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tranche purpose</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTypeSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The purpose for which the Tranche may exist. Notes 10 Feb: Question: What about a website that offers facilities for multiple purposes? Sometimes facility and purpose are not kept distinct. Differences: Retail lending - as modeled here commercial lending - see notes Purpose - Specific lenders e.g. Sallie Mae: Is it a loan or a credit facility? Is it structured similar to Construction / project loan? May look like multiple loans but these are fungible so it looks like one loan? Semantically: Facility v Loan? Student loan: usually for no more than one year. Would have multiple loans, so e.g. 2 or 3 semesters. School sets up number of disbursements so that tan equal amount goes at the start of a given semestrer. Next year you apply again for the loan AND before that you reassess the credit worthiness, so this means you are applying for a new Credit Facility Tranche as defined here. Always treated as a separate loan. School also has to certify that loan. See status - schol status, grace period status. Defer, small fixed, etc. versus full P&amp;I which applies when they have left school May be 10 years or so. Would be separate loans, but pulled into one bull group, with one payment. May be a min payment amount to be applied abgainst each loan, say min $50 per payment, based upon the Program. Is the Program a facility?? Or should we regard it as a kind of pool of loans, with a single repayment schedule. Account? Consolidation. The individual doesn&apos;t have to see loads of statements.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;issuedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-fbc-dae-dbt;Debt"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;setsOutCommitmentTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out commitment to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacilityAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacility"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fbc-dae-crf;trancheHasLoanPurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche has loan purpose</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-dae-crf;CreditFacilityLoanTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-crf;trancheLoanPurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche loan purpose</rdfs:label>
+bu</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/fbc/DebtAndEquityExt/DebtPerspectives.rdf
+++ b/fbc/DebtAndEquityExt/DebtPerspectives.rdf
@@ -1,104 +1,107 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-accx-bal "https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
-	<!ENTITY fibo-fnd-accx-dbpx "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/">
-	<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-accx-bal "https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
+bu<!ENTITY fibo-fnd-accx-dbpx "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/">
+bu<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-accx-bal="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"
-	xmlns:fibo-fnd-accx-dbpx="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"
-	xmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/">
-		<rdfs:label xml:lang="en">DebtPerspectives</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-dbpx;CreditSide">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-dbpx;OwingSide"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;Claim"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-dbpx;hasOtherViewpoint"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-dbpx;DebtSide"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-dbpx;isPositionInRespectOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit side</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-dbpx;DebtSide"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;AccountReceivableBalance"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-dbpx;DebtSide">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-dbpx;OwingSide"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Liability"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;Claim"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-dbpx;isDebtTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-dbpx;isPositionInRespectOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt side</rdfs:label>
-		<skos:definition xml:lang="en">Money which is owed by one party (the Debtor) to another party (the Creditor) at some point in time, as seen from the perspective of the Debtor.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an amount that varies over time, in the form of a debt balance. This is distinct from &quot;Debt&quot; such as a bond or other debt instrument, which is a specific debt amount advanced to the borrower at a given point of time; the balance of the latter at any point in time is the debt owed by the borrower (as Debtor) to the Lender (as Creditor).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-dbpx;OwingSide">
-		<rdfs:label xml:lang="en">owing side</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-dbpx;hasOtherViewpoint">
-		<rdfs:label xml:lang="en">has other viewpoint</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-dbpx;DebtSide"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-dbpx;isDebtTo">
-		<rdfs:label xml:lang="en">is debt to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-dbpx;DebtSide"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-dbpx;isPositionInRespectOf">
-		<rdfs:label xml:lang="en">is position in respect of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-dbpx;OwingSide"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-accx-bal="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"
+buxmlns:fibo-fnd-accx-dbpx="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"
+buxmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtPerspectives</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Debt and credit as sides or aspects of the same kind of thing as seen from different perspectives.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-dbpx;CreditSide">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-dbpx;OwingSide"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;Claim"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-dbpx;hasOtherViewpoint"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-dbpx;DebtSide"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-dbpx;isPositionInRespectOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit side</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-dbpx;DebtSide"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;AccountReceivableBalance"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-dbpx;DebtSide">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-dbpx;OwingSide"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Liability"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;Claim"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-dbpx;isDebtTo"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-dbpx;isPositionInRespectOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt side</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Money which is owed by one party (the Debtor) to another party (the Creditor) at some point in time, as seen from the perspective of the Debtor.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is an amount that varies over time, in the form of a debt balance. This is distinct from &quot;Debt&quot; such as a bond or other debt instrument, which is a specific debt amount advanced to the borrower at a given point of time; the balance of the latter at any point in time is the debt owed by the borrower (as Debtor) to the Lender (as Creditor).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-dbpx;OwingSide">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">owing side</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-dbpx;hasOtherViewpoint">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has other viewpoint</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-dbpx;DebtSide"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-dbpx;isDebtTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is debt to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-dbpx;DebtSide"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-dbpx;isPositionInRespectOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is position in respect of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-dbpx;OwingSide"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/AccountingExt/AccountsMain.rdf
+++ b/fnd/AccountingExt/AccountsMain.rdf
@@ -1,715 +1,719 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-accx-bal "https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/">
-	<!ENTITY fibo-fnd-arrxx-col "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/">
-	<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
-	<!ENTITY fibo-fnd-bus-pol "https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/">
-	<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-accx-bal "https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/">
+bu<!ENTITY fibo-fnd-arrxx-col "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/">
+bu<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
+bu<!ENTITY fibo-fnd-bus-pol "https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/">
+bu<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
+bu<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-accx-bal="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"
-	xmlns:fibo-fnd-arrxx-col="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/"
-	xmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
-	xmlns:fibo-fnd-bus-pol="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"
-	xmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-		<rdfs:label xml:lang="en">AccountsMain</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;AbstractCashflowConstruct">
-		<rdfs:label xml:lang="en">abstract cashflow construct</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-acc;RelativeCashflow"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Account">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;accountHasProvider"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasBalance"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-bal;Balance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasHolder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">account</rdfs:label>
-		<skos:definition xml:lang="en">Business relationship between two entities; one entity is the account owner, the other entity is the account servicer.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review session notes: A container that contains assets and/or commitments?</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">account holder</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountPayable">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
-		<rdfs:label xml:lang="en">account payable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">account provider</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountReceivable">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
-		<rdfs:label xml:lang="en">account receivable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountServicing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasPartyAccountHolder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasPartyAccountProvider"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">account servicing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">accounting party</rdfs:label>
-		<skos:definition xml:lang="en">The Party from the perspective of which these accounts are prepared. This is the to whom the balances apply. There would be corresponding accounts (supplier, customer) for counterparties with whom the Accounting Party does business.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;AccruedLiability">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Liability"/>
-		<rdfs:label xml:lang="en">accrued liability</rdfs:label>
-		<skos:definition xml:lang="en">Liability which has been incurred by the entity and is yet to be paid off.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Appreciation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;increaseIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">appreciation</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-acc;Depreciation"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Cash">
-		<rdfs:label xml:lang="en">cash</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-accx-acc;CashCurrency">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-accx-acc;Coinage">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition xml:lang="en">Something that is widely accepted in payment for goods and services and in settling debts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;CashCurrency">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;PromissoryNote"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;issuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;CashIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash currency</rdfs:label>
-		<skos:definition xml:lang="en">Money in the form of promissory notes issued by some central bank.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;CashIssuer">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasIssuerIdentity"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/CentralBank"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash issuer</rdfs:label>
-		<skos:definition xml:lang="en">The issuer and underwriter of cash. This takes the form of some Central Bank.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Coinage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-phy-phy;ContinuousPhysicalStuff"/>
-		<rdfs:label xml:lang="en">coinage</rdfs:label>
-		<skos:definition xml:lang="en">Money in the form of coins minted by some authorized mint.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;DatedBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;Balance"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:label xml:lang="en">dated balance</rdfs:label>
-		<skos:definition xml:lang="en">A balance at a point in time in the past, present or future.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Depreciation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;decreaseIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">depreciation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;DirectExpense">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Expenditure"/>
-		<rdfs:label xml:lang="en">direct expense</rdfs:label>
-		<skos:definition xml:lang="en">Cost of Sales</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Distribution">
-		<rdfs:label xml:lang="en">distribution</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Draft">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:label xml:lang="en">draft</rdfs:label>
-		<skos:definition xml:lang="en">A draft is a legally binding order by one party (the drawer) to a second party (the drawee) to make payment to a third party (the payee). A simple example is a bank check -which is simply an order directing a bank to pay a third party. The three parties don&apos;t have to be distinct. For example, someone might write himself a check as a simple means of transferring funds from one bank account to another. In this case, the drawer and payee are the same person. When a draft guarantees payment for goods in international trade, it is called a bill of exchange. A draft can require immediate payment by the second party to the third upon presentation of the draft. This is called a sight draft. Checks are sight drafts. In trade, drafts often are for deferred payment. An importer might write a draft promising payment to an exporter for delivery of goods with payment to occur 60 days after the goods are delivered. Such drafts are called time drafts. They are said to mature on the payment date. In this example, the importer is both the drawer and the drawee. Definition source: riskglossary.com</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;EconomicValue">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isValueOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">economic value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Expenditure">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;RelativeCashflow"/>
-		<rdfs:label xml:lang="en">expenditure</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Fee">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Liability"/>
-		<rdfs:label xml:lang="en">fee</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;GrossIncome">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Income"/>
-		<rdfs:label xml:lang="en">gross income</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;GrossSalesIncome">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;GrossIncome"/>
-		<rdfs:label xml:lang="en">gross sales income</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Income">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;RelativeCashflow"/>
-		<rdfs:label xml:lang="en">income</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;IncomeFromOperations">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NetIncome"/>
-		<rdfs:label xml:lang="en">income from operations</rdfs:label>
-		<skos:definition xml:lang="en">Gross Profit</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;InvestmentPortfolio">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Account"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;strategy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;InvestmentStrategy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">investment portfolio</rdfs:label>
-		<skos:definition xml:lang="en">An account containing a number of financial instruments along with cash positions in one or more currencies.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;InvestmentStrategy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;BusinessStrategy"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;toFulfil"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">investment strategy</rdfs:label>
-		<skos:definition xml:lang="en">A plan, method, or series of maneuvers or stratagems for obtaining a specific investment goal.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;LedgerAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Account"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasBalance"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;LedgerBalance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;preparedFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">ledger account</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;LedgerBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;Balance"/>
-		<rdfs:label xml:lang="en">ledger balance</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Liability">
-		<rdfs:label xml:lang="en">liability</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;LongTermDebt">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
-		<rdfs:label xml:lang="en">long term debt</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;MasterCreditFacility">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-arr;Collection"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-col;hasCollectionConstituent"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/CreditFacility"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">master credit facility</rdfs:label>
-		<skos:definition xml:lang="en">A pool of credit facilities is combined into a Master Credit Facility for more efficient management of credit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This cannot be sold as a pool based security. The credit facilities are pooled, or brought together, purely for management purposes. Given that the semantics of Pool is that a pool is brought together to achieve some business goal, as distinct to being brought together for management purposes, this term does not follow the archetype of Pool although it is similar in many respects.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;NetBalanceSheetIncome">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NetIncome"/>
-		<rdfs:label xml:lang="en">net balance sheet income</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;NetIncome">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Income"/>
-		<rdfs:label xml:lang="en">net income</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;NetSalesIncome">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NetIncome"/>
-		<rdfs:label xml:lang="en">net sales income</rdfs:label>
-		<skos:definition xml:lang="en">Profit</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;NostroAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NostroOrVostro"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasPartyBalance"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-bal;NostroBalance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isViewOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Account"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;nostroAccountHasPerspective"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">nostro account</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-acc;VostroAccount"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;NostroOrVostro">
-		<rdfs:label xml:lang="en">nostro or vostro</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;OperatingExpense">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Expenditure"/>
-		<rdfs:label xml:lang="en">operating expense</rdfs:label>
-		<skos:definition xml:lang="en">Operating Overheads</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;OtherIncome">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;GrossIncome"/>
-		<rdfs:label xml:lang="en">other income</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;PaymentProcess">
-		<rdfs:label xml:lang="en">payment process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;Price">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;purportsToReflect"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-accx-acc;ValueInExchange">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-accx-acc;ValueInUse">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;reflects"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">price</rdfs:label>
-		<skos:definition xml:lang="en">Some monetary value ascribed to something, as being a measure of its value or perceived value.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">At this point in the model we do not distinguish between valuations (as for insurance purposes) and prices as quoted in market data price feeds and the like. These are pinned down at the point where different kinds of price are defined such as quote prices, trade prices and so on. At this highest level, price is essentially synonymous with valuation.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;PriceSpecification">
-		<rdfs:label xml:lang="en">price specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a price, that is some formal and actionable definition of the value in exchange of some item.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;RelativeCashflow">
-		<rdfs:label xml:lang="en">relative cashflow</rdfs:label>
-		<skos:definition xml:lang="en">A cash flow as seen from the perspective of a given balance sheet or by a given entity, that is a flow of funds into or or out of that balance sheet or on the part of that entity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a relative entity - the cash flow from a given perspective (&quot;flow&quot;) being towards or away from some independent entity. This is not to be confused with a Cashflow Commitment, that is a concrete, independent description of a flow of funds as committed by some party. The latter is for example a feature of swaps and other derivatives, and in principle many or all instruments can be described as or reduced to (from one business perspective) some &quot;Cashflow&quot; in the sense of Cashflow Commitment.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;RetainedIncome">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Income"/>
-		<rdfs:label xml:lang="en">retained income</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;ShortTermDebt">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
-		<rdfs:label xml:lang="en">short term debt</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;StockAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
-		<rdfs:label xml:lang="en">stock amount</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;StockInTrade">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
-		<rdfs:label xml:lang="en">stock in trade</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;TaxExpense">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Expenditure"/>
-		<rdfs:label xml:lang="en">tax expense</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;TotalAssets">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetTotal"/>
-		<rdfs:label xml:lang="en">total assets</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;TotalLiabilities">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetTotal"/>
-		<rdfs:label xml:lang="en">total liabilities</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;TotalOwnersEquity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetTotal"/>
-		<rdfs:label xml:lang="en">total owners equity</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;ValueInExchange">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
-		<rdfs:label xml:lang="en">value in exchange</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-acc;ValueInUse"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;ValueInUse">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
-		<rdfs:label xml:lang="en">value in use</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-acc;VostroAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NostroOrVostro"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasPartyBalance"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-bal;VostroBalance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isViewOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Account"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;vostroAccountHasPerspective"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">vostro account</rdfs:label>
-		<skos:definition xml:lang="en">Your account with us.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;accountHasProvider">
-		<rdfs:label xml:lang="en">account has provider</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Account"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-fnd-accx-acc;balance">
-		<rdfs:label xml:lang="en">balance</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;decreaseIn">
-		<rdfs:label xml:lang="en">decrease in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Depreciation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;denomination">
-		<rdfs:label xml:lang="en">denomination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Coinage"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the money is denominated.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasBalance">
-		<rdfs:label xml:lang="en">has balance</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Account"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-bal;Balance"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasHolder">
-		<rdfs:label xml:lang="en">has holder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Account"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasIssuerIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">has issuer identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;CashIssuer"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/CentralBank"/>
-		<skos:definition xml:lang="en">The identity of the party which is the issuer of cash as promissory notes is a Central Bank.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasPartyAccountHolder">
-		<rdfs:label xml:lang="en">has party account holder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;AccountServicing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasPartyAccountProvider">
-		<rdfs:label xml:lang="en">has party account provider</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;AccountServicing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasPartyBalance">
-		<rdfs:label xml:lang="en">has party balance</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;NostroOrVostro"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-bal;Balance"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;holds">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;InvestmentPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;increaseIn">
-		<rdfs:label xml:lang="en">increase in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Appreciation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isMeasuredAs">
-		<rdfs:label>is measured as</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isOf">
-		<rdfs:label xml:lang="en">is of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isQuantityOf.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-ecr;takesMaterialForm"/>
-		<rdfs:label xml:lang="en">is quantity of</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Cash"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isValueOf">
-		<rdfs:label xml:lang="en">is value of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isViewOn">
-		<rdfs:label xml:lang="en">is view on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;NostroOrVostro"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Account"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;issuedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
-		<rdfs:label xml:lang="en">issued by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;CashIssuer"/>
-		<skos:definition xml:lang="en">The issuer of the cash currency.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;nostroAccountHasPerspective">
-		<rdfs:label xml:lang="en">nostro account has perspective</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;NostroAccount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;preparedFor">
-		<rdfs:label xml:lang="en">prepared for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;purportsToReflect">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-accx-acc;reflects"/>
-		<rdfs:label xml:lang="en">purports to reflect</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-accx-acc;ValueInExchange">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-accx-acc;ValueInUse">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;reflects">
-		<rdfs:label xml:lang="en">reflects value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Price"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;strategy">
-		<rdfs:label xml:lang="en">strategy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;InvestmentPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;InvestmentStrategy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;takesForm">
-		<rdfs:label>takes form</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;takesFormOf">
-		<rdfs:label xml:lang="en">takes form of</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;value">
-		<rdfs:label xml:lang="en">value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;DatedBalance"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;vostroAccountHasPerspective">
-		<rdfs:label xml:lang="en">vostro account has perspective</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;VostroAccount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-accx-bal="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"
+buxmlns:fibo-fnd-arrxx-col="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/"
+buxmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
+buxmlns:fibo-fnd-bus-pol="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"
+buxmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+buxmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AccountsMain</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extensive conceptual model of concepts in accounting, including ledger accounts and cashflow constructs. 
+		Concepts in this model and the accompanying Balance Sheet Balances ontology are conceptually grounded, and as such are intended to be deprecated in favor of similar or equivalent terms elsewhere in the Release ontologies over time.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;AbstractCashflowConstruct">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">abstract cashflow construct</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-acc;RelativeCashflow"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Account">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;accountHasProvider"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasBalance"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-bal;Balance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasHolder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">account</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Business relationship between two entities; one entity is the account owner, the other entity is the account servicer.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review session notes: A container that contains assets and/or commitments?</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountHolder">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">account holder</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountPayable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">account payable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountProvider">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">account provider</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountReceivable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">account receivable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountServicing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasPartyAccountHolder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasPartyAccountProvider"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">account servicing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;AccountingParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accounting party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Party from the perspective of which these accounts are prepared. This is the to whom the balances apply. There would be corresponding accounts (supplier, customer) for counterparties with whom the Accounting Party does business.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;AccruedLiability">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Liability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accrued liability</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Liability which has been incurred by the entity and is yet to be paid off.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Appreciation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;increaseIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">appreciation</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-acc;Depreciation"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Cash">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-acc;CashCurrency">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-acc;Coinage">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something that is widely accepted in payment for goods and services and in settling debts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;CashCurrency">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;PromissoryNote"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;issuedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;CashIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash currency</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Money in the form of promissory notes issued by some central bank.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;CashIssuer">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasIssuerIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/CentralBank"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer and underwriter of cash. This takes the form of some Central Bank.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Coinage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-phy-phy;ContinuousPhysicalStuff"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coinage</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Money in the form of coins minted by some authorized mint.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;DatedBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;Balance"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dated balance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A balance at a point in time in the past, present or future.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Depreciation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;decreaseIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">depreciation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;DirectExpense">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Expenditure"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">direct expense</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Cost of Sales</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Distribution">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">distribution</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Draft">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draft</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A draft is a legally binding order by one party (the drawer) to a second party (the drawee) to make payment to a third party (the payee). A simple example is a bank check -which is simply an order directing a bank to pay a third party. The three parties don&apos;t have to be distinct. For example, someone might write himself a check as a simple means of transferring funds from one bank account to another. In this case, the drawer and payee are the same person. When a draft guarantees payment for goods in international trade, it is called a bill of exchange. A draft can require immediate payment by the second party to the third upon presentation of the draft. This is called a sight draft. Checks are sight drafts. In trade, drafts often are for deferred payment. An importer might write a draft promising payment to an exporter for delivery of goods with payment to occur 60 days after the goods are delivered. Such drafts are called time drafts. They are said to mature on the payment date. In this example, the importer is both the drawer and the drawee. Definition source: riskglossary.com</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;EconomicValue">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isValueOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Expenditure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;RelativeCashflow"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expenditure</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Fee">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Liability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fee</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;GrossIncome">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Income"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gross income</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;GrossSalesIncome">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;GrossIncome"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gross sales income</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Income">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;RelativeCashflow"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">income</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;IncomeFromOperations">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NetIncome"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">income from operations</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Gross Profit</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;InvestmentPortfolio">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;strategy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;InvestmentStrategy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment portfolio</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An account containing a number of financial instruments along with cash positions in one or more currencies.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;InvestmentStrategy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;BusinessStrategy"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;toFulfil"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment strategy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A plan, method, or series of maneuvers or stratagems for obtaining a specific investment goal.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;LedgerAccount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasBalance"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;LedgerBalance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;preparedFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ledger account</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;LedgerBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;Balance"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ledger balance</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Liability">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">liability</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;LongTermDebt">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">long term debt</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;MasterCreditFacility">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-arr;Collection"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-col;hasCollectionConstituent"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/CreditFacility"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">master credit facility</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool of credit facilities is combined into a Master Credit Facility for more efficient management of credit.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This cannot be sold as a pool based security. The credit facilities are pooled, or brought together, purely for management purposes. Given that the semantics of Pool is that a pool is brought together to achieve some business goal, as distinct to being brought together for management purposes, this term does not follow the archetype of Pool although it is similar in many respects.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;NetBalanceSheetIncome">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NetIncome"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">net balance sheet income</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;NetIncome">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Income"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">net income</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;NetSalesIncome">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NetIncome"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">net sales income</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Profit</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;NostroAccount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NostroOrVostro"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasPartyBalance"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-bal;NostroBalance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isViewOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;nostroAccountHasPerspective"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">nostro account</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-acc;VostroAccount"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;NostroOrVostro">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">nostro or vostro</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;OperatingExpense">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Expenditure"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">operating expense</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Operating Overheads</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;OtherIncome">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;GrossIncome"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">other income</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;PaymentProcess">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;Price">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;purportsToReflect"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-accx-acc;ValueInExchange">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-accx-acc;ValueInUse">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;reflects"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some monetary value ascribed to something, as being a measure of its value or perceived value.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">At this point in the model we do not distinguish between valuations (as for insurance purposes) and prices as quoted in market data price feeds and the like. These are pinned down at the point where different kinds of price are defined such as quote prices, trade prices and so on. At this highest level, price is essentially synonymous with valuation.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;PriceSpecification">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a price, that is some formal and actionable definition of the value in exchange of some item.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;RelativeCashflow">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relative cashflow</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A cash flow as seen from the perspective of a given balance sheet or by a given entity, that is a flow of funds into or or out of that balance sheet or on the part of that entity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a relative entity - the cash flow from a given perspective (&quot;flow&quot;) being towards or away from some independent entity. This is not to be confused with a Cashflow Commitment, that is a concrete, independent description of a flow of funds as committed by some party. The latter is for example a feature of swaps and other derivatives, and in principle many or all instruments can be described as or reduced to (from one business perspective) some &quot;Cashflow&quot; in the sense of Cashflow Commitment.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;RetainedIncome">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Income"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">retained income</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;ShortTermDebt">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">short term debt</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;StockAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stock amount</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;StockInTrade">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stock in trade</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;TaxExpense">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Expenditure"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax expense</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;TotalAssets">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetTotal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">total assets</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;TotalLiabilities">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetTotal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">total liabilities</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;TotalOwnersEquity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetTotal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">total owners equity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;ValueInExchange">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value in exchange</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-acc;ValueInUse"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;ValueInUse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value in use</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-acc;VostroAccount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;NostroOrVostro"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;hasPartyBalance"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-bal;VostroBalance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isViewOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;vostroAccountHasPerspective"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">vostro account</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Your account with us.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;accountHasProvider">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">account has provider</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-fnd-accx-acc;balance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;decreaseIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">decrease in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Depreciation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;denomination">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Coinage"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which the money is denominated.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has balance</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-bal;Balance"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasHolder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has holder</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasIssuerIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has issuer identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;CashIssuer"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/CentralBank"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The identity of the party which is the issuer of cash as promissory notes is a Central Bank.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasPartyAccountHolder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has party account holder</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;AccountServicing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasPartyAccountProvider">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has party account provider</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;AccountServicing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;hasPartyBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has party balance</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;NostroOrVostro"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-bal;Balance"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;holds">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;InvestmentPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;increaseIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">increase in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Appreciation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isMeasuredAs">
+bubu<rdfs:label>is measured as</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isQuantityOf.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-ecr;takesMaterialForm"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is quantity of</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Cash"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isValueOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is value of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;isViewOn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is view on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;NostroOrVostro"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;issuedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;CashIssuer"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer of the cash currency.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;nostroAccountHasPerspective">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">nostro account has perspective</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;NostroAccount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountHolder"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;preparedFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prepared for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;purportsToReflect">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-accx-acc;reflects"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purports to reflect</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-acc;ValueInExchange">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-acc;ValueInUse">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;reflects">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reflects value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;EconomicValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;strategy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strategy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;InvestmentPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;InvestmentStrategy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;takesForm">
+bubu<rdfs:label>takes form</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;takesFormOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes form of</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;value">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;DatedBalance"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-acc;vostroAccountHasPerspective">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">vostro account has perspective</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-acc;VostroAccount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;AccountProvider"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/AccountingExt/AssetExtensions.rdf
+++ b/fnd/AccountingExt/AssetExtensions.rdf
@@ -1,96 +1,99 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-assx "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/">
-	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-assx "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/">
+bu<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
+bu<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-assx="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"
-	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/">
-		<rdfs:label xml:lang="en">AssetExtensions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-assx;MeasurableAsset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-assx;measuredIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">measurable asset</rdfs:label>
-		<skos:definition xml:lang="en">Some asset which is or may be measured monearality in some currency. Editorial Note: This class introduced because the original FIBO model has a property &quot;measured in&quot; (with range of Currency) which is not in FIBO-FND v1.0 and because this lets us use the parent class to define anything as an asset if it is owned whether or not it is measured monetarily. Applications of the concept of Asset to accouting, book-keeping etc where it is measured should use this now term in place of the parent term &quot;Asset&quot;. Note also that the moved property &quot;measured in&quot; is an object property, having a range of Currency.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-assx;PhysicalAsset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-assx;MeasurableAsset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-assx;physicalAssetTakesForm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">physical asset</rdfs:label>
-		<skos:definition xml:lang="en">A Physical Thing held by some party and having some value.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-assx;PropertyAsset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-assx;PhysicalAsset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-assx;propertyAssetTakesForm"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">property asset</rdfs:label>
-		<skos:definition xml:lang="en">A physical property (building) regarded as an asset.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-assx;measuredIn">
-		<rdfs:label xml:lang="en">measured in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-assx;MeasurableAsset"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the asset is denominated, measured and / or reported. Explanatory Note: This property was introduced as part of accounting alignment to identify how an asset, when reported for accounting purposes, has some currency in which it may be measured.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-assx;physicalAssetTakesForm">
-		<rdfs:label xml:lang="en">physical asset takes form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-assx;PhysicalAsset"/>
-		<rdfs:range rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
-		<skos:definition xml:lang="en">The individual thing which itself makes up the Asset.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-assx;propertyAssetTakesForm">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-accx-assx;physicalAssetTakesForm"/>
-		<rdfs:label xml:lang="en">property asset takes form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-assx;PropertyAsset"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-		<skos:definition xml:lang="en">The physical form of the Property Asset is Real Estate, also known as Bricks and Mortar.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-assx="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"
+buxmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+buxmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AssetExtensions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extensions of concepts in the Asset concept in the main Ownership ontology, where asset is defined as something owned. This ontology covers different categories of asset in that sense, such as physical and real estate (property) assets.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-assx;MeasurableAsset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-assx;measuredIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">measurable asset</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some asset which is or may be measured monearality in some currency. Editorial Note: This class introduced because the original FIBO model has a property &quot;measured in&quot; (with range of Currency) which is not in FIBO-FND v1.0 and because this lets us use the parent class to define anything as an asset if it is owned whether or not it is measured monetarily. Applications of the concept of Asset to accouting, book-keeping etc where it is measured should use this now term in place of the parent term &quot;Asset&quot;. Note also that the moved property &quot;measured in&quot; is an object property, having a range of Currency.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-assx;PhysicalAsset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-assx;MeasurableAsset"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-assx;physicalAssetTakesForm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">physical asset</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Physical Thing held by some party and having some value.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-assx;PropertyAsset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-assx;PhysicalAsset"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-assx;propertyAssetTakesForm"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property asset</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A physical property (building) regarded as an asset.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-assx;measuredIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">measured in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-assx;MeasurableAsset"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which the asset is denominated, measured and / or reported. Explanatory Note: This property was introduced as part of accounting alignment to identify how an asset, when reported for accounting purposes, has some currency in which it may be measured.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-assx;physicalAssetTakesForm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">physical asset takes form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-assx;PhysicalAsset"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The individual thing which itself makes up the Asset.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-assx;propertyAssetTakesForm">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-accx-assx;physicalAssetTakesForm"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property asset takes form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-assx;PropertyAsset"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The physical form of the Property Asset is Real Estate, also known as Bricks and Mortar.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/AccountingExt/BalanceSheetBalances.rdf
+++ b/fnd/AccountingExt/BalanceSheetBalances.rdf
@@ -1,251 +1,254 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-accx-assx "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/">
-	<!ENTITY fibo-fnd-accx-bal "https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
-	<!ENTITY fibo-fnd-accx-dbpx "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-accx-assx "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/">
+bu<!ENTITY fibo-fnd-accx-bal "https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
+bu<!ENTITY fibo-fnd-accx-dbpx "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-accx-assx="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"
-	xmlns:fibo-fnd-accx-bal="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"
-	xmlns:fibo-fnd-accx-dbpx="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
-		<rdfs:label xml:lang="en">BalanceSheetBalances</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-acc-aeq;OwnersEquity">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;AccountPayableBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerBalance"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;isBalanceOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountPayable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">account payable balance</rdfs:label>
-		<skos:definition xml:lang="en">Balance of accounts receivable</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;AccountReceivableBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerBalance"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;isBalanceOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountReceivable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">account receivable balance</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
-		<skos:definition xml:lang="en">Balance of accounts receivable</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;Balance">
-		<rdfs:label xml:lang="en">balance</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetAssetBalance">
-		<rdfs:label xml:lang="en">balance sheet asset balance</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-acc-aeq;OwnersEquity"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;BalanceSheetLiabilityBalance"/>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-accx-bal;AccountReceivableBalance">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-accx-bal;CashBalance">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-accx-bal;StockBalance">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-accx-dbpx;CreditSide">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition xml:lang="en">A balance sheet entry representing some asset of the entity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetFeature"/>
-		<rdfs:label xml:lang="en">balance sheet balance</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetEntry">
-		<rdfs:label xml:lang="en">balance sheet entry</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-accx-bal;BalanceSheetAssetBalance">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-accx-bal;BalanceSheetLiabilityBalance">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-acc-aeq;OwnersEquity">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition xml:lang="en">Some entry on the balance sheet of some business entity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetFeature">
-		<rdfs:label xml:lang="en">balance sheet feature</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetLiabilityBalance">
-		<rdfs:label xml:lang="en">balance sheet liability balance</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-acc-aeq;OwnersEquity"/>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-accx-acc;AccruedLiability">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-accx-bal;AccountPayableBalance">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-accx-dbpx;DebtSide">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition xml:lang="en">A balance sheet entry representing some asset of the entity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetTotal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetFeature"/>
-		<rdfs:label xml:lang="en">balance sheet total</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;CashBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerBalance"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;representsAmountOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;representsMonetaryAmount"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash balance</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
-		<skos:definition xml:lang="en">A balance of cash. This is identified as an amount of cash which is denominated with a currency.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;NostroBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;Balance"/>
-		<rdfs:label xml:lang="en">nostro balance</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;VostroBalance"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;StockBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-assx;PhysicalAsset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;isQuantityOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;StockInTrade"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;represents"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;StockAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">stock balance</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
-		<skos:definition xml:lang="en">Balance of stock in trade.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-bal;VostroBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;Balance"/>
-		<rdfs:label xml:lang="en">vostro balance</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;appliesTo">
-		<rdfs:label xml:lang="en">applies to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;BalanceSheetEntry"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/Interval"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;balance">
-		<rdfs:label xml:lang="en">balance</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;BalanceSheetBalance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;isBalanceOf">
-		<rdfs:label xml:lang="en">is balance of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;Balance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Account"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;isFor">
-		<rdfs:label xml:lang="en">is for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;BalanceSheetEntry"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;isQuantityOf">
-		<rdfs:label xml:lang="en">is quantity of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;StockInTrade"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;represents">
-		<rdfs:label xml:lang="en">represents</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;StockAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;representsAmountOf">
-		<rdfs:label xml:lang="en">represents amount of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;representsMonetaryAmount">
-		<rdfs:label xml:lang="en">represents monetary amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-accx-assx="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"
+buxmlns:fibo-fnd-accx-bal="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"
+buxmlns:fibo-fnd-accx-dbpx="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BalanceSheetBalances</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Conceptual model of kinds of balance and other balance sheet features. This ontology has been extracted from the Accounts Main ontology and is intended to work alongside that.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-acc-aeq;OwnersEquity">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;AccountPayableBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerBalance"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;isBalanceOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountPayable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">account payable balance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Balance of accounts receivable</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;AccountReceivableBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerBalance"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;isBalanceOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;AccountReceivable"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">account receivable balance</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Balance of accounts receivable</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;Balance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetAssetBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance sheet asset balance</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-acc-aeq;OwnersEquity"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;BalanceSheetLiabilityBalance"/>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-bal;AccountReceivableBalance">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-bal;CashBalance">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-bal;StockBalance">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-dbpx;CreditSide">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A balance sheet entry representing some asset of the entity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetFeature"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance sheet balance</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetEntry">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance sheet entry</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-bal;BalanceSheetAssetBalance">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-bal;BalanceSheetLiabilityBalance">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-acc-aeq;OwnersEquity">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some entry on the balance sheet of some business entity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetFeature">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance sheet feature</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetLiabilityBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance sheet liability balance</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-acc-aeq;OwnersEquity"/>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-acc;AccruedLiability">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-bal;AccountPayableBalance">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-accx-dbpx;DebtSide">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A balance sheet entry representing some asset of the entity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;BalanceSheetTotal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;BalanceSheetFeature"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance sheet total</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;CashBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;LedgerBalance"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;representsAmountOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;representsMonetaryAmount"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash balance</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A balance of cash. This is identified as an amount of cash which is denominated with a currency.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;NostroBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;Balance"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">nostro balance</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-bal;VostroBalance"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;StockBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-assx;PhysicalAsset"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;isQuantityOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;StockInTrade"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-bal;represents"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;StockAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stock balance</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Balance of stock in trade.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-bal;VostroBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-bal;Balance"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">vostro balance</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;appliesTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applies to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;BalanceSheetEntry"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/Interval"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;balance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;BalanceSheetBalance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;isBalanceOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is balance of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;Balance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;Account"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;isFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;BalanceSheetEntry"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;isQuantityOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is quantity of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;StockInTrade"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;represents">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">represents</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;StockBalance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;StockAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;representsAmountOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">represents amount of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;CashCurrency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-bal;representsMonetaryAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">represents monetary amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-bal;CashBalance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;AmountOfMoney"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/AccountingExt/InvestmentCapital.rdf
+++ b/fnd/AccountingExt/InvestmentCapital.rdf
@@ -1,71 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
-	<!ENTITY fibo-fnd-accx-cap "https://spec.edmcouncil.org/fibo/FND/AccountingExt/InvestmentCapital/">
-	<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
+bu<!ENTITY fibo-fnd-accx-cap "https://spec.edmcouncil.org/fibo/FND/AccountingExt/InvestmentCapital/">
+bu<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/AccountingExt/InvestmentCapital/"
-	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
-	xmlns:fibo-fnd-accx-cap="https://spec.edmcouncil.org/fibo/FND/AccountingExt/InvestmentCapital/"
-	xmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/InvestmentCapital/">
-		<rdfs:label xml:lang="en">InvestmentCapital</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/InvestmentCapital/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-cap;InvestmentCapital">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveAmount"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-cap;investmentCapitalHasPurpose"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-cap;InvestmentPurpose"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-cap;investmentCapitalIsApplicationOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;Capital"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">investment capital</rdfs:label>
-		<skos:definition xml:lang="en">Capital employed for some investment purpose Editorial Note: In one sense, all capital is by definition employed for some investment purpose and this is the meaning of capital. However, this model expresses the concept of capital at two levels of relative use: 1. Capital as an economic resource (something which can be seen to be of come value because it may be put to some purpose (&quot;Capital&quot;) 2. Capital when described from the perspective of being used for the purposes for which capital is intended, i.e. investment (whether by a speculative investor, or from the perspective of an entrepreneur as in capitlizing an endeavor). This is given the label &quot;Investment Capital&quot; In day to day usage the word &quot;Capital&quot; ranges across both meanings.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-cap;InvestmentPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
-		<rdfs:label xml:lang="en">investment purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-cap;investmentCapitalHasPurpose">
-		<rdfs:label xml:lang="en">investment capital has purpose</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-cap;InvestmentCapital"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-cap;InvestmentPurpose"/>
-		<skos:definition xml:lang="en">The investment purpose to which the capital is to be put.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-cap;investmentCapitalIsApplicationOf">
-		<rdfs:label xml:lang="en">investment capital is application of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-cap;InvestmentCapital"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-aeq;Capital"/>
-		<skos:definition xml:lang="en">The Capital (as an economic resource) which is identified as the Investment Capital.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
+buxmlns:fibo-fnd-accx-cap="https://spec.edmcouncil.org/fibo/FND/AccountingExt/InvestmentCapital/"
+buxmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/InvestmentCapital/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">InvestmentCapital</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the notion of capital as being money with some purpose. This is a conceptually oriented ontology and need not be referenced in Release ontologies. It provides the deeper meaning of what capital effectively is.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/InvestmentCapital/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-cap;InvestmentCapital">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveAmount"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-cap;investmentCapitalHasPurpose"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-cap;InvestmentPurpose"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-cap;investmentCapitalIsApplicationOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;Capital"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment capital</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Capital employed for some investment purpose Editorial Note: In one sense, all capital is by definition employed for some investment purpose and this is the meaning of capital. However, this model expresses the concept of capital at two levels of relative use: 1. Capital as an economic resource (something which can be seen to be of come value because it may be put to some purpose (&quot;Capital&quot;) 2. Capital when described from the perspective of being used for the purposes for which capital is intended, i.e. investment (whether by a speculative investor, or from the perspective of an entrepreneur as in capitlizing an endeavor). This is given the label &quot;Investment Capital&quot; In day to day usage the word &quot;Capital&quot; ranges across both meanings.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-cap;InvestmentPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-cap;investmentCapitalHasPurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment capital has purpose</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-cap;InvestmentCapital"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-cap;InvestmentPurpose"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The investment purpose to which the capital is to be put.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-cap;investmentCapitalIsApplicationOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment capital is application of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-cap;InvestmentCapital"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-aeq;Capital"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Capital (as an economic resource) which is identified as the Investment Capital.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/AccountingExt/Taxation.rdf
+++ b/fnd/AccountingExt/Taxation.rdf
@@ -1,188 +1,191 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-accx-tax "https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-accx-tax "https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/"
-	xmlns:fibo-fnd-accx-tax="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/">
-		<rdfs:label xml:lang="en">Taxation</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxJurisdiction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:label xml:lang="en">tax jurisdiction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;applicableIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxJurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;laysDown"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tax law</rdfs:label>
-		<skos:definition xml:lang="en">A law or body of law pertaining to the liability for and payment of tax by persons or legal entities which are subject to the jurisdiction covered by that law.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxRule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;applicableIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxJurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;isLaidDownIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxLaw"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxTreatment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tax rule</rdfs:label>
-		<skos:definition xml:lang="en">The tax rule which is applied in determing the applicable tax.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxRuleCode">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;RuleCode"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-meth;standsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/hasDefinition"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRuleScheme"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tax rule code</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxRuleScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;RuleScheme"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/defines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRuleCode"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tax rule scheme</rdfs:label>
-		<skos:definition xml:lang="en">The scheme in which the tax rule is identified and defined.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxTreatment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;definedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tax treatment</rdfs:label>
-		<skos:definition xml:lang="en">Amount of money due to the government or tax authority, applicable to some thing or activity in some jurisdiction</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;applicableIn">
-		<rdfs:label xml:lang="en">applicable in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxLaw"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxJurisdiction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;definedIn">
-		<rdfs:label xml:lang="en">defined in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxTreatment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-accx-tax;setsOut"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;description">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Free text description of the tax rule.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;effectivePeriod">
-		<rdfs:label xml:lang="en">effective period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">Period during which the tax rule applies within the jurisdiction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;isLaidDownIn">
-		<rdfs:label xml:lang="en">is laid down in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxLaw"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;laysDown">
-		<rdfs:label xml:lang="en">lays down</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxLaw"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-accx-tax;isLaidDownIn"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;rate">
-		<rdfs:label xml:lang="en">rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Rate used for calculation of the tax.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;ruleName">
-		<rdfs:label xml:lang="en">rule name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Common name of the Tax Rule</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;setsOut">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxTreatment"/>
-		<skos:definition xml:lang="en">The treatment of the financial instrument for taxation purposes. This is the most general form of tax treatment for financial instruments, including cash.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-accx-tax="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Taxation</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Tax laws, rules and their jurisdictions. This ontology is intended for reference by instrument terms that have some tax related implication.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxJurisdiction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax jurisdiction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;applicableIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxJurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;laysDown"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A law or body of law pertaining to the liability for and payment of tax by persons or legal entities which are subject to the jurisdiction covered by that law.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxRule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;applicableIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxJurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;isLaidDownIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxLaw"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxTreatment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax rule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The tax rule which is applied in determing the applicable tax.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxRuleCode">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;RuleCode"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-meth;standsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/hasDefinition"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRuleScheme"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax rule code</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxRuleScheme">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;RuleScheme"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/defines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRuleCode"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax rule scheme</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The scheme in which the tax rule is identified and defined.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-accx-tax;TaxTreatment">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-tax;definedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax treatment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Amount of money due to the government or tax authority, applicable to some thing or activity in some jurisdiction</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;applicableIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxLaw"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxJurisdiction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;definedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxTreatment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-accx-tax;setsOut"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;description">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Free text description of the tax rule.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;effectivePeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effective period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Period during which the tax rule applies within the jurisdiction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;isLaidDownIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is laid down in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxLaw"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;laysDown">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lays down</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxLaw"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-accx-tax;isLaidDownIn"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;rate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Rate used for calculation of the tax.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;ruleName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rule name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Common name of the Tax Rule</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-accx-tax;setsOut">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-accx-tax;TaxRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-tax;TaxTreatment"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The treatment of the financial instrument for taxation purposes. This is the most general form of tax treatment for financial instruments, including cash.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/AgreementsExt/ContractElements.rdf
+++ b/fnd/AgreementsExt/ContractElements.rdf
@@ -1,190 +1,194 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-ele "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-ele "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-ele="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/">
-		<rdfs:label xml:lang="en">ContractElements</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
-		<owl:equivalentClass rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;definedInClause"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;definedInSection"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ele;ContractSection"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;WrittenContract">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractClause">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;clauseContainsTerm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ele;ContractTerm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contract clause</rdfs:label>
-		<skos:definition xml:lang="en">A set of contractual terms, grouped according to subject, intent or the type of rights and / or obligations to which it refers.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractPart">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:label xml:lang="en">contract part</rdfs:label>
-		<skos:definition xml:lang="en">A formal part of a contract such as a clause or term.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractPreamble">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
-		<rdfs:label xml:lang="en">contract preamble</rdfs:label>
-		<skos:definition xml:lang="en">The part of a contract which defines the parties and gives sufficient information for them to be unambiguously identified, along with other pertinent information such as the subject of the contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractSection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;sectionContainsClause"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contract section</rdfs:label>
-		<skos:definition xml:lang="en">A formally identified Section of a Contract, comtaining terms dealing with a specific type of subject matter.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractTerm">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:label xml:lang="en">contract term</rdfs:label>
-		<skos:definition xml:lang="en">An individual term in a Contract. Forms part of a set of Contractual Terms. Also exists within a Clause of a Contract A Clause exists within a Section of a Contract</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ele;DRIP">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
-		<rdfs:label xml:lang="en">d r i p</rdfs:label>
-		<skos:definition xml:lang="en">A kind of financial contract.</skos:definition>
-		<skos:editorialNote xml:lang="en">This term is awaitilng further analysis and will then be moved to the appropriate financial instrument section.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ele;RepresentationsSection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
-		<rdfs:label xml:lang="en">representations section</rdfs:label>
-		<skos:definition xml:lang="en">Section containing statements held out by one party to the other as being true and correct at the time of the Agreement. A representation, as contained in this section of a contract, is a statement by one other party asserting that some given state of the world exists.</skos:definition>
-		<skos:editorialNote xml:lang="en">Things still to tease out: there is a difference at law between a warranty and a representation. There are differences between the implications if one or other proves to be untrue: one will render the contract void; the other renders only specific elements of the contract void or makes some difference between those elements. A warranty is likely a stronger assertion thatn a representation (has greater impact).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ele;TerminationProvisions">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:label xml:lang="en">termination provisions</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms setting out how the written contract may be terminated and what happens when it is.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ele;WarrantiesSection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
-		<rdfs:label xml:lang="en">warranties section</rdfs:label>
-		<skos:definition xml:lang="en">Section defining what is warranted by either party to the other. A warranty, as contained in this section of a contract, is a statement by one other party asserting that some given state of the world exists.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the contract section which formalizes these aspects of the Agreement between the parties.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;clauseContainsTerm">
-		<rdfs:label xml:lang="en">clause contains term</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;ContractTerm"/>
-		<skos:definition xml:lang="en">An individual term contained within the clause.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;definedInClause">
-		<rdfs:label xml:lang="en">defined in clause</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
-		<skos:definition xml:lang="en">The individual clause of the contract in which the set of terms is defined, if applicable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;definedInSection">
-		<rdfs:label xml:lang="en">defined in section</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;ContractSection"/>
-		<skos:definition xml:lang="en">The section of the contract in which the contract terms set is defined.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;definesPrincipals">
-		<rdfs:label xml:lang="en">defines principals</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agrx-ele;ContractPreamble"/>
-		<skos:definition xml:lang="en">The identification of parties to the contract as embodied in the preamble.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;hasProvisions">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has provisions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;TerminationProvisions"/>
-		<skos:definition xml:lang="en">Termination provisions as contained in the Contract. These set out the conditions under which the contract may be terminated and the rights and obligations of each party in the event of such termination.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;identifiesCounterparty">
-		<rdfs:label xml:lang="en">identifies counterparty</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
-		<skos:definition xml:lang="en">The counterparty to the contract, identified in the contract principals identification.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;identifiesPrincipal">
-		<rdfs:label xml:lang="en">identifies principal</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<skos:definition xml:lang="en">The principal to the contract, identified in the contract principals identification.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;identifiesThirdParty">
-		<rdfs:label xml:lang="en">identifies third party</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
-		<skos:definition xml:lang="en">A third party identified in the third party identification.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;sectionContainsClause">
-		<rdfs:label xml:lang="en">section contains clause</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agrx-ele;ContractSection"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
-		<skos:definition xml:lang="en">A clause contained in the contract section.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-ele="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ContractElements</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts related to the detailed physical elements of contracts (clauses, sections and so on) as distinct from the subject matter of those parts. This ontology can be used when there is a need to talk about parts of a contract as distinct from the commitments and other subject matter that these represent or describe. 
+		This is not an extension to an existing ontology but an additional scope of contract related subject matter.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
+bubu<owl:equivalentClass rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;definedInClause"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;definedInSection"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ele;ContractSection"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-ctr;WrittenContract">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractClause">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;clauseContainsTerm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ele;ContractTerm"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract clause</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of contractual terms, grouped according to subject, intent or the type of rights and / or obligations to which it refers.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractPart">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract part</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal part of a contract such as a clause or term.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractPreamble">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract preamble</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The part of a contract which defines the parties and gives sufficient information for them to be unambiguously identified, along with other pertinent information such as the subject of the contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractSection">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;sectionContainsClause"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract section</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formally identified Section of a Contract, comtaining terms dealing with a specific type of subject matter.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ele;ContractTerm">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract term</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An individual term in a Contract. Forms part of a set of Contractual Terms. Also exists within a Clause of a Contract A Clause exists within a Section of a Contract</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ele;DRIP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">d r i p</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A kind of financial contract.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This term is awaitilng further analysis and will then be moved to the appropriate financial instrument section.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ele;RepresentationsSection">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">representations section</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Section containing statements held out by one party to the other as being true and correct at the time of the Agreement. A representation, as contained in this section of a contract, is a statement by one other party asserting that some given state of the world exists.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Things still to tease out: there is a difference at law between a warranty and a representation. There are differences between the implications if one or other proves to be untrue: one will render the contract void; the other renders only specific elements of the contract void or makes some difference between those elements. A warranty is likely a stronger assertion thatn a representation (has greater impact).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ele;TerminationProvisions">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">termination provisions</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal terms setting out how the written contract may be terminated and what happens when it is.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ele;WarrantiesSection">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;ContractPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">warranties section</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Section defining what is warranted by either party to the other. A warranty, as contained in this section of a contract, is a statement by one other party asserting that some given state of the world exists.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the contract section which formalizes these aspects of the Agreement between the parties.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;clauseContainsTerm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">clause contains term</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;ContractTerm"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An individual term contained within the clause.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;definedInClause">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined in clause</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The individual clause of the contract in which the set of terms is defined, if applicable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;definedInSection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined in section</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;ContractSection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The section of the contract in which the contract terms set is defined.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;definesPrincipals">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines principals</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agrx-ele;ContractPreamble"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The identification of parties to the contract as embodied in the preamble.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;hasProvisions">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has provisions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;TerminationProvisions"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Termination provisions as contained in the Contract. These set out the conditions under which the contract may be terminated and the rights and obligations of each party in the event of such termination.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;identifiesCounterparty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies counterparty</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The counterparty to the contract, identified in the contract principals identification.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;identifiesPrincipal">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies principal</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The principal to the contract, identified in the contract principals identification.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;identifiesThirdParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies third party</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A third party identified in the third party identification.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ele;sectionContainsClause">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">section contains clause</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agrx-ele;ContractSection"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ele;ContractClause"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A clause contained in the contract section.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/AgreementsExt/ContractsExtensions.rdf
+++ b/fnd/AgreementsExt/ContractsExtensions.rdf
@@ -1,101 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
-	<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
+bu<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
-	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
-	xmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
-		<rdfs:label xml:lang="en">ContractsExtensions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ctrx;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractualRelationship"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<owl:equivalentClass rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ctrx;ContractualRelationship">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-		<rdfs:label xml:lang="en">contractual relationship</rdfs:label>
-		<skos:definition xml:lang="en">A relationship in which two or more parties have some contractual obligations or extend some rights under a contract, to one another.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;MutualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ctrx;contractualCommitmentConferredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ctrx;mandatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractually conferred commitment</rdfs:label>
-		<skos:definition xml:lang="en">Some commitment which has its existence through some provision in some contract. Further notes: &quot;Contractual commitment&quot; has 2 tests: 1. It is certain in time [certainty is defined in some legal sense; there has to be some ability to terminate the contract] 2. there is some consideration Without these 2 tests passing, this is not recognized in law as a contractual commitment. so for instance a Will is not legally binding upon a person who is alive. (from Aus / commonwealth law) NB: Terminating: Not the termination of a contract in a Termination Clause but the termination of the life of the Obligation as set out in the contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ctrx;contractualCommitmentConferredBy">
-		<rdfs:label xml:lang="en">contractual commitment conferred by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-agrx-con;confersContractualCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ctrx;embodies">
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractualRelationship"/>
-		<skos:definition xml:lang="en">A relationship between two parties, embodied in and created by that contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ctrx;mandatedBy">
-		<rdfs:label xml:lang="en">mandated by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-agrx-con;mandates"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ctrx;varies">
-		<rdfs:label xml:lang="en">varies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ConditionsPrecedent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualObligation"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
+buxmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ContractsExtensions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Conceptual extensions to the Contracts ontology, including the corresponding contractual relationship and commitments conferred specifically by a contract, along with some additional properties.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ctrx;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractualRelationship"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<owl:equivalentClass rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ctrx;ContractualRelationship">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual relationship</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A relationship in which two or more parties have some contractual obligations or extend some rights under a contract, to one another.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;MutualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ctrx;contractualCommitmentConferredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ctrx;mandatedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractually conferred commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some commitment which has its existence through some provision in some contract. Further notes: &quot;Contractual commitment&quot; has 2 tests: 1. It is certain in time [certainty is defined in some legal sense; there has to be some ability to terminate the contract] 2. there is some consideration Without these 2 tests passing, this is not recognized in law as a contractual commitment. so for instance a Will is not legally binding upon a person who is alive. (from Aus / commonwealth law) NB: Terminating: Not the termination of a contract in a Termination Clause but the termination of the life of the Obligation as set out in the contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ctrx;contractualCommitmentConferredBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual commitment conferred by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-agrx-con;confersContractualCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ctrx;embodies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractualRelationship"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A relationship between two parties, embodied in and created by that contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ctrx;mandatedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandated by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-agrx-con;mandates"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ctrx;varies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">varies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ConditionsPrecedent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualObligation"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/AgreementsExt/ContractsIllustrative.rdf
+++ b/fnd/AgreementsExt/ContractsIllustrative.rdf
@@ -1,77 +1,81 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-ill "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsIllustrative/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-ill "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsIllustrative/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsIllustrative/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-ill="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsIllustrative/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsIllustrative/">
-		<rdfs:label xml:lang="en">ContractsIllustrative</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsIllustrative/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ill;License">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ill;Licensee"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ill;issuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ill;Licensor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">license</rdfs:label>
-		<skos:definition xml:lang="en">A contract conferring certain rights and obligations on the holder of the contract (the licensee) who is generally unknown to the license issuer (the licensor).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A License may be transferred by the licensee (holder) to another party that becomes the new licensee without reference to the licensor. A software license is a kind of license in this sense.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ill;Licensee">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
-		<rdfs:label xml:lang="en">licensee</rdfs:label>
-		<skos:definition xml:lang="en">The holder of a license such as a software license.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ill;Licensor">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractOriginator"/>
-		<rdfs:label xml:lang="en">licensor</rdfs:label>
-		<skos:definition xml:lang="en">The issuer of a license such as a software llicense.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-ill;SoftwareLicense">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ill;License"/>
-		<rdfs:label xml:lang="en">software license</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ill;issuedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
-		<rdfs:label xml:lang="en">issued by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agrx-ill;License"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ill;Licensor"/>
-		<skos:definition xml:lang="en">The party which issues the license and extends the rights defined in the license agreement.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-ill="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsIllustrative/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsIllustrative/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ContractsIllustrative</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the notion of a license, in the sense that a software license is one such. 
+		This ontology is included to flesh out the notion of what was meant by transferable contract, of which tradable securities are a kind, by illustration a separate example of this class in the form of software licenses. Note that this has no relationship to the notion of licenses such as a banking license. This ontology does not cover any aspect of FIBO scope and may be ignored for financial industry applications.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsIllustrative/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ill;License">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ill;Licensee"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ill;issuedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ill;Licensor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">license</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A contract conferring certain rights and obligations on the holder of the contract (the licensee) who is generally unknown to the license issuer (the licensor).</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A License may be transferred by the licensee (holder) to another party that becomes the new licensee without reference to the licensor. A software license is a kind of license in this sense.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ill;Licensee">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">licensee</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The holder of a license such as a software license.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ill;Licensor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractOriginator"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">licensor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer of a license such as a software llicense.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-ill;SoftwareLicense">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ill;License"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">software license</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-ill;issuedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agrx-ill;License"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ill;Licensor"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which issues the license and extends the rights defined in the license agreement.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/AgreementsExt/ContractualConstructs.rdf
+++ b/fnd/AgreementsExt/ContractualConstructs.rdf
@@ -1,195 +1,198 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
-	<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
-	<!ENTITY fibo-fnd-soc-pty "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
+bu<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
+bu<!ENTITY fibo-fnd-soc-pty "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
-	xmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
-	xmlns:fibo-fnd-soc-pty="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-		<rdfs:label xml:lang="en">ContractualConstructs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;mandates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;setsOutRight"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<owl:equivalentClass rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;agreementFormalizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confersContractualCommitment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractual agreement</rdfs:label>
-		<skos:definition xml:lang="en">An agreement which is formalized by a contract between two parties to the agreement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualBeneficiary">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
-		<rdfs:label xml:lang="en">contractual beneficiary</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;impliedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractual obligation</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-soc-asp;LegalObligation"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualObligor">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-pty;Obligor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;obligedTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualBeneficiary"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractual obligor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualOption">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-		<rdfs:label xml:lang="en">contractual option</rdfs:label>
-		<skos:definition xml:lang="en">The option to take up some right at some future time, at the discretion of the party defined as the holder of this option in the contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;hasContractualBasis"/>
-				<owl:onClass rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;impliesSome"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractual right</rdfs:label>
-		<skos:definition xml:lang="en">Some right conferred by some contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Whereas Rights may be conferred by various instruments, this is the kind of Right specifically conferred by some Contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;agreementFormalizedBy">
-		<rdfs:label xml:lang="en">agreement formalized by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;confers">
-		<rdfs:label xml:lang="en">confers</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-		<skos:definition xml:lang="en">Some right conferred by the contract, by one party upon the other, for example the right to occupy some space unmolested or the right to receive some cash flows.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;confersContractualCommitment">
-		<rdfs:label xml:lang="en">confers contractual commitment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-agrx-ctrx;contractualCommitmentConferredBy"/>
-		<skos:definition xml:lang="en">Some Contractual Commitment which arises from the Contractual Agreement and is documented in the Contract which evidences the agreement between the parties.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;contractEmbodies">
-		<rdfs:label xml:lang="en">contract embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;hasContractualBasis">
-		<rdfs:label xml:lang="en">has contractual basis</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;mandates">
-		<rdfs:label xml:lang="en">mandates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-agrx-ctrx;mandatedBy"/>
-		<skos:definition xml:lang="en">Some obligation set out by the contract, by one party upon the other.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;setsOutRight">
-		<rdfs:label xml:lang="en">sets out right</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-		<skos:definition xml:lang="en">The rights set out in the set of terms.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;varies">
-		<rdfs:label xml:lang="en">varies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-		<skos:definition xml:lang="en">Some Obligation defined in some other contract or instrument between the parties, which is varied in some way by this contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typical usage is when a Confirmation for an OTC Derivative specifies some variation in an Obligation defined in the covering Master Agreement under which the transaction is conducted.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
+buxmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
+buxmlns:fibo-fnd-soc-pty="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ContractualConstructs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology provides additional contractual constructs including contractual obligations and their beneficiaries and obligors, contractual rights and options and the conferral or variation of these by contract.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;mandates"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;setsOutRight"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<owl:equivalentClass rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;agreementFormalizedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confersContractualCommitment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual agreement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An agreement which is formalized by a contract between two parties to the agreement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualBeneficiary">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual beneficiary</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;impliedBy"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual obligation</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-soc-asp;LegalObligation"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualObligor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-pty;Obligor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;obligedTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualBeneficiary"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual obligor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualOption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual option</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The option to take up some right at some future time, at the discretion of the party defined as the holder of this option in the contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agrx-con;ContractualRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;hasContractualBasis"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;impliesSome"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-con;ContractualObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some right conferred by some contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Whereas Rights may be conferred by various instruments, this is the kind of Right specifically conferred by some Contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;agreementFormalizedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agreement formalized by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;confers">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some right conferred by the contract, by one party upon the other, for example the right to occupy some space unmolested or the right to receive some cash flows.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;confersContractualCommitment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers contractual commitment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-agrx-ctrx;contractualCommitmentConferredBy"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some Contractual Commitment which arises from the Contractual Agreement and is documented in the Contract which evidences the agreement between the parties.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;contractEmbodies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;hasContractualBasis">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has contractual basis</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;mandates">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandates</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-agrx-ctrx;mandatedBy"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some obligation set out by the contract, by one party upon the other.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;setsOutRight">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out right</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rights set out in the set of terms.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-agrx-con;varies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">varies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some Obligation defined in some other contract or instrument between the parties, which is varied in some way by this contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Typical usage is when a Confirmation for an OTC Derivative specifies some variation in an Obligation defined in the covering Master Agreement under which the transaction is conducted.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/ArrangementsExt/Collections.rdf
+++ b/fnd/ArrangementsExt/Collections.rdf
@@ -1,65 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/">
-	<!ENTITY fibo-fnd-arrxx-col "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/">
+bu<!ENTITY fibo-fnd-arrxx-col "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/"
-	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"
-	xmlns:fibo-fnd-arrxx-col="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/">
-		<rdfs:label xml:lang="en">Collections</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-arr-arr;Collection">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-col;hasCollectionConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-col;Constituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasMember"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<skos:definition xml:lang="en">A set of things collected together for some purpose.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-col;Constituent">
-		<rdfs:label xml:lang="en">constituent</rdfs:label>
-		<skos:definition xml:lang="en">Something which makes up part of a collection, formalized in terms of its existence as a member of that collection.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The collection may be of almost anything, brought together in some specific context in which the Constituent is defined as such. It differs from a less formal collection in that there are facts defined about the constituents and the proportions of these in the collection, and specific facts about that item as a member of that collection. Constituents are defined for Pools and for Baskets.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-col;hasCollectionConstituent">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
-		<rdfs:label xml:lang="en">has collection constituent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-arr-arr;Collection"/>
-		<rdfs:range rdf:resource="&fibo-fnd-arrxx-col;Constituent"/>
-		<skos:definition xml:lang="en">A constituent of the Collection, that is one of the things that is collected up in bring the collection into being. Further notes: Some kinds of collection are defined in terms of collections of relative things (e.g. basket constituents) with qualifying facts, while others may be defined simply as sets of independent things. It is also possible to have a collection of collections. This is covered by the identity criterion for the Constituent being any Independent Thing, including Collection.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"
+buxmlns:fibo-fnd-arrxx-col="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Collections</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology extends the concept of Collection that exists in the published Release Arrangements ontology, to define the notion of a constituent and its membership of the collection. This is intended to be referred to in models of baskets and other collections of things in the financial world, in order to be able to talk about the inclusion or otherwise of some instrument in some basket or similar construct.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/Collections/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arr-arr;Collection">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-col;hasCollectionConstituent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-col;Constituent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasMember"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of things collected together for some purpose.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-col;Constituent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something which makes up part of a collection, formalized in terms of its existence as a member of that collection.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The collection may be of almost anything, brought together in some specific context in which the Constituent is defined as such. It differs from a less formal collection in that there are facts defined about the constituents and the proportions of these in the collection, and specific facts about that item as a member of that collection. Constituents are defined for Pools and for Baskets.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-col;hasCollectionConstituent">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/hasConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has collection constituent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-arr-arr;Collection"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-arrxx-col;Constituent"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A constituent of the Collection, that is one of the things that is collected up in bring the collection into being. Further notes: Some kinds of collection are defined in terms of collections of relative things (e.g. basket constituents) with qualifying facts, while others may be defined simply as sets of independent things. It is also possible to have a collection of collections. This is covered by the identity criterion for the Constituent being any Independent Thing, including Collection.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/ArrangementsExt/MethodsAndRules.rdf
+++ b/fnd/ArrangementsExt/MethodsAndRules.rdf
@@ -1,112 +1,116 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-		<rdfs:label xml:lang="en">MethodsAndRules</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;AdjustmentMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">adjustment method</rdfs:label>
-		<skos:definition xml:lang="en">The method by which something is adjusted, for example the terms of a contract, in reaction to events.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;DeliveryMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">delivery method</rdfs:label>
-		<skos:definition xml:lang="en">The means or process used in delivering something.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;DistributionMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">distribution method</rdfs:label>
-		<skos:definition xml:lang="en">The means by which monies or benefits accruing from the possession of something are distributed to the holders of that thing.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;Method">
-		<rdfs:label xml:lang="en">method</rdfs:label>
-		<skos:definition xml:lang="en">A way in which something is done.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;Preference">
-		<rdfs:label xml:lang="en">preference</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;PriceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;VariableDeterminationMethod"/>
-		<rdfs:label xml:lang="en">price determination method</rdfs:label>
-		<skos:definition xml:lang="en">The way in which the price of something is determined or is to be determined.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;Rule">
-		<rdfs:label xml:lang="en">rule</rdfs:label>
-		<skos:definition xml:lang="en">A Rule is any statement which determines how something must be. It is defined in relation to that something (which may be an event or a parameter), and with some reference to the way in which that Rule is defined, e.g. whether it forms part of some legally binding contract, is defined by physics and so on.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;RuleCode">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-meth;standsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">rule code</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;RuleScheme">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/defines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-meth;RuleCode"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">rule scheme</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;SaleMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">sale method</rdfs:label>
-		<skos:definition xml:lang="en">The means by which something is sold.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-meth;VariableDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">variable determination method</rdfs:label>
-		<skos:definition xml:lang="en">The way in which some variable amount, quantity or value is determined or is to be determined.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-meth;isWayOfDoing">
-		<rdfs:label xml:lang="en">is way of doing</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<skos:definition xml:lang="en">What the Method is a means of carrying out.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-meth;standsFor">
-		<rdfs:label xml:lang="en">stands for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-arrxx-meth;RuleCode"/>
-		<rdfs:range rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">MethodsAndRules</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology sets out the basic concepts of method and rule along with kinds and variations of either of these, as a basis for extensive lists of kinds of method such as accrual method, or kinds of rule such as date roll rules, throughout FIBO reference concepts. These form the bulk of the concepts that underlie the contents of extensional code lists in financial data. 
+		This is intended to be a Provisional ontology not (as now) an Informative one, since the vast majority of lists of things that were once in textual code lists, are sets of methods or rules. This usage is endemic across all of the FIBO reference information universe.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;AdjustmentMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">adjustment method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which something is adjusted, for example the terms of a contract, in reaction to events.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;DeliveryMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delivery method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The means or process used in delivering something.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;DistributionMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">distribution method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The means by which monies or benefits accruing from the possession of something are distributed to the holders of that thing.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;Method">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A way in which something is done.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;Preference">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">preference</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;PriceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;VariableDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The way in which the price of something is determined or is to be determined.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;Rule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Rule is any statement which determines how something must be. It is defined in relation to that something (which may be an event or a parameter), and with some reference to the way in which that Rule is defined, e.g. whether it forms part of some legally binding contract, is defined by physics and so on.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;RuleCode">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeElement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-meth;standsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rule code</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;RuleScheme">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/defines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-meth;RuleCode"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rule scheme</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;SaleMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sale method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The means by which something is sold.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-meth;VariableDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">variable determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The way in which some variable amount, quantity or value is determined or is to be determined.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-meth;isWayOfDoing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is way of doing</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">What the Method is a means of carrying out.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-meth;standsFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stands for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-arrxx-meth;RuleCode"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/ArrangementsExt/ToolsAndInstruments.rdf
+++ b/fnd/ArrangementsExt/ToolsAndInstruments.rdf
@@ -1,140 +1,144 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
-	<!ENTITY fibo-fnd-txn-qr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
+bu<!ENTITY fibo-fnd-txn-qr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
-	xmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
-	xmlns:fibo-fnd-txn-qr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
-		<rdfs:label xml:lang="en">ToolsAndInstruments</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-ins;FinancialInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Instrument"/>
-		<rdfs:label xml:lang="en">financial instrument</rdfs:label>
-		<skos:definition xml:lang="en">Some financial contract or agreement, described in the context of its use in furthering some investment purpose. Explanatory Note: This is specific to its usage. The term &quot;Financial Instrument&quot; is frequently applied to the contract (as a thing), which might be put to such purpose, rather than to the instrument as it is used as an instrument, which is what is defined by this concept.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-ins;Instrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
-		<rdfs:label xml:lang="en">instrument</rdfs:label>
-		<skos:definition xml:lang="en">Something which is used to further some purpose or to measure some variable in furtherance of some purpose. Explanatory Note: This may include more abstract or even relative or mediating things such as contracts, put to some purpose. For example, financial instruments. It also include physical measurement instruments (flow meters etc.) in industrial plant.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-ins;MeasurementInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Instrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;hasPurpose"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-ins;MeasurementPurpose"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">measurement instrument</rdfs:label>
-		<skos:definition xml:lang="en">An instrument whose purpose is to measure some variable, for example in some physical process.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-ins;MeasurementPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
-		<rdfs:label xml:lang="en">measurement purpose</rdfs:label>
-		<skos:definition xml:lang="en">The purpose of measuring things.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-ins;Purpose">
-		<rdfs:label xml:lang="en">purpose</rdfs:label>
-		<skos:definition xml:lang="en">The context in which some thing is, may be or is planned to be put to some use by someone.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-ins;PurposiveAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;hasPurpose"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;isApplicationOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-qr;QuantifiedResource"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">purposive amount</rdfs:label>
-		<skos:definition xml:lang="en">An amount of something defined in terms of its usefulness for some purpose. Scope Note: Includes investment capital (an amount of capital intended or used for investment), and amounts of raw material used or to be used in e.g. manufacture of something.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-ins;PurposiveThing">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;hasPurpose"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;isApplicationOf"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">purposive thing</rdfs:label>
-		<skos:definition xml:lang="en">Something described in terms of its purpose or potential purpose. Editorial Note: That which fulfils this role is generally taken to be some kind of Independent Thing However it is conceivable that the existence of some relative thing, for example an asset, may itself be put to a purpose over and above the role or context already defined for it, and wholly dependent on it being that relative thing and not siply a thing in itself. therefore the identity relationship is modeled with a range of Thing, but is modeled as a separate relationship to that of Relative Thing in order to make this conclusion explicit. This relationship need not be used in operational application ontologies as it adds no new logical assertion.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-ins;RawMaterial">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveAmount"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;rawMaterialIsApplicationOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-qr;QuantifiedRawMaterial"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">raw material</rdfs:label>
-		<skos:definition xml:lang="en">An amount of some material intended to be used for some purpose e.g. in manufacture, refinery. Scope Note: This is out of scope for financial services applications (unless it is needed for various loan purposes). This may be implemented in manufacturing models to define various manufacturing and refinement purposes, but at this level it is more general than any one of those.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrxx-ins;Tool">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
-		<rdfs:label xml:lang="en">tool</rdfs:label>
-		<skos:definition xml:lang="en">Some physical object which is put to some purpose.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-ins;hasPurpose">
-		<rdfs:label xml:lang="en">has purpose</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
-		<skos:definition xml:lang="en">The purpose for which the Purposive Thing is defined; the reason some thing, with some (usually independent) form, is defined as a Purposive Thing. The actual or intended usage to which the thing is put or may be put.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-ins;isApplicationOf">
-		<rdfs:label xml:lang="en">is application of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-		<skos:definition xml:lang="en">The actual form of the Purposive Thing; the thing which is defined according to its purpose and is employed for that purpose. Editorial Note: This would usually be some Independent Thing. However it is conceivable that the existence of some relative thing, For example an asset, may itself be put to a purpose over and above the role or context already defined for it, and wholly dependent on it being that relative thing and not simply a thing in itself. Therefore this identity relationship has a range of Thing, but is modeled as a sub property of &quot;identity&quot; to make this conclusion explicit. This relationship need not be used in operational application ontologies as it adds no new logical assertion.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-ins;rawMaterialIsApplicationOf">
-		<rdfs:label xml:lang="en">raw material is application of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-arrxx-ins;RawMaterial"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-qr;QuantifiedRawMaterial"/>
-		<skos:definition xml:lang="en">The amount of material which is identified for the purpose, identified as a kind of economic resource.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
+buxmlns:fibo-fnd-txn-qr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ToolsAndInstruments</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines what it means for something to be a tool or an instrument, which I both cases is something defined in terms of its usage to some end. This is the deeper conceptual basis for concepts like capital (money with a purpose; a tool) or financial instruments in the most literal sense of that word (some contract used to achieve some investment objective). 
+		This ontology is intended to be entirely conceptual, providing the disambiguation between concepts that are often conflated in natural language, and as such would almost certainly never be included in an application ontology.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-ins;FinancialInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Instrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some financial contract or agreement, described in the context of its use in furthering some investment purpose. Explanatory Note: This is specific to its usage. The term &quot;Financial Instrument&quot; is frequently applied to the contract (as a thing), which might be put to such purpose, rather than to the instrument as it is used as an instrument, which is what is defined by this concept.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-ins;Instrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something which is used to further some purpose or to measure some variable in furtherance of some purpose. Explanatory Note: This may include more abstract or even relative or mediating things such as contracts, put to some purpose. For example, financial instruments. It also include physical measurement instruments (flow meters etc.) in industrial plant.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-ins;MeasurementInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Instrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;hasPurpose"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-ins;MeasurementPurpose"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">measurement instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An instrument whose purpose is to measure some variable, for example in some physical process.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-ins;MeasurementPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">measurement purpose</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The purpose of measuring things.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-ins;Purpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purpose</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The context in which some thing is, may be or is planned to be put to some use by someone.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-ins;PurposiveAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;hasPurpose"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;isApplicationOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-qr;QuantifiedResource"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purposive amount</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An amount of something defined in terms of its usefulness for some purpose. Scope Note: Includes investment capital (an amount of capital intended or used for investment), and amounts of raw material used or to be used in e.g. manufacture of something.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-ins;PurposiveThing">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;hasPurpose"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;isApplicationOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purposive thing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something described in terms of its purpose or potential purpose. Editorial Note: That which fulfils this role is generally taken to be some kind of Independent Thing However it is conceivable that the existence of some relative thing, for example an asset, may itself be put to a purpose over and above the role or context already defined for it, and wholly dependent on it being that relative thing and not siply a thing in itself. therefore the identity relationship is modeled with a range of Thing, but is modeled as a separate relationship to that of Relative Thing in order to make this conclusion explicit. This relationship need not be used in operational application ontologies as it adds no new logical assertion.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-ins;RawMaterial">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveAmount"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-arrxx-ins;rawMaterialIsApplicationOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-qr;QuantifiedRawMaterial"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">raw material</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An amount of some material intended to be used for some purpose e.g. in manufacture, refinery. Scope Note: This is out of scope for financial services applications (unless it is needed for various loan purposes). This may be implemented in manufacturing models to define various manufacturing and refinement purposes, but at this level it is more general than any one of those.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrxx-ins;Tool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some physical object which is put to some purpose.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-ins;hasPurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has purpose</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The purpose for which the Purposive Thing is defined; the reason some thing, with some (usually independent) form, is defined as a Purposive Thing. The actual or intended usage to which the thing is put or may be put.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-ins;isApplicationOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is application of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-arrxx-ins;PurposiveThing"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The actual form of the Purposive Thing; the thing which is defined according to its purpose and is employed for that purpose. Editorial Note: This would usually be some Independent Thing. However it is conceivable that the existence of some relative thing, For example an asset, may itself be put to a purpose over and above the role or context already defined for it, and wholly dependent on it being that relative thing and not simply a thing in itself. Therefore this identity relationship has a range of Thing, but is modeled as a sub property of &quot;identity&quot; to make this conclusion explicit. This relationship need not be used in operational application ontologies as it adds no new logical assertion.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-arrxx-ins;rawMaterialIsApplicationOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">raw material is application of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-arrxx-ins;RawMaterial"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-qr;QuantifiedRawMaterial"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of material which is identified for the purpose, identified as a kind of economic resource.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/BusinessExt/AgentsContexts.rdf
+++ b/fnd/BusinessExt/AgentsContexts.rdf
@@ -1,95 +1,98 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-bus-agc "https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/">
-	<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-bus-agc "https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/">
+bu<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
+bu<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"
-	xmlns:fibo-fnd-bus-agc="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"
-	xmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/">
-		<rdfs:label xml:lang="en">AgentsContexts</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-agc;BusinessAgent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-agc;businessAgentHasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-agc;motivation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">business agent</rdfs:label>
-		<skos:definition xml:lang="en">An agent which is capable of causing some business event or providing some service in a business context.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-agc;BusinessAgentContext">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-agc;goal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-agc;involves"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-agc;BusinessAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">business agent context</rdfs:label>
-		<skos:definition xml:lang="en">A business process, work stream or other business area, in which various processes, actors, activities and so on are combined to achieve some business goal.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-agc;businessAgentHasIdentity">
-		<rdfs:label xml:lang="en">business agent has identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-agc;BusinessAgent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
-		<skos:definition xml:lang="en">That which performs the role of the Business Agent in the specified context.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is generally some organization which is able to function as a business, and so is defined as being Formal Business Organization.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-agc;goal">
-		<rdfs:label xml:lang="en">goal</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-agc;involves">
-		<rdfs:label xml:lang="en">involves</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-agc;BusinessAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-agc;motivation">
-		<rdfs:label xml:lang="en">motivation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-agc;BusinessAgent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-		<skos:definition xml:lang="en">The goal in furtherance of which the agent acts.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-bus-agc="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"
+buxmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
+buxmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AgentsContexts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts that extend the notion of an agent (in the sense of something with agency in some context, labeled AgentInRole) to describe business agents and the context in which they act.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/AgentsContexts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-agc;BusinessAgent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-agc;businessAgentHasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-agc;motivation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business agent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An agent which is capable of causing some business event or providing some service in a business context.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-agc;BusinessAgentContext">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-agc;goal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-agc;involves"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-agc;BusinessAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business agent context</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A business process, work stream or other business area, in which various processes, actors, activities and so on are combined to achieve some business goal.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-agc;businessAgentHasIdentity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business agent has identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-agc;BusinessAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That which performs the role of the Business Agent in the specified context.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is generally some organization which is able to function as a business, and so is defined as being Formal Business Organization.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-agc;goal">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">goal</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-agc;involves">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">involves</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-agc;BusinessAgentContext"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-agc;BusinessAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-agc;motivation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">motivation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-agc;BusinessAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The goal in furtherance of which the agent acts.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/BusinessExt/BusinessGoals.rdf
+++ b/fnd/BusinessExt/BusinessGoals.rdf
@@ -1,86 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
-	<!ENTITY fibo-fnd-gao-gl "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
+bu<!ENTITY fibo-fnd-gao-gl "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
-	xmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
-	xmlns:fibo-fnd-gao-gl="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
-		<rdfs:label xml:lang="en">BusinessGoals</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-bg;BusinessGoal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-gl;Goal"/>
-		<rdfs:label xml:lang="en">business goal</rdfs:label>
-		<skos:definition xml:lang="en">A Goal is a state or condition of the enterprise to be brought about or sustained through appropriate Means.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-bg;CorporateGoal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-		<rdfs:label xml:lang="en">corporate goal</rdfs:label>
-		<skos:definition xml:lang="en">A business goal in the furtherance of the aims and profitability of a corporation.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-bg;FinancialWellbeing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
-		<rdfs:label xml:lang="en">financial wellbeing</rdfs:label>
-		<skos:definition xml:lang="en">The overall balance sheet and well being of the organisation.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-bg;InvestmentGoal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-		<rdfs:label xml:lang="en">investment goal</rdfs:label>
-		<skos:definition xml:lang="en">A goal for which is to be achieved by investments within an investment institution.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-bg;LendingGoal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
-		<rdfs:label xml:lang="en">lending goal</rdfs:label>
-		<skos:definition xml:lang="en">Reasons for extending loans and credit, i.e. the organisation has a goal to create capital growth by extending credit or making loans.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-bg;MarketInvestmentGoal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
-		<rdfs:label xml:lang="en">market investment goal</rdfs:label>
-		<skos:definition xml:lang="en">A business goal driving investment activities as distinct from day to day commercial trading activities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-bg;ProjectGoal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-gl;Goal"/>
-		<rdfs:label xml:lang="en">project goal</rdfs:label>
-		<skos:definition xml:lang="en">Some stated goal of a project as set out in the project planning documentation.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Project risks are framed in terms of their impact on stated project goals. Examples including meeting deadlines, meeting cost projections, and so on.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-bg;Reputation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-		<rdfs:label xml:lang="en">reputation</rdfs:label>
-		<skos:definition xml:lang="en">The goal of a business to maintain or enhance its reputation.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-bg;TransactionProcessingGoal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
-		<rdfs:label xml:lang="en">transaction processing goal</rdfs:label>
-		<skos:definition xml:lang="en">The goal of processing transactions in which the organization is engaged, without error and within the stated time constraints.</skos:definition>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
+buxmlns:fibo-fnd-gao-gl="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BusinessGoals</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts that extend the notion of Goal to describe various business-specific goals. These form the basis of one dimension of risk models, namely the impact of some risk event on some goal of the organization. 
+		Note that this will be needed in published FIBO for risk models, at which point this ontology should be moved into the GoalsAndObjectives module, since there is no module for Business.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-bg;BusinessGoal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-gl;Goal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business goal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Goal is a state or condition of the enterprise to be brought about or sustained through appropriate Means.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-bg;CorporateGoal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate goal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A business goal in the furtherance of the aims and profitability of a corporation.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-bg;FinancialWellbeing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial wellbeing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The overall balance sheet and well being of the organisation.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-bg;InvestmentGoal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment goal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A goal for which is to be achieved by investments within an investment institution.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-bg;LendingGoal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lending goal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Reasons for extending loans and credit, i.e. the organisation has a goal to create capital growth by extending credit or making loans.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-bg;MarketInvestmentGoal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market investment goal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A business goal driving investment activities as distinct from day to day commercial trading activities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-bg;ProjectGoal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-gl;Goal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">project goal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some stated goal of a project as set out in the project planning documentation.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Project risks are framed in terms of their impact on stated project goals. Examples including meeting deadlines, meeting cost projections, and so on.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-bg;Reputation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reputation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The goal of a business to maintain or enhance its reputation.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-bg;TransactionProcessingGoal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction processing goal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The goal of processing transactions in which the organization is engaged, without error and within the stated time constraints.</skos:definition>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/BusinessExt/Policy.rdf
+++ b/fnd/BusinessExt/Policy.rdf
@@ -1,146 +1,149 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
-	<!ENTITY fibo-fnd-bus-pol "https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/">
-	<!ENTITY fibo-fnd-gao-gl "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/">
-	<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
-	<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
+bu<!ENTITY fibo-fnd-bus-pol "https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/">
+bu<!ENTITY fibo-fnd-gao-gl "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/">
+bu<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
+bu<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"
-	xmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
-	xmlns:fibo-fnd-bus-pol="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"
-	xmlns:fibo-fnd-gao-gl="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
-	xmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
-	xmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/">
-		<rdfs:label xml:lang="en">Policy</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-pol;BusinessFunctionReferent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;SynechdocalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;impliesContext"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-pol;OrganizationContext"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">business function referent</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-pol;BusinessStrategy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;toFulfil"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">business strategy</rdfs:label>
-		<skos:definition xml:lang="en">A plan, method, or series of maneuvers or stratagems for obtaining a specific business goal.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-pol;OrganizationContext">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-		<rdfs:label xml:lang="en">organization context</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-pol;Policy">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;constrains"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;sets"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">policy</rdfs:label>
-		<skos:definition xml:lang="en">A high-level overall plan embracing the general goals and acceptable procedures especially of a governmental body Further notes: A policy defines the requirements and constraints for a strategy in which some entity pursues some goals.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-pol;ReportingPolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
-		<rdfs:label xml:lang="en">reporting policy</rdfs:label>
-		<skos:definition xml:lang="en">A policy relating to the provision of reports,</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example a policy for how frequently a given kind of report is produced.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-bus-pol;Strategy">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;hasObjective"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-gao-gl;Goal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">strategy</rdfs:label>
-		<skos:definition xml:lang="en">A plan, method, or series of maneuvers or stratagems for obtaining a specific goal or result.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In model terms, a strategy is a collection of Activities in pursuit of one or more Goals. It may take into account one or more policies or any number of restrictions and constraints. The activities that form part of the Strategy may take place in the future, the present or the past.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;constrains">
-		<rdfs:label xml:lang="en">constrains</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;Policy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;hasObjective">
-		<rdfs:label xml:lang="en">has objective</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-gao-gl;Goal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;implementsPolicy">
-		<rdfs:label xml:lang="en">implements policy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;BusinessFunctionReferent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-pol;Policy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;involves">
-		<rdfs:label xml:lang="en">involves</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;pursuesPolicy">
-		<rdfs:label xml:lang="en">pursues policy</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;BusinessFunctionReferent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-pol;Policy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;sets">
-		<rdfs:label xml:lang="en">sets</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;Policy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;toFulfil">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-bus-pol;hasObjective"/>
-		<rdfs:label xml:lang="en">to fulfil</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;BusinessStrategy"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
+buxmlns:fibo-fnd-bus-pol="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"
+buxmlns:fibo-fnd-gao-gl="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
+buxmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
+buxmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Policy</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts of policies and strategies and the relationships between these. Includes extension inis specific types of policy and strategy sich as reporting policies. These concepts are extended and referred to further in the Collective Investment Vehicles models, where fund policy and fund strategy are defined.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/Policy/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-pol;BusinessFunctionReferent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;SynechdocalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;impliesContext"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-pol;OrganizationContext"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business function referent</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-pol;BusinessStrategy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;toFulfil"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business strategy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A plan, method, or series of maneuvers or stratagems for obtaining a specific business goal.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-pol;OrganizationContext">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">organization context</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-pol;Policy">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;constrains"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;sets"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A high-level overall plan embracing the general goals and acceptable procedures especially of a governmental body Further notes: A policy defines the requirements and constraints for a strategy in which some entity pursues some goals.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-pol;ReportingPolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-bus-pol;Policy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reporting policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A policy relating to the provision of reports,</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example a policy for how frequently a given kind of report is produced.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-bus-pol;Strategy">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-bus-pol;hasObjective"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-gao-gl;Goal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strategy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A plan, method, or series of maneuvers or stratagems for obtaining a specific goal or result.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In model terms, a strategy is a collection of Activities in pursuit of one or more Goals. It may take into account one or more policies or any number of restrictions and constraints. The activities that form part of the Strategy may take place in the future, the present or the past.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;constrains">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">constrains</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;Policy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;hasObjective">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has objective</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-gao-gl;Goal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;implementsPolicy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">implements policy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;BusinessFunctionReferent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-pol;Policy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;involves">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">involves</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;Strategy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;pursuesPolicy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pursues policy</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;BusinessFunctionReferent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-pol;Policy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;sets">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;Policy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-bus-pol;toFulfil">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-bus-pol;hasObjective"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">to fulfil</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-bus-pol;BusinessStrategy"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/GoalsAndObjectivesExt/AutonomousAgentGoals.rdf
+++ b/fnd/GoalsAndObjectivesExt/AutonomousAgentGoals.rdf
@@ -1,37 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-gao-gl "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/">
-	<!ENTITY fibo-fnd-gaox-aag "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/AutonomousAgentGoals/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-gao-gl "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/">
+bu<!ENTITY fibo-fnd-gaox-aag "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/AutonomousAgentGoals/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/AutonomousAgentGoals/"
-	xmlns:fibo-fnd-gao-gl="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
-	xmlns:fibo-fnd-gaox-aag="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/AutonomousAgentGoals/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/AutonomousAgentGoals/">
-		<rdfs:label xml:lang="en">AutonomousAgentGoals</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/AutonomousAgentGoals/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-gaox-aag;pursuesGoal">
-		<rdfs:label xml:lang="en">pursues goal</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-gao-gl;Goal"/>
-		<skos:definition xml:lang="en">The thing acts in furtherance of some goal. Editorial Note: In one sense, having, seeking or pursuing some goal is a necessary and sufficient condition of being an autonomous entity, i.e. these are defined by their having goal seeking behaviour. This is represented here by naming the relationship one of pursuing rather than merely of having. Note that this has no relation to the concept of pursuing in the sense of &quot;pursued by a bear&quot;, for the purposes of this ontology (the relationship between the two word senses is metaphorical). For this reason, the property is labeled &quot;pursues goal&quot; rather than simply &quot;pursues&quot;. Other sense exist for having a goal, for example a plan or policy, a project plan etc. may be said to have one or more goals, even though these goals are actually pursued by the organization making the plan. To accommodate this, pursues has been made a property of Independent Thing, with a restriction for Autonomous Agent to carry the sense of this thing having, as its own, the property of pursues some Goal.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-gao-gl="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
+buxmlns:fibo-fnd-gaox-aag="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/AutonomousAgentGoals/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/AutonomousAgentGoals/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AutonomousAgentGoals</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology extends the notion of a goal by adding the property that some thing pursues some goal, that is that a goal is a thing that can be pursued, in one sense of that word.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/AutonomousAgentGoals/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-gaox-aag;pursuesGoal">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pursues goal</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-gao-gl;Goal"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The thing acts in furtherance of some goal. Editorial Note: In one sense, having, seeking or pursuing some goal is a necessary and sufficient condition of being an autonomous entity, i.e. these are defined by their having goal seeking behaviour. This is represented here by naming the relationship one of pursuing rather than merely of having. Note that this has no relation to the concept of pursuing in the sense of &quot;pursued by a bear&quot;, for the purposes of this ontology (the relationship between the two word senses is metaphorical). For this reason, the property is labeled &quot;pursues goal&quot; rather than simply &quot;pursues&quot;. Other sense exist for having a goal, for example a plan or policy, a project plan etc. may be said to have one or more goals, even though these goals are actually pursued by the organization making the plan. To accommodate this, pursues has been made a property of Independent Thing, with a restriction for Autonomous Agent to carry the sense of this thing having, as its own, the property of pursues some Goal.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/GoalsAndObjectivesExt/DesiredResults.rdf
+++ b/fnd/GoalsAndObjectivesExt/DesiredResults.rdf
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY core "http://www.w3.org/2004/02/skos/core/">
-	<!ENTITY fibo-fnd-gaox-dr "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/DesiredResults/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY core "http://www.w3.org/2004/02/skos/core/">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-gaox-dr "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/DesiredResults/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/DesiredResults/"
-	xmlns:core="http://www.w3.org/2004/02/skos/core/"
-	xmlns:fibo-fnd-gaox-dr="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/DesiredResults/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/DesiredResults/">
-		<rdfs:label xml:lang="en">DesiredResults</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/DesiredResults/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-gaox-dr;DesiredResult">
-		<rdfs:label xml:lang="en">desired result</rdfs:label>
-		<skos:definition xml:lang="en">End that is a state or target that an autonomous agent intends to maintain or sustain Editorial Note: Original definition from BMM, which is too narrow (defined only in context of business) states: &quot;end that is a state or target that the enterprise intends to maintain or sustain&quot; Definition Adapted From: BMM</skos:definition>
-	</owl:Class>
+<rdf:RDF
+buxmlns:core="http://www.w3.org/2004/02/skos/core/"
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-gaox-dr="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/DesiredResults/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/DesiredResults/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DesiredResults</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology introduces the notion of Desired Result, as defined and labeled as such in the OMG Business Motivation Model (BMM) specification, while noting that BMM is narrower in its application. This concept is also referred to from the upper ontology in distinguishing between intended occurrents (being in furtherance of some desired result) and other occurrents.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/DesiredResults/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-gaox-dr;DesiredResult">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">desired result</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">End that is a state or target that an autonomous agent intends to maintain or sustain Editorial Note: Original definition from BMM, which is too narrow (defined only in context of business) states: &quot;end that is a state or target that the enterprise intends to maintain or sustain&quot; Definition Adapted From: BMM</skos:definition>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/GoalsAndObjectivesExt/ObjectivesDetail.rdf
+++ b/fnd/GoalsAndObjectivesExt/ObjectivesDetail.rdf
@@ -1,36 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-gao-gl "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/">
-	<!ENTITY fibo-fnd-gaox-objx "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/ObjectivesDetail/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-gao-gl "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/">
+bu<!ENTITY fibo-fnd-gaox-objx "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/ObjectivesDetail/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/ObjectivesDetail/"
-	xmlns:fibo-fnd-gao-gl="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
-	xmlns:fibo-fnd-gaox-objx="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/ObjectivesDetail/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/ObjectivesDetail/">
-		<rdfs:label xml:lang="en">ObjectivesDetail</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/ObjectivesDetail/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-gaox-objx;isInFurtheranceOf">
-		<rdfs:label xml:lang="en">is in furtherance of</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-gao-gl;Goal"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-gao-gl="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"
+buxmlns:fibo-fnd-gaox-objx="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/ObjectivesDetail/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/ObjectivesDetail/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ObjectivesDetail</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology extends the notion of objective by adding the property that some thing is in furtherance of some objective, that is that an objective is a thing of which some other thing can be in furtherance.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectivesExt/ObjectivesDetail/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-gaox-objx;isInFurtheranceOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is in furtherance of</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-gao-gl;Goal"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/InformationExt/AddressExtensions.rdf
+++ b/fnd/InformationExt/AddressExtensions.rdf
@@ -1,96 +1,99 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-inf-adrx "https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/FND/Places/Locations/">
-	<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-inf-adrx "https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
+bu<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/FND/Places/Locations/">
+bu<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"
-	xmlns:fibo-fnd-inf-adrx="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"
-	xmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/">
-		<rdfs:label xml:lang="en">AddressExtensions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-adrx;GeolocationCoordinates">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-adrx;identifiesPhysicalArea"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">geolocation coordinates</rdfs:label>
-		<skos:definition xml:lang="en">Co-ordinates which uniquely identify some physical location.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, a pair of northing and easting co-ordinates. Scope Note: Note that the precise granularity is not specified here.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-adrx;LegallyDeliverableLocation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-adrx;isSuitableIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">legally deliverable location</rdfs:label>
-		<skos:definition xml:lang="en">An address which is considered suitable for service of legal documents.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-adrx;NetworkAddress">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>
-		<rdfs:label xml:lang="en">network address</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-adrx;identifiesPhysicalArea">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-adrx;isIndexTo"/>
-		<rdfs:label xml:lang="en">identifies physical area</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-adrx;GeolocationCoordinates"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-adrx;isIndexTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-		<rdfs:label xml:lang="en">is index to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-adr;Address"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-loc;Location"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-adrx;isSuitableIn">
-		<rdfs:label xml:lang="en">is suitable in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-adrx;LegallyDeliverableLocation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-fnd-plc-adr;Address">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-inf-adrx="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
+buxmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"
+buxmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AddressExtensions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extensions to the main Address ontology in Places. An address is defined as an index to a location to which communications may be delivered. This ontology fleshes out that concept by defining kinds of address including geolocation and network addresses.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-adrx;GeolocationCoordinates">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-adrx;identifiesPhysicalArea"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">geolocation coordinates</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Co-ordinates which uniquely identify some physical location.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example, a pair of northing and easting co-ordinates. Scope Note: Note that the precise granularity is not specified here.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-adrx;LegallyDeliverableLocation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-adrx;isSuitableIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legally deliverable location</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An address which is considered suitable for service of legal documents.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-adrx;NetworkAddress">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">network address</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-adrx;identifiesPhysicalArea">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-adrx;isIndexTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies physical area</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-adrx;GeolocationCoordinates"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-adrx;isIndexTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is index to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-adr;Address"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-loc;Location"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-adrx;isSuitableIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is suitable in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-adrx;LegallyDeliverableLocation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plc-adr;Address">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/InformationExt/Documentation.rdf
+++ b/fnd/InformationExt/Documentation.rdf
@@ -1,409 +1,413 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/">
+bu<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-		<rdfs:label xml:lang="en">Documentation</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;Certificate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;issuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;issuedTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">certificate</rdfs:label>
-		<skos:definition xml:lang="en">Some formal written document prepared by some party which is typically regarded as an authority in the subject matter, setting out some formal position in respect of some other party, which may be used by that party as a point of reference about that subject matter to the world at large.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;ControlDocument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;identifiedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;Document"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">control document</rdfs:label>
-		<skos:definition xml:lang="en">A formal document which controls some activity or process. The actual document which takes on the role of Control Document for a given activity or process is identified as a property of this Control Document.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;Declaration">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
-		<rdfs:label xml:lang="en">declaration</rdfs:label>
-		<skos:definition xml:lang="en">Some formal communication in which some party makes a statement to the reader or the world at large about some fact or occurrence.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;Document">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;hasStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;DocumentStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">document</rdfs:label>
-		<skos:definition xml:lang="en">An information deliverable created in the course of some business process, and with some lifecycle independent of its use to communicate the information therein.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Documents are usually in sections and contain a multiplicity of information, generally on a given subject and for a given audience. In particular, documents generally have parts. This term is defined so that parts of documents may be defined. This is a difficult concept to define, but there is some value in distinguishing information of this sort, from memoranda, reports and the like. This is particularly for the identification of things such as contracts, prospectuses and the like, as distinct from the elements of information which may make up their parts, and allowing for the possibility of these having different status at different times and so on (Draft document versus Formal Document). However, certain of those others (e.g. Report) may also be considered documents in some cases.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;DocumentInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;about"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">document information</rdfs:label>
-		<skos:definition xml:lang="en">Information about a document which is not in the document.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;DocumentStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">document status</rdfs:label>
-		<skos:definition xml:lang="en">Type or status of a document, specifically Draft or final. Not the same as versioning of a revision-controlled formal document.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;DraftContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DraftDocument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;comesIntoEffectAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">draft contract</rdfs:label>
-		<skos:definition xml:lang="en">A document which, once agreed to be such by some parties, may become a contract between those parties. Term origin:SR Modeling</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;DraftDocument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Document"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;becomesFormalizedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;hsaPart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;DraftDocumentPart"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">draft document</rdfs:label>
-		<skos:definition xml:lang="en">A document which is self identified as being a draft for a later formal iteration of this same document as a formal document, formal contract or other formal document.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;DraftDocumentPart">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:label xml:lang="en">draft document part</rdfs:label>
-		<skos:definition xml:lang="en">A section or component of a document that is in draft; this is later to to be a part of a formal document. Ahead of formal release of that document this part may be originated, reviewed or managed as a separate information deliverable.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a Part in the sense that it is or may form part of something; it is not defined as &quot;a part of something&quot; (i.e. this is like a wheel, whereas &quot;a part of something&quot; is like a nearside front wheel). Therefore removed the &quot;is a&quot; relationship to &quot;Part&quot;, which only defines parts in the latter sense. For clarity, it may be desirable to add a new concept &quot;Part of a Document&quot; as a child of &quot;Part&quot;. To be considered after mereology upper model is finalized (MGB, 3 June 2011).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;Form">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:label xml:lang="en">form</rdfs:label>
-		<skos:definition xml:lang="en">Written information entered into a physical document or a computer application containing information entered by a person.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;FormalControlledDocument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
-		<rdfs:label xml:lang="en">formal controlled document</rdfs:label>
-		<skos:definition xml:lang="en">A formal document which has applied to it some degree of formal control including version management, as defined within some pre-defined document control process.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As a minimum this would have a version identifier, and some identification of the document in all its versions, as distinct from the specific version in hand. Additional controls as mandated in the applicable document control process would usually include author identification formal status, audience, information on allowable circulation of the ducument and so on.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;FormalDocument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Document"/>
-		<rdfs:label xml:lang="en">formal document</rdfs:label>
-		<skos:definition xml:lang="en">A document which has some self-identified and defined formal status, usually but not necessarily within some pre-defined business process for document formalization.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;FormalStatement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;formalStatementBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">formal statement</rdfs:label>
-		<skos:definition xml:lang="en">Some formal written communication, setting out the position of some party or parties about some matter.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;InsurancePolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
-		<rdfs:label xml:lang="en">insurance policy</rdfs:label>
-		<skos:definition xml:lang="en">Some policy by which some party (directly or more usually through an intermediary who writes this policy) agrees to cover some risk as identified in this policy, on behalf of the holder of the policy. further Notes: Added specifically to cover financial instruments modeling of insurance backed Guaranty. This term would belong within a separate section of specialist insurance terms if there were such a section. Later notes: also relevant to Mortgage Indemnity Guaranty, taken out by Lender before pooling a mortgage into a security. This may even be what was intended by &quot;Insurance Backed Guaranty&quot; in the original FIBIM terms. To be determined at further review.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;Memorandum">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;from"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-org;Organization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;to"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">memorandum</rdfs:label>
-		<skos:definition xml:lang="en">A semi-formal communication from one party to one or more other parties, communicating some information to them and identifying the fact that this has been communicated.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">As well as the usual context of a memorandum (which is captured in the above definition), this is also used specificalyl for offering memorandums for securities issues. This is the main reason this term is included at present. Term origin:SR Modeling</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;Notice">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;onThePartOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">notice</rdfs:label>
-		<skos:definition xml:lang="en">Some formal communication in which some party makes a statement to the reader or the world at large about some fact or occurrence.</skos:definition>
-		<skos:definition xml:lang="en">Some formal written communication from some party to another party or parties or to the world at large, notifying them about some fact or occurrence.</skos:definition>
-		<skos:definition xml:lang="en">Some formal written communication, notifying some party or parties about some fact or occurrence.</skos:definition>
-		<skos:definition xml:lang="en">Some formal written communication, setting out the position of some party or parties about some matter.</skos:definition>
-		<skos:definition xml:lang="en">Some formal written document prepared by some party which is typically regarded as an authority in the subject matter, setting out some formal position in respect of some other party, which may be used by that party as a point of reference about that subject matter to the world at large.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;Prospectus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
-		<rdfs:label xml:lang="en">prospectus</rdfs:label>
-		<skos:definition xml:lang="en">A document which at one and the same time describes some future potential investment and sets out the legal terms which will form part of the contract which embodies that investment, should the recipient choose to invest as described in the prospectus. Term origin:SR Modeling</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;ReportDocument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Document"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;reportAuthorBusinessOrganization"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">report document</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;TermsSheet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:label xml:lang="en">terms sheet</rdfs:label>
-		<skos:definition xml:lang="en">A set of written terms setting out legal or contractual rights, obligations and the like, but not (or not yet) forming part of a set of Contractual Terms.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A typical case would be a termsheet in a prospectus, informing potential investors in something, what terms they will expect when the prospectus becomes a formal contract. Term origin:MBS PoC Reviews</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-doc;WrittenCommunication">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:label xml:lang="en">written communication</rdfs:label>
-		<skos:definition xml:lang="en">Some formal written communication from some party to another party or parties or to the world at large, notifying them about some fact or occurrence.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;about">
-		<rdfs:label xml:lang="en">about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;DocumentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;authorOf">
-		<rdfs:label xml:lang="en">author of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;becomesFormalizedAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;documentBecomesDocument"/>
-		<rdfs:label xml:lang="en">becomes formalized as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;DraftDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;comesIntoEffectAs">
-		<rdfs:label xml:lang="en">comes into effect as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;DraftContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<skos:definition xml:lang="en">Signing and bringing into effect of the Draft Contract to become a formal, written Contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;controlDate">
-		<rdfs:label xml:lang="en">control date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;ControlDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date at which the controlling aspect of the document takes effect, for example the valid date for a permit, the sign-off date for a written document that is required to proceed with a process or activity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;documentBecomesDocument">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;informationFlow"/>
-		<rdfs:label xml:lang="en">document becomes document</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Document"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-doc;Document"/>
-		<skos:definition xml:lang="en">A document may in the course of its life become another document, for example a draft becoming a later draft or becoming a formal document, or a new revision of a formally revision controlled document.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;formalStatementBy">
-		<rdfs:label xml:lang="en">formal statement by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;FormalStatement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;from">
-		<rdfs:label xml:lang="en">from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-org;Organization"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-inf-doc;writes"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;hasStatus">
-		<rdfs:label xml:lang="en">has status</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Document"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-doc;DocumentStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;hsaPart">
-		<rdfs:label xml:lang="en">hsa part</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;DraftDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-doc;DraftDocumentPart"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;identifiedAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;ControlDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-doc;Document"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;issuedBy">
-		<rdfs:label xml:lang="en">issued by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Certificate"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;issuedTo">
-		<rdfs:label xml:lang="en">issued to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Certificate"/>
-		<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;issuerOf">
-		<rdfs:label xml:lang="en">issuer of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;onThePartOf">
-		<rdfs:label xml:lang="en">on the part of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Notice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
-		<skos:definition xml:lang="en">The legal entity by whom or on whose behalf the Notice is written.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;reportAuthorBusinessOrganization">
-		<rdfs:label xml:lang="en">report author business organization</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;ReportDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;title">
-		<rdfs:label xml:lang="en">title</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The formal title of the Document.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;to">
-		<rdfs:label xml:lang="en">to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;version">
-		<rdfs:label xml:lang="en">version</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The formal Revision of the document, as recorded on the document and on any relevant Revision Management System.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;writes">
-		<rdfs:label xml:lang="en">writes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;Organization"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-fnd-org-org;Organization">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"
+buxmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Documentation</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Conceptual ontology covering the concept of document as a kind of written information along with various kinds of document as referred to elsewhere in FIBO. 
+		This is intended as to the main Documents ontology in Arrangements but at present these have not been integrated as those documents concepts were introduced independently and have yet to be reviewed and de-duplicated. This also applies to the concepts of Report versus ReportDocument and others.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;Certificate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;issuedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;issuedTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">certificate</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some formal written document prepared by some party which is typically regarded as an authority in the subject matter, setting out some formal position in respect of some other party, which may be used by that party as a point of reference about that subject matter to the world at large.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;ControlDocument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;identifiedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;Document"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">control document</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal document which controls some activity or process. The actual document which takes on the role of Control Document for a given activity or process is identified as a property of this Control Document.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;Declaration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">declaration</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some formal communication in which some party makes a statement to the reader or the world at large about some fact or occurrence.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;Document">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;hasStatus"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;DocumentStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">document</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An information deliverable created in the course of some business process, and with some lifecycle independent of its use to communicate the information therein.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Documents are usually in sections and contain a multiplicity of information, generally on a given subject and for a given audience. In particular, documents generally have parts. This term is defined so that parts of documents may be defined. This is a difficult concept to define, but there is some value in distinguishing information of this sort, from memoranda, reports and the like. This is particularly for the identification of things such as contracts, prospectuses and the like, as distinct from the elements of information which may make up their parts, and allowing for the possibility of these having different status at different times and so on (Draft document versus Formal Document). However, certain of those others (e.g. Report) may also be considered documents in some cases.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;DocumentInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;about"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">document information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about a document which is not in the document.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;DocumentStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">document status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Type or status of a document, specifically Draft or final. Not the same as versioning of a revision-controlled formal document.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;DraftContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;DraftDocument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;comesIntoEffectAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draft contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A document which, once agreed to be such by some parties, may become a contract between those parties. Term origin:SR Modeling</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;DraftDocument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Document"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;becomesFormalizedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;hsaPart"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-doc;DraftDocumentPart"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draft document</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A document which is self identified as being a draft for a later formal iteration of this same document as a formal document, formal contract or other formal document.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;DraftDocumentPart">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draft document part</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A section or component of a document that is in draft; this is later to to be a part of a formal document. Ahead of formal release of that document this part may be originated, reviewed or managed as a separate information deliverable.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a Part in the sense that it is or may form part of something; it is not defined as &quot;a part of something&quot; (i.e. this is like a wheel, whereas &quot;a part of something&quot; is like a nearside front wheel). Therefore removed the &quot;is a&quot; relationship to &quot;Part&quot;, which only defines parts in the latter sense. For clarity, it may be desirable to add a new concept &quot;Part of a Document&quot; as a child of &quot;Part&quot;. To be considered after mereology upper model is finalized (MGB, 3 June 2011).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;Form">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">form</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Written information entered into a physical document or a computer application containing information entered by a person.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;FormalControlledDocument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formal controlled document</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal document which has applied to it some degree of formal control including version management, as defined within some pre-defined document control process.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">As a minimum this would have a version identifier, and some identification of the document in all its versions, as distinct from the specific version in hand. Additional controls as mandated in the applicable document control process would usually include author identification formal status, audience, information on allowable circulation of the ducument and so on.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;FormalDocument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Document"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formal document</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A document which has some self-identified and defined formal status, usually but not necessarily within some pre-defined business process for document formalization.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;FormalStatement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;formalStatementBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formal statement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some formal written communication, setting out the position of some party or parties about some matter.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;InsurancePolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">insurance policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some policy by which some party (directly or more usually through an intermediary who writes this policy) agrees to cover some risk as identified in this policy, on behalf of the holder of the policy. further Notes: Added specifically to cover financial instruments modeling of insurance backed Guaranty. This term would belong within a separate section of specialist insurance terms if there were such a section. Later notes: also relevant to Mortgage Indemnity Guaranty, taken out by Lender before pooling a mortgage into a security. This may even be what was intended by &quot;Insurance Backed Guaranty&quot; in the original FIBIM terms. To be determined at further review.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;Memorandum">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;from"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-org-org;Organization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;to"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">memorandum</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A semi-formal communication from one party to one or more other parties, communicating some information to them and identifying the fact that this has been communicated.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">As well as the usual context of a memorandum (which is captured in the above definition), this is also used specificalyl for offering memorandums for securities issues. This is the main reason this term is included at present. Term origin:SR Modeling</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;Notice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;WrittenCommunication"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;onThePartOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notice</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some formal communication in which some party makes a statement to the reader or the world at large about some fact or occurrence.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some formal written communication from some party to another party or parties or to the world at large, notifying them about some fact or occurrence.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some formal written communication, notifying some party or parties about some fact or occurrence.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some formal written communication, setting out the position of some party or parties about some matter.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some formal written document prepared by some party which is typically regarded as an authority in the subject matter, setting out some formal position in respect of some other party, which may be used by that party as a point of reference about that subject matter to the world at large.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;Prospectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A document which at one and the same time describes some future potential investment and sets out the legal terms which will form part of the contract which embodies that investment, should the recipient choose to invest as described in the prospectus. Term origin:SR Modeling</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;ReportDocument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Document"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-doc;reportAuthorBusinessOrganization"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">report document</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;TermsSheet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">terms sheet</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of written terms setting out legal or contractual rights, obligations and the like, but not (or not yet) forming part of a set of Contractual Terms.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A typical case would be a termsheet in a prospectus, informing potential investors in something, what terms they will expect when the prospectus becomes a formal contract. Term origin:MBS PoC Reviews</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-doc;WrittenCommunication">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">written communication</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some formal written communication from some party to another party or parties or to the world at large, notifying them about some fact or occurrence.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;about">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;DocumentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;authorOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">author of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;becomesFormalizedAs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-doc;documentBecomesDocument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes formalized as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;DraftDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;comesIntoEffectAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">comes into effect as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;DraftContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Signing and bringing into effect of the Draft Contract to become a formal, written Contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;controlDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">control date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;ControlDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the controlling aspect of the document takes effect, for example the valid date for a permit, the sign-off date for a written document that is required to proceed with a process or activity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;documentBecomesDocument">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;informationFlow"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">document becomes document</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Document"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-doc;Document"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A document may in the course of its life become another document, for example a draft becoming a later draft or becoming a formal document, or a new revision of a formally revision controlled document.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;formalStatementBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formal statement by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;FormalStatement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;from">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">from</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-org-org;Organization"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-inf-doc;writes"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;hasStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has status</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Document"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-doc;DocumentStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;hsaPart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">hsa part</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;DraftDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-doc;DraftDocumentPart"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;identifiedAs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;ControlDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-doc;Document"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;issuedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Certificate"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;issuedTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Certificate"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-cb;Corporation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;issuerOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;onThePartOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">on the part of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Notice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The legal entity by whom or on whose behalf the Notice is written.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;reportAuthorBusinessOrganization">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">report author business organization</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;ReportDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;title">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">title</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;FormalDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formal title of the Document.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;to">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;version">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">version</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-doc;FormalControlledDocument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formal Revision of the document, as recorded on the document and on any relevant Revision Management System.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-doc;writes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">writes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-org-org;Organization"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-doc;Memorandum"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-org-org;Organization">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/InformationExt/InfoCore.rdf
+++ b/fnd/InformationExt/InfoCore.rdf
@@ -1,125 +1,129 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-		<rdfs:label xml:lang="en">InfoCore</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-inf;Information">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;derivedFrom"/>
-				<owl:allValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">information</rdfs:label>
-		<skos:definition xml:lang="en">Information in any of its forms.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For an ontology, these are only kinds of information construct which are of direct relevance to the business domain and exist exclusively or primarily in the business domain, for example documents, identifiers and the like. Identifiers which are internal to some application are not included.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-inf;Name">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">name</rdfs:label>
-		<skos:definition xml:lang="en">Some text or sounds by which an autonomous entity may be known and which is used to refer to it.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-inf;StructuredName">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Name"/>
-		<rdfs:label xml:lang="en">structured name</rdfs:label>
-		<skos:definition xml:lang="en">A name with additional details besides simply being a string of text. This may include multilingual support or structuring of name content (as seen for example in financial securities names).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-inf;WrittenInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;originator"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">written information</rdfs:label>
-		<skos:definition xml:lang="en">Some information which is written in some format (physical or electronic) and is or may be communicated in some way.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;derivedFrom">
-		<rdfs:label xml:lang="en">derived from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-		<skos:definition xml:lang="en">What the information derives from or refers to in order to be complete.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is semantically distinct from what the information is &apos;about&apos;. Here, we refer to something (usually but not necessarily some other information) which is referred to in the course of arriving at this information. Examples include mathematical terms referred to in order to derive this information, which in turn is actually about something else (the &apos;is about&apos; thing).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;details">
-		<rdfs:label xml:lang="en">details</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-inf;Information"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;hasName">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
-		<rdfs:label xml:lang="en">has name</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-inf;Name"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;informationFlow">
-		<rdfs:label xml:lang="en">information flow</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<skos:definition xml:lang="en">Information Flow, whereby one piece of information becomes another. The information which the information becomes. Term origin:SR modeling</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;isAbout">
-		<rdfs:label xml:lang="en">is about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-		<skos:definition xml:lang="en">What the information is about</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;nameWrittenAs">
-		<rdfs:label xml:lang="en">name written as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;Name"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The textual string which forms the name. In the case of a human being, this primary name becomes the surname.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;originator">
-		<rdfs:label xml:lang="en">originator</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">InfoCore</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This is the core conceptual ontology for the notion of an information construct (being any non random or information artifact), along with semantically primitive kinds of information such as names and written information. 
+		This is intended as a purely conceptual ontology and the concepts here would not be used in published Release FIBO for applications. Some work remains to integrate these concepts with those being introduced in Release under the Arrangements module.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-inf;Information">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;derivedFrom"/>
+bubububu<owl:allValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information in any of its forms.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For an ontology, these are only kinds of information construct which are of direct relevance to the business domain and exist exclusively or primarily in the business domain, for example documents, identifiers and the like. Identifiers which are internal to some application are not included.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-inf;Name">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">name</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some text or sounds by which an autonomous entity may be known and which is used to refer to it.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-inf;StructuredName">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Name"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">structured name</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A name with additional details besides simply being a string of text. This may include multilingual support or structuring of name content (as seen for example in financial securities names).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-inf;WrittenInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;originator"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">written information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some information which is written in some format (physical or electronic) and is or may be communicated in some way.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;derivedFrom">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derived from</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">What the information derives from or refers to in order to be complete.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is semantically distinct from what the information is &apos;about&apos;. Here, we refer to something (usually but not necessarily some other information) which is referred to in the course of arriving at this information. Examples include mathematical terms referred to in order to derive this information, which in turn is actually about something else (the &apos;is about&apos; thing).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;details">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">details</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;hasName">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has name</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-inf;Name"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;informationFlow">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">information flow</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information Flow, whereby one piece of information becomes another. The information which the information becomes. Term origin:SR modeling</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;isAbout">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">What the information is about</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;nameWrittenAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">name written as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;Name"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The textual string which forms the name. In the case of a human being, this primary name becomes the surname.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-inf;originator">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">originator</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/InformationExt/Messaging.rdf
+++ b/fnd/InformationExt/Messaging.rdf
@@ -1,103 +1,107 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-msg "https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-msg "https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-msg="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/">
-		<rdfs:label xml:lang="en">Messaging</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-msg;Applicant">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;RequestingParty"/>
-		<rdfs:label xml:lang="en">applicant</rdfs:label>
-		<skos:definition xml:lang="en">The party making some application.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-msg;ApplicationInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;Request"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;madeBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-msg;Applicant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">application information</rdfs:label>
-		<skos:definition xml:lang="en">A formal application by some party to some other party, in which the requesting party sets out some requirement which they request to be fulfilled by the other party.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-msg;Message">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;hasSubject"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">message</rdfs:label>
-		<skos:definition xml:lang="en">Some message communicating something from some party to some other party.</skos:definition>
-		<skos:editorialNote xml:lang="en">Added to support Corporate Events messages. Grammatical facts to be added, for example sender and receiveer, as defining facts about a Message. Decide whether Party or Actor, or something new.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-msg;Request">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;requestedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-msg;RequestingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">request</rdfs:label>
-		<skos:definition xml:lang="en">A request by some party to some other party for some thing or service.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-msg;RequestingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">requesting party</rdfs:label>
-		<skos:definition xml:lang="en">The party making some request.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-msg;hasSubject">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">has subject</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-msg;Message"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-msg;madeBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-msg;requestedBy"/>
-		<rdfs:label xml:lang="en">made by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-msg;ApplicationInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-msg;Applicant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-msg;requestedBy">
-		<rdfs:label xml:lang="en">requested by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-msg;Request"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-msg;RequestingParty"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-msg="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Messaging</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This is a conceptual ontology for the core notion of a message and the basic facts that apply to all messages. These include applications, messages and requests, as being relevant both for corporate events and for many loan related information exchanges such as loan applications. 
+		Note that the newly introduced (Dec 2017) Communications module and ontology are intended to cover the same ground in a more data- and application-facing format. Some de-duplication is required for these concepts. At present parts of Provisional FIBO refer to these concepts, principally in the Corporate Actions and Events domain and in Loans.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-msg;Applicant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;RequestingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicant</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party making some application.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-msg;ApplicationInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;Request"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;madeBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-msg;Applicant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">application information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal application by some party to some other party, in which the requesting party sets out some requirement which they request to be fulfilled by the other party.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-msg;Message">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;hasSubject"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">message</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some message communicating something from some party to some other party.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Added to support Corporate Events messages. Grammatical facts to be added, for example sender and receiveer, as defining facts about a Message. Decide whether Party or Actor, or something new.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-msg;Request">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;requestedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-msg;RequestingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">request</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A request by some party to some other party for some thing or service.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-msg;RequestingParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requesting party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party making some request.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-msg;hasSubject">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has subject</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-msg;Message"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-msg;madeBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-msg;requestedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">made by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-msg;ApplicationInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-msg;Applicant"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-msg;requestedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requested by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-msg;Request"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-msg;RequestingParty"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/InformationExt/PostalAddress.rdf
+++ b/fnd/InformationExt/PostalAddress.rdf
@@ -1,323 +1,326 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-inf-adrx "https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/">
-	<!ENTITY fibo-fnd-inf-padr "https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/">
-	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
-	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/FND/Places/Locations/">
-	<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
-	<!ENTITY fibo-fnd-plcx-re "https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-inf-adrx "https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/">
+bu<!ENTITY fibo-fnd-inf-padr "https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/">
+bu<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
+bu<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
+bu<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/FND/Places/Locations/">
+bu<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
+bu<!ENTITY fibo-fnd-plcx-re "https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"
-	xmlns:fibo-fnd-inf-adrx="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"
-	xmlns:fibo-fnd-inf-padr="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"
-	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
-	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"
-	xmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
-	xmlns:fibo-fnd-plcx-re="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/">
-		<rdfs:label xml:lang="en">PostalAddress</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesBuildingSubUnit"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">building sub unit address fragment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-padr;CountryName">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesCountry"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">country name</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-padr;NonSpecificAddressText">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
-		<rdfs:label xml:lang="en">non specific address text</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-padr;POBoxNumber">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesPostBox"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;PostBox"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">p o box number</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-padr;PostBox">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
-		<rdfs:label xml:lang="en">post box</rdfs:label>
-		<skos:definition xml:lang="en">A PO Box.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is physical and essentially geographical in that it has a location.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-padr;PostalAddressElement">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-plc-cty;Country">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-inf-padr;PostBox">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-plcx-gph;GeophysicalLocation">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">postal address element</rdfs:label>
-		<skos:definition xml:lang="en">Text which is part of some Postal Address. Editorial Note: This is labeled as Address Element but is specific to Postal Addresses. The more general term for elements of any type of address is Address Component. This also covers e.g. network addresses, URIs.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-padr;PostalCode">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesPostCodeArea"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-adr;PostCodeArea"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">postal code</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-padr;StreetAddressText">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesBuilding"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-re;Building"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">street address text</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;addressFragment">
-		<rdfs:label xml:lang="en">address fragment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;apartmentIdentifiedBy">
-		<rdfs:label>apartment identified by</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;boxNumber">
-		<rdfs:label xml:lang="en">box number</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;POBoxNumber"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The PO Box number expressed as text.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;buildingIdentifiedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;physicalAddressComponentIdentifiedBy"/>
-		<rdfs:label xml:lang="en">building identified by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-re;Building"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;countryHasName">
-		<rdfs:label xml:lang="en">country has name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-padr;CountryName"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;countryName">
-		<rdfs:label xml:lang="en">country name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;CountryName"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;floorIdentifiedBy">
-		<rdfs:label>floor identified by</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesBuilding">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
-		<rdfs:label xml:lang="en">identifies building</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-re;Building"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-inf-padr;buildingIdentifiedBy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesBuildingSubUnit">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
-		<rdfs:label xml:lang="en">identifies building sub unit</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesCountry">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
-		<rdfs:label xml:lang="en">identifies country</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;CountryName"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-inf-padr;countryHasName"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-adrx;isIndexTo"/>
-		<rdfs:label xml:lang="en">identifies physical address component</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-plc-cty;Country">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-inf-padr;PostBox">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-plcx-gph;GeophysicalLocation">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesPostBox">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
-		<rdfs:label xml:lang="en">identifies post box</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;POBoxNumber"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-padr;PostBox"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesPostCodeArea">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
-		<rdfs:label xml:lang="en">identifies post code area</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;PostalCode"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;PostCodeArea"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-inf-padr;postCodeAreaIdentifiedBy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;isOf">
-		<rdfs:label>is of</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;nonSpecificAddressText">
-		<rdfs:label xml:lang="en">non specific address text</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;NonSpecificAddressText"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;physicalAddressComponentIdentifiedBy">
-		<rdfs:label xml:lang="en">physical address component identified by</rdfs:label>
-		<rdfs:domain>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-plc-cty;Country">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-inf-padr;PostBox">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-plcx-gph;GeophysicalLocation">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:domain>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;postCodeAreaIdentifiedBy">
-		<rdfs:label xml:lang="en">post code area identified by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-adr;PostCodeArea"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-padr;PostalCode"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;postalCode">
-		<rdfs:label xml:lang="en">postal code</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;PostalCode"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;streetAddress">
-		<rdfs:label xml:lang="en">street address</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;streetIdentifiedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;physicalAddressComponentIdentifiedBy"/>
-		<rdfs:label xml:lang="en">street identified by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-gph;Street"/>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;suiteIdentifiedBy">
-		<rdfs:label>suite identified by</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-fnd-plc-adr;PostCodeArea">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;postCodeAreaIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;PostalCode"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isPartOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plc-cty;Country">
-		<owl:equivalentClass rdf:resource="&fibo-fnd-plc-cty;Country"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;Street">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-inf-adrx="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"
+buxmlns:fibo-fnd-inf-padr="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"
+buxmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
+buxmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
+buxmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"
+buxmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
+buxmlns:fibo-fnd-plcx-re="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">PostalAddress</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extensions to the Addresses ontology in Places, to include concepts specific to postal addresses and physical address concepts, where these are not already covered in that ontology. This follows the conceptual pattern whereby address concepts bring together information constructs that are indices to some kind of location or real estate, and the corresponding geophysical geopolitical and real estate constructs to which they refer.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesBuildingSubUnit"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">building sub unit address fragment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-padr;CountryName">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesCountry"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">country name</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-padr;NonSpecificAddressText">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non specific address text</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-padr;POBoxNumber">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesPostBox"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;PostBox"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">p o box number</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-padr;PostBox">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">post box</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A PO Box.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is physical and essentially geographical in that it has a location.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-padr;PostalAddressElement">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-plc-cty;Country">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-inf-padr;PostBox">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-plcx-gph;GeophysicalLocation">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">postal address element</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Text which is part of some Postal Address. Editorial Note: This is labeled as Address Element but is specific to Postal Addresses. The more general term for elements of any type of address is Address Component. This also covers e.g. network addresses, URIs.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-padr;PostalCode">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesPostCodeArea"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-adr;PostCodeArea"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">postal code</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-padr;StreetAddressText">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;identifiesBuilding"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-re;Building"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">street address text</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;addressFragment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">address fragment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;apartmentIdentifiedBy">
+bubu<rdfs:label>apartment identified by</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;boxNumber">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">box number</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;POBoxNumber"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The PO Box number expressed as text.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;buildingIdentifiedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;physicalAddressComponentIdentifiedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">building identified by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-re;Building"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;countryHasName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">country has name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-padr;CountryName"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;countryName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">country name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;CountryName"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;floorIdentifiedBy">
+bubu<rdfs:label>floor identified by</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesBuilding">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies building</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-re;Building"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-inf-padr;buildingIdentifiedBy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesBuildingSubUnit">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies building sub unit</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesCountry">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies country</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;CountryName"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-inf-padr;countryHasName"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-adrx;isIndexTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies physical address component</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-plc-cty;Country">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-inf-padr;PostBox">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-plcx-gph;GeophysicalLocation">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesPostBox">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies post box</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;POBoxNumber"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-padr;PostBox"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;identifiesPostCodeArea">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies post code area</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;PostalCode"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-adr;PostCodeArea"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-inf-padr;postCodeAreaIdentifiedBy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;isOf">
+bubu<rdfs:label>is of</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;nonSpecificAddressText">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non specific address text</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;NonSpecificAddressText"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;physicalAddressComponentIdentifiedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">physical address component identified by</rdfs:label>
+bubu<rdfs:domain>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-plc-cty;Country">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-inf-padr;PostBox">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-plcx-gph;GeophysicalLocation">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:domain>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-padr;PostalAddressElement"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-inf-padr;identifiesPhysicalAddressComponent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;postCodeAreaIdentifiedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">post code area identified by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-adr;PostCodeArea"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-padr;PostalCode"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;postalCode">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">postal code</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;PostalCode"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;streetAddress">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">street address</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;streetIdentifiedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-padr;physicalAddressComponentIdentifiedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">street identified by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-gph;Street"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-padr;suiteIdentifiedBy">
+bubu<rdfs:label>suite identified by</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plc-adr;PostCodeArea">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;postCodeAreaIdentifiedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;PostalCode"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isPartOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plc-cty;Country">
+bubu<owl:equivalentClass rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;Street">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/InformationExt/TemporalInfo.rdf
+++ b/fnd/InformationExt/TemporalInfo.rdf
@@ -1,215 +1,219 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-		<rdfs:label xml:lang="en">TemporalInfo</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-tem;AnalyticalInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;analyzes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;derivedFrom"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-inf-tem;AnalyticsCalculationModel">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-utl-alx;Formula">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">analytical information</rdfs:label>
-		<skos:definition xml:lang="en">Information about some item at some time past, present or future. This takes the form of some measure about the thing being analyzed; the measure will have some values at different times as shown in the Math grammar for dated parameters.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-tem;AnalyticsCalculationModel">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalModel"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;includes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Formula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">analytics calculation model</rdfs:label>
-		<skos:definition xml:lang="en">A model used for formal calculation of parameters.</skos:definition>
-		<skos:editorialNote xml:lang="en">This may be the status of some independent thing but may also reflect the status of something defined in terms of its role within the process or activity in question or in relation to some other related context (a relative thing), or the status of some agreement or other thing which itself forms the context for other things (some mediating thing)</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An example would be the sort of mathematical model used to derive certain financial securities analytics.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-tem;HistoricalInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">historical information</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-tem;IndependentThing">
-		<rdfs:label xml:lang="en">independent thing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-tem;Phase">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;TimeSensitiveInformation"/>
-		<rdfs:label xml:lang="en">phase</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-tem;Rating">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeElement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;TimeSensitiveInformation"/>
-		<rdfs:label xml:lang="en">rating</rdfs:label>
-		<skos:definition xml:lang="en">A schematic code which is used to express an opinion about something, as expressed by some agent. This may take different values at different times, as the agent expressing that opinion may revise it from time to time.</skos:definition>
-		<skos:definition xml:lang="en">The standing of some thing within some lifecycle or process.</skos:definition>
-		<skos:definition xml:lang="en">has some indication of the standing of the thing within some lifecycle or process.</skos:definition>
-		<skos:definition xml:lang="en">that of which the status represents some standing within some lifecycle or process which varies over time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-tem;RatingScheme">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/defines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-tem;Rating"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">rating scheme</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-tem;Status">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;TimeSensitiveInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;isOf"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">status</rdfs:label>
-		<skos:definition xml:lang="en">The standing of some thing within some lifecycle or process.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-inf-tem;TimeSensitiveInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">time sensitive information</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;analyzes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">analyzes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;derivedFrom">
-		<rdfs:label xml:lang="en">derived from</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-inf-tem;AnalyticsCalculationModel">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-utl-alx;Formula">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;hasStatus">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
-		<rdfs:label xml:lang="en">has status</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-inf-tem;isOf"/>
-		<skos:definition xml:lang="en">has some indication of the standing of the thing within some lifecycle or process.</skos:definition>
-		<skos:editorialNote xml:lang="en">This may be the status of some independent thing but may also reflect the status of something defined in terms of its role within the process or activity in question or in relation to some other related context (a relative thing), or the status of some agreement or other thing which itself forms the context for other things (some mediating thing)</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;hasTense">
-		<rdfs:label xml:lang="en">has tense</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;TimeSensitiveInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Tense"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;includes">
-		<rdfs:label xml:lang="en">includes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;AnalyticsCalculationModel"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;Formula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;isOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">is of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-		<skos:definition xml:lang="en">that of which the status represents some standing within some lifecycle or process which varies over time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;makesReferenceTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;derivedFrom"/>
-		<rdfs:label xml:lang="en">makes reference to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;ratingHasTense">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;hasTense"/>
-		<rdfs:label xml:lang="en">rating has tense</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;Rating"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Tense"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;statusHasTense">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;hasTense"/>
-		<rdfs:label xml:lang="en">status has tense</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Tense"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-fnd-utl-alx;Formula">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">TemporalInfo</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Conceptual representations of information constructs that a temporal aspect. These include ratings and statuses as well as analytical concepts that are extended in the market data domain. 
+		Note that some of these concepts may subsequently have been introduced into the Release published ontologies, particularly the codes and schemes relating to statuses (trading status etc.) and credit ratings, under the Arrangements module.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-tem;AnalyticalInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;analyzes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;derivedFrom"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-inf-tem;AnalyticsCalculationModel">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-utl-alx;Formula">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">analytical information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about some item at some time past, present or future. This takes the form of some measure about the thing being analyzed; the measure will have some values at different times as shown in the Math grammar for dated parameters.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-tem;AnalyticsCalculationModel">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalModel"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;includes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Formula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">analytics calculation model</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A model used for formal calculation of parameters.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This may be the status of some independent thing but may also reflect the status of something defined in terms of its role within the process or activity in question or in relation to some other related context (a relative thing), or the status of some agreement or other thing which itself forms the context for other things (some mediating thing)</skos:editorialNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">An example would be the sort of mathematical model used to derive certain financial securities analytics.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-tem;HistoricalInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">historical information</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-tem;IndependentThing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">independent thing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-tem;Phase">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;TimeSensitiveInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">phase</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-tem;Rating">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeElement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;TimeSensitiveInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rating</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A schematic code which is used to express an opinion about something, as expressed by some agent. This may take different values at different times, as the agent expressing that opinion may revise it from time to time.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The standing of some thing within some lifecycle or process.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">has some indication of the standing of the thing within some lifecycle or process.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">that of which the status represents some standing within some lifecycle or process which varies over time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-tem;RatingScheme">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/defines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-tem;Rating"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rating scheme</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-tem;Status">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;TimeSensitiveInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;isOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The standing of some thing within some lifecycle or process.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-inf-tem;TimeSensitiveInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">time sensitive information</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;analyzes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">analyzes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;derivedFrom">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derived from</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-inf-tem;AnalyticsCalculationModel">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-utl-alx;Formula">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;hasStatus">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has status</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-inf-tem;isOf"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">has some indication of the standing of the thing within some lifecycle or process.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This may be the status of some independent thing but may also reflect the status of something defined in terms of its role within the process or activity in question or in relation to some other related context (a relative thing), or the status of some agreement or other thing which itself forms the context for other things (some mediating thing)</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;hasTense">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tense</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;TimeSensitiveInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Tense"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;includes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;AnalyticsCalculationModel"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;Formula"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;isOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">that of which the status represents some standing within some lifecycle or process which varies over time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;makesReferenceTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;derivedFrom"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">makes reference to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;ratingHasTense">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;hasTense"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rating has tense</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;Rating"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Tense"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-inf-tem;statusHasTense">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;hasTense"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">status has tense</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Tense"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utl-alx;Formula">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/LawExt/JuridicalReach.rdf
+++ b/fnd/LawExt/JuridicalReach.rdf
@@ -1,75 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-lawx-jr "https://spec.edmcouncil.org/fibo/FND/LawExt/JuridicalReach/">
-	<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-lawx-jr "https://spec.edmcouncil.org/fibo/FND/LawExt/JuridicalReach/">
+bu<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/LawExt/JuridicalReach/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-lawx-jr="https://spec.edmcouncil.org/fibo/FND/LawExt/JuridicalReach/"
-	xmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/LawExt/JuridicalReach/">
-		<rdfs:label xml:lang="en">JuridicalReach</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/JuridicalReach/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;CivilLawJurisdiction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-jr;civilJurisdictionHasGeographicalReach"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;Jurisdiction">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;StatuteLaw">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-jr;statuteLawHasGeographicalReach"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<owl:equivalentClass rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jr;civilJurisdictionHasGeographicalReach">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-jur;hasReach"/>
-		<rdfs:label xml:lang="en">civil jurisdiction has geographical reach</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
-		<skos:definition xml:lang="en">The geopolitical entity (usually country) over which the Civil Jurisdiction has its reach.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is typically one country, since civil law applies to the country which makes the laws.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jr;statuteLawHasGeographicalReach">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-jur;hasReach"/>
-		<rdfs:label xml:lang="en">statute law has geographical reach</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
-		<skos:definition xml:lang="en">The geographical extent of the jurisdiction in which the Statute Law has effect.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is usually but not always a Country. It may also be a part of a country (England-and-Wales) or a State or Province within a Federal country, or it may be the federal country itself if the statute is a federal law.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-lawx-jr="https://spec.edmcouncil.org/fibo/FND/LawExt/JuridicalReach/"
+buxmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/LawExt/JuridicalReach/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">JuridicalReach</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extends the Jurisdictions ontology with a more nuanced view of juridical reach.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/JuridicalReach/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-law-jur;CivilLawJurisdiction">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-jr;civilJurisdictionHasGeographicalReach"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-law-jur;Jurisdiction">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-law-jur;StatuteLaw">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-jr;statuteLawHasGeographicalReach"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<owl:equivalentClass rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jr;civilJurisdictionHasGeographicalReach">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-jur;hasReach"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">civil jurisdiction has geographical reach</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The geopolitical entity (usually country) over which the Civil Jurisdiction has its reach.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is typically one country, since civil law applies to the country which makes the laws.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jr;statuteLawHasGeographicalReach">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-law-jur;hasReach"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">statute law has geographical reach</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The geographical extent of the jurisdiction in which the Statute Law has effect.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is usually but not always a Country. It may also be a part of a country (England-and-Wales) or a State or Province within a Federal country, or it may be the federal country itself if the statute is a federal law.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/LawExt/JurisdictionExtended.rdf
+++ b/fnd/LawExt/JurisdictionExtended.rdf
@@ -1,191 +1,194 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-lawx-jurx "https://spec.edmcouncil.org/fibo/FND/LawExt/JurisdictionExtended/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-lawx-jurx "https://spec.edmcouncil.org/fibo/FND/LawExt/JurisdictionExtended/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/LawExt/JurisdictionExtended/"
-	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-lawx-jurx="https://spec.edmcouncil.org/fibo/FND/LawExt/JurisdictionExtended/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/LawExt/JurisdictionExtended/">
-		<rdfs:label xml:lang="en">JurisdictionExtended</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/JurisdictionExtended/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;LegalSystem">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-jurx;definesTheApplicationOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;BijuridicialJurisdiction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-jurx;isPartiallyGovernedUnder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;CivilLawSystem"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-jurx;isPartiallyGovernedUnder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;CommonLawSystem"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bijuridicial jurisdiction</rdfs:label>
-		<skos:definition xml:lang="en">A Jurisdiction in which two or more systems of law are in force.</skos:definition>
-		<skos:definition xml:lang="en">One system of law under which a Bijuridicial Jurisdiction is governed is the system of Civil Law.</skos:definition>
-		<skos:definition xml:lang="en">One system of law under which a Bijuridicial Jurisdiction is governed is the system of Common Law.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Bijuridicial Jurisdiction is governed under two systems of law, of which this is one.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Examples include South Africa, Quebec, Louisiana and a few others, where or example Civil Law and Common Law arrangements are in force.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;BodyOfLaw">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-jurx;incorporatesSome"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-cor;Law"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">body of law</rdfs:label>
-		<skos:definition xml:lang="en">Some body of law, that is some set of laws, statutes, ordinances and the like.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;CanonLawSystem">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;ReligiousLawSystem"/>
-		<rdfs:label xml:lang="en">canon law system</rdfs:label>
-		<skos:definition xml:lang="en">The body of laws &amp; regulations made or adopted by ecclesiastical authority, for the government of the Christian organization and its members.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In force in both the Western (Roman) and Eastern churches, and in some form in the Anglican Church. There appear to be no current instances national jurisdictions which take this as a legal framework, with the possible exception of the Vatican. In historical contexts there would be.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;CivilLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;CommonLaw"/>
-		<rdfs:label xml:lang="en">civil law</rdfs:label>
-		<skos:definition xml:lang="en">The branch of the law dealing with disputes between individuals or organizations, in which compensation may be awarded to the victim.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;CommonLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
-		<rdfs:label xml:lang="en">common law</rdfs:label>
-		<skos:definition xml:lang="en">Law developed by judges through decisions of courts and similar tribunals rather than through legislative statutes or executive branch action.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ConstitutionalLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
-		<rdfs:label xml:lang="en">constitutional law</rdfs:label>
-		<skos:definition xml:lang="en">The body of law which defines the relationship of different entities within a state, namely the executive, legislature and the judiciary. Further notes: (from Wikipedia): Constitutional laws may be considered second order rulemaking or rules about making rules to exercise power.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;CriminalLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;CommonLaw"/>
-		<rdfs:label xml:lang="en">criminal law</rdfs:label>
-		<skos:definition xml:lang="en">The body of law that defines conduct that is not allowed because it is held to threaten, harm or endanger the safety and welfare of people, and that sets out the punishments to be imposed on people who do not obey these laws.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;InternationalLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
-		<rdfs:label xml:lang="en">international law</rdfs:label>
-		<skos:definition xml:lang="en">The set of rules generally regarded and accepted as binding in relations between states and nations.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can refer to three distinct legal disciplines: 1. Public international law governing the relations between provinces and national entities 2. Private international lse, which addresses questions of which jurisdiction may hear a case and which jurisdiction applies to issues in a case 3. Supranational law which concerns regional agreements where the laws of nation states may be held inapplicable when conflicting with a supranational legal system.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ReligiousLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
-		<rdfs:label xml:lang="en">religious law</rdfs:label>
-		<skos:definition xml:lang="en">Some set of laws derived from and practised in the name of some religion.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ReligiousLawJurisdiction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-lawx-jurx;ReligiousLawSystem"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">religious law jurisdiction</rdfs:label>
-		<skos:definition xml:lang="en">A Jurisdiction in which some system of religious law is in force.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This includes Sharia Law jurisdictions.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ReligiousLawSystem">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;LegalSystem"/>
-		<rdfs:label xml:lang="en">religious law system</rdfs:label>
-		<skos:definition xml:lang="en">Some system of law based on the ordering principle of reality as being knowledge as revealed by God and governing all human affairs.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are several mutually incompatible systems of Religious Law - the term referred to here is ancestral to all of those and defines simply that the jurisdiction in question is some kind of religious law jurisdiction - specific types are to be defined per system of religious law (two are included in the model for reference and possible use; there may be others).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ShariaLawJurisdiction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;ReligiousLawJurisdiction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-lawx-jurx;ShariaLawSystem"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">sharia law jurisdiction</rdfs:label>
-		<skos:definition xml:lang="en">A Jurisdiction in which a Shari&apos;a system of law is in force.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ShariaLawSystem">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;ReligiousLawSystem"/>
-		<rdfs:label xml:lang="en">sharia law system</rdfs:label>
-		<skos:definition xml:lang="en">A system of Shari&apos;a Law.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are several schools of law in Islamic jurisprudence; these are not articulated here at present. The bodies of law and other textual corpora referred to in the implementation of this system of law are the Qur&apos;an and the Hadith, with variations in interpretation and precedence according to the system (school) in question. Also known as the Qanun &apos;Islami (Islamic Canon)</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-jurx;StatutoryLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
-		<rdfs:label xml:lang="en">statutory law</rdfs:label>
-		<skos:definition xml:lang="en">Written law set down by a legislature or by a legislator.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Statutory Law may originate with national, state legislatures or local municipalities. Statutes of lower jurisdictions are subordinate to the law of higher. Definition adapted from: Wikipedia</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jurx;definesTheApplicationOf">
-		<rdfs:label xml:lang="en">defines the application of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-law-jur;LegalSystem"/>
-		<rdfs:range rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
-		<skos:definition xml:lang="en">The Body of Law, the application of which is defined in the Legal System.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jurx;incorporatesSome">
-		<rdfs:label xml:lang="en">incorporates some</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-cor;Law"/>
-		<skos:definition xml:lang="en">The laws included in this Body of Law.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jurx;isPartiallyGovernedUnder">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
-		<rdfs:label xml:lang="en">is partially governed under</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-lawx-jurx;BijuridicialJurisdiction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;LegalSystem"/>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Bijuridicial Jurisdiction is governed under two systems of law, of which this is one.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-lawx-jurx="https://spec.edmcouncil.org/fibo/FND/LawExt/JurisdictionExtended/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/LawExt/JurisdictionExtended/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">JurisdictionExtended</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Detailed extended concepts for jurisdictions, bodies of law and legal systems, including the distinctions between civil versus common law, religious law and their related kinds of jurisdiction.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/JurisdictionExtended/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-law-jur;LegalSystem">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-jurx;definesTheApplicationOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;BijuridicialJurisdiction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-jurx;isPartiallyGovernedUnder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;CivilLawSystem"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-jurx;isPartiallyGovernedUnder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;CommonLawSystem"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bijuridicial jurisdiction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Jurisdiction in which two or more systems of law are in force.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One system of law under which a Bijuridicial Jurisdiction is governed is the system of Civil Law.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One system of law under which a Bijuridicial Jurisdiction is governed is the system of Common Law.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A Bijuridicial Jurisdiction is governed under two systems of law, of which this is one.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Examples include South Africa, Quebec, Louisiana and a few others, where or example Civil Law and Common Law arrangements are in force.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;BodyOfLaw">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-jurx;incorporatesSome"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-cor;Law"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">body of law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some body of law, that is some set of laws, statutes, ordinances and the like.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;CanonLawSystem">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;ReligiousLawSystem"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">canon law system</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The body of laws &amp; regulations made or adopted by ecclesiastical authority, for the government of the Christian organization and its members.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In force in both the Western (Roman) and Eastern churches, and in some form in the Anglican Church. There appear to be no current instances national jurisdictions which take this as a legal framework, with the possible exception of the Vatican. In historical contexts there would be.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;CivilLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;CommonLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">civil law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The branch of the law dealing with disputes between individuals or organizations, in which compensation may be awarded to the victim.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;CommonLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">common law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Law developed by judges through decisions of courts and similar tribunals rather than through legislative statutes or executive branch action.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ConstitutionalLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">constitutional law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The body of law which defines the relationship of different entities within a state, namely the executive, legislature and the judiciary. Further notes: (from Wikipedia): Constitutional laws may be considered second order rulemaking or rules about making rules to exercise power.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;CriminalLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;CommonLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">criminal law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The body of law that defines conduct that is not allowed because it is held to threaten, harm or endanger the safety and welfare of people, and that sets out the punishments to be imposed on people who do not obey these laws.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;InternationalLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">international law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The set of rules generally regarded and accepted as binding in relations between states and nations.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This can refer to three distinct legal disciplines: 1. Public international law governing the relations between provinces and national entities 2. Private international lse, which addresses questions of which jurisdiction may hear a case and which jurisdiction applies to issues in a case 3. Supranational law which concerns regional agreements where the laws of nation states may be held inapplicable when conflicting with a supranational legal system.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ReligiousLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">religious law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some set of laws derived from and practised in the name of some religion.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ReligiousLawJurisdiction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-lawx-jurx;ReligiousLawSystem"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">religious law jurisdiction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Jurisdiction in which some system of religious law is in force.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This includes Sharia Law jurisdictions.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ReligiousLawSystem">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;LegalSystem"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">religious law system</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some system of law based on the ordering principle of reality as being knowledge as revealed by God and governing all human affairs.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There are several mutually incompatible systems of Religious Law - the term referred to here is ancestral to all of those and defines simply that the jurisdiction in question is some kind of religious law jurisdiction - specific types are to be defined per system of religious law (two are included in the model for reference and possible use; there may be others).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ShariaLawJurisdiction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;ReligiousLawJurisdiction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-lawx-jurx;ShariaLawSystem"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sharia law jurisdiction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Jurisdiction in which a Shari&apos;a system of law is in force.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;ShariaLawSystem">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;ReligiousLawSystem"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sharia law system</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A system of Shari&apos;a Law.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There are several schools of law in Islamic jurisprudence; these are not articulated here at present. The bodies of law and other textual corpora referred to in the implementation of this system of law are the Qur&apos;an and the Hadith, with variations in interpretation and precedence according to the system (school) in question. Also known as the Qanun &apos;Islami (Islamic Canon)</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-jurx;StatutoryLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">statutory law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Written law set down by a legislature or by a legislator.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Statutory Law may originate with national, state legislatures or local municipalities. Statutes of lower jurisdictions are subordinate to the law of higher. Definition adapted from: Wikipedia</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jurx;definesTheApplicationOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines the application of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-law-jur;LegalSystem"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Body of Law, the application of which is defined in the Legal System.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jurx;incorporatesSome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incorporates some</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-lawx-jurx;BodyOfLaw"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-cor;Law"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The laws included in this Body of Law.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-jurx;isPartiallyGovernedUnder">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is partially governed under</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-lawx-jurx;BijuridicialJurisdiction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;LegalSystem"/>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A Bijuridicial Jurisdiction is governed under two systems of law, of which this is one.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/LawExt/RegulatoryRestrictions.rdf
+++ b/fnd/LawExt/RegulatoryRestrictions.rdf
@@ -1,164 +1,168 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-reg-req "https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-reg-req "https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
-	xmlns:fibo-bp-reg-req="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
-		<rdfs:label>RegulatoryRestrictions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;StatuteLaw">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-cor;Law">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-rst;ContractualRestriction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-rst;contractuallyImposedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>contractual restriction</rdfs:label>
-		<skos:definition>A restriction defined in a Contract as opposed to being defined in a body of Law.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-rst;Instrumentality">
-		<rdfs:label>instrumentality</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-agr-ctr;Contract">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-law-cor;Law">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition>some law or contract which is instrumental in the existence of some recognized construct such as a restriction</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-rst;LegalRestriction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-rst;legallyImposedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>legal restriction</rdfs:label>
-		<skos:definition>A Restriction defined in a body of Law.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-rst;RegulatoryRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;LegalRequirement"/>
-		<rdfs:label>regulatory requirement</rdfs:label>
-		<skos:definition>A requirement of some sort by which something is to be regulated.</skos:definition>
-		<skos:editorialNote>There is not presently a common &quot;Financial&quot; sub-type of this, since regulations like investment, consumer protection, systemic risk and so on are quite different and quite far reaching. However, readers of this model should keep in mind that this term does not apply only to financial types of regulation. For instance, insurance regulation would also be a sub-type of this item.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-lawx-rst;Restriction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-rst;restricts"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>restriction</rdfs:label>
-		<skos:definition>Anything which prevents something being done which might otherwise be done. The Restriction is defined relative to the thing which might otherwise be done, which may be an activity of some sort. It is therefore a Relative Thing, with a property identifying that act or event.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;contractuallyImposedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;imposedBy"/>
-		<rdfs:label>contractually imposed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;ContractualRestriction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;contractuallyImposes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;imposes"/>
-		<rdfs:label>contractually imposes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;ContractualRestriction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;imposedBy">
-		<rdfs:label>imposed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;Instrumentality"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;imposes">
-		<rdfs:label>imposes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;Instrumentality"/>
-		<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-lawx-rst;imposedBy"/>
-		<skos:definition>some instrumentality such as a contract or law imposes a restriction on some entity in regard to some subject matter</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;legallyImposedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;imposedBy"/>
-		<rdfs:label>legally imposed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;LegalRestriction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;legallyImposes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;imposes"/>
-		<rdfs:label>legally imposes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-		<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;LegalRestriction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;restrictionAppliesIn">
-		<rdfs:label>restriction applies in</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;restricts">
-		<rdfs:label>restricts</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;restrictsActivity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;restricts"/>
-		<rdfs:label>restricts activity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-reg-req="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
+bubu<rdfs:label>RegulatoryRestrictions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Conceptual representation of the notion of a restriction and the kinds of regulatory requirements that are based on this. 
+		Note that these are simple first order declarations of these concepts, with no recourse to deontic logic.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-law-jur;StatuteLaw">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-law-cor;Law">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-rst;ContractualRestriction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-rst;contractuallyImposedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>contractual restriction</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">A restriction defined in a Contract as opposed to being defined in a body of Law.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-rst;Instrumentality">
+bubu<rdfs:label>instrumentality</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-agr-ctr;Contract">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-law-cor;Law">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&xsd;string">some law or contract which is instrumental in the existence of some recognized construct such as a restriction</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-rst;LegalRestriction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-rst;legallyImposedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>legal restriction</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">A Restriction defined in a body of Law.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-rst;RegulatoryRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;LegalRequirement"/>
+bubu<rdfs:label>regulatory requirement</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">A requirement of some sort by which something is to be regulated.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&xsd;string">There is not presently a common &quot;Financial&quot; sub-type of this, since regulations like investment, consumer protection, systemic risk and so on are quite different and quite far reaching. However, readers of this model should keep in mind that this term does not apply only to financial types of regulation. For instance, insurance regulation would also be a sub-type of this item.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-lawx-rst;Restriction">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-rst;restricts"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>restriction</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Anything which prevents something being done which might otherwise be done. The Restriction is defined relative to the thing which might otherwise be done, which may be an activity of some sort. It is therefore a Relative Thing, with a property identifying that act or event.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;contractuallyImposedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;imposedBy"/>
+bubu<rdfs:label>contractually imposed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;ContractualRestriction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;contractuallyImposes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;imposes"/>
+bubu<rdfs:label>contractually imposes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;ContractualRestriction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;imposedBy">
+bubu<rdfs:label>imposed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;Instrumentality"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;imposes">
+bubu<rdfs:label>imposes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;Instrumentality"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-lawx-rst;imposedBy"/>
+bubu<skos:definition rdf:datatype="&xsd;string">some instrumentality such as a contract or law imposes a restriction on some entity in regard to some subject matter</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;legallyImposedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;imposedBy"/>
+bubu<rdfs:label>legally imposed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;LegalRestriction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;legallyImposes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;imposes"/>
+bubu<rdfs:label>legally imposes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-lawx-rst;LegalRestriction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;restrictionAppliesIn">
+bubu<rdfs:label>restriction applies in</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;restricts">
+bubu<rdfs:label>restricts</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-lawx-rst;restrictsActivity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-lawx-rst;restricts"/>
+bubu<rdfs:label>restricts activity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-lawx-rst;Restriction"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/MathExt/Amounts.rdf
+++ b/fnd/MathExt/Amounts.rdf
@@ -1,161 +1,164 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
-	<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
+bu<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
-	xmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
-	xmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
-		<rdfs:label xml:lang="en">Amounts</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-amt;MaterialAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-amt;hasBaseUnit"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-amt;isAmountOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-phy-phy;ContinuousPhysicalStuff"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-amt;mayBeExpressedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-amt;Measure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">material amount</rdfs:label>
-		<skos:definition xml:lang="en">A qualified amount of some continuous substance or some thing measured in units. Material Amount is always qualified by some unit in which the substance is measured.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-amt;MathematicalThing">
-		<rdfs:label xml:lang="en">mathematical thing</rdfs:label>
-		<skos:definition xml:lang="en">A Mathematical Thing is something in the universe of mathematics. That is, something that is a parameter (mathematical quantity) or something that is used to express that parameter, such as a value or components of a formula.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-amt;Measure">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;MathematicalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-amt;isMeasuredIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-amt;reciprocal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-amt;Measure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">measure</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-amt;NumericAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;QuantitativeAmount"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-amt;isQuantityOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">numeric amount</rdfs:label>
-		<skos:definition xml:lang="en">An amount of some discrete thing Note: does not require units as the individual things are counted. Tech note: in other (data) standards this stands alongside (material) Amount rather than above it see e.g. CCTS, ISO 20022 v1.5</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-amt;QuantitativeAmount">
-		<rdfs:label xml:lang="en">quantitative amount</rdfs:label>
-		<skos:definition xml:lang="en">A measured amount of anything (material or time). This is an actual quantity of something rather than the abstract concept of the amount that something is of. Hence it is concrete not abstract.</skos:definition>
-		<skos:editorialNote xml:lang="en">Later internal review: This term is currently ancestral to terms with both meanings - an actual amount of some kind of thing, such as an amount of money; and the measure which is the amount of some quantity of things, e.g. an amount specified in a contract as &quot;this much&quot; of something. We should probably clean this up. Until we do, this term is ancestral to both types of amount term. So for instance it is not incorrect to talk about some amount of something, and have a datatype for a term within that, which is a Monetary Amount (for example, Monetary Amount as part of some specification of a Retained Amount in a loan contract). . This will probably flag up as inconsistent and need fixing later.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-amt;Unit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricThing"/>
-		<rdfs:label xml:lang="en">unit</rdfs:label>
-		<skos:definition xml:lang="en">A unit of measure ofa quantity, time or anything else which is measurable. NB don&apos;t confuse this with units in a Trust Fund!!</skos:definition>
-	</owl:Class>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-fnd-math-amt;amount">
-		<rdfs:label xml:lang="en">amount</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;hasBaseUnit">
-		<rdfs:label xml:lang="en">has base unit</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-		<skos:definition xml:lang="en">That in which the material amount is measured.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;hasValue">
-		<rdfs:label xml:lang="en">has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;Value"/>
-		<skos:definition xml:lang="en">The amount of whatever this is a quantity of.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;isAmountOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-amt;isQuantityOf"/>
-		<rdfs:label xml:lang="en">is amount of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-phy-phy;ContinuousPhysicalStuff"/>
-		<skos:definition xml:lang="en">That which the Material Amount is an amount of.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;isMeasuredIn">
-		<rdfs:label xml:lang="en">is measured in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-amt;Measure"/>
-		<rdfs:range rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-		<skos:definition xml:lang="en">The unit of measure in which the Measure is formally expressed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;isQuantityOf">
-		<rdfs:label xml:lang="en">is quantity of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
-		<skos:definition xml:lang="en">That which the amount is an amount of.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;mayBeExpressedAs">
-		<rdfs:label xml:lang="en">may be expressed as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-amt;Measure"/>
-		<skos:definition xml:lang="en">A measure in which the material amount may be expressed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;reciprocal">
-		<rdfs:label xml:lang="en">reciprocal</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-amt;Measure"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-amt;Measure"/>
-		<skos:definition xml:lang="en">A measure stated in terms of the recpirocal of another measure.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
+buxmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Amounts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Conceptual abstractions for kinds of amount, namely quantitative, numeric and material amounts – these support the distinction between having a count of some discrete items and a unitary measure of some quantity.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-amt;MaterialAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-amt;hasBaseUnit"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-amt;isAmountOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-phy-phy;ContinuousPhysicalStuff"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-amt;mayBeExpressedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-amt;Measure"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">material amount</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A qualified amount of some continuous substance or some thing measured in units. Material Amount is always qualified by some unit in which the substance is measured.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-amt;MathematicalThing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mathematical thing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Mathematical Thing is something in the universe of mathematics. That is, something that is a parameter (mathematical quantity) or something that is used to express that parameter, such as a value or components of a formula.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-amt;Measure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;MathematicalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-amt;isMeasuredIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-amt;reciprocal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-amt;Measure"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">measure</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-amt;NumericAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;QuantitativeAmount"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-amt;isQuantityOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numeric amount</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An amount of some discrete thing Note: does not require units as the individual things are counted. Tech note: in other (data) standards this stands alongside (material) Amount rather than above it see e.g. CCTS, ISO 20022 v1.5</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-amt;QuantitativeAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quantitative amount</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measured amount of anything (material or time). This is an actual quantity of something rather than the abstract concept of the amount that something is of. Hence it is concrete not abstract.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Later internal review: This term is currently ancestral to terms with both meanings - an actual amount of some kind of thing, such as an amount of money; and the measure which is the amount of some quantity of things, e.g. an amount specified in a contract as &quot;this much&quot; of something. We should probably clean this up. Until we do, this term is ancestral to both types of amount term. So for instance it is not incorrect to talk about some amount of something, and have a datatype for a term within that, which is a Monetary Amount (for example, Monetary Amount as part of some specification of a Retained Amount in a loan contract). . This will probably flag up as inconsistent and need fixing later.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-amt;Unit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A unit of measure ofa quantity, time or anything else which is measurable. NB don&apos;t confuse this with units in a Trust Fund!!</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-fnd-math-amt;amount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">amount</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;hasBaseUnit">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has base unit</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That in which the material amount is measured.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;hasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;Value"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of whatever this is a quantity of.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;isAmountOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-amt;isQuantityOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is amount of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-phy-phy;ContinuousPhysicalStuff"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That which the Material Amount is an amount of.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;isMeasuredIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is measured in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-amt;Measure"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The unit of measure in which the Measure is formally expressed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;isQuantityOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is quantity of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That which the amount is an amount of.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;mayBeExpressedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be expressed as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-amt;Measure"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure in which the material amount may be expressed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-amt;reciprocal">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reciprocal</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-amt;Measure"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-amt;Measure"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure stated in terms of the recpirocal of another measure.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/MathExt/Math.rdf
+++ b/fnd/MathExt/Math.rdf
@@ -1,616 +1,620 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-		<rdfs:label xml:lang="en">Math</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Comparison">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalQuantity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;isBetween"/>
-				<owl:onClass rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">comparison</rdfs:label>
-		<skos:definition xml:lang="en">A comparison among numerical parameters.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Constant">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-		<rdfs:label xml:lang="en">constant</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;ContractuallyDefinedNumericalParameter">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractually defined numerical parameter</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;CurrentValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;tense"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Present"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">current value</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-math-math;PastValue"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
-		<skos:definition xml:lang="en">The value at the current point in time.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This immediately becomes a past value.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Difference">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Comparison"/>
-		<rdfs:label xml:lang="en">difference</rdfs:label>
-		<skos:definition xml:lang="en">The difference between two numerical parameters.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Direction">
-		<rdfs:label xml:lang="en">Direction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Down">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Direction"/>
-		<rdfs:label xml:lang="en">down</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Formula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalExpression"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasExpression"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasSubject"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">formula</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;FormulaArgument">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/MathematicalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;constant.1"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasOperand"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">formula argument</rdfs:label>
-		<skos:definition xml:lang="en">The Right Hand Side of the Formula.</skos:definition>
-		<fibo-fnd-utl-av:usageNote xml:lang="en">This is modeled as one or more numerical parameters, and one or more constants. The constants are the simple fact &quot;Constant&quot; while the parameters are the target of the relationship fact &quot;Operand&quot;. Note that it is not possible to model the argument mathematically. This model simply identifies what are the operands and constants that make up the argument, or right hand side, of the formula. Note also that any formula can be expressed with different parameters on the left and right hand sides; this model identifies and lists the elements on the right hand side of the formula when a given &quot;Formulka Subject&quot; makes up the left hand side of the formula, that is, semantically the formula relates a particular variable to a number of other variables and constants in an expression, and is not set up to be able to identify equivalent formule in which a different subject is the left hand side of that formula. If useful, an equivalence relationship could be defined between two such formula semantics. That is, the same formula may not have the same meaning and vice versa.</fibo-fnd-utl-av:usageNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;FormulaExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaPart"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasArgument"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">formula expression</rdfs:label>
-		<skos:definition xml:lang="en">How the Formula is expressed i.e. the Right Hand Side of the Formula.</skos:definition>
-		<fibo-fnd-utl-av:usageNote xml:lang="en">This is alternative to and in addition to the textual expression of the Formula in the &quot;Expression&quot; Simple Fact for Formula. This is so that if appropriate and relevant, the formula can be described semantically in terms of its component parts. Where this would not add to the model, use the textual simple fact &quot;Expression&quot; instead.</fibo-fnd-utl-av:usageNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;FormulaPart">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/MathematicalThing"/>
-		<rdfs:label xml:lang="en">formula part</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;FormulaSubject">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaPart"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;subjectTakesForm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">formula subject</rdfs:label>
-		<skos:definition xml:lang="en">The Left Hand Side of the Formula, giving what is being expressed in terms of the Right Hand Side.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;InternalValueDetermination">
-		<rdfs:label xml:lang="en">internal value determination</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalCurve">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalSurface"/>
-		<rdfs:label xml:lang="en">mathematical curve</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalExpression">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/MathematicalThing"/>
-		<rdfs:label xml:lang="en">mathematical expression</rdfs:label>
-		<skos:definition xml:lang="en">Some expression of some mathematical quantity or quantities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalModel">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalExpression"/>
-		<rdfs:label xml:lang="en">mathematical model</rdfs:label>
-		<skos:definition xml:lang="en">A model for determining one or more parameters or the behaviour of parameters with respect to one another.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalQuantity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricThing"/>
-		<rdfs:label xml:lang="en">mathematical quantity</rdfs:label>
-		<skos:definition xml:lang="en">Some mathematical quantity which is to be expressed in some way. This is not itself an expression.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalSurface">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalModel"/>
-		<rdfs:label xml:lang="en">mathematical surface</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;MeasuredThing">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasNumericallyMeasurableProperty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">measured thing</rdfs:label>
-		<skos:definition xml:lang="en">Any Independent Thing. This is included as a separate term only so that we can refer to the trivial fact that all Independent Things have any number of properties, without cluttering the Independent Thing itself. This is for the modeling of reference entities. Note that the measurable quantity should be replaced with the actual parent property in all cases. DO NOT USE THIS TERM ELSEWHERE</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;NumericalParameter">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalQuantity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;takesValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Value"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">numerical parameter</rdfs:label>
-		<skos:definition xml:lang="en">Anything which is defined as a parameter of something, and takes a numerical value.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;NumericalVariable">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-		<rdfs:label xml:lang="en">numerical variable</rdfs:label>
-		<skos:definition xml:lang="en">Some numerical variable.</skos:definition>
-		<skos:editorialNote xml:lang="en">Not used to date. Use Dated Parameter instead in most cases. Use this when it is necessary to identify a variable but not that it&apos;s the variable value of something.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Operator">
-		<rdfs:label xml:lang="en">operator</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;ParametricReferenceEntity">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;takesReferenceParameter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">parametric reference entity</rdfs:label>
-		<skos:definition xml:lang="en">An entity, the value of some property of which is used in calculations for some purpose.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The identity of this entity can be any Independent Thing, provided that that thing has some property which is numerical in nature and can be identified as the property used for reference in the context of this Reference Entity. For example, a Treasury Bill, the interest rate of which is the reference rate. This model does not have the means to formally identify which property of the Reference Entity is used for reference. Instead, the modeler should as a matter of convention provide a reference relationship which inherits its meaning both from the property relationship of the Independent Thing and the identify relationship of the Reference Entity. Future: On OWL2 this arrangement should be reviewed, and a transitive relationship used as appropriate.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;ParametricThing">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/MathematicalThing"/>
-		<rdfs:label xml:lang="en">parametric thing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;PastValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;tense"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Past"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">past value</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
-		<skos:definition xml:lang="en">The value is determined at some point in the past.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Probability">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-		<rdfs:label xml:lang="en">probability</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;ProbabilityDistribution">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalModel"/>
-		<rdfs:label xml:lang="en">probability distribution</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;ProjectedValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Value"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;projectedValueDeterminedBy"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-math-math;InternalValueDetermination">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-math-math;PublishedFutureValue">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-pub-pub;Publisher">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;tense"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Future"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">projected value</rdfs:label>
-		<skos:definition xml:lang="en">The value is some projected future value.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that the future is not known, so in fact future tense refers to some project value. The value should therefore be accompanied by terms defining how and by what means it is being predicted.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;PublishedFutureValue">
-		<rdfs:label xml:lang="en">published future value</rdfs:label>
-		<skos:definition xml:lang="en">A value defined in advance in a schedule, as part of the bond terms in the prospectus. an example of this is a stepped coupon in a bond.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Rate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;isOver"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;isRateOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Value"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">rate</rdfs:label>
-		<skos:definition xml:lang="en">The rate of change of some measurable parameter over some period of time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Relation">
-		<rdfs:label xml:lang="en">relation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;TimeBasedPlot">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Comparison"/>
-		<rdfs:label xml:lang="en">time based plot</rdfs:label>
-		<skos:definition xml:lang="en">A comparison among several parameters, one of which is time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;TimedBasedSurface">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalSurface"/>
-		<rdfs:label xml:lang="en">timed based surface</rdfs:label>
-		<skos:definition xml:lang="en">A three way relationship between three variable parameters.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is analogous to a curve, but whereas a curve plots a relationship between two parameters in a two dimensional plane, a surface is the relationship between three parameters in a three-dimensional space. In the context of credit risk, there is a 3D relation of Rating, Term and Credit Spread, defining a 3D surface.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;TimedParameter">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hadValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;PastValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasProjectedValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;CurrentValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">timed parameter</rdfs:label>
-		<skos:definition xml:lang="en">A numerical parameter which may be expected to vary over time, and will therefore have values for different times past, persent and future.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;TimedValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Value"/>
-		<rdfs:label xml:lang="en">timed value</rdfs:label>
-		<skos:definition xml:lang="en">The value of a dated parameter, at a stated point in the past, present or future.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A value can be, by definition, either a value in the present or a value in the past. There can also be a value which is predicted for some time in the future, predicted either now or in the past. These are modeled separately. By definition then all values are exclusively either past, present or future. All parameters which take a value, take that value in the past and the present or have it predeicted for a date and time in the future. Therefore all terms which are a kind of &quot;Value&quot; by being descended from this class of Thing, are also capable of being past, present or future, i.e. the concepts of Past Value and Current Value are also applicable to those.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Up">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Direction"/>
-		<rdfs:label xml:lang="en">up</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-math;Value">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalExpression"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;denomination"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">value</rdfs:label>
-		<skos:definition xml:lang="en">Any value, stated as a number.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;constant.1">
-		<rdfs:label xml:lang="en">constant</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">A Constant used in the formula argument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;denomination">
-		<rdfs:label xml:lang="en">denomination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Value"/>
-		<rdfs:range rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;expressedNumericallyAs">
-		<rdfs:label xml:lang="en">expressed numerically as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Constant"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hadValue">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
-		<rdfs:label xml:lang="en">had value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;PastValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasArgument">
-		<rdfs:label xml:lang="en">has argument</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasExpression">
-		<rdfs:label xml:lang="en">has expression</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasNumericallyMeasurableProperty">
-		<rdfs:label xml:lang="en">has numerically measurable property</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;MeasuredThing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasOperand">
-		<rdfs:label xml:lang="en">has operand</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasOperator">
-		<rdfs:label xml:lang="en">has operator</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;Operator"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasProjectedValue">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
-		<rdfs:label xml:lang="en">has projected value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasSubject">
-		<rdfs:label xml:lang="en">has subject</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasTerms">
-		<rdfs:label xml:lang="en">has terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;ContractuallyDefinedNumericalParameter"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasTextualExpression">
-		<rdfs:label xml:lang="en">has textual expression</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The expression of the Formula in text. The arguments and parameters are also linked separately - there is no formal connection between the components of the Formula as modelled here and the textual expresion of it - these can either or both be expressed depending on the business information available.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasValue">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
-		<rdfs:label xml:lang="en">has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;CurrentValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isBetween">
-		<rdfs:label xml:lang="en">is between</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Comparison"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isOver">
-		<rdfs:label xml:lang="en">is over</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Rate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isParameterOf">
-		<rdfs:label xml:lang="en">is parameter of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;MeasuredThing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isParameterOfReferenceEntity">
-		<rdfs:label xml:lang="en">is parameter of reference entity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isRateOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValue"/>
-		<rdfs:label xml:lang="en">is rate of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Rate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;Value"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;percentageProbability">
-		<rdfs:label xml:lang="en">percentage probability</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Probability"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;plottedBetween">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;isBetween"/>
-		<rdfs:label xml:lang="en">plotted between</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimeBasedPlot"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;projectedDate">
-		<rdfs:label xml:lang="en">projected date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The calendar date on which the value is project to apply.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;projectedValueDeterminedBy">
-		<rdfs:label xml:lang="en">projected value determined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-math-math;InternalValueDetermination">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-math-math;PublishedFutureValue">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-pub-pub;Publisher">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;relation">
-		<rdfs:label xml:lang="en">relation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;Relation"/>
-		<skos:definition xml:lang="en">The Relation at the center of the Formula, usually &quot;Equals&quot;.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;subjectTakesForm">
-		<rdfs:label xml:lang="en">subject takes form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;takesReferenceParameter">
-		<rdfs:label xml:lang="en">takes reference parameter</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;takesValue">
-		<rdfs:label xml:lang="en">takes value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;Value"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;takesValuesOverTime">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValue"/>
-		<rdfs:label xml:lang="en">takes values over time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;tense">
-		<rdfs:label xml:lang="en">tense</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Tense"/>
-		<skos:definition xml:lang="en">Whether the value is in the past, present or future tense. Note that different qualifying terms are required for each of these, so the specific sub-type should be referred to in all cases.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;valueExpressedAs">
-		<rdfs:label xml:lang="en">value expressed as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;Value"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The numerical value of the Parameter.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;valueTime">
-		<rdfs:label xml:lang="en">value time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-math-math;PastValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Math</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This is the main mathematical conceptual ontology covering all the mathematical concepts needed to support descriptions of things elsewhere in the model and the high-level abstractions that frame these concepts. These include parameters and values, past present and future values; differences, curves and surfaces and other analytical primitives, formulae and their component parts and so on.
+		Much of this material is to be deprecated in favor of simpler concepts in the published Release ontologies, which will be distributed in various parts of FIBO. These include parameters and their values (to be deprecated in favor of new material in the Values ontology). Some of the concepts in this ontology will need to be reviewed and brought forward to support market data and financial analytics concepts.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Comparison">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalQuantity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;isBetween"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">comparison</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A comparison among numerical parameters.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Constant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">constant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;ContractuallyDefinedNumericalParameter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractually defined numerical parameter</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;CurrentValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;tense"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Present"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current value</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-math-math;PastValue"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value at the current point in time.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This immediately becomes a past value.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Difference">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Comparison"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">difference</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The difference between two numerical parameters.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Direction">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Direction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Down">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Direction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">down</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Formula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalExpression"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasExpression"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasSubject"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formula</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;FormulaArgument">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/MathematicalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;constant.1"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasOperand"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formula argument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Right Hand Side of the Formula.</skos:definition>
+bubu<fibo-fnd-utl-av:usageNote rdf:datatype="&rdf;langString" xml:lang="en">This is modeled as one or more numerical parameters, and one or more constants. The constants are the simple fact &quot;Constant&quot; while the parameters are the target of the relationship fact &quot;Operand&quot;. Note that it is not possible to model the argument mathematically. This model simply identifies what are the operands and constants that make up the argument, or right hand side, of the formula. Note also that any formula can be expressed with different parameters on the left and right hand sides; this model identifies and lists the elements on the right hand side of the formula when a given &quot;Formulka Subject&quot; makes up the left hand side of the formula, that is, semantically the formula relates a particular variable to a number of other variables and constants in an expression, and is not set up to be able to identify equivalent formule in which a different subject is the left hand side of that formula. If useful, an equivalence relationship could be defined between two such formula semantics. That is, the same formula may not have the same meaning and vice versa.</fibo-fnd-utl-av:usageNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;FormulaExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaPart"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasArgument"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formula expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How the Formula is expressed i.e. the Right Hand Side of the Formula.</skos:definition>
+bubu<fibo-fnd-utl-av:usageNote rdf:datatype="&rdf;langString" xml:lang="en">This is alternative to and in addition to the textual expression of the Formula in the &quot;Expression&quot; Simple Fact for Formula. This is so that if appropriate and relevant, the formula can be described semantically in terms of its component parts. Where this would not add to the model, use the textual simple fact &quot;Expression&quot; instead.</fibo-fnd-utl-av:usageNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;FormulaPart">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/MathematicalThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formula part</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;FormulaSubject">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaPart"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;subjectTakesForm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">formula subject</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Left Hand Side of the Formula, giving what is being expressed in terms of the Right Hand Side.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;InternalValueDetermination">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">internal value determination</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalCurve">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalSurface"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mathematical curve</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalExpression">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/MathematicalThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mathematical expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some expression of some mathematical quantity or quantities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalModel">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalExpression"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mathematical model</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A model for determining one or more parameters or the behaviour of parameters with respect to one another.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalQuantity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mathematical quantity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some mathematical quantity which is to be expressed in some way. This is not itself an expression.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;MathematicalSurface">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalModel"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mathematical surface</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;MeasuredThing">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasNumericallyMeasurableProperty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">measured thing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any Independent Thing. This is included as a separate term only so that we can refer to the trivial fact that all Independent Things have any number of properties, without cluttering the Independent Thing itself. This is for the modeling of reference entities. Note that the measurable quantity should be replaced with the actual parent property in all cases. DO NOT USE THIS TERM ELSEWHERE</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;NumericalParameter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalQuantity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;takesValue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Value"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/appliesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numerical parameter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Anything which is defined as a parameter of something, and takes a numerical value.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;NumericalVariable">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numerical variable</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some numerical variable.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Not used to date. Use Dated Parameter instead in most cases. Use this when it is necessary to identify a variable but not that it&apos;s the variable value of something.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Operator">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">operator</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;ParametricReferenceEntity">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;takesReferenceParameter"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">parametric reference entity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An entity, the value of some property of which is used in calculations for some purpose.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The identity of this entity can be any Independent Thing, provided that that thing has some property which is numerical in nature and can be identified as the property used for reference in the context of this Reference Entity. For example, a Treasury Bill, the interest rate of which is the reference rate. This model does not have the means to formally identify which property of the Reference Entity is used for reference. Instead, the modeler should as a matter of convention provide a reference relationship which inherits its meaning both from the property relationship of the Independent Thing and the identify relationship of the Reference Entity. Future: On OWL2 this arrangement should be reviewed, and a transitive relationship used as appropriate.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;ParametricThing">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/MathematicalThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">parametric thing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;PastValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;tense"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Past"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">past value</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value is determined at some point in the past.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Probability">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">probability</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;ProbabilityDistribution">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalModel"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">probability distribution</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;ProjectedValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Value"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;projectedValueDeterminedBy"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-math-math;InternalValueDetermination">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-math-math;PublishedFutureValue">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-pub-pub;Publisher">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;tense"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Future"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">projected value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value is some projected future value.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note that the future is not known, so in fact future tense refers to some project value. The value should therefore be accompanied by terms defining how and by what means it is being predicted.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;PublishedFutureValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">published future value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A value defined in advance in a schedule, as part of the bond terms in the prospectus. an example of this is a stepped coupon in a bond.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Rate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;isOver"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;isRateOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Value"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rate</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rate of change of some measurable parameter over some period of time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Relation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;TimeBasedPlot">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Comparison"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">time based plot</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A comparison among several parameters, one of which is time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;TimedBasedSurface">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalSurface"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">timed based surface</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A three way relationship between three variable parameters.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is analogous to a curve, but whereas a curve plots a relationship between two parameters in a two dimensional plane, a surface is the relationship between three parameters in a three-dimensional space. In the context of credit risk, there is a 3D relation of Rating, Term and Credit Spread, defining a 3D surface.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;TimedParameter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hadValue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;PastValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasProjectedValue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasValue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;CurrentValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">timed parameter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A numerical parameter which may be expected to vary over time, and will therefore have values for different times past, persent and future.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;TimedValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Value"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">timed value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of a dated parameter, at a stated point in the past, present or future.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A value can be, by definition, either a value in the present or a value in the past. There can also be a value which is predicted for some time in the future, predicted either now or in the past. These are modeled separately. By definition then all values are exclusively either past, present or future. All parameters which take a value, take that value in the past and the present or have it predeicted for a date and time in the future. Therefore all terms which are a kind of &quot;Value&quot; by being descended from this class of Thing, are also capable of being past, present or future, i.e. the concepts of Past Value and Current Value are also applicable to those.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Up">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Direction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">up</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-math;Value">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalExpression"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;denomination"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any value, stated as a number.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;constant.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">constant</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Constant used in the formula argument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;denomination">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Value"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;expressedNumericallyAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expressed numerically as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Constant"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hadValue">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">had value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;PastValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasArgument">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has argument</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasExpression">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has expression</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasNumericallyMeasurableProperty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has numerically measurable property</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;MeasuredThing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasOperand">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has operand</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasOperator">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has operator</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;Operator"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasProjectedValue">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has projected value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasSubject">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has subject</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;ContractuallyDefinedNumericalParameter"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;ContractualDefinition"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasTextualExpression">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has textual expression</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The expression of the Formula in text. The arguments and parameters are also linked separately - there is no formal connection between the components of the Formula as modelled here and the textual expresion of it - these can either or both be expressed depending on the business information available.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;hasValue">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;CurrentValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isBetween">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is between</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Comparison"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isOver">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is over</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Rate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isParameterOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is parameter of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;MeasuredThing"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isParameterOfReferenceEntity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is parameter of reference entity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;isRateOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is rate of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Rate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;Value"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;percentageProbability">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage probability</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Probability"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;plottedBetween">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;isBetween"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">plotted between</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimeBasedPlot"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;projectedDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">projected date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The calendar date on which the value is project to apply.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;projectedValueDeterminedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">projected value determined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-math-math;InternalValueDetermination">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-math-math;PublishedFutureValue">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-pub-pub;Publisher">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;relation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;Relation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Relation at the center of the Formula, usually &quot;Equals&quot;.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;subjectTakesForm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subject takes form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;takesReferenceParameter">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes reference parameter</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;takesValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;NumericalParameter"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;Value"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;takesValuesOverTime">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes values over time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;tense">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tense</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Tense"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the value is in the past, present or future tense. Note that different qualifying terms are required for each of these, so the specific sub-type should be referred to in all cases.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;valueExpressedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value expressed as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;Value"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The numerical value of the Parameter.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-math-math;valueTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-math-math;PastValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/MathExt/Quantities.rdf
+++ b/fnd/MathExt/Quantities.rdf
@@ -1,44 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
-	<!ENTITY fibo-fnd-math-qty "https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
+bu<!ENTITY fibo-fnd-math-qty "https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/"
-	xmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
-	xmlns:fibo-fnd-math-qty="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/">
-		<rdfs:label xml:lang="en">Quantities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-math-qty;SecuritiesQuantity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-amt;isQuantityOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities quantity</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
+buxmlns:fibo-fnd-math-qty="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Quantities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Defines the concept of a Securities Quantity, this being a quantity of securities and references in one securities issuance ontology where the issue subscription information include a reference to the quantity of securities involved. 
+		This ontology is misnamed – it should be called SecurityQuantities. Or it can be deprecated once the two remaining model references to it are replaced with something available elsewhere.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Quantities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-math-qty;SecuritiesQuantity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-amt;isQuantityOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities quantity</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/PartiesExt/PartyExtensions.rdf
+++ b/fnd/PartiesExt/PartyExtensions.rdf
@@ -1,72 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
-		<rdfs:label xml:lang="en">PartyExtensions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-org-org;Organization">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;hasOrganizationMember"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pty-pty;PartyInRole">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;hasRelatedParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-ptyx;becomesParty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-ptyx;hasRelatedParty"/>
-		<rdfs:label xml:lang="en">becomes party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-ptyx;hasOrganizationMember">
-		<rdfs:label xml:lang="en">has organization member</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-org-org;Organization"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-ptyx;hasRelatedParty">
-		<rdfs:label xml:lang="en">has related party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<skos:definition xml:lang="en">A party which is in some relationship to the party.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">PartyExtensions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extensions to the basic notion of a party.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-org-org;Organization">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;hasOrganizationMember"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pty-pty;PartyInRole">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-ptyx;hasRelatedParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-ptyx;becomesParty">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-ptyx;hasRelatedParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-ptyx;hasOrganizationMember">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has organization member</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-org-org;Organization"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-ptyx;hasRelatedParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has related party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which is in some relationship to the party.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PartiesExt/PartyInverses.rdf
+++ b/fnd/PartiesExt/PartyInverses.rdf
@@ -1,36 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-ptyx-inv "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyInverses/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-ptyx-inv "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyInverses/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyInverses/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-ptyx-inv="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyInverses/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyInverses/">
-		<rdfs:label xml:lang="en">PartyInverses</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyInverses/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-inv;isPartyInRole">
-		<rdfs:label xml:lang="en">is party in role</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-ptyx-inv="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyInverses/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyInverses/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">PartyInverses</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology retains an inverse property that was not included in the published Release ontology but adds no further business detail.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyInverses/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-inv;isPartyInRole">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is party in role</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PartiesExt/PartyRoleContext.rdf
+++ b/fnd/PartiesExt/PartyRoleContext.rdf
@@ -1,100 +1,103 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/">
-	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/">
+bu<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
-	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
-	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
-		<rdfs:label xml:lang="en">PartyRoleContext</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-agr;Agreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-oac-own;Ownership">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pty-pty;PartyInRole">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-ptyx-prc;RelationshipContext">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;hasPartyInRole"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">relationship context</rdfs:label>
-		<skos:definition xml:lang="en">Any context in which Parties are defined.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example when someone says that a Fund has a party, such as a fund manager that party is really party to the broader context of fund management, but the assertion is made with reference to the Fund. In that sense saying that the fund has a party is a synechdocal way of saying that the fund is the context in which there is that party.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, a contractual relationship, transaction etc. This is any relationship in which something is defined as being party to something. It is from this context that it is possible to extract what are the parties involved, and, from those, what are the types of entity which may fulfil those roles.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-ptyx-prc;SynechdocalThing">
-		<rdfs:subClassOf rdf:resource="&owl;Thing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;hasRelatedParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;impliesContext"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synechdocal thing</rdfs:label>
-		<skos:definition xml:lang="en">Something which represents one kind of thing when things are asserted about it that really relate to another kind of thing</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example when someone says that a Fund has a party, such as a fund manager that party is really party to the broader context of fund management, but the assertion is made with reference to the Fund. In that sense saying that the fund has a party is a synechdocal way of saying that the fund is the context in which there is that party.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-prc;hasPartyInRole">
-		<rdfs:label xml:lang="en">has party in role</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<skos:definition xml:lang="en">Something which represents one kind of thing when things are asserted about it that really relate to another kind of thing</skos:definition>
-		<skos:definition xml:lang="en">The role fulfilled by a party in a relationship context.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-prc;hasRelatedParty">
-		<rdfs:label xml:lang="en">has related party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-ptyx-prc;SynechdocalThing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-prc;impliesContext">
-		<rdfs:label xml:lang="en">implies context</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-ptyx-prc;SynechdocalThing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
+buxmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">PartyRoleContext</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extends the notion of a party in a role, to define the context in which something is defined as such, with reference to the upper ontology.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-agr;Agreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-oac-own;Ownership">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pty-pty;PartyInRole">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-ptyx-prc;RelationshipContext">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;hasPartyInRole"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relationship context</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any context in which Parties are defined.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example when someone says that a Fund has a party, such as a fund manager that party is really party to the broader context of fund management, but the assertion is made with reference to the Fund. In that sense saying that the fund has a party is a synechdocal way of saying that the fund is the context in which there is that party.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example, a contractual relationship, transaction etc. This is any relationship in which something is defined as being party to something. It is from this context that it is possible to extract what are the parties involved, and, from those, what are the types of entity which may fulfil those roles.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-ptyx-prc;SynechdocalThing">
+bubu<rdfs:subClassOf rdf:resource="&owl;Thing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;hasRelatedParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;impliesContext"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synechdocal thing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something which represents one kind of thing when things are asserted about it that really relate to another kind of thing</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example when someone says that a Fund has a party, such as a fund manager that party is really party to the broader context of fund management, but the assertion is made with reference to the Fund. In that sense saying that the fund has a party is a synechdocal way of saying that the fund is the context in which there is that party.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-prc;hasPartyInRole">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has party in role</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something which represents one kind of thing when things are asserted about it that really relate to another kind of thing</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The role fulfilled by a party in a relationship context.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-prc;hasRelatedParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has related party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-ptyx-prc;SynechdocalThing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-ptyx-prc;impliesContext">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">implies context</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-ptyx-prc;SynechdocalThing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PhysicalExt/Physical.rdf
+++ b/fnd/PhysicalExt/Physical.rdf
@@ -1,44 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
-	xmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
-		<rdfs:label xml:lang="en">Physical</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-phy-phy;ContinuousPhysicalStuff">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-phy-phy;PhysicalItem"/>
-		<rdfs:label xml:lang="en">continuous physical stuff</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-phy-phy;DiscretePhysicalThing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-phy-phy;PhysicalItem"/>
-		<rdfs:label xml:lang="en">discrete physical thing</rdfs:label>
-		<skos:definition xml:lang="en">Some physical item with well defined physical extent.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-phy-phy;PhysicalItem">
-		<rdfs:label xml:lang="en">physical item</rdfs:label>
-		<skos:definition xml:lang="en">Something you can touch.</skos:definition>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Physical</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Defines the basic concept of a physical thing, for extension elsewhere where physical things need to be described.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-phy-phy;ContinuousPhysicalStuff">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-phy-phy;PhysicalItem"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">continuous physical stuff</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-phy-phy;DiscretePhysicalThing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-phy-phy;PhysicalItem"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">discrete physical thing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some physical item with well defined physical extent.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-phy-phy;PhysicalItem">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">physical item</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something you can touch.</skos:definition>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/PlacesExt/AddressPropertyChain.rdf
+++ b/fnd/PlacesExt/AddressPropertyChain.rdf
@@ -1,35 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plcx-apc "https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressPropertyChain/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
+bu<!ENTITY fibo-fnd-plcx-apc "https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressPropertyChain/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressPropertyChain/"
-	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plcx-apc="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressPropertyChain/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressPropertyChain/">
-		<rdfs:label xml:lang="en">AddressPropertyChain</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressPropertyChain/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-apc;tradingAtPostalAddress">
-		<rdfs:label xml:lang="en">trading at postal address</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
+buxmlns:fibo-fnd-plcx-apc="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressPropertyChain/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressPropertyChain/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AddressPropertyChain</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology draws on the notion of a kind of address as a relative thing, as defined in the Address Sites ontology, and provides a property chain that combines these relative notions to reflect the direct relationship used elsewhere. 
+		Note that this ontology is a prototype for how relations to relative things may be parlayed into relations to the corresponding independent things, a pattern which is implied extensively in other parts of FIBO (e.g. for securities issuers) but which in those models does not yet use this property chain approach.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressPropertyChain/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-apc;tradingAtPostalAddress">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading at postal address</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PlacesExt/AddressSites.rdf
+++ b/fnd/PlacesExt/AddressSites.rdf
@@ -1,127 +1,131 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/FND/Places/Facilities/">
-	<!ENTITY fibo-fnd-plcx-sit "https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-fnd-plc-fac "https://spec.edmcouncil.org/fibo/FND/Places/Facilities/">
+bu<!ENTITY fibo-fnd-plcx-sit "https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/FND/Places/Facilities/"
-	xmlns:fibo-fnd-plcx-sit="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/">
-		<rdfs:label xml:lang="en">AddressSites</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Facilities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-cb;Corporation">
-		<owl:equivalentClass rdf:resource="&fibo-be-le-cb;Corporation"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
-		<owl:equivalentClass rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-sit;BusinessSite">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-fac;PhysicalSite"/>
-		<rdfs:label xml:lang="en">business site</rdfs:label>
-		<skos:definition xml:lang="en">An address from which a business entity carries out its business, such as a shop or offices. This is the address which is generally shown on advertising by that company.</skos:definition>
-		<skos:editorialNote xml:lang="en">Term agreed in reviews but written definition not re-reviewed. Defined as a relative thing called &quot;Business Address Relation&quot; in Proof of Concept works. Renamed to Business Site in line with W3C Site semantics .</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-sit;OperatingBusinessAddressRelation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
-		<rdfs:label xml:lang="en">operating business address relation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-sit;PrimaryBusinessAddressRelation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
-		<rdfs:label xml:lang="en">primary business address relation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-sit;RegisteredAddressSite">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-fac;PhysicalSite"/>
-		<rdfs:label xml:lang="en">registered address site</rdfs:label>
-		<skos:definition xml:lang="en">An official Registered Address of a company, as registered with the appropriate Companies Registry for the jurisdiction in which the company is registered, and at which legal proceedings may be served upon the entity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It is usually a requirement to display this on stationery and other correspondence. This is defined as the address at which legal papers may be served upon the entity. In many jurisdictions this therefore cannot be a Post Box number or Poste Restante, however some jurisdictions (e.g. South Africa) do allow this.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;hasOperatingAddress">
-		<rdfs:label xml:lang="en">has operating address site</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;OperatingBusinessAddressRelation"/>
-		<skos:definition xml:lang="en">The address at which the organization carries out its business and receives correspondence relating to its business activities.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;hasPrimaryAddressSite">
-		<rdfs:label xml:lang="en">has primary address site</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;PrimaryBusinessAddressRelation"/>
-		<skos:definition xml:lang="en">The primary address at which this organization does business and received correspondence.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;headquarteredAt">
-		<rdfs:label xml:lang="en">headquartered at</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;PrimaryBusinessAddressRelation"/>
-		<skos:definition xml:lang="en">The address of the company&apos;s head office.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;isPrimaryAddress">
-		<rdfs:label xml:lang="en">is primary address</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-sit;OperatingBusinessAddressRelation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;isPrimaryAddress.1">
-		<rdfs:label xml:lang="en">is primary address</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-sit;PrimaryBusinessAddressRelation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;isPrimaryAddress.2">
-		<rdfs:label xml:lang="en">is primary address</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the address is the primary or headquarters address of the entity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;tradingAt">
-		<rdfs:label xml:lang="en">trading at</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;OperatingBusinessAddressRelation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;tradingAtSite">
-		<rdfs:label xml:lang="en">trading at site</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-fnd-plc-fac="https://spec.edmcouncil.org/fibo/FND/Places/Facilities/"
+buxmlns:fibo-fnd-plcx-sit="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AddressSites</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Defines the concepts of different kinds of address delineated according to their function, for example delivery address, headquarters address. 
+		The published Release ontologies use a simpler pattern in which the role or nature of the address is conveyed in the relationships only. This conceptual ontology is provided for those uses where things need to be said about these kinds of address, for example in regulations about reporing or company registration.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Facilities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/AddressSites/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-cb;Corporation">
+bubu<owl:equivalentClass rdf:resource="&fibo-be-le-cb;Corporation"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
+bubu<owl:equivalentClass rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-sit;BusinessSite">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-fac;PhysicalSite"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business site</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An address from which a business entity carries out its business, such as a shop or offices. This is the address which is generally shown on advertising by that company.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Term agreed in reviews but written definition not re-reviewed. Defined as a relative thing called &quot;Business Address Relation&quot; in Proof of Concept works. Renamed to Business Site in line with W3C Site semantics .</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-sit;OperatingBusinessAddressRelation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">operating business address relation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-sit;PrimaryBusinessAddressRelation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary business address relation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-sit;RegisteredAddressSite">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-fac;PhysicalSite"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registered address site</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An official Registered Address of a company, as registered with the appropriate Companies Registry for the jurisdiction in which the company is registered, and at which legal proceedings may be served upon the entity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">It is usually a requirement to display this on stationery and other correspondence. This is defined as the address at which legal papers may be served upon the entity. In many jurisdictions this therefore cannot be a Post Box number or Poste Restante, however some jurisdictions (e.g. South Africa) do allow this.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;hasOperatingAddress">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has operating address site</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;OperatingBusinessAddressRelation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The address at which the organization carries out its business and receives correspondence relating to its business activities.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;hasPrimaryAddressSite">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has primary address site</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;PrimaryBusinessAddressRelation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The primary address at which this organization does business and received correspondence.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;headquarteredAt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">headquartered at</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;PrimaryBusinessAddressRelation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The address of the company&apos;s head office.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;isPrimaryAddress">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is primary address</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-sit;OperatingBusinessAddressRelation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;isPrimaryAddress.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is primary address</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-sit;PrimaryBusinessAddressRelation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;isPrimaryAddress.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is primary address</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the address is the primary or headquarters address of the entity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;tradingAt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading at</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;OperatingBusinessAddressRelation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-sit;tradingAtSite">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading at site</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-le-cb;Corporation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-sit;BusinessSite"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PlacesExt/Geophysical.rdf
+++ b/fnd/PlacesExt/Geophysical.rdf
@@ -1,122 +1,125 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-inf-padr "https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/">
-	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/FND/Places/Locations/">
-	<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-inf-padr "https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/">
+bu<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/FND/Places/Locations/">
+bu<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
-	xmlns:fibo-fnd-inf-padr="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"
-	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"
-	xmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
-		<rdfs:label xml:lang="en">Geophysical</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;County">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
-		<rdfs:label xml:lang="en">county</rdfs:label>
-		<skos:definition xml:lang="en">An area within a country or state, designated by that country or state as a County for its own descriptive and administrative purposes. Fiurther Notes: Specific properties of counties will vary from one country or state to another and are not erpresented here - this is purely a labelled area of land within a country, similar to a Region.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;GeographicalArea">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeographicalFeature"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-		<rdfs:label xml:lang="en">geographical area</rdfs:label>
-		<skos:definition xml:lang="en">A named and formally defined area of the world defined in terms of its physical extent. Scope Note: A Geographical Area is both a Geographical Feature (some named physical location on Earth) and a Geophysical Location (having two-dimensional extent on the Earth&apos;s surface).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;GeographicalFeature">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
-		<rdfs:label xml:lang="en">geographical feature</rdfs:label>
-		<skos:definition xml:lang="en">Some named physical location on Earth, identified geographically such as a specific land area, city or geographical feature. Scope Note: This is usually an alternative way of describing some geophysical extent or location, for example describing a city as a city as distinct from describing the physical extent of that city. Many concepts may therefore extend from this and from Geophysical or Geospatial concepts. For many purposes, modelers may ignore this class. Scope Note: This differs from Geophysical Location in that may include geographical features identified as points on the Earth&apos;s surface, or as linear features such as rivers and shorelines.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;GeophysicalLocation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;TopographicalLocation"/>
-		<rdfs:label xml:lang="en">geophysical location</rdfs:label>
-		<skos:definition xml:lang="en">Some physical two dimensional extent on the surface of the Earth. Scope Note: The definition given in the FIBO Foundations specification for Physical Location defines some n- e.g. three dimensional space. This concept extends this to define a two dimensional extent on the Earth or other planets. Explanatory Note: Some of these locations may also be co-extensive with Geographical Features, the latter being named geophysical lications.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;LandParcel">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-		<rdfs:label xml:lang="en">land parcel</rdfs:label>
-		<skos:definition xml:lang="en">Some parcel or subdivision of land.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;Neighborhood">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-		<rdfs:label xml:lang="en">neighborhood</rdfs:label>
-		<skos:definition xml:lang="en">Some residential area.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;NeighborhoodSubdivision">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-		<rdfs:label xml:lang="en">neighborhood subdivision</rdfs:label>
-		<skos:definition xml:lang="en">A block or subdivision within some residential area, commonly designated sa such for the purposes of addressing and containing within it some streets and / or residential blocks.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;Region">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
-		<rdfs:label xml:lang="en">region</rdfs:label>
-		<skos:definition xml:lang="en">Some area of land, either within a country or state or encompassing several countries and states, and referred to as a Region for some purpose or other.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;Street">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;streetIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">street</rdfs:label>
-		<skos:definition xml:lang="en">Some traversable strip of land or water containing along it some buildings or land.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;Territory">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
-		<rdfs:label xml:lang="en">territory</rdfs:label>
-		<skos:definition xml:lang="en">A physical extent of land and water generally corresponding to the area claimed or governmed by some geopolitical entity. .</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Corresponds to the physical extent of some Geopolitical Terirtory.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gph;TopographicalLocation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
-		<rdfs:label xml:lang="en">topographical location</rdfs:label>
-		<skos:definition xml:lang="en">Some physical two dimensional extent on the surface of some planet or natural satellite. Scope Note: The definition given in the FIBO Foundations specification for Physical Location defines some n- e.g. three dimensional space. This concept extends this to define a two dimensional extent on the Earth or other planets, moons etc. Scope Note: Potential specializations of this concept would include areographical locations (on Mars) and other planetographahical features. These are not in scope for FIBO but this abstraction has been included so that models which do explore that scope may be compatible with this model. Explanatory Note: Please refer to the discipline of topynymy for further details and possible extensions.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gph;name">
-		<rdfs:label xml:lang="en">name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-gph;GeographicalFeature"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The name of the geographical thing, as text.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-inf-padr="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"
+buxmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"
+buxmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Geophysical</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts that are geophysical in nature, that is land features and the like, without reference to any geopolitical component. These are the kinds of place (land areas etc.) upon which geopolitical things may be projected. Note that addresses may refer to a combination of geopolitical and geophysical things.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;County">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">county</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An area within a country or state, designated by that country or state as a County for its own descriptive and administrative purposes. Fiurther Notes: Specific properties of counties will vary from one country or state to another and are not erpresented here - this is purely a labelled area of land within a country, similar to a Region.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;GeographicalArea">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeographicalFeature"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">geographical area</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A named and formally defined area of the world defined in terms of its physical extent. Scope Note: A Geographical Area is both a Geographical Feature (some named physical location on Earth) and a Geophysical Location (having two-dimensional extent on the Earth&apos;s surface).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;GeographicalFeature">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">geographical feature</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some named physical location on Earth, identified geographically such as a specific land area, city or geographical feature. Scope Note: This is usually an alternative way of describing some geophysical extent or location, for example describing a city as a city as distinct from describing the physical extent of that city. Many concepts may therefore extend from this and from Geophysical or Geospatial concepts. For many purposes, modelers may ignore this class. Scope Note: This differs from Geophysical Location in that may include geographical features identified as points on the Earth&apos;s surface, or as linear features such as rivers and shorelines.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;GeophysicalLocation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;TopographicalLocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">geophysical location</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some physical two dimensional extent on the surface of the Earth. Scope Note: The definition given in the FIBO Foundations specification for Physical Location defines some n- e.g. three dimensional space. This concept extends this to define a two dimensional extent on the Earth or other planets. Explanatory Note: Some of these locations may also be co-extensive with Geographical Features, the latter being named geophysical lications.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;LandParcel">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">land parcel</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some parcel or subdivision of land.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;Neighborhood">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">neighborhood</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some residential area.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;NeighborhoodSubdivision">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">neighborhood subdivision</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A block or subdivision within some residential area, commonly designated sa such for the purposes of addressing and containing within it some streets and / or residential blocks.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;Region">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">region</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some area of land, either within a country or state or encompassing several countries and states, and referred to as a Region for some purpose or other.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;Street">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;streetIdentifiedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">street</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some traversable strip of land or water containing along it some buildings or land.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;Territory">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">territory</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A physical extent of land and water generally corresponding to the area claimed or governmed by some geopolitical entity. .</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Corresponds to the physical extent of some Geopolitical Terirtory.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gph;TopographicalLocation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">topographical location</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some physical two dimensional extent on the surface of some planet or natural satellite. Scope Note: The definition given in the FIBO Foundations specification for Physical Location defines some n- e.g. three dimensional space. This concept extends this to define a two dimensional extent on the Earth or other planets, moons etc. Scope Note: Potential specializations of this concept would include areographical locations (on Mars) and other planetographahical features. These are not in scope for FIBO but this abstraction has been included so that models which do explore that scope may be compatible with this model. Explanatory Note: Please refer to the discipline of topynymy for further details and possible extensions.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gph;name">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-gph;GeographicalFeature"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The name of the geographical thing, as text.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PlacesExt/Geopolitical.rdf
+++ b/fnd/PlacesExt/Geopolitical.rdf
@@ -1,147 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
-	<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
-	<!ENTITY fibo-fnd-plcx-gpo "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geopolitical/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
+bu<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
+bu<!ENTITY fibo-fnd-plcx-gpo "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geopolitical/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geopolitical/"
-	xmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
-	xmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
-	xmlns:fibo-fnd-plcx-gpo="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geopolitical/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geopolitical/">
-		<rdfs:label xml:lang="en">Geopolitical</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geopolitical/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-plc-cty;Country">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;hasCapital"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gpo;City"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gpo;City">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gpo;MunicipalArea"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;officialName"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;cityCorrespondsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;PopulatedPlace"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">city</rdfs:label>
-		<skos:definition xml:lang="en">An urban center defined as a geopolitical entity, that is one coming under one or more specific adminstrations</skos:definition>
-		<skos:editorialNote xml:lang="en">Identified the need for a suitable formal definition of a City, in SME Reviews. Taking this further there are requirements for physical city or urban center concepts e.g. for addresses, risk, and requirements for geopolitical concepts of an urban center or cityt e.g. for their relationship to a municipality which issues debt instruments.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gpo;GeopoliticalGroup">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;hasMember"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">geopolitical group</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-gpo;MunicipalArea">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;municipalAreaCorrespondsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">municipal area</rdfs:label>
-		<skos:definition xml:lang="en">An area which is identified as a municipality and governed by a municipal government. Scope Note: In most of the world this term or word corresponds to a city area. In the US, municipalities are also identified as coextensive with counties and some other geographical areas.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;cityCorrespondsTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-plcx-gpo;municipalAreaCorrespondsTo"/>
-		<rdfs:label xml:lang="en">city corresponds to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-gpo;City"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;PopulatedPlace"/>
-		<skos:definition xml:lang="en">The geographical area which is a city, defined in terms of its geospatial extent.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is distinct from a City described in geopolitical terms as an area of government. The names of most cities refer both to the Municipal Area and the City; in other cases they do not.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;hasBorderWith">
-		<rdfs:label xml:lang="en">has border with</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;hasCapital">
-		<rdfs:label xml:lang="en">has capital</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-gpo;City"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;hasMember">
-		<rdfs:label xml:lang="en">has member</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-gpo;GeopoliticalGroup"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-plcx-gpo;isInGroup"/>
-		<skos:editorialNote xml:lang="en">Note: inspired by geopolitical ontology (FAO)</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;isInGroup">
-		<rdfs:label xml:lang="en">is in group</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-gpo;GeopoliticalGroup"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;municipalAreaCorrespondsTo">
-		<rdfs:label xml:lang="en">municipal area corresponds to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-gpo;MunicipalArea"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
-		<skos:definition xml:lang="en">The geographical area which is a municipality defined in terms of its geospatial extent.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is distinct from a municipality described in geopolitical terms as an area of government. This term exists to support the US situation in which municipalities may govern areas other than cities, with cities being specializations of these concepts.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;officialName">
-		<rdfs:label xml:lang="en">official name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-gpo;City"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The Official Name by which the City is formally referred, if different from the Common Name. Also usually the name of the State Actor.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;recognizedBy">
-		<rdfs:label xml:lang="en">recognized by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<skos:definition xml:lang="en">Countries which recognize the existence of the Country.</skos:definition>
-		<skos:editorialNote xml:lang="en">Work in progress: relationship between Country and ISO Country (which is a sub-class of Country). when a country first exists, it is recognized by some country - otherwise it&apos;s dubious to call it a country. Only once the UN recognizes a country e.g. South Sudan, it is on the road to becoming an ISO Country (via first being a UN-FAO Territory). Then disputed territories (a UN-FAO term), are recognized by some and not others, e..g Kosovo.</skos:editorialNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
+buxmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
+buxmlns:fibo-fnd-plcx-gpo="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geopolitical/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geopolitical/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Geopolitical</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Geopolitical things are social constructs that are projected onto or related to geophysical things. These include notions of countries, municipalities and the like. Note that addresses may refer to a combination of geopolitical and geophysical things.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geopolitical/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plc-cty;Country">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;hasCapital"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gpo;City"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gpo;City">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-gpo;MunicipalArea"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;officialName"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;cityCorrespondsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;PopulatedPlace"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">city</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An urban center defined as a geopolitical entity, that is one coming under one or more specific adminstrations</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Identified the need for a suitable formal definition of a City, in SME Reviews. Taking this further there are requirements for physical city or urban center concepts e.g. for addresses, risk, and requirements for geopolitical concepts of an urban center or cityt e.g. for their relationship to a municipality which issues debt instruments.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gpo;GeopoliticalGroup">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;hasMember"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">geopolitical group</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-gpo;MunicipalArea">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-cty;GeopoliticalEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-plcx-gpo;municipalAreaCorrespondsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal area</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An area which is identified as a municipality and governed by a municipal government. Scope Note: In most of the world this term or word corresponds to a city area. In the US, municipalities are also identified as coextensive with counties and some other geographical areas.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;cityCorrespondsTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-plcx-gpo;municipalAreaCorrespondsTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">city corresponds to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-gpo;City"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;PopulatedPlace"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The geographical area which is a city, defined in terms of its geospatial extent.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is distinct from a City described in geopolitical terms as an area of government. The names of most cities refer both to the Municipal Area and the City; in other cases they do not.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;hasBorderWith">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has border with</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;hasCapital">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has capital</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-gpo;City"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;hasMember">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has member</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-gpo;GeopoliticalGroup"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-plcx-gpo;isInGroup"/>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Note: inspired by geopolitical ontology (FAO)</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;isInGroup">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is in group</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-gpo;GeopoliticalGroup"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;municipalAreaCorrespondsTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal area corresponds to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-gpo;MunicipalArea"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-gph;GeographicalArea"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The geographical area which is a municipality defined in terms of its geospatial extent.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is distinct from a municipality described in geopolitical terms as an area of government. This term exists to support the US situation in which municipalities may govern areas other than cities, with cities being specializations of these concepts.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;officialName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">official name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-gpo;City"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Official Name by which the City is formally referred, if different from the Common Name. Also usually the name of the State Actor.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-gpo;recognizedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">recognized by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Countries which recognize the existence of the Country.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Work in progress: relationship between Country and ISO Country (which is a sub-class of Country). when a country first exists, it is recognized by some country - otherwise it&apos;s dubious to call it a country. Only once the UN recognizes a country e.g. South Sudan, it is on the road to becoming an ISO Country (via first being a UN-FAO Territory). Then disputed territories (a UN-FAO term), are recognized by some and not others, e..g Kosovo.</skos:editorialNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PlacesExt/RealEstate.rdf
+++ b/fnd/PlacesExt/RealEstate.rdf
@@ -1,218 +1,222 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-padr "https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/">
-	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
-	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
-	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/FND/Places/Locations/">
-	<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
-	<!ENTITY fibo-fnd-plcx-re "https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-padr "https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/">
+bu<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
+bu<!ENTITY fibo-fnd-phy-phy "https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/">
+bu<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
+bu<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/FND/Places/Locations/">
+bu<!ENTITY fibo-fnd-plcx-gph "https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/">
+bu<!ENTITY fibo-fnd-plcx-re "https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-padr="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"
-	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
-	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
-	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"
-	xmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
-	xmlns:fibo-fnd-plcx-re="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/">
-		<rdfs:label xml:lang="en">RealEstate</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-plc-adr;PhysicalAddress">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;isOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plc-loc;RealEstate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plcx-re;realEstateCoextensiveWith"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-plcx-gph;LandParcel">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plcx-re;realEstateOwnedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-re;PropertyOwner"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<skos:definition xml:lang="en">Land plus anything permanently fixed to it, including buildings, sheds and other items attached to the structure. Explanatory Note: Although, media often refers to the &quot;real estate market&quot; from the perspective of residential living, real estate can be grouped into three broad categories based on its use, namely residential, commercial and industrial. Explanatory Note: Examples of real estate include undeveloped land, houses, condominiums, townhomes, office buildings, retail store buildings and factories. Scope Note: Bricks and mortar or land which can be owned.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-re;Apartment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;apartmentIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">apartment</rdfs:label>
-		<skos:definition xml:lang="en">A building subbdivision intended for habitation.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-re;Building">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuiltProperty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;buildingIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">building</rdfs:label>
-		<skos:definition xml:lang="en">A discrete construction on its own foundations or pilings.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-re;BuildingSubUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuiltProperty"/>
-		<rdfs:label xml:lang="en">building sub unit</rdfs:label>
-		<skos:definition xml:lang="en">A discrete subdivision of some Building.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plcx-re;hasLocation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">built property</rdfs:label>
-		<skos:definition xml:lang="en">Something which is constructed via construction methods; bricks and mortar.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-re;Floor">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;floorIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">floor</rdfs:label>
-		<skos:definition xml:lang="en">A building subdivision whose extent is the horizontal extent of the building at that height.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-re;PropertyOwner">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Owner"/>
-		<rdfs:label xml:lang="en">property owner</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-re;Suite">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;suiteIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">suite</rdfs:label>
-		<skos:definition xml:lang="en">A subdivision of a building for which the purposes are not clearly defined or may be variable, generally consisting of a number of contiguous rooms on one or more floors.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;hasLocation">
-		<rdfs:label xml:lang="en">has location</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plcx-re;BuiltProperty"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
-		<skos:definition xml:lang="en">The physical location of the built item or property.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;identifiedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
-		<rdfs:label xml:lang="en">identified by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;leasehold">
-		<rdfs:label xml:lang="en">leasehold</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Typically a leasehold is where the land is not owned by the borrower, rather it is leased from a third party for a term that exceeds the life of the mortgage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;realEstateCoextensiveWith">
-		<rdfs:label xml:lang="en">real estate coextensive with</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-plcx-gph;LandParcel">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-		<skos:definition xml:lang="en">Real Estate corresponds to either some built item or some parcel of land.</skos:definition>
-		<skos:scopeNote xml:lang="en">This is represented as a logical union of Built Item and Land Parcel. Scope Note: Future changes in Real Estate ontology alignment may well change or elaborate on this.</skos:scopeNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;realEstateOwnedBy">
-		<rdfs:label xml:lang="en">real estate owned by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plcx-re;PropertyOwner"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-padr="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"
+buxmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+buxmlns:fibo-fnd-phy-phy="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"
+buxmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"
+buxmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"
+buxmlns:fibo-fnd-plcx-gph="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"
+buxmlns:fibo-fnd-plcx-re="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">RealEstate</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Defines the notion of real estate. This draws on a combination of geophysical (land parcel) and built environment concepts, and also allows for the use of leasehold contracts as collateral in mortgages as a kind of real estate asset. 
+		This model is considerably more complex and conceptual than the published Release ontology for real estate, which defines it merely as some kind of location. Some of these concepts will be needed in defining details about mortgage loans and other applications of collateral.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/AddressExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/PostalAddress/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PhysicalExt/Physical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plc-adr;PhysicalAddress">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;isOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plc-loc;RealEstate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-loc;PhysicalLocation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-plcx-re;realEstateCoextensiveWith"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-plcx-gph;LandParcel">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-plcx-re;realEstateOwnedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-re;PropertyOwner"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Land plus anything permanently fixed to it, including buildings, sheds and other items attached to the structure. Explanatory Note: Although, media often refers to the &quot;real estate market&quot; from the perspective of residential living, real estate can be grouped into three broad categories based on its use, namely residential, commercial and industrial. Explanatory Note: Examples of real estate include undeveloped land, houses, condominiums, townhomes, office buildings, retail store buildings and factories. Scope Note: Bricks and mortar or land which can be owned.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-re;Apartment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;apartmentIdentifiedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">apartment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A building subbdivision intended for habitation.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-re;Building">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuiltProperty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;buildingIdentifiedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;StreetAddressText"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">building</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A discrete construction on its own foundations or pilings.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-re;BuildingSubUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuiltProperty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">building sub unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A discrete subdivision of some Building.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-phy-phy;DiscretePhysicalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-plcx-re;hasLocation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">built property</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something which is constructed via construction methods; bricks and mortar.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-re;Floor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;floorIdentifiedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A building subdivision whose extent is the horizontal extent of the building at that height.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-re;PropertyOwner">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Owner"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property owner</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-re;Suite">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-re;BuildingSubUnit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-padr;suiteIdentifiedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-inf-padr;BuildingSubUnitAddressFragment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">suite</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A subdivision of a building for which the purposes are not clearly defined or may be variable, generally consisting of a number of contiguous rooms on one or more floors.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;hasLocation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has location</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plcx-re;BuiltProperty"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-gph;GeophysicalLocation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The physical location of the built item or property.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;identifiedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;leasehold">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">leasehold</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Typically a leasehold is where the land is not owned by the borrower, rather it is leased from a third party for a term that exceeds the life of the mortgage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;realEstateCoextensiveWith">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">real estate coextensive with</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-plcx-gph;LandParcel">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-plcx-re;BuiltProperty">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Real Estate corresponds to either some built item or some parcel of land.</skos:definition>
+bubu<skos:scopeNote rdf:datatype="&rdf;langString" xml:lang="en">This is represented as a logical union of Built Item and Land Parcel. Scope Note: Future changes in Real Estate ontology alignment may well change or elaborate on this.</skos:scopeNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-re;realEstateOwnedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">real estate owned by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-loc;RealEstate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plcx-re;PropertyOwner"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PlacesExt/VirtualPlaces.rdf
+++ b/fnd/PlacesExt/VirtualPlaces.rdf
@@ -1,55 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/FND/Places/VirtualPlaces/">
-	<!ENTITY fibo-fnd-plcx-vrtx "https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/FND/Places/VirtualPlaces/">
+bu<!ENTITY fibo-fnd-plcx-vrtx "https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/"
-	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/FND/Places/VirtualPlaces/"
-	xmlns:fibo-fnd-plcx-vrtx="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/">
-		<rdfs:label xml:lang="en">VirtualPlacesExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/VirtualPlaces/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-plc-vrt;VirtualLocation">
-		<skos:definition xml:lang="en">A place which has no physical location.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-plcx-vrtx;NotionalPlace">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-vrt;VirtualLocation"/>
-		<rdfs:label xml:lang="en">notional place</rdfs:label>
-		<skos:definition xml:lang="en">A place described in terms of some abstract description or as a list of commonly understood concepts such as domestic, Eurozone etc.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-vrtx;knownAs">
-		<rdfs:label xml:lang="en">known as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-plc-vrt;VirtualLocation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">How the place is commonly referred to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-fnd-plcx-vrtx;uRL">
-		<rdfs:label xml:lang="en">u r l</rdfs:label>
-	</owl:DatatypeProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/FND/Places/VirtualPlaces/"
+buxmlns:fibo-fnd-plcx-vrtx="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">VirtualPlacesExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Defines the notion of a virtual place as being a place that is not physically located, for example a network address or a notional marketplace such as the global bond market. 
+		This is a duplicate to be deprecated, as all or most of these concepts are already given in the Release ontology of the same name.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/VirtualPlaces/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plc-vrt;VirtualLocation">
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A place which has no physical location.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-plcx-vrtx;NotionalPlace">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-vrt;VirtualLocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notional place</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A place described in terms of some abstract description or as a list of commonly understood concepts such as domestic, Eurozone etc.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-plcx-vrtx;knownAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">known as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-plc-vrt;VirtualLocation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How the place is commonly referred to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-fnd-plcx-vrtx;uRL">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">u r l</rdfs:label>
+bu</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/fnd/PublicationsExt/Conventions.rdf
+++ b/fnd/PublicationsExt/Conventions.rdf
@@ -1,73 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-pub-con "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-pub-std "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-pub-con "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-pub-std "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"
-	xmlns:fibo-fnd-pub-con="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-pub-std="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
-		<rdfs:label xml:lang="en">Conventions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-con;Convention">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">convention</rdfs:label>
-		<skos:definition xml:lang="en">The way something is usually done.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-con;ISOStandard">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
-		<rdfs:label xml:lang="en">i s o standard</rdfs:label>
-		<skos:definition xml:lang="en">A standard published and mandated by the International Standards Organisation (ISO).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-con;IndustryModelConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-con;Convention"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pub-con;industryModelConventionDefinedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pub-std;IndustryAssociation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">industry model convention</rdfs:label>
-		<skos:definition xml:lang="en">Standard conventions which exist in the public domain but are not enshrined in an existing ISO Standard are defined in this model and published as such.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-con;industryModelConventionDefinedBy">
-		<rdfs:label xml:lang="en">industry model convention defined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-con;IndustryModelConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pub-std;IndustryAssociation"/>
-		<skos:definition xml:lang="en">Some Industry Association which defines the convention.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This relationship exists in order to be able to define conventions which do not have the formal standards but which are maintained in some way by some industry association, for example by publication of a website.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-pub-con="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-pub-std="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Conventions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">The notion of a convention is widely used in securities models, usually in the form of code lists, for example for interest accrual conventions. This ontology sets out the basic notion of a published convention. For the same of simplicity, conventions that are not published by anyone specifically are treated as though published here by the EDM Council, thereby satisfying the ontology modeling rule that only codes that are published are considered real enough for inclusion in FIBO.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-con;Convention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convention</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The way something is usually done.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-con;ISOStandard">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i s o standard</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A standard published and mandated by the International Standards Organisation (ISO).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-con;IndustryModelConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-con;Convention"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pub-con;industryModelConventionDefinedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pub-std;IndustryAssociation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">industry model convention</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Standard conventions which exist in the public domain but are not enshrined in an existing ISO Standard are defined in this model and published as such.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-con;industryModelConventionDefinedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">industry model convention defined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-con;IndustryModelConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pub-std;IndustryAssociation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some Industry Association which defines the convention.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This relationship exists in order to be able to define conventions which do not have the formal standards but which are maintained in some way by some industry association, for example by publication of a website.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PublicationsExt/Publications.rdf
+++ b/fnd/PublicationsExt/Publications.rdf
@@ -1,127 +1,131 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/FND/Parties/Roles/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/FND/Parties/Roles/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-		<rdfs:label xml:lang="en">Publications</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-pub;PublishedInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">published information</rdfs:label>
-		<skos:definition xml:lang="en">Information put into the public domain by some party or sold at a profit.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-pub;Publisher">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-rl;AgentInRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pub-pub;publisherIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">publisher</rdfs:label>
-		<skos:definition xml:lang="en">An organization (such as a publishing house) which makes information. available.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the role of publisher, whether or not the role is filled by a publishing house. For example it may also be the entity which publishes standard contract terms, e.g. an industry association or an exchange.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-pub;PublishingHouse">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:label xml:lang="en">publishing house</rdfs:label>
-		<skos:definition xml:lang="en">Some business entity which specializes in publishing information.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-pub;WebPage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Document"/>
-		<rdfs:label xml:lang="en">web page</rdfs:label>
-		<skos:definition xml:lang="en">A document published on the World Wide Web and accessible via a Universal Resource Locator.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;brandName">
-		<rdfs:label xml:lang="en">brand name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The name of marque by which the publisher is identified in its publications. This may or may not be identical to the legal name or the Trading As name, but represents a separate semantic. Usually to be found on book jackets, press releases etc.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;publishedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-		<rdfs:label xml:lang="en">is published by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
-		<skos:definition xml:lang="en">The organization which makes this information available.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;publisherIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">publisher identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">A publisher of information may be identified as any Business Entity, including for example specialized publishing house, ratings agency, standards body and so on.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;publishes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;provides"/>
-		<rdfs:label xml:lang="en">publishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;uRL">
-		<rdfs:label xml:lang="en">u r l</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;WebPage"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;URIValue"/>
-		<skos:definition xml:lang="en">The URL of the web page.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Publications</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology sets out the basic notions of published information and the entities that publish this. 
+		Note that there is a convention in FIBO that, since the ontology is intended to be a computationally independent representation of real things in the world, no information construct (such as identifiers) is considered real unless it is published by someone. This ontology provides the conceptual underpinning for this notion and may not be needed in application ontologies.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-pub;PublishedInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">published information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information put into the public domain by some party or sold at a profit.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-pub;Publisher">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-rl;AgentInRole"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pub-pub;publisherIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">publisher</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An organization (such as a publishing house) which makes information. available.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the role of publisher, whether or not the role is filled by a publishing house. For example it may also be the entity which publishes standard contract terms, e.g. an industry association or an exchange.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-pub;PublishingHouse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">publishing house</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some business entity which specializes in publishing information.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-pub;WebPage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;Document"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">web page</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A document published on the World Wide Web and accessible via a Universal Resource Locator.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;brandName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">brand name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The name of marque by which the publisher is identified in its publications. This may or may not be identical to the legal name or the Trading As name, but represents a separate semantic. Usually to be found on book jackets, press releases etc.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;publishedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is published by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The organization which makes this information available.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;publisherIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">publisher identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A publisher of information may be identified as any Business Entity, including for example specialized publishing house, ratings agency, standards body and so on.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;publishes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;provides"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">publishes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-pub;uRL">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">u r l</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-pub;WebPage"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;URIValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The URL of the web page.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PublicationsExt/Standards.rdf
+++ b/fnd/PublicationsExt/Standards.rdf
@@ -1,128 +1,132 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-pub-std "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-pub-std "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-pub-std="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/">
-		<rdfs:label xml:lang="en">Standards</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-std;IndustryAssociation">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:label xml:lang="en">industry association</rdfs:label>
-		<skos:definition xml:lang="en">An organization which has membership drawn from members of some industry and acts to serve the interests of those members.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-std;StandardsBody">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:label xml:lang="en">standards body</rdfs:label>
-		<skos:definition xml:lang="en">An organization dedicated exclusively to the propagation of standards.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-std;StandardsSetter">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pub-std;standardsSetterIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standards setter</rdfs:label>
-		<skos:definition xml:lang="en">An agent which acts to set standards such as message standards, programming standards and so on. This may in principal be any kind of business entity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that by virtue of its activities the Standards Setter is also a Publisher, that is it publishes versions of the standards that it sets. However the activity of setting a standard is not itself a direct specialization of the activity of publishing, rather it is a by-product of that activity. This is why there is an apparently redundant parent relationship with Publisher.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-std;TechnicalStandard">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pub-std;hasStandardSetter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pub-std;StandardsSetter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pub-std;standardSetBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pub-std;StandardsBody"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">technical standard</rdfs:label>
-		<skos:definition xml:lang="en">An established norm or requirement about technical systems; a published document formally setting out such established norm.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;acronym">
-		<rdfs:label xml:lang="en">acronym</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The abbreviation by which the Standard is referred.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;bodyAcronym">
-		<rdfs:label xml:lang="en">body acronym</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-std;StandardsSetter"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The common acronym by which the standards body is referred in relation to the standards it sets e.g. FIX. Not necessarily the same as the legal name of the business entity that performs this role (e.g. FPL).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;hasStandardSetter">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-		<rdfs:label xml:lang="en">has standard setter</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pub-std;StandardsSetter"/>
-		<skos:definition xml:lang="en">The agency by which the standard is set.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be one of a range of types of entity; this relationship is defined in terms of some entity standing in the role of Standards Setter.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;standardName">
-		<rdfs:label xml:lang="en">standard name</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The full formal name of the standard.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;standardSetBy">
-		<rdfs:label xml:lang="en">standard set by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pub-std;StandardsBody"/>
-		<skos:definition xml:lang="en">A Standards Body which acts as the setter of the Standard.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the case whereby the entity which sets the standard is one which is specifically set up for the purpose of setting standards.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;standardsSetterIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publisherIdentity"/>
-		<rdfs:label xml:lang="en">standards setter identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-pub-std;StandardsSetter"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<skos:definition xml:lang="en">The entity which performs the role of Standards Setter.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This could be any type of Formal Organization.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-pub-std="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Standards</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Defines the notion of a standard as a kind of published artifact in which something is set out in a standardized and widely recognized way. 
+		This provides the conceptual underpinning for the notion that some published conventions are real because they are published in some standard, including FIBO itself. This model does not attempt to provide a detailed reflection of the standards process itself, it is merely the conceptual underpinning for the notion that certain codes and conventions are real because they are published in some standard.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Standards/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-std;IndustryAssociation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">industry association</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An organization which has membership drawn from members of some industry and acts to serve the interests of those members.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-std;StandardsBody">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standards body</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An organization dedicated exclusively to the propagation of standards.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-std;StandardsSetter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pub-std;standardsSetterIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standards setter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An agent which acts to set standards such as message standards, programming standards and so on. This may in principal be any kind of business entity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note that by virtue of its activities the Standards Setter is also a Publisher, that is it publishes versions of the standards that it sets. However the activity of setting a standard is not itself a direct specialization of the activity of publishing, rather it is a by-product of that activity. This is why there is an apparently redundant parent relationship with Publisher.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-std;TechnicalStandard">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pub-std;hasStandardSetter"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pub-std;StandardsSetter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pub-std;standardSetBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-pub-std;StandardsBody"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">technical standard</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An established norm or requirement about technical systems; a published document formally setting out such established norm.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;acronym">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">acronym</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The abbreviation by which the Standard is referred.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;bodyAcronym">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">body acronym</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-std;StandardsSetter"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The common acronym by which the standards body is referred in relation to the standards it sets e.g. FIX. Not necessarily the same as the legal name of the business entity that performs this role (e.g. FPL).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;hasStandardSetter">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has standard setter</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pub-std;StandardsSetter"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The agency by which the standard is set.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be one of a range of types of entity; this relationship is defined in terms of some entity standing in the role of Standards Setter.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;standardName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standard name</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The full formal name of the standard.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;standardSetBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standard set by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-std;TechnicalStandard"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-pub-std;StandardsBody"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Standards Body which acts as the setter of the Standard.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the case whereby the entity which sets the standard is one which is specifically set up for the purpose of setting standards.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-pub-std;standardsSetterIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publisherIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">standards setter identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-pub-std;StandardsSetter"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity which performs the role of Standards Setter.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This could be any type of Formal Organization.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/PublicationsExt/StandardsIndividuals.rdf
+++ b/fnd/PublicationsExt/StandardsIndividuals.rdf
@@ -1,36 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-pub-con "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
-	<!ENTITY fibo-fnd-pub-stdi "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-pub-con "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
+bu<!ENTITY fibo-fnd-pub-stdi "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/"
-	xmlns:fibo-fnd-pub-con="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"
-	xmlns:fibo-fnd-pub-stdi="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/">
-		<rdfs:label xml:lang="en">StandardsIndividuals</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-pub-stdi;EDMCouncilConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-con;IndustryModelConvention"/>
-		<rdfs:label xml:lang="en">e d m council convention</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-pub-con="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"
+buxmlns:fibo-fnd-pub-stdi="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">StandardsIndividuals</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology extends to the Standards ontology to name one or two individuals (e.g. ISO and the EDM Council) in order to provide the assertion that certain conventions or other information constructs are real things in the world. 
+		Note also that this ontology written included individuals, restriction and other ontology design patterns that were not supported in the original modeling toolset and will have been eroded by this point. This ontology, the Standards ontology and the Conventions ontology provide conceptual support for conventions and other codes as real things, and would play no role in any application ontology.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/StandardsIndividuals/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-pub-stdi;EDMCouncilConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-con;IndustryModelConvention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">e d m council convention</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/QuantitiesExt/QuantitiesAndUnitsExt.rdf
+++ b/fnd/QuantitiesExt/QuantitiesAndUnitsExt.rdf
@@ -1,119 +1,122 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-arrx-qtux "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesAndUnitsExt/">
-	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-arrx-qtux "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesAndUnitsExt/">
+bu<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesAndUnitsExt/"
-	xmlns:fibo-fnd-arrx-qtux="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesAndUnitsExt/"
-	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesAndUnitsExt/">
-		<rdfs:label xml:lang="en">QuantitiesAndUnitsExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesAndUnitsExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-qt-qtu;SystemOfQuantities">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Acceleration">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;MultiDimensionalProperty"/>
-		<rdfs:label xml:lang="en">Acceleration</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Charge">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
-		<rdfs:label xml:lang="en">Charge</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;CoherentDerivedUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;DerivedUnit"/>
-		<rdfs:label xml:lang="en">Coherent Derived Unit</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;CoherentSystemOfUnits">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;SystemOfUnits"/>
-		<rdfs:label xml:lang="en">Coherent System Of Units</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Dimension">
-		<rdfs:label xml:lang="en">Dimension</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;DimensionVector">
-		<rdfs:label xml:lang="en">Dimension Vector</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Energy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;MultiDimensionalProperty"/>
-		<rdfs:label xml:lang="en">Energy</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Force">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;MultiDimensionalProperty"/>
-		<rdfs:label xml:lang="en">Force</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Length">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
-		<rdfs:label xml:lang="en">Length</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Mass">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
-		<rdfs:label xml:lang="en">Mass</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;MultiDimensionalProperty">
-		<rdfs:label xml:lang="en">Multi Dimensional Property</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;RatioSystemOfQuantities">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;SystemOfQuantities"/>
-		<rdfs:label xml:lang="en">Ratio System Of Quantities</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Time">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
-		<rdfs:label xml:lang="en">Time</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-arrx-qtux;TroyWeightSystemOfQuantities">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;SystemOfQuantities"/>
-		<rdfs:label xml:lang="en">Troy Weight System Of Quantities</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-arrx-qtux;hasDimension">
-		<rdfs:label xml:lang="en">has dimension</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-qt-qtu;SystemOfQuantities"/>
-		<rdfs:range rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-arrx-qtux;hasVector">
-		<rdfs:label xml:lang="en">has vector</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
-		<rdfs:range rdf:resource="&fibo-fnd-arrx-qtux;DimensionVector"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-arrx-qtux;isDefinedUnder">
-		<rdfs:label xml:lang="en">is defined under</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-arrx-qtux;MultiDimensionalProperty"/>
-		<rdfs:range rdf:resource="&fibo-fnd-arrx-qtux;CoherentSystemOfUnits"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-arrx-qtux="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesAndUnitsExt/"
+buxmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesAndUnitsExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">QuantitiesAndUnitsExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extends the existing models of quantities and units of measure, within the broader conceptual framework.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesAndUnitsExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-qt-qtu;SystemOfQuantities">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Acceleration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;MultiDimensionalProperty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Acceleration</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Charge">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Charge</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;CoherentDerivedUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;DerivedUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Coherent Derived Unit</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;CoherentSystemOfUnits">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;SystemOfUnits"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Coherent System Of Units</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Dimension">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Dimension</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;DimensionVector">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Dimension Vector</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Energy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;MultiDimensionalProperty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Energy</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Force">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;MultiDimensionalProperty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Force</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Length">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Length</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Mass">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Mass</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;MultiDimensionalProperty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Multi Dimensional Property</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;RatioSystemOfQuantities">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;SystemOfQuantities"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Ratio System Of Quantities</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;Time">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Time</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-arrx-qtux;TroyWeightSystemOfQuantities">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;SystemOfQuantities"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Troy Weight System Of Quantities</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-arrx-qtux;hasDimension">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has dimension</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-qt-qtu;SystemOfQuantities"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-arrx-qtux;hasVector">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has vector</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-arrx-qtux;Dimension"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-arrx-qtux;DimensionVector"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-arrx-qtux;isDefinedUnder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is defined under</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-arrx-qtux;MultiDimensionalProperty"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-arrx-qtux;CoherentSystemOfUnits"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/QuantitiesExt/QuantitiesExt.rdf
+++ b/fnd/QuantitiesExt/QuantitiesExt.rdf
@@ -1,134 +1,137 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/">
-	<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/">
+bu<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/"
-	xmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
-		<rdfs:label xml:lang="en">Quantities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;Barrel">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;ReferenceMaterial"/>
-		<rdfs:label xml:lang="en">Barrel</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;DiscountedValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;MeasuredValue"/>
-		<rdfs:label xml:lang="en">Discounted Value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;MeasurableQuantity">
-		<rdfs:label xml:lang="en">Measurable Quantity</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;MeasuredValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
-		<rdfs:label xml:lang="en">Measured Value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;MeasurementProcedure">
-		<rdfs:label xml:lang="en">Measurement Procedure</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;MonetaryReference">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;QuantityReference"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-quax-qua;takesReferenceForm"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">Monetary Reference</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;MonetaryValuationProcedure">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;MeasurementProcedure"/>
-		<rdfs:label xml:lang="en">Monetary Valuation Procedure</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;QuantityReference">
-		<rdfs:label xml:lang="en">Quantity Reference</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;QuantityReferent">
-		<rdfs:label xml:lang="en">Quantity Referent</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-quax-qua;ReferenceMaterial">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-quax-qua;Unit">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-quax-qua;UnitaryValue">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;ReferenceMaterial">
-		<rdfs:label xml:lang="en">Reference Material</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-		<owl:disjointWith rdf:resource="&fibo-fnd-quax-qua;UnitaryValue"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;Unit">
-		<rdfs:label xml:lang="en">Unit</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-quax-qua;UnitaryValue"/>
-		<owl:equivalentClass rdf:resource="&fibo-fnd-qt-qtu;MeasurementUnit"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-quax-qua;UnitaryValue">
-		<rdfs:label xml:lang="en">Unitary Value</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-quax-qua;mayBeTreatedAs">
-		<rdfs:label xml:lang="en">may be treated as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-quax-qua;ReferenceMaterial"/>
-		<rdfs:range rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-quax-qua;resultsIn">
-		<rdfs:label xml:lang="en">results in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-quax-qua;MeasurementProcedure"/>
-		<rdfs:range rdf:resource="&fibo-fnd-quax-qua;UnitaryValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-quax-qua;resultsInMeasuredValue">
-		<rdfs:label xml:lang="en">results in measured value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-quax-qua;MonetaryValuationProcedure"/>
-		<rdfs:range rdf:resource="&fibo-fnd-quax-qua;MeasuredValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-quax-qua;takesReferenceForm">
-		<rdfs:label xml:lang="en">takes reference form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-quax-qua;QuantityReference"/>
-		<rdfs:range rdf:resource="&fibo-fnd-quax-qua;QuantityReferent"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/"
+buxmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Quantities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extends the existing models of quantities and units of measure, within the broader conceptual framework.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;Barrel">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;ReferenceMaterial"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Barrel</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;DiscountedValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;MeasuredValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Discounted Value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;MeasurableQuantity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Measurable Quantity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;MeasuredValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Measured Value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;MeasurementProcedure">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Measurement Procedure</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;MonetaryReference">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;QuantityReference"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-quax-qua;takesReferenceForm"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Monetary Reference</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;MonetaryValuationProcedure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;MeasurementProcedure"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Monetary Valuation Procedure</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;QuantityReference">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Quantity Reference</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;QuantityReferent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Quantity Referent</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-quax-qua;ReferenceMaterial">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-quax-qua;Unit">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-quax-qua;UnitaryValue">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;ReferenceMaterial">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Reference Material</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-quax-qua;UnitaryValue"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;Unit">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Unit</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-quax-qua;UnitaryValue"/>
+bubu<owl:equivalentClass rdf:resource="&fibo-fnd-qt-qtu;MeasurementUnit"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-quax-qua;UnitaryValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Unitary Value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-quax-qua;mayBeTreatedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be treated as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-quax-qua;ReferenceMaterial"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-quax-qua;resultsIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-quax-qua;MeasurementProcedure"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-quax-qua;UnitaryValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-quax-qua;resultsInMeasuredValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in measured value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-quax-qua;MonetaryValuationProcedure"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-quax-qua;MeasuredValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-quax-qua;takesReferenceForm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes reference form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-quax-qua;QuantityReference"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-quax-qua;QuantityReferent"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/RiskExt/Risk.rdf
+++ b/fnd/RiskExt/Risk.rdf
@@ -1,239 +1,243 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-risk-risk "https://spec.edmcouncil.org/fibo/FND/RiskExt/Risk/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-bus-bg "https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-risk-risk "https://spec.edmcouncil.org/fibo/FND/RiskExt/Risk/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/RiskExt/Risk/"
-	xmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-risk-risk="https://spec.edmcouncil.org/fibo/FND/RiskExt/Risk/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/RiskExt/Risk/">
-		<rdfs:label xml:lang="en">Risk</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/RiskExt/Risk/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;Consequence">
-		<rdfs:label xml:lang="en">consequence</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;CreditRisk">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;FinancialRisk"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;LossGivenDefault"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;probability"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;ProbabilityOfDefault"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit risk</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;FinancialRisk">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Risk"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;FinancialRiskConsequence"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial risk</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;FinancialRiskConsequence">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Impact"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impactsUpon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial risk consequence</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;FinancialTransactionRisk">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;FinancialRisk"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;OperationalRisk"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;TransactionFailure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial transaction risk</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;Impact">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Consequence"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impactsUpon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">impact</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;LossGivenDefault">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Impact"/>
-		<rdfs:label xml:lang="en">loss given default</rdfs:label>
-		<skos:definition xml:lang="en">The loss given some default.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;OperationalRisk">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Risk"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;OperationalRiskConsequence"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">operational risk</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;OperationalRiskConsequence">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Impact"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impactsUpon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;CorporateGoal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">operational risk consequence</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;PerceptionOfRisk">
-		<rdfs:label xml:lang="en">perception of risk</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;ProbabilityOfDefault">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Probability"/>
-		<rdfs:label xml:lang="en">probability of default</rdfs:label>
-		<skos:definition xml:lang="en">The probability of some default on some obligation.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;ProjectRisk">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Risk"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;ProjectRiskConsequence"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">project risk</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;ProjectRiskConsequence">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Impact"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impactsUpon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;ProjectGoal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">project risk consequence</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;Risk">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;Impact"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;isRiskOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;RiskStateTransition"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;probability"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Probability"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">risk</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;RiskStateTransition">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;eventHasConsequence"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;Consequence"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">risk state transition</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-risk-risk;TransactionFailure">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;OperationalRiskConsequence"/>
-		<rdfs:label xml:lang="en">transaction failure</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;eventHasConsequence">
-		<rdfs:label xml:lang="en">event has consequence</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;RiskStateTransition"/>
-		<rdfs:range rdf:resource="&fibo-fnd-risk-risk;Consequence"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;impact">
-		<rdfs:label xml:lang="en">impact</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;CreditRisk"/>
-		<rdfs:range rdf:resource="&fibo-fnd-risk-risk;LossGivenDefault"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;impact.1">
-		<rdfs:label xml:lang="en">impact</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;Risk"/>
-		<rdfs:range rdf:resource="&fibo-fnd-risk-risk;Impact"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;impact.2">
-		<rdfs:label xml:lang="en">impact</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;FinancialTransactionRisk"/>
-		<rdfs:range rdf:resource="&fibo-fnd-risk-risk;TransactionFailure"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;impactsUpon">
-		<rdfs:label xml:lang="en">impacts upon</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;Impact"/>
-		<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;isRiskOf">
-		<rdfs:label xml:lang="en">is risk of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;Risk"/>
-		<rdfs:range rdf:resource="&fibo-fnd-risk-risk;RiskStateTransition"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;probability">
-		<rdfs:label xml:lang="en">probability</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;Risk"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;Probability"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-bus-bg="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-risk-risk="https://spec.edmcouncil.org/fibo/FND/RiskExt/Risk/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/RiskExt/Risk/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Risk</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Risk is defined here as the product of the probability of some event and the impact of that event on some goal. Categories of risk are defined in terms of the different kinds of goal that the event would impact, to distinguish between operational and various forms of financial risk. Other categorizations are also possible based on probabilities or on differences in the kinds of events themselves. 
+		Note that a risk event is generally an event that does not happen, so it will be beneficial in future work to make use of the extended sub-partitions of Occurrent to provide a clearer segregation across the model between actual events and mostly avoided or hypothetical events.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/BusinessExt/BusinessGoals/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/RiskExt/Risk/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;Consequence">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consequence</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;CreditRisk">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;FinancialRisk"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;LossGivenDefault"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;probability"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;ProbabilityOfDefault"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit risk</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;FinancialRisk">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Risk"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;FinancialRiskConsequence"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial risk</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;FinancialRiskConsequence">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Impact"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impactsUpon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;InvestmentGoal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial risk consequence</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;FinancialTransactionRisk">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;FinancialRisk"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;OperationalRisk"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;TransactionFailure"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial transaction risk</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;Impact">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Consequence"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impactsUpon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">impact</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;LossGivenDefault">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Impact"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loss given default</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The loss given some default.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;OperationalRisk">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Risk"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;OperationalRiskConsequence"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">operational risk</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;OperationalRiskConsequence">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Impact"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impactsUpon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;CorporateGoal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">operational risk consequence</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;PerceptionOfRisk">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">perception of risk</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;ProbabilityOfDefault">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Probability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">probability of default</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The probability of some default on some obligation.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;ProjectRisk">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Risk"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;ProjectRiskConsequence"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">project risk</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;ProjectRiskConsequence">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;Impact"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impactsUpon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-bus-bg;ProjectGoal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">project risk consequence</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;Risk">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;impact.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;Impact"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;isRiskOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;RiskStateTransition"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;probability"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Probability"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">risk</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;RiskStateTransition">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-risk-risk;eventHasConsequence"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-risk-risk;Consequence"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">risk state transition</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-risk-risk;TransactionFailure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-risk-risk;OperationalRiskConsequence"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction failure</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;eventHasConsequence">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">event has consequence</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;RiskStateTransition"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-risk-risk;Consequence"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;impact">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">impact</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;CreditRisk"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-risk-risk;LossGivenDefault"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;impact.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">impact</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;Risk"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-risk-risk;Impact"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;impact.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">impact</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;FinancialTransactionRisk"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-risk-risk;TransactionFailure"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;impactsUpon">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">impacts upon</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;Impact"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-bus-bg;BusinessGoal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;isRiskOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is risk of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;Risk"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-risk-risk;RiskStateTransition"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-risk-risk;probability">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">probability</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-risk-risk;Risk"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;Probability"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/SocialConstructsExt/ConstructAspects.rdf
+++ b/fnd/SocialConstructsExt/ConstructAspects.rdf
@@ -1,263 +1,266 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
-	<!ENTITY fibo-fnd-soc-pty "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/">
-	<!ENTITY fibo-fnd-soc-soc "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
+bu<!ENTITY fibo-fnd-soc-pty "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/">
+bu<!ENTITY fibo-fnd-soc-soc "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
-	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
-	xmlns:fibo-fnd-soc-pty="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"
-	xmlns:fibo-fnd-soc-soc="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
-		<rdfs:label xml:lang="en">ConstructAspects</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-lp;LegalPerson">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-aap-ppl;Person">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;Claim">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LegalConstruct"/>
-		<rdfs:label xml:lang="en">claim</rdfs:label>
-		<skos:definition xml:lang="en">A claim by one party on another, which arises from the existence of a Commitment agreed upon between those parties or as implicitly agreed upon through the operation of Law or Constitution.</skos:definition>
-		<skos:editorialNote xml:lang="en">Originally introduced as part of REA alignment, to link Commitments (in the round) to party-specific aspects of that commitment. Subsequent feedback from Bill McCarthy indicates that this is equivalent to the REA concept of Claim.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;ConditionalObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-		<rdfs:label xml:lang="en">conditional obligation</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-soc-asp;UnconditionalObligation"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;ConditionalRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-		<rdfs:label xml:lang="en">conditional right</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-soc-asp;UnconditionalRight"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;ConstitutionalRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-cor;Constitution"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">constitutional right</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;ContingentObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;Claim"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;impliedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;incurredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lei;ContractuallyCapableEntity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;inRespectOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;undertakenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-pty;Obligor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contingent obligation</rdfs:label>
-		<skos:definition xml:lang="en">Some obligation set out by some contract or by law, mandated upon some party.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example the obligation to pay some cash flows or to allow some party to occupy some residence unmolested. A tighter legal definition would be beneficial, but this term is almost axiomatic to law.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;ContingentRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;Claim"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;enjoyedBy"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-le-lp;LegalPerson">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-fnd-aap-ppl;Person">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;impliesSome"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;accruesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contingent right</rdfs:label>
-		<skos:definition xml:lang="en">Some right conferred by some contract or by law.</skos:definition>
-		<skos:editorialNote xml:lang="en">A tighter legal definition of right itself would be beneficial, but this term is almost axiomatic to law. A Right conveys the ability to compel the behavior of another party. A right always carries the choice for the holder to exercise it - otherwise it would become an Obligation.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;LegalObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;mandatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">legal obligation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;LegalRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">legal right</rdfs:label>
-		<skos:definition xml:lang="en">A right conferred by some law.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;ObligationConditionalOnSomeCircumstance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ConditionalObligation"/>
-		<rdfs:label xml:lang="en">obligation conditional on some circumstance</rdfs:label>
-		<skos:definition xml:lang="en">An Obligation which is conditional on the existence or continuing existence of some circumstance.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are situational conditions, e.g. if after 90 days the insured party has failed to remedy some condition (e.g. the lowering of credit in the above) then another obligation occurs. Situation has to continue for a duration. Example if your credit rating has lowered and has remained low during the entirety of a 90 day period. If it goes back out of that window and back again, then the reappearance within that window is the start of a new 90 day period.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;ObligationConditionalOnSomeEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ConditionalObligation"/>
-		<rdfs:label xml:lang="en">obligation conditional on some event</rdfs:label>
-		<skos:definition xml:lang="en">Obligation conditional on the occurrence of some event.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An event is something which happens at some point in time. e.g. the obligation on the party being insured to increase the amount of posted collateral in the event of a change to credit rating.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;UnconditionalObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-		<rdfs:label xml:lang="en">unconditional obligation</rdfs:label>
-		<skos:definition xml:lang="en">An obligation which is not conditional on the occurrence of any event or the existence or continuation of any condition.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-asp;UnconditionalRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-		<rdfs:label xml:lang="en">unconditional right</rdfs:label>
-		<skos:definition xml:lang="en">A right to which no conditions are applied. Further Notes; these may be moral, consititutional. Contractual and so on.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;contractualCommitmentDescribes">
-		<rdfs:label xml:lang="en">contractual commitment describes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-soc-asp;Claim"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;enjoyedBy">
-		<rdfs:label xml:lang="en">enjoyed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-be-le-lp;LegalPerson">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-aap-ppl;Person">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-		<skos:definition xml:lang="en">That which enjoys the right.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a union of types of entity which may enjoy rights. This is broader than the set of entities that may have obligations (including those corresponding to such rights) because it includes human beings under the age of majority (minors) who are not in any other sense legal entities, and also includes legal entities which are not human beings, since rights can be extended to such by contractual agreement. It does not include other types of autonomous entity (animals, automata etc.) since these by definition have no rights. There is some ambiguity at present about non human &quot;persons&quot; i.e. intelligent and self-aware animals, but this is a relatively new legal concept and not relevant to our scope.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;impliedBy">
-		<rdfs:label xml:lang="en">implied by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-soc-asp;impliesSome"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;impliesSome">
-		<rdfs:label xml:lang="en">implies some</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-		<rdfs:range rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;incurredBy">
-		<rdfs:label xml:lang="en">incurred by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lei;ContractuallyCapableEntity"/>
-		<skos:definition xml:lang="en">An obligation may be incurred by any Legal Entity, either through duty at law or by agreement in a contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It is assumed that anything which is not a Legal Entity does not or cannot incur any obligation, that is that in the case of any duty or obligation falling to some non legal entity, such as a Trust, this ultimately unwinds as being a duty or obligation on the part of some legal entity, usually identified by whatever formal contract binds the various legal entities in that undertaking and defines the various duties and obligations that they severally incur or would incur under given circumstances.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;mandatedBy">
-		<rdfs:label xml:lang="en">mandated by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;LegalObligation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
+buxmlns:fibo-fnd-soc-pty="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"
+buxmlns:fibo-fnd-soc-soc="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ConstructAspects</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology sets out the concepts of some aspect of a social construct, using the conceptual notion of aspects defined elsewhere. This forms the basis for relating commitments to rights and obligations as aspects of commitments, and thereby as something that can be reflected in a general ledger account.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-lp;LegalPerson">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-aap-ppl;Person">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-ctr;ContractualCommitment">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;Claim">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;LegalConstruct"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">claim</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A claim by one party on another, which arises from the existence of a Commitment agreed upon between those parties or as implicitly agreed upon through the operation of Law or Constitution.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Originally introduced as part of REA alignment, to link Commitments (in the round) to party-specific aspects of that commitment. Subsequent feedback from Bill McCarthy indicates that this is equivalent to the REA concept of Claim.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;ConditionalObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conditional obligation</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-soc-asp;UnconditionalObligation"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;ConditionalRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conditional right</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-soc-asp;UnconditionalRight"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;ConstitutionalRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-cor;Constitution"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">constitutional right</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;ContingentObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;Claim"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;impliedBy"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;incurredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-lei;ContractuallyCapableEntity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;inRespectOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;undertakenBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-pty;Obligor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contingent obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some obligation set out by some contract or by law, mandated upon some party.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example the obligation to pay some cash flows or to allow some party to occupy some residence unmolested. A tighter legal definition would be beneficial, but this term is almost axiomatic to law.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;ContingentRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;Claim"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;enjoyedBy"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-be-le-lp;LegalPerson">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-fnd-aap-ppl;Person">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;impliesSome"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;accruesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contingent right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some right conferred by some contract or by law.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">A tighter legal definition of right itself would be beneficial, but this term is almost axiomatic to law. A Right conveys the ability to compel the behavior of another party. A right always carries the choice for the holder to exercise it - otherwise it would become an Obligation.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;LegalObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-asp;mandatedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal obligation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;LegalRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A right conferred by some law.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;ObligationConditionalOnSomeCircumstance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ConditionalObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obligation conditional on some circumstance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Obligation which is conditional on the existence or continuing existence of some circumstance.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are situational conditions, e.g. if after 90 days the insured party has failed to remedy some condition (e.g. the lowering of credit in the above) then another obligation occurs. Situation has to continue for a duration. Example if your credit rating has lowered and has remained low during the entirety of a 90 day period. If it goes back out of that window and back again, then the reappearance within that window is the start of a new 90 day period.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;ObligationConditionalOnSomeEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ConditionalObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obligation conditional on some event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Obligation conditional on the occurrence of some event.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">An event is something which happens at some point in time. e.g. the obligation on the party being insured to increase the amount of posted collateral in the event of a change to credit rating.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;UnconditionalObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unconditional obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An obligation which is not conditional on the occurrence of any event or the existence or continuation of any condition.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-asp;UnconditionalRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unconditional right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A right to which no conditions are applied. Further Notes; these may be moral, consititutional. Contractual and so on.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;contractualCommitmentDescribes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual commitment describes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-soc-asp;Claim"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;enjoyedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">enjoyed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-be-le-lp;LegalPerson">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-aap-ppl;Person">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That which enjoys the right.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a union of types of entity which may enjoy rights. This is broader than the set of entities that may have obligations (including those corresponding to such rights) because it includes human beings under the age of majority (minors) who are not in any other sense legal entities, and also includes legal entities which are not human beings, since rights can be extended to such by contractual agreement. It does not include other types of autonomous entity (animals, automata etc.) since these by definition have no rights. There is some ambiguity at present about non human &quot;persons&quot; i.e. intelligent and self-aware animals, but this is a relatively new legal concept and not relevant to our scope.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;impliedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">implied by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-soc-asp;impliesSome"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;impliesSome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">implies some</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;incurredBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incurred by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-lei;ContractuallyCapableEntity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An obligation may be incurred by any Legal Entity, either through duty at law or by agreement in a contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">It is assumed that anything which is not a Legal Entity does not or cannot incur any obligation, that is that in the case of any duty or obligation falling to some non legal entity, such as a Trust, this ultimately unwinds as being a duty or obligation on the part of some legal entity, usually identified by whatever formal contract binds the various legal entities in that undertaking and defines the various duties and obligations that they severally incur or would incur under given circumstances.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-asp;mandatedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandated by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;LegalObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/SocialConstructsExt/LegalConstructParties.rdf
+++ b/fnd/SocialConstructsExt/LegalConstructParties.rdf
@@ -1,56 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-soc-pty "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-soc-pty "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"
-	xmlns:fibo-fnd-soc-pty="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/">
-		<rdfs:label xml:lang="en">LegalConstructParties</rdfs:label>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-pty;Beneficiary">
-		<rdfs:label xml:lang="en">beneficiary</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-pty;Obligor">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;obligedTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">obligor</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-pty;accruesTo">
-		<rdfs:label>accrues to</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-pty;inRespectOf">
-		<rdfs:label>in respect of</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-pty;obligedTo">
-		<rdfs:label xml:lang="en">obliged to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-soc-pty;Obligor"/>
-		<rdfs:range rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-pty;undertakenBy">
-		<rdfs:label>undertaken by</rdfs:label>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-soc-pty="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LegalConstructParties</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Describes the various kinds of party to different kinds of legal construct, these being specializations of social constructs.</dct:abstract>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/LegalConstructParties/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-pty;Beneficiary">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">beneficiary</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-pty;Obligor">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-pty;obligedTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obligor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-pty;accruesTo">
+bubu<rdfs:label>accrues to</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-pty;inRespectOf">
+bubu<rdfs:label>in respect of</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-pty;obligedTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obliged to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-soc-pty;Obligor"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-soc-pty;Beneficiary"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-pty;undertakenBy">
+bubu<rdfs:label>undertaken by</rdfs:label>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/SocialConstructsExt/SocialConstructs.rdf
+++ b/fnd/SocialConstructsExt/SocialConstructs.rdf
@@ -1,199 +1,203 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
-	<!ENTITY fibo-fnd-soc-soc "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-aap-agt "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
+bu<!ENTITY fibo-fnd-soc-soc "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/"
-	xmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
-	xmlns:fibo-fnd-soc-soc="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/">
-		<rdfs:label xml:lang="en">SocialConstructs</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-aap-agt;AutonomousAgent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-soc;hasCapacity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-soc;ConferredSocialConstruct"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;Ability">
-		<rdfs:label xml:lang="en">ability</rdfs:label>
-		<skos:definition xml:lang="en">The possession of the means to do a thing</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;AlienableRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
-		<rdfs:label xml:lang="en">alienable right</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-soc-soc;InalienableRight"/>
-		<skos:definition xml:lang="en">A right which can be taken away from the entity that holds it</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;Authority">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-soc-soc;isConferredBySomeAutonomousAgent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">authority</rdfs:label>
-		<skos:definition xml:lang="en">The right to do something, as conferred by some autonomous agent</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;Capability">
-		<rdfs:label xml:lang="en">capability</rdfs:label>
-		<skos:definition xml:lang="en">The ability of a thing to do or have done to it</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;Capacity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Ability"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
-		<rdfs:label xml:lang="en">capacity</rdfs:label>
-		<skos:definition xml:lang="en">The right to do a thing along with the actual e.g. physical ability to do that thing.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;CompulsionCapacity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Control"/>
-		<rdfs:label xml:lang="en">compulsion capacity</rdfs:label>
-		<skos:definition xml:lang="en">The ability to compel the activities of a thing</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;ConferredSocialConstruct">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;SocialConstruct"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">conferred social construct</rdfs:label>
-		<skos:definition xml:lang="en">Some social construct that is conferred on some autonomous entity</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;Control">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Capacity"/>
-		<rdfs:label xml:lang="en">control</rdfs:label>
-		<skos:definition xml:lang="en">The ability to direct the activities of a thing</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The right to determine an action</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;DispositionRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
-		<rdfs:label xml:lang="en">disposition right</rdfs:label>
-		<skos:definition xml:lang="en">The right to dispose of a thing as one sees fit</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;HoldingRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
-		<rdfs:label xml:lang="en">holding right</rdfs:label>
-		<skos:definition xml:lang="en">The right to hold a thing</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;InalienableRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
-		<rdfs:label xml:lang="en">inalienable right</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;InherentPotential">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Capability"/>
-		<rdfs:label xml:lang="en">inherent potential</rdfs:label>
-		<skos:definition xml:lang="en">The inherent potential to be able do a thing. This is the capability of acquiring the ability to do a thing. Further Notes The synonym &quot;Capacity&quot; for this concept is itself is a homonym of Capacity in the sense of the cubic capacity of some vessel. The thing this is a capability of, is the act of learning or acquiring some other ability.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;Privilege">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;AlienableRight"/>
-		<rdfs:label xml:lang="en">privilege</rdfs:label>
-		<skos:definition xml:lang="en">The alienable liberty to do something.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the kind of privilege which is able to be taken away, which is really a partial or conditional right.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;Responsibility">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-		<rdfs:label xml:lang="en">responsibility</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;Right">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;ConferredSocialConstruct"/>
-		<rdfs:label xml:lang="en">right</rdfs:label>
-		<skos:definition xml:lang="en">entitlement (not) to perform certain actions, or (not) to be in certain states; or entitlement that others (not) perform certain actions or (not) be in certain states Stanford Encyclopedia of Philosophy</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;RightsAllocationAbility">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
-		<rdfs:label xml:lang="en">rights allocation ability</rdfs:label>
-		<skos:definition xml:lang="en">The ability to reallocate rights Similarly Authority is the authority to impose some duties on others. Someone has the right to carry out the authority that imposes duties on another person, or to command them to do it.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;SocialConstruct">
-		<rdfs:label xml:lang="en">social construct</rdfs:label>
-		<skos:definition xml:lang="en">Something which has its existence as a result of social interactions between and among people.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This forms the basic concept set out in Searle&apos;s Ontology, with specific social constructs being sub types of this.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;TreatmentCapability">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Capability"/>
-		<rdfs:label xml:lang="en">treatment capability</rdfs:label>
-		<skos:definition xml:lang="en">Whereby it is possible that a thing can be treated according to these constructs</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-soc-soc;UnconditionalPrivilege">
-		<rdfs:label xml:lang="en">unconditional privilege</rdfs:label>
-		<skos:definition xml:lang="en">The liberty to do something.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is distinct from the kind of privilege which is able to be taken away, which is really a partial or conditional right. Here Privilege is synonymous with one use of Liberty, that is it is the unconditional liberty to do something, and as such as no corresponding Obligation.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-soc;hasCapacity">
-		<rdfs:label xml:lang="en">has capacity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-soc-soc;ConferredSocialConstruct"/>
-		<skos:definition xml:lang="en">The entity has some legal capacity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-soc;isCapabilityToDo">
-		<rdfs:label xml:lang="en">is capability to do</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-soc-soc;Ability"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-soc-soc;isConferredBySomeAutonomousAgent">
-		<rdfs:label xml:lang="en">is conferred by some autonomous agent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-soc-soc;Authority"/>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-aap-agt="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
+buxmlns:fibo-fnd-soc-soc="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SocialConstructs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This is the core ontology setting out the notion of a socal construct. 
+		At present this is just a placeholder for the concept of social construct itself. Future work would refine these concepts in line with Searle’s published ontology of social constructs, for example to reflect the pattern whereby X counts as Y in context C. This would use the existing relative things pattern.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/SocialConstructs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-aap-agt;AutonomousAgent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-soc;hasCapacity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-soc;ConferredSocialConstruct"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;Ability">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ability</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The possession of the means to do a thing</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;AlienableRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">alienable right</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-soc-soc;InalienableRight"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A right which can be taken away from the entity that holds it</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;Authority">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-soc-soc;isConferredBySomeAutonomousAgent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">authority</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right to do something, as conferred by some autonomous agent</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;Capability">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">capability</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The ability of a thing to do or have done to it</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;Capacity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Ability"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">capacity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right to do a thing along with the actual e.g. physical ability to do that thing.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;CompulsionCapacity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Control"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">compulsion capacity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The ability to compel the activities of a thing</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;ConferredSocialConstruct">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;SocialConstruct"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conferred social construct</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some social construct that is conferred on some autonomous entity</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;Control">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Capacity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">control</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The ability to direct the activities of a thing</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The right to determine an action</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;DispositionRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">disposition right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right to dispose of a thing as one sees fit</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;HoldingRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holding right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right to hold a thing</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;InalienableRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inalienable right</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;InherentPotential">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Capability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inherent potential</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The inherent potential to be able do a thing. This is the capability of acquiring the ability to do a thing. Further Notes The synonym &quot;Capacity&quot; for this concept is itself is a homonym of Capacity in the sense of the cubic capacity of some vessel. The thing this is a capability of, is the act of learning or acquiring some other ability.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;Privilege">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;AlienableRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">privilege</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The alienable liberty to do something.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the kind of privilege which is able to be taken away, which is really a partial or conditional right.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;Responsibility">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">responsibility</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;Right">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;ConferredSocialConstruct"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">entitlement (not) to perform certain actions, or (not) to be in certain states; or entitlement that others (not) perform certain actions or (not) be in certain states Stanford Encyclopedia of Philosophy</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;RightsAllocationAbility">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Right"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rights allocation ability</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The ability to reallocate rights Similarly Authority is the authority to impose some duties on others. Someone has the right to carry out the authority that imposes duties on another person, or to command them to do it.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;SocialConstruct">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">social construct</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something which has its existence as a result of social interactions between and among people.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This forms the basic concept set out in Searle&apos;s Ontology, with specific social constructs being sub types of this.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;TreatmentCapability">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-soc;Capability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">treatment capability</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whereby it is possible that a thing can be treated according to these constructs</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-soc-soc;UnconditionalPrivilege">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unconditional privilege</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The liberty to do something.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is distinct from the kind of privilege which is able to be taken away, which is really a partial or conditional right. Here Privilege is synonymous with one use of Liberty, that is it is the unconditional liberty to do something, and as such as no corresponding Obligation.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-soc;hasCapacity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has capacity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-soc-soc;ConferredSocialConstruct"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The entity has some legal capacity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-soc;isCapabilityToDo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is capability to do</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-soc-soc;Ability"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-soc-soc;isConferredBySomeAutonomousAgent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is conferred by some autonomous agent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-soc-soc;Authority"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TimeExt/Time.rdf
+++ b/fnd/TimeExt/Time.rdf
@@ -1,1176 +1,1180 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-ext-snap-par-wt "https://spec.edmcouncil.org/fibo/EXT/snap/partial/W3CTime/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
-	<!ENTITY fibo-fnd-pub-con "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
-	<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-mm-trd "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-ext-snap-par-wt "https://spec.edmcouncil.org/fibo/EXT/snap/partial/W3CTime/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
+bu<!ENTITY fibo-fnd-pub-con "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
+bu<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-mm-trd "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-ext-snap-par-wt="https://spec.edmcouncil.org/fibo/EXT/snap/partial/W3CTime/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
-	xmlns:fibo-fnd-pub-con="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"
-	xmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-mm-trd="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-		<rdfs:label xml:lang="en">Time</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;AgencyDeterminedDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
-		<rdfs:label xml:lang="en">agency determined date</rdfs:label>
-		<skos:definition xml:lang="en">A date which is or which is to be determined by some external agency.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;BusinessCalendarCode">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeElement"/>
-		<rdfs:label xml:lang="en">business calendar code</rdfs:label>
-		<skos:definition xml:lang="en">The Calendar for a particular business center, which defines what are the working days in that center.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the identification code for the calendar, not the calendar of dates itself. This code uniquely identifies the business calendar in which business days are defined. This is usually published year on year, but formal terms only need to identify the Calendar so that events are understood to be specified in terms of that calendar.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;BusinessDay">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;definedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;BusinessCalendarCode"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">business day</rdfs:label>
-		<skos:definition xml:lang="en">A working day as defined in the Business Calendar for a particular business center.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;BusinessDayConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-con;Convention"/>
-		<rdfs:label xml:lang="en">business day convention</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;BusinessDayType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
-		<rdfs:label xml:lang="en">business day type</rdfs:label>
-		<skos:definition xml:lang="en">When calculating the number of days between two dates the count includes only business days.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;CalculatedDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
-		<rdfs:label xml:lang="en">calculated date</rdfs:label>
-		<skos:definition xml:lang="en">A Date which is calculated according to some defined formula or calculation method. The results of such calculation are not known in the present, e.g. one or more parameters for the calculation are not yet known.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;CalculatedDateOffset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalculatedTimeOffset"/>
-		<rdfs:label xml:lang="en">calculated date offset</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;CalculatedTimeOffset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalThing"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TimeOffset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determination"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDetermination"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">calculated time offset</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;CalendarDay">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
-		<rdfs:label xml:lang="en">calendar day</rdfs:label>
-		<skos:definition xml:lang="en">A day. This is the time it takes the Sun to orbit the Earth, without any additional qualifications or rules applied.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;CalendarDayType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
-		<rdfs:label xml:lang="en">calendar day type</rdfs:label>
-		<skos:definition xml:lang="en">When calculating the number of days between two dates the count includes all calendar days.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;CalendarTemporalUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
-		<rdfs:label xml:lang="en">calendar temporal unit</rdfs:label>
-		<skos:definition xml:lang="en">A Temporal Unit (measure of time) which is to be found in a regular calendar, i.e. a day, month etc., as distinct from units with additional parameters such as business days.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is similar to the FpML enumeration &quot;PeriodEnum&quot;, with the exception that this does not include &quot;Term&quot; since that is not a calendar unit and is only meaningful in relation to the specific instrument.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;CommodityBusinessDayType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
-		<rdfs:label xml:lang="en">commodity business day type</rdfs:label>
-		<skos:definition xml:lang="en">When calculating the number of days between two dates the count includes only commodity business days.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;ContractualDateSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateSpecification"/>
-		<rdfs:label xml:lang="en">contractual date specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a date in a contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;ContractuallyDeterminedDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;contractuallyDeterminedWithReferenceTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DateDeterminationTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractually determined date</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;ContractuallySpecifiedDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedDate"/>
-		<rdfs:label xml:lang="en">contractually specified date</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;ConventionDeterminedDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
-		<rdfs:label xml:lang="en">convention determined date</rdfs:label>
-		<skos:definition xml:lang="en">A Date which is or is to be determined according to some established or published convention for date determination.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;CurrencyBusinessDayType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
-		<rdfs:label xml:lang="en">currency business day type</rdfs:label>
-		<skos:definition xml:lang="en">When calculating the number of days between two dates the count includes only currency business days.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Date">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Instant"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;occursOnDate"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">date</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateCalculation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
-		<rdfs:label xml:lang="en">date calculation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDescription">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateTimeDescription"/>
-		<rdfs:label xml:lang="en">date description</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;InstantDetermination"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;reference.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">date determination</rdfs:label>
-		<skos:definition xml:lang="en">The determination or adjustment of some date according to some rule.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminationAgency">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
-		<rdfs:label xml:lang="en">date determination agency</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminationConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
-		<rdfs:label xml:lang="en">date determination convention</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminationReferenceRule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;modifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;modifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">date determination reference rule</rdfs:label>
-		<skos:definition xml:lang="en">A rule for determining a date or for making adjustments from a date determined by some means, to return another date, for example adjusting from a non working to a working date.</skos:definition>
-		<skos:editorialNote xml:lang="en">These kinds of rules are referred to in two separate FpML enumerations, the &quot;BusinessDayConventionEnum&quot; for determining when a returned date is rolled to a suitable business day, and one for scheduled event dates (called, confusingly &quot;Roll&quot; dates) as defined in &quot;RollConventionEnum&quot;. One such rule appears in both. Also included in this set of rules is the optional rule for further modifying the date returned by a date roll rule. In FpML description for &quot;BusinessDayConventionEnum&quot;: &quot;The convention for adjusting any relevant date if it would otherwise fall on a day that is not a valid business day. Note that FRN is included here as a type of business day convention although it does not strictly fall within ISDA&apos;s definition of a Business Day Convention and does not conform to the simple definition given above.&quot; These rules (with the possible exception of &quot;FRN&quot;) are applied to dates returned by some date specification or parametric schedule specification or some other such rule, and detail treatment of those returned dates in the event of them being for example a working day, being in the wrong month or year and so on. The Date Roll Rule operates on the date returned by the date specification or parametric schedule, and return a further date. If the Date Roll Rule is used alone, that is the final date to be returned from the entire specification or parametric schedule, as the date on which the scheduled event is to take place. In the case of the Modify Convention Roll Rule, this rule is applied to the date returned by the Date Roll Rule, and returns a date which is itself the event date for the scheduled event.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminationTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;identifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;BusinessCalendarCode"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;ContractualDateSpecification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">date determination terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out how to determine dates in the future.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminingAgent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;AgencyDeterminedDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">date determining agent</rdfs:label>
-		<skos:definition xml:lang="en">The agent which determines or is to determine the Determined Date.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DatePeriod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Interval"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasBeginning"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasEnd"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownDateDuration"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">date period</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateRollRule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
-		<rdfs:label xml:lang="en">date roll rule</rdfs:label>
-		<skos:definition xml:lang="en">A rule to apply when a date returned by some date specification or parametric schedule specification results in a non working day.</skos:definition>
-		<skos:editorialNote xml:lang="en">Covers the FpML business day roll enumeration terms &quot;FOLLOWING and &quot;PRECEDING&quot;. &quot;MODFOLLOWING and &quot;MODPRECEDING&quot; consist of this rule applied along with the accompanying &quot;Modify Convention Roll Rule&quot;. These are two separate rules but the FpML enum schema conbines them.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateRollRuleDirection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">DateRollRuleDirection</rdfs:label>
-		<skos:definition xml:lang="en">The selection of possible directions in which to roll dates in a Date Roll Rule or in a Modify Convention Roll Rule.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;InstantSpecification"/>
-		<rdfs:label xml:lang="en">date specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a Specified Date.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the parametric description of the date in the form of some description or algorithm which will return the date, or some list of dates.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateTerminationTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
-		<rdfs:label xml:lang="en">date termination terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DateTimeDescription">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDescription"/>
-		<rdfs:label xml:lang="en">date time description</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DayType">
-		<rdfs:label xml:lang="en">day type</rdfs:label>
-		<skos:definition xml:lang="en">The type of day specified when stating some duration as a number of days between two dates.</skos:definition>
-		<fibo-fnd-utl-av:termOrigin xml:lang="en">FpML DayTypeEnum</fibo-fnd-utl-av:termOrigin>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalThing"/>
-		<rdfs:label xml:lang="en">determined date</rdfs:label>
-		<skos:definition xml:lang="en">Date determined by some means or method at some time in the future, such as by applying roll rules to a business calendar.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DeterminedTemporalEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalThing"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determination"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDetermination"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">determined temporal entity</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DeterminedTemporalThing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determination"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">determined temporal thing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Duration">
-		<rdfs:label xml:lang="en">duration</rdfs:label>
-		<skos:definition xml:lang="en">A length of time, whether known or unknown</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDescription">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;denominatedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">duration description</rdfs:label>
-		<skos:definition xml:lang="en">The description of a Duration in terms of numbers of days, hours, years etc.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDescriptionInCalendarDays">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;CalendarDay"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">duration description in calendar days</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">duration description in calendar temporal unit</rdfs:label>
-		<skos:definition xml:lang="en">Duration Description for Durations that are denominated in Days, Months and Years only (these may be calendar days or business days).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalMeasureDetermination"/>
-		<rdfs:label xml:lang="en">duration determination</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDeterminationInDays">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDetermination"/>
-		<rdfs:label xml:lang="en">duration determination in days</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;description.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;MoreThenOneYearDescription"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">duration of more than one year</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-tim-tim;UpToOneYear"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;ExchangeBusinessDayType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
-		<rdfs:label xml:lang="en">exchange business day type</rdfs:label>
-		<skos:definition xml:lang="en">When calculating the number of days between two dates the count includes only stock exchange business days.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;FRNDateRule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
-		<rdfs:label xml:lang="en">f r n date rule</rdfs:label>
-		<skos:definition xml:lang="en">The rule applied to FRN instruments as defined in the ISDA definitions of 2000, Section 4.11, as defined in those rules for either or both of &apos;FRN Convention&apos; and &apos;Eurodollar Convention&apos;.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML definition: &quot;Per 2000 ISDA Definitions, Section 4.11, FRN Convention, Eurodollar Convention.&quot; The above definition is from FpML and does not give the meaning or nature of this rule. FpML notes that this is not strictly a Date Roll Rule (but it may be selected in place of one). On inspection of the ISDA 2000 definition text, this may be because the FRN rule contains within it a specification of the Modified Following date roll rule (Date following rule modified by Modification rule). This rule appears in FpML both in the BusinessDayConventionEnum and the RollConventionEnum (for date roll rules and for scheduled event dates respectively). From FpML definition for BusinessDayConventionEnum: &quot;... Note that FRN is included here as a type of business day convention although it does not strictly fall within ISDA&apos;s definition of a Business Day Convention and does not conform to the simple definition given above.&quot; Note that this FRN rule is also included in the FpML enumeration for &quot;RollConventionEnum&quot;. This is the enumeration of possible Calculation Period End Dates and uses the word &quot;Roll&quot; in a completely different sense (the date that the application of some calculation to some amount is rolled over from one rate to the next). Full definition from ISDA 2000 Section 4.11: Section 4.11. FRN Convention; Eurodollar Convention. &quot;FRN Convention&quot; or &quot;Eurodollar Convention&quot; means, in respect of either Payment Dates or Period End Dates for a Swap Transaction and a party, that the Payment Dates or Period End Dates of that party will be each day during the Term of the Swap Transaction that numerically corresponds to the preceding applicable Payment Date or Period End Date, as the case may be, of that party in the calendar month that is the specified number of months after the month in which the preceding applicable Payment Date or Period End Date occurred (or, in the case of the first applicable Payment Date or the Period End Date, the day that numerically corresponds to the Effective Date in the calendar month that is the specified number of months after the month in which the Effective Date occurred), except that (a) if there is not any such numerically corresponding day in the calendar month in which a Payment Date or Period End Date, as the case may be, of that party should occur, then the Payment Date or Period End Date will be the last day that is a Business Day in that month, (b) if a Payment Date or Period End Date, as the case may be, of the party would otherwise fall on a day that is not a Business Day, then the Payment Date or Period End Date will be the first following day that is a Business Day unless that day falls in the next calendar month, in which case the Payment Date or Period End Date will be the first preceding day that is a Business Day and (c) if the preceding applicable Payment Date or Period End Date, as the case may be, of that party occurred on the last day in a calendar month that was a Business Day, then all subsequent applicable Payment Dates or Period End Dates, as the case may be, of that party prior to the Termination Date will be the last day that is a Business Day in the month that is the specified number of months after the month in which the preceding applicable Payment Date or Period End Date occurred.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Frequency">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-amt;reciprocal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">frequency</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Future">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Tense"/>
-		<rdfs:label xml:lang="en">future</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Instant">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
-		<rdfs:label xml:lang="en">instant</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-fnd-tim-tim;Interval"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;InstantDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDetermination"/>
-		<rdfs:label xml:lang="en">instant determination</rdfs:label>
-		<skos:definition xml:lang="en">The determination or adjustment of some instant according to some rule.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;InstantSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntitySpecification"/>
-		<rdfs:label xml:lang="en">instant specification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Interval">
-		<rdfs:label xml:lang="en">interval</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownCalendarDuration">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
-				<owl:onClass rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">known calendar duration</rdfs:label>
-		<skos:definition xml:lang="en">A duration defined as a known number of calendar days.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;occursOnDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">known date</rdfs:label>
-		<skos:definition xml:lang="en">A date which is explicitly known i.e. a calendar date.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownDateDuration">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarDays"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">known date duration</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownDateOffset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTimeOffset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">known date offset</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownDuration">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">known duration</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a period of time. This is denominated in time units but is not a Date Time and so is not defined using &quot;Time&quot; or &quot;Date&quot;. Instead it uses Temporal Units</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownTemporalEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDescription"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">known temporal entity</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownTemporalThing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">known temporal thing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownTimeOffset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TimeOffset"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">known time offset</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;ModifyConventionRollRule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
-		<rdfs:label xml:lang="en">modify convention roll rule</rdfs:label>
-		<skos:definition xml:lang="en">A rule to apply when the Date Rool Rule results in a specified date falling on a working date in the month or year following the date which was returned before the Date Roll Rule was applied.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is used for month end roll and year end roll rule. In FpML this rule equates to the &quot;MOD&quot; aspect of the enumeration entries &quot;MODFOLLOWING and MODPRECEDING.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Month">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
-		<rdfs:label xml:lang="en">month</rdfs:label>
-		<skos:definition xml:lang="en">A Julian calendar month</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;MoreThenOneYearDescription">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;YearBasedDurationDescription"/>
-		<rdfs:label xml:lang="en">more then one year description</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Past">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Tense"/>
-		<rdfs:label xml:lang="en">past</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;PeriodicDateSeries">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;PeriodicTimeSeries"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasBeginning"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasPeriodDuration"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasSeriesEnd"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">periodic date series</rdfs:label>
-		<skos:definition xml:lang="en">A series of dates at regular intervals.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The series is specified using the parameters modeled here: Start of the whole regular periodic series (and therefore of the first regular period); The length of each repeating period The end of the entire series. Alternatively, one such period may be defined with a start and end date, and no frequency be specified. Alternatively, rather than a &quot;Start&quot; and &quot;End&quot; of each period, since these are essentially the same repeating date definition, this can be specified with reference to some published set of dates, or some convention. For monthly schedules it can be specified as a day of the month; for weekly, a day of the week and so on.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;PeriodicTimeSeries">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">periodic time series</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Present">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Tense"/>
-		<rdfs:label xml:lang="en">present</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;RelativeDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedDate"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;relativeTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">relative date</rdfs:label>
-		<skos:definition xml:lang="en">A date defined in relation to some other date.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;RelativeDatePeriod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;relativeTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">relative date period</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;RelativeTime">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;relativeTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Instant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">relative time</rdfs:label>
-		<skos:definition xml:lang="en">Time defined in relation to some other time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;RollBack">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateRollRuleDirection"/>
-		<rdfs:label xml:lang="en">roll back</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;RollForward">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateRollRuleDirection"/>
-		<rdfs:label xml:lang="en">roll forward</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;ScheduledTradingDayType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
-		<rdfs:label xml:lang="en">scheduled trading day type</rdfs:label>
-		<skos:definition xml:lang="en">When calculating the number of days between two dates the count includes only scheduled trading days.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;SpecifiedDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedTemporalThing"/>
-		<rdfs:label xml:lang="en">specified date</rdfs:label>
-		<skos:definition xml:lang="en">A date which is unknown in terms of not having a specific calendar date attached to it, but known in the sense of being specified unambiguously by some specification.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;SpecifiedTemporalEntity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedTemporalThing"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;specification"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalEntitySpecification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">specified temporal entity</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;SpecifiedTemporalThing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;specification"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalThingSpecification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">specified temporal thing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntity">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasBeginning"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Instant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasEnd"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Instant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;temporalDefinition"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDefinition"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">temporal entity</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntityDefinition">
-		<rdfs:label xml:lang="en">temporal entity definition</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalEntityDescription">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalEntityDetermination">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalEntitySpecification">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition xml:lang="en">How a temporal entity is defined. This may be in terms of a simple definition (like a date), a specification that unambiguously specifies the temporal entity, or a method for determing a date, instant or interval such that it is not known now but can be determined at some future time. The different ways that an instant or interrval can be determined, are themselves different kinds of Thing (Measures, Specifications or Methods) and therefore this class of Thing is a union of those possible ways of specifiying a temporal entity, and not a kind of Thing in its own right.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntityDescription">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
-		<rdfs:label xml:lang="en">temporal entity description</rdfs:label>
-		<skos:definition xml:lang="en">A direct description of some temporal entity, for example a date or date time. These are defined as simple types of thing (such as date), without recourse to some specification external to or additional to the provision of simple types.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntityDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod"/>
-		<rdfs:label xml:lang="en">temporal entity determination</rdfs:label>
-		<skos:definition xml:lang="en">A Temporal Entity determination sets out how some Temporal Entity, currently unknown, is to be determined. For example, how a payment date or other event is to be determined at some point in the future, based on information prevailing at that future time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntitySpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThingSpecification"/>
-		<rdfs:label xml:lang="en">temporal entity specification</rdfs:label>
-		<skos:definition xml:lang="en">A Temporal Entity Specification specifies how some Temporal Entity (instant or intervl, e.g. Day or Period) actually is, other than by direct description.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalMeasure">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;Measure"/>
-		<rdfs:label xml:lang="en">temporal measure</rdfs:label>
-		<skos:definition xml:lang="en">A measure of description of time</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalMeasureDefinition">
-		<rdfs:label xml:lang="en">temporal measure definition</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalMeasure">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalMeasureDetermination">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalMeasureDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod"/>
-		<rdfs:label xml:lang="en">temporal measure determination</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalThing">
-		<rdfs:subClassOf rdf:resource="&owl;Thing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;temporalDefinition"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalThingExpression"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">temporal thing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">temporal thing determination method</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalThingExpression">
-		<rdfs:label xml:lang="en">temporal thing expression</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalEntityDefinition">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalMeasureDefinition">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalThingSpecification">
-		<rdfs:label xml:lang="en">temporal thing specification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;Unit"/>
-		<rdfs:label xml:lang="en">temporal unit</rdfs:label>
-		<skos:definition xml:lang="en">Units in which Time and Date are measured, for example in defining Durations</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Tense">
-		<rdfs:label xml:lang="en">Tense</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TimeOfDay">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;relativeTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">time of day</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TimeOffset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">time offset</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;TypicalDuration">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-trd;CPTypicalDurationDescription"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">typical duration</rdfs:label>
-		<skos:definition xml:lang="en">The maturity of the CP instrument, as a typical, known duration.</skos:definition>
-		<skos:editorialNote xml:lang="en">The US default for Commercial Paper as being 270 days. Further review for other jurisdictions indicated that this is not a universally recognized duration that defines something as being included in the set of Money Market instruments. This duration may be formally described for specific markets but is not described here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;UnknownDuration">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determination"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDetermination"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">unknown duration</rdfs:label>
-		<skos:definition xml:lang="en">A length of time whose length is not known.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;UpToOneYear">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;description.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;UpToOneYearDescription"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">up to one year</rdfs:label>
-		<skos:definition xml:lang="en">A known duration of one calendar year.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;UpToOneYearDescription">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;YearBasedDurationDescription"/>
-		<rdfs:label xml:lang="en">up to one year description</rdfs:label>
-		<skos:definition xml:lang="en">Formal duration description for Durations of up to one year.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Week">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
-		<rdfs:label xml:lang="en">week</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;WeekDaySelection">
-		<rdfs:label xml:lang="en">WeekDaySelection</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Weekday">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
-		<rdfs:label xml:lang="en">weekday</rdfs:label>
-		<skos:definition xml:lang="en">A day during the week, as a temporal unit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">this means that if a duration (for example) is cited as being x number of weekdays, these are the days Monday through Friday (irrespective of holidays). So a Thursday plus 3 days is Tuesday. This is included in the model in case this is needed as a unit but as at June 2011 has not been referenced in any models. Note that ISDA FpML parametric schedules have a scheduled event definition which may be any of the 7 days of the week - that is a different term &quot;Day Of The Week&quot;. That is not a temporal unit but a sort of day.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;Year">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
-		<rdfs:label xml:lang="en">year</rdfs:label>
-		<skos:definition xml:lang="en">A Gregorian calendar year</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-tim-tim;YearBasedDurationDescription">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedWithReferenceTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Year"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">year based duration description</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;clockTime">
-		<rdfs:label xml:lang="en">clock time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;TimeOfDay"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TimeValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;contractuallyDeterminedWithReferenceTo">
-		<rdfs:label xml:lang="en">contractually determined with reference to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;ContractuallyDeterminedDate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateDeterminationTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;date">
-		<rdfs:label xml:lang="en">date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDescription"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;dateAndTime">
-		<rdfs:label xml:lang="en">date and time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateTimeDescription"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;dateOffset">
-		<rdfs:label xml:lang="en">date offset</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;RelativeDate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The offset applied to the date referred to, to define this date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;dateOffsetDayType">
-		<rdfs:label xml:lang="en">date offset day type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;RelativeDate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DayType"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;definedIn">
-		<rdfs:label xml:lang="en">defined in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;BusinessDay"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;BusinessCalendarCode"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;denominatedIn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-amt;isMeasuredIn"/>
-		<rdfs:label xml:lang="en">denominated in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;describedBy">
-		<rdfs:label xml:lang="en">described by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;describedInCalendarTermsBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;describedBy"/>
-		<rdfs:label xml:lang="en">described in calendar terms by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;describedWithReferenceTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
-		<rdfs:label xml:lang="en">described with reference to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;YearBasedDurationDescription"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Year"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;description">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;FRNDateRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Textual description of the FRN Date Rule.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;description.1">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;MoreThenOneYearDescription"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;description.2">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;UpToOneYear"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;UpToOneYearDescription"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;determination">
-		<rdfs:label xml:lang="en">determination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalThing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;determines">
-		<rdfs:label xml:lang="en">determines</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDeterminingAgent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;AgencyDeterminedDate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasBeginning">
-		<rdfs:label xml:lang="en">has beginning</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Instant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasCalendarDenomination">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;denominatedIn"/>
-		<rdfs:label xml:lang="en">has calendar denomination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasEnd">
-		<rdfs:label xml:lang="en">has end</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Instant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasPeriodDuration">
-		<rdfs:label xml:lang="en">has period duration</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;PeriodicDateSeries"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasSeriesEnd">
-		<rdfs:label xml:lang="en">has series end</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;PeriodicDateSeries"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;identifies">
-		<rdfs:label xml:lang="en">identifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDeterminationTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;BusinessCalendarCode"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;length">
-		<rdfs:label xml:lang="en">length</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;Interval"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;length.1">
-		<rdfs:label xml:lang="en">length</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;KnownTimeOffset"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;modified">
-		<rdfs:label xml:lang="en">modified</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateRollRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the Date Roll Rule includes a Modify Convention Roll Rule, defining treatment of non business days which result from the application of this rule to the date returned by the date specification or parametric schedule.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;modifiedBy">
-		<rdfs:label xml:lang="en">modified by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
-		<skos:definition xml:lang="en">This is the top Relationship Fact in this hierarchy.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;multiplier">
-		<rdfs:label xml:lang="en">multiplier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;MoreThenOneYearDescription"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;multiplier.1">
-		<rdfs:label xml:lang="en">multiplier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;UpToOneYearDescription"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of years is defined as less than or equal to one.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;multiplier.2">
-		<rdfs:label xml:lang="en">multiplier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The number of units as specified, that the duration consists of.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;numberOfDays">
-		<rdfs:label xml:lang="en">number of days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarDays"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of days in the period, expressed as a whole number.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;occursOnDate">
-		<rdfs:label xml:lang="en">occursOnDate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;reference">
-		<rdfs:label xml:lang="en">reference</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;FRNDateRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Textual reference to the document and section that contains the rule.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;reference.1">
-		<rdfs:label xml:lang="en">reference</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;relativeTo">
-		<rdfs:label xml:lang="en">relative to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Instant"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;ruleDirection">
-		<rdfs:label xml:lang="en">rule direction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;ModifyConventionRollRule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateRollRuleDirection"/>
-		<skos:definition xml:lang="en">The direction in which the rule is to be applied to the date returned by the Date Roll Rule.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;setsOut">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDeterminationTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;ContractualDateSpecification"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;specification">
-		<rdfs:label xml:lang="en">specification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;SpecifiedTemporalThing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalThingSpecification"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;temporalDefinition">
-		<rdfs:label xml:lang="en">temporal definition</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalThingExpression"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-ext-snap-par-wt="https://spec.edmcouncil.org/fibo/EXT/snap/partial/W3CTime/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
+buxmlns:fibo-fnd-pub-con="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"
+buxmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-mm-trd="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Time</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology sets out a complete range of concepts about time. The core of the ontology is based on the core concepts of instant and interval in the W3C Time ontology, while the scope and extent of the concepts are based on those concepts reflected in the FpML standard for time, calendar and schedule terms. This is a conceptual ontology and as such it makes a clear distinction between kinds of time and kinds of measurement or statement about time in calendars or data. 
+		The Release ontology FinancialDates provides a more pragmatic and data friendly reflection of most of the concepts included in this Time ontology, for example by focusing on calendar and data statements about time as distinct from time itself. Properties that refer to concepts in this ontology are to be moved over to the corresponding concepts in that ontology, adding further concepts from this one where necessary. On completion of that work, this ontology may be deprecated. In the meantime parts of it may be deprecated when they are no longer referred to or were never referred to.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Forwards/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/DerivativesBasicsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;AgencyDeterminedDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency determined date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A date which is or which is to be determined by some external agency.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;BusinessCalendarCode">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business calendar code</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Calendar for a particular business center, which defines what are the working days in that center.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the identification code for the calendar, not the calendar of dates itself. This code uniquely identifies the business calendar in which business days are defined. This is usually published year on year, but formal terms only need to identify the Calendar so that events are understood to be specified in terms of that calendar.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;BusinessDay">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;definedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;BusinessCalendarCode"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business day</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A working day as defined in the Business Calendar for a particular business center.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;BusinessDayConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-con;Convention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business day convention</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;BusinessDayType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">business day type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">When calculating the number of days between two dates the count includes only business days.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;CalculatedDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calculated date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Date which is calculated according to some defined formula or calculation method. The results of such calculation are not known in the present, e.g. one or more parameters for the calculation are not yet known.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;CalculatedDateOffset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalculatedTimeOffset"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calculated date offset</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;CalculatedTimeOffset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalThing"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TimeOffset"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determination"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDetermination"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calculated time offset</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;CalendarDay">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calendar day</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A day. This is the time it takes the Sun to orbit the Earth, without any additional qualifications or rules applied.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;CalendarDayType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calendar day type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">When calculating the number of days between two dates the count includes all calendar days.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;CalendarTemporalUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calendar temporal unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Temporal Unit (measure of time) which is to be found in a regular calendar, i.e. a day, month etc., as distinct from units with additional parameters such as business days.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is similar to the FpML enumeration &quot;PeriodEnum&quot;, with the exception that this does not include &quot;Term&quot; since that is not a calendar unit and is only meaningful in relation to the specific instrument.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;CommodityBusinessDayType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commodity business day type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">When calculating the number of days between two dates the count includes only commodity business days.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;ContractualDateSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual date specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a date in a contract.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;ContractuallyDeterminedDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;contractuallyDeterminedWithReferenceTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DateDeterminationTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractually determined date</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;ContractuallySpecifiedDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractually specified date</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;ConventionDeterminedDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convention determined date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Date which is or is to be determined according to some established or published convention for date determination.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;CurrencyBusinessDayType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">currency business day type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">When calculating the number of days between two dates the count includes only currency business days.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Date">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Instant"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;occursOnDate"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateCalculation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date calculation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDescription">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateTimeDescription"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date description</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;InstantDetermination"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;reference.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date determination</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The determination or adjustment of some date according to some rule.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminationAgency">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date determination agency</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminationConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date determination convention</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminationReferenceRule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;modifiedBy"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;modifiedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date determination reference rule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A rule for determining a date or for making adjustments from a date determined by some means, to return another date, for example adjusting from a non working to a working date.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">These kinds of rules are referred to in two separate FpML enumerations, the &quot;BusinessDayConventionEnum&quot; for determining when a returned date is rolled to a suitable business day, and one for scheduled event dates (called, confusingly &quot;Roll&quot; dates) as defined in &quot;RollConventionEnum&quot;. One such rule appears in both. Also included in this set of rules is the optional rule for further modifying the date returned by a date roll rule. In FpML description for &quot;BusinessDayConventionEnum&quot;: &quot;The convention for adjusting any relevant date if it would otherwise fall on a day that is not a valid business day. Note that FRN is included here as a type of business day convention although it does not strictly fall within ISDA&apos;s definition of a Business Day Convention and does not conform to the simple definition given above.&quot; These rules (with the possible exception of &quot;FRN&quot;) are applied to dates returned by some date specification or parametric schedule specification or some other such rule, and detail treatment of those returned dates in the event of them being for example a working day, being in the wrong month or year and so on. The Date Roll Rule operates on the date returned by the date specification or parametric schedule, and return a further date. If the Date Roll Rule is used alone, that is the final date to be returned from the entire specification or parametric schedule, as the date on which the scheduled event is to take place. In the case of the Modify Convention Roll Rule, this rule is applied to the date returned by the Date Roll Rule, and returns a date which is itself the event date for the scheduled event.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminationTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;identifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;BusinessCalendarCode"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;ContractualDateSpecification"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date determination terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out how to determine dates in the future.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateDeterminingAgent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;AgencyDeterminedDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date determining agent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The agent which determines or is to determine the Determined Date.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DatePeriod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Interval"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasBeginning"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasEnd"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownDateDuration"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date period</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateRollRule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Rule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date roll rule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A rule to apply when a date returned by some date specification or parametric schedule specification results in a non working day.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Covers the FpML business day roll enumeration terms &quot;FOLLOWING and &quot;PRECEDING&quot;. &quot;MODFOLLOWING and &quot;MODPRECEDING&quot; consist of this rule applied along with the accompanying &quot;Modify Convention Roll Rule&quot;. These are two separate rules but the FpML enum schema conbines them.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateRollRuleDirection">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DateRollRuleDirection</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The selection of possible directions in which to roll dates in a Date Roll Rule or in a Modify Convention Roll Rule.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;InstantSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a Specified Date.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the parametric description of the date in the form of some description or algorithm which will return the date, or some list of dates.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateTerminationTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date termination terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DateTimeDescription">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDescription"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date time description</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DayType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">day type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of day specified when stating some duration as a number of days between two dates.</skos:definition>
+bubu<fibo-fnd-utl-av:termOrigin rdf:datatype="&rdf;langString" xml:lang="en">FpML DayTypeEnum</fibo-fnd-utl-av:termOrigin>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DeterminedDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determined date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date determined by some means or method at some time in the future, such as by applying roll rules to a business calendar.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DeterminedTemporalEntity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalThing"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determination"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDetermination"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determined temporal entity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DeterminedTemporalThing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determination"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determined temporal thing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Duration">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">duration</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A length of time, whether known or unknown</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDescription">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;denominatedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">duration description</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The description of a Duration in terms of numbers of days, hours, years etc.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDescriptionInCalendarDays">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;CalendarDay"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">duration description in calendar days</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">duration description in calendar temporal unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Duration Description for Durations that are denominated in Days, Months and Years only (these may be calendar days or business days).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalMeasureDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">duration determination</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationDeterminationInDays">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">duration determination in days</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;description.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;MoreThenOneYearDescription"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">duration of more than one year</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-tim-tim;UpToOneYear"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;ExchangeBusinessDayType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange business day type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">When calculating the number of days between two dates the count includes only stock exchange business days.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;FRNDateRule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">f r n date rule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rule applied to FRN instruments as defined in the ISDA definitions of 2000, Section 4.11, as defined in those rules for either or both of &apos;FRN Convention&apos; and &apos;Eurodollar Convention&apos;.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpML definition: &quot;Per 2000 ISDA Definitions, Section 4.11, FRN Convention, Eurodollar Convention.&quot; The above definition is from FpML and does not give the meaning or nature of this rule. FpML notes that this is not strictly a Date Roll Rule (but it may be selected in place of one). On inspection of the ISDA 2000 definition text, this may be because the FRN rule contains within it a specification of the Modified Following date roll rule (Date following rule modified by Modification rule). This rule appears in FpML both in the BusinessDayConventionEnum and the RollConventionEnum (for date roll rules and for scheduled event dates respectively). From FpML definition for BusinessDayConventionEnum: &quot;... Note that FRN is included here as a type of business day convention although it does not strictly fall within ISDA&apos;s definition of a Business Day Convention and does not conform to the simple definition given above.&quot; Note that this FRN rule is also included in the FpML enumeration for &quot;RollConventionEnum&quot;. This is the enumeration of possible Calculation Period End Dates and uses the word &quot;Roll&quot; in a completely different sense (the date that the application of some calculation to some amount is rolled over from one rate to the next). Full definition from ISDA 2000 Section 4.11: Section 4.11. FRN Convention; Eurodollar Convention. &quot;FRN Convention&quot; or &quot;Eurodollar Convention&quot; means, in respect of either Payment Dates or Period End Dates for a Swap Transaction and a party, that the Payment Dates or Period End Dates of that party will be each day during the Term of the Swap Transaction that numerically corresponds to the preceding applicable Payment Date or Period End Date, as the case may be, of that party in the calendar month that is the specified number of months after the month in which the preceding applicable Payment Date or Period End Date occurred (or, in the case of the first applicable Payment Date or the Period End Date, the day that numerically corresponds to the Effective Date in the calendar month that is the specified number of months after the month in which the Effective Date occurred), except that (a) if there is not any such numerically corresponding day in the calendar month in which a Payment Date or Period End Date, as the case may be, of that party should occur, then the Payment Date or Period End Date will be the last day that is a Business Day in that month, (b) if a Payment Date or Period End Date, as the case may be, of the party would otherwise fall on a day that is not a Business Day, then the Payment Date or Period End Date will be the first following day that is a Business Day unless that day falls in the next calendar month, in which case the Payment Date or Period End Date will be the first preceding day that is a Business Day and (c) if the preceding applicable Payment Date or Period End Date, as the case may be, of that party occurred on the last day in a calendar month that was a Business Day, then all subsequent applicable Payment Dates or Period End Dates, as the case may be, of that party prior to the Termination Date will be the last day that is a Business Day in the month that is the specified number of months after the month in which the preceding applicable Payment Date or Period End Date occurred.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Frequency">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-amt;reciprocal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">frequency</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Future">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Tense"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">future</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Instant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instant</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-fnd-tim-tim;Interval"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;InstantDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instant determination</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The determination or adjustment of some instant according to some rule.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;InstantSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntitySpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instant specification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Interval">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interval</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownCalendarDuration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">known calendar duration</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A duration defined as a known number of calendar days.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;occursOnDate"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">known date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A date which is explicitly known i.e. a calendar date.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownDateDuration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarDays"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">known date duration</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownDateOffset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTimeOffset"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">known date offset</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownDuration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">known duration</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a period of time. This is denominated in time units but is not a Date Time and so is not defined using &quot;Time&quot; or &quot;Date&quot;. Instead it uses Temporal Units</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownTemporalEntity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDescription"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">known temporal entity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownTemporalThing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">known temporal thing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;KnownTimeOffset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TimeOffset"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">known time offset</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;ModifyConventionRollRule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">modify convention roll rule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A rule to apply when the Date Rool Rule results in a specified date falling on a working date in the month or year following the date which was returned before the Date Roll Rule was applied.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is used for month end roll and year end roll rule. In FpML this rule equates to the &quot;MOD&quot; aspect of the enumeration entries &quot;MODFOLLOWING and MODPRECEDING.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Month">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">month</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Julian calendar month</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;MoreThenOneYearDescription">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;YearBasedDurationDescription"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">more then one year description</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Past">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Tense"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">past</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;PeriodicDateSeries">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;PeriodicTimeSeries"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasBeginning"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasPeriodDuration"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasSeriesEnd"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">periodic date series</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A series of dates at regular intervals.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The series is specified using the parameters modeled here: Start of the whole regular periodic series (and therefore of the first regular period); The length of each repeating period The end of the entire series. Alternatively, one such period may be defined with a start and end date, and no frequency be specified. Alternatively, rather than a &quot;Start&quot; and &quot;End&quot; of each period, since these are essentially the same repeating date definition, this can be specified with reference to some published set of dates, or some convention. For monthly schedules it can be specified as a day of the month; for weekly, a day of the week and so on.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;PeriodicTimeSeries">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">periodic time series</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Present">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Tense"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">present</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;RelativeDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedDate"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;relativeTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relative date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A date defined in relation to some other date.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;RelativeDatePeriod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;relativeTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relative date period</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;RelativeTime">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;relativeTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Instant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relative time</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Time defined in relation to some other time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;RollBack">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateRollRuleDirection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">roll back</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;RollForward">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateRollRuleDirection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">roll forward</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;ScheduledTradingDayType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DayType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheduled trading day type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">When calculating the number of days between two dates the count includes only scheduled trading days.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;SpecifiedDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedTemporalThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specified date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A date which is unknown in terms of not having a specific calendar date attached to it, but known in the sense of being specified unambiguously by some specification.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;SpecifiedTemporalEntity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedTemporalThing"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;specification"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalEntitySpecification"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specified temporal entity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;SpecifiedTemporalThing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;specification"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalThingSpecification"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specified temporal thing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntity">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasBeginning"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Instant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasEnd"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Instant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;temporalDefinition"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDefinition"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal entity</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntityDefinition">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal entity definition</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalEntityDescription">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalEntityDetermination">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalEntitySpecification">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How a temporal entity is defined. This may be in terms of a simple definition (like a date), a specification that unambiguously specifies the temporal entity, or a method for determing a date, instant or interval such that it is not known now but can be determined at some future time. The different ways that an instant or interrval can be determined, are themselves different kinds of Thing (Measures, Specifications or Methods) and therefore this class of Thing is a union of those possible ways of specifiying a temporal entity, and not a kind of Thing in its own right.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntityDescription">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal entity description</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A direct description of some temporal entity, for example a date or date time. These are defined as simple types of thing (such as date), without recourse to some specification external to or additional to the provision of simple types.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntityDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal entity determination</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Temporal Entity determination sets out how some Temporal Entity, currently unknown, is to be determined. For example, how a payment date or other event is to be determined at some point in the future, based on information prevailing at that future time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalEntitySpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThingSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal entity specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Temporal Entity Specification specifies how some Temporal Entity (instant or intervl, e.g. Day or Period) actually is, other than by direct description.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalMeasure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;Measure"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal measure</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure of description of time</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalMeasureDefinition">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal measure definition</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalMeasure">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalMeasureDetermination">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalMeasureDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal measure determination</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalThing">
+bubu<rdfs:subClassOf rdf:resource="&owl;Thing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;temporalDefinition"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;TemporalThingExpression"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal thing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal thing determination method</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalThingExpression">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal thing expression</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalEntityDefinition">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;TemporalMeasureDefinition">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalThingSpecification">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal thing specification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TemporalUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;Unit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Units in which Time and Date are measured, for example in defining Durations</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Tense">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Tense</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TimeOfDay">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;relativeTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">time of day</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TimeOffset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;length"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">time offset</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;TypicalDuration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-trd;CPTypicalDurationDescription"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">typical duration</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The maturity of the CP instrument, as a typical, known duration.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The US default for Commercial Paper as being 270 days. Further review for other jurisdictions indicated that this is not a universally recognized duration that defines something as being included in the set of Money Market instruments. This duration may be formally described for specific markets but is not described here.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;UnknownDuration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determination"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationDetermination"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unknown duration</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A length of time whose length is not known.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;UpToOneYear">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;description.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;UpToOneYearDescription"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">up to one year</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A known duration of one calendar year.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;UpToOneYearDescription">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;YearBasedDurationDescription"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">up to one year description</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal duration description for Durations of up to one year.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Week">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">week</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;WeekDaySelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">WeekDaySelection</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Weekday">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">weekday</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A day during the week, as a temporal unit.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">this means that if a duration (for example) is cited as being x number of weekdays, these are the days Monday through Friday (irrespective of holidays). So a Thursday plus 3 days is Tuesday. This is included in the model in case this is needed as a unit but as at June 2011 has not been referenced in any models. Note that ISDA FpML parametric schedules have a scheduled event definition which may be any of the 7 days of the week - that is a different term &quot;Day Of The Week&quot;. That is not a temporal unit but a sort of day.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;Year">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">year</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Gregorian calendar year</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-tim-tim;YearBasedDurationDescription">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedWithReferenceTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Year"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">year based duration description</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;clockTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">clock time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;TimeOfDay"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TimeValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;contractuallyDeterminedWithReferenceTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractually determined with reference to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;ContractuallyDeterminedDate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateDeterminationTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;date">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDescription"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;dateAndTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date and time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateTimeDescription"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;dateOffset">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date offset</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;RelativeDate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The offset applied to the date referred to, to define this date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;dateOffsetDayType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date offset day type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;RelativeDate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DayType"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;definedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;BusinessDay"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;BusinessCalendarCode"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;denominatedIn">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-amt;isMeasuredIn"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denominated in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;describedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">described by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;KnownTemporalThing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalMeasure"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;describedInCalendarTermsBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;describedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">described in calendar terms by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;describedWithReferenceTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">described with reference to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;YearBasedDurationDescription"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Year"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;description">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;FRNDateRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Textual description of the FRN Date Rule.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;description.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;MoreThenOneYearDescription"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;description.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;UpToOneYear"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;UpToOneYearDescription"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;determination">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determination</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalThing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalThingDeterminationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;determines">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determines</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDeterminingAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;AgencyDeterminedDate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasBeginning">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has beginning</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Instant"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasCalendarDenomination">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;denominatedIn"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has calendar denomination</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;CalendarTemporalUnit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has end</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;TemporalEntity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Instant"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasPeriodDuration">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has period duration</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;PeriodicDateSeries"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;hasSeriesEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has series end</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;PeriodicDateSeries"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;identifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDeterminationTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;BusinessCalendarCode"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;length">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">length</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;Interval"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;length.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">length</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;KnownTimeOffset"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;modified">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">modified</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateRollRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Date Roll Rule includes a Modify Convention Roll Rule, defining treatment of non business days which result from the application of this rule to the date returned by the date specification or parametric schedule.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;modifiedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">modified by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">This is the top Relationship Fact in this hierarchy.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;multiplier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiplier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;MoreThenOneYearDescription"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;multiplier.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiplier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;UpToOneYearDescription"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of years is defined as less than or equal to one.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;multiplier.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiplier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of units as specified, that the duration consists of.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;numberOfDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of days</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarDays"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of days in the period, expressed as a whole number.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;occursOnDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">occursOnDate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;reference">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;FRNDateRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Textual reference to the document and section that contains the rule.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;reference.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDetermination"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateDeterminationReferenceRule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;relativeTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relative to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;RelativeTime"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Instant"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;ruleDirection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rule direction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;ModifyConventionRollRule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateRollRuleDirection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The direction in which the rule is to be applied to the date returned by the Date Roll Rule.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;setsOut">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;DateDeterminationTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;ContractualDateSpecification"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;specification">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specification</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;SpecifiedTemporalThing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalThingSpecification"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-tim-tim;temporalDefinition">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal definition</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-tim-tim;TemporalThing"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TemporalThingExpression"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/EconomicResources.rdf
+++ b/fnd/TransactionsExt/EconomicResources.rdf
@@ -1,65 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
-	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-quax-qua "https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/">
+bu<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
-	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-		<rdfs:label xml:lang="en">EconomicResources</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-ecr;EconomicContext">
-		<rdfs:label xml:lang="en">economic context</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-ecr;EconomicResource">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;ReferenceMaterial"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ecr;takesMaterialForm"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;definedInContextOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">economic resource</rdfs:label>
-		<skos:definition xml:lang="en">Anything that can bought sold or exchanged.</skos:definition>
-		<skos:editorialNote xml:lang="en">Formerly labeled as Negotiable Thing. Changed to REA terminology with no effect on meaning. Note that this is a relative thing - the thing which is itself the economic resource, is some good or some service (i.e. some physical thing or some event/activity) which can be framed as an economic resource in the context of exchanging it for some other economic resource. Scope Note: Economic Resource may also define things which are not exchanged but are defined as resources in some other context, for example Capital is a kind of economic resource.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ecr;takesMaterialForm">
-		<rdfs:label xml:lang="en">takes material form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-		<skos:definition xml:lang="en">The material form of the Economic Resource; that is the thing which is recognized as being an Economic Resource as defined here, Editorial Note: This would usually be some Independent Thing. However it is conceivable that the existence of some relative thing, for example an asset, may itself be regarded and defined as a resource, over and above the role or context already defined for it. Therefore this identity relationship has a range of Thing, but is modeled as a sub property of &quot;identity&quot; to make this conclusion explicit. Editorial Note: This is a relationship with the sense that some relative thing takes the form of something, but is distinct from the similar concept as applied to Asset, in which the thing which takes the form of some asset is owned by someone. Here it is a resource, irrespective of whether or by whom it is owned. Labeled as &quot;takes material form&quot; to disambiguate these two relationships.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-quax-qua="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"
+buxmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">EconomicResources</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Provides the contextually defined concept of an economic resource, corresponding to the same concept in REA.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-ecr;EconomicContext">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic context</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-ecr;EconomicResource">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-quax-qua;ReferenceMaterial"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ecr;takesMaterialForm"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;definedInContextOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic resource</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Anything that can bought sold or exchanged.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Formerly labeled as Negotiable Thing. Changed to REA terminology with no effect on meaning. Note that this is a relative thing - the thing which is itself the economic resource, is some good or some service (i.e. some physical thing or some event/activity) which can be framed as an economic resource in the context of exchanging it for some other economic resource. Scope Note: Economic Resource may also define things which are not exchanged but are defined as resources in some other context, for example Capital is a kind of economic resource.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ecr;takesMaterialForm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes material form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The material form of the Economic Resource; that is the thing which is recognized as being an Economic Resource as defined here, Editorial Note: This would usually be some Independent Thing. However it is conceivable that the existence of some relative thing, for example an asset, may itself be regarded and defined as a resource, over and above the role or context already defined for it. Therefore this identity relationship has a range of Thing, but is modeled as a sub property of &quot;identity&quot; to make this conclusion explicit. Editorial Note: This is a relationship with the sense that some relative thing takes the form of something, but is distinct from the similar concept as applied to Asset, in which the thing which takes the form of some asset is owned by someone. Here it is a resource, irrespective of whether or by whom it is owned. Labeled as &quot;takes material form&quot; to disambiguate these two relationships.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/MarketTransactions.rdf
+++ b/fnd/TransactionsExt/MarketTransactions.rdf
@@ -1,141 +1,145 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-	<!ENTITY fibo-fnd-txn-mkt "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bu<!ENTITY fibo-fnd-txn-mkt "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-txn-mkt="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/">
-		<rdfs:label xml:lang="en">MarketTransactions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-mkt;MarketTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;consideration"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;counterparty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;paymentTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-mkt;MarketTransactionPaymentTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;principal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-mkt;TransactionPrincipal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">market transaction</rdfs:label>
-		<skos:definition xml:lang="en">Any transaction which defines a supply of some negotiable item in return for some Consideration. The Market Transaction has a Principal and a Counterparty, i.e. it is not symmetrical.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-mkt;MarketTransactionInvoicingTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-		<rdfs:label xml:lang="en">market transaction invoicing terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-mkt;MarketTransactionPaymentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;governs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;PaymentProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">market transaction payment terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-mkt;TransactionCounterparty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-		<rdfs:label xml:lang="en">transaction counterparty</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-mkt;TransactionPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;transactsWith"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">transaction principal</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;consideration">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;subject"/>
-		<rdfs:label xml:lang="en">consideration</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;counterparty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;hasTransactionParty"/>
-		<rdfs:label xml:lang="en">counterparty</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;customerTransactsWithVendor">
-		<rdfs:label xml:lang="en">customer transacts with vendor</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-sup;Vendor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;governs">
-		<rdfs:label xml:lang="en">governs</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransactionPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;PaymentProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;paymentTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactedUnder"/>
-		<rdfs:label xml:lang="en">payment terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-mkt;MarketTransactionPaymentTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;principal">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;hasTransactionParty"/>
-		<rdfs:label xml:lang="en">principal</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-mkt;TransactionPrincipal"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
+buxmlns:fibo-fnd-txn-mkt="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">MarketTransactions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Defines the concepts for market transactions in general, on any kind of marketplace. 
+		This ontology is not used directly in FIBO content but provides the conceptual underpinnings for securities market transactions.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-mkt;MarketTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;consideration"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;counterparty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;paymentTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-mkt;MarketTransactionPaymentTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;principal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-mkt;TransactionPrincipal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any transaction which defines a supply of some negotiable item in return for some Consideration. The Market Transaction has a Principal and a Counterparty, i.e. it is not symmetrical.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-mkt;MarketTransactionInvoicingTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market transaction invoicing terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-mkt;MarketTransactionPaymentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;governs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;PaymentProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market transaction payment terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-mkt;TransactionCounterparty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction counterparty</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-mkt;TransactionPrincipal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;transactsWith"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction principal</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;consideration">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;subject"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consideration</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;counterparty">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;hasTransactionParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">counterparty</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;customerTransactsWithVendor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">customer transacts with vendor</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-sup;Vendor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;governs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governs</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransactionPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;PaymentProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;paymentTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactedUnder"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-mkt;MarketTransactionPaymentTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-mkt;principal">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;hasTransactionParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">principal</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-mkt;TransactionPrincipal"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/QuantifiedResources.rdf
+++ b/fnd/TransactionsExt/QuantifiedResources.rdf
@@ -1,66 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
-	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-	<!ENTITY fibo-fnd-txn-qr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
+bu<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bu<!ENTITY fibo-fnd-txn-qr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/"
-	xmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
-	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-txn-qr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/">
-		<rdfs:label xml:lang="en">QuantifiedResources</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-qr;QuantifiedRawMaterial">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-qr;QuantifiedResource"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-qr;quantifiedRawMaterialTakesMaterialForm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">quantified raw material</rdfs:label>
-		<skos:definition xml:lang="en">Some measured or quantified amount of some raw material. Scope Note: This is a kind of economic resource i.e. it may be bought or sold or exchanged, or put to work in some process.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-qr;QuantifiedResource">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ecr;takesMaterialForm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">quantified resource</rdfs:label>
-		<skos:definition xml:lang="en">An amount of something which is defined in terms of its use for some purpose.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An example would be Capital, which is an amount of money with a purpose.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-qr;quantifiedRawMaterialTakesMaterialForm">
-		<rdfs:label xml:lang="en">quantified raw material takes material form</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-qr;QuantifiedRawMaterial"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
-		<skos:definition xml:lang="en">The actual numerical amount of some material, that is represented as quantified raw material.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
+buxmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
+buxmlns:fibo-fnd-txn-qr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">QuantifiedResources</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Provides for the quantification of economic resources and raw material</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/QuantifiedResources/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-qr;QuantifiedRawMaterial">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-qr;QuantifiedResource"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-qr;quantifiedRawMaterialTakesMaterialForm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quantified raw material</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some measured or quantified amount of some raw material. Scope Note: This is a kind of economic resource i.e. it may be bought or sold or exchanged, or put to work in some process.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-qr;QuantifiedResource">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ecr;takesMaterialForm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quantified resource</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An amount of something which is defined in terms of its use for some purpose.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">An example would be Capital, which is an amount of money with a purpose.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-qr;quantifiedRawMaterialTakesMaterialForm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quantified raw material takes material form</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-qr;QuantifiedRawMaterial"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-amt;MaterialAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The actual numerical amount of some material, that is represented as quantified raw material.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/REAClaimsEvents.rdf
+++ b/fnd/TransactionsExt/REAClaimsEvents.rdf
@@ -1,119 +1,122 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
-	<!ENTITY fibo-fnd-txn-cle "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/">
-	<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-txnx "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
+bu<!ENTITY fibo-fnd-txn-cle "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/">
+bu<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-txnx "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
-	xmlns:fibo-fnd-txn-cle="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/"
-	xmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-txnx="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/">
-		<rdfs:label xml:lang="en">REAClaimsEvents</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-cle;AccountingReportingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-cle;AspectViewingParty"/>
-		<rdfs:label xml:lang="en">accounting reporting party</rdfs:label>
-		<skos:definition xml:lang="en">The party, from the perspective of which economic facts are defined.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These include the definitions of rights versus obligations, and the Claim as imbalance between those.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-cle;AspectViewingParty">
-		<rdfs:label xml:lang="en">aspect viewing party</rdfs:label>
-		<skos:definition xml:lang="en">The party from the perspective of which the aspect is defined.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-cle;CashflowCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-txnx;ContractuallyDefinedBenefit"/>
-		<rdfs:label xml:lang="en">cashflow commitment</rdfs:label>
-		<skos:definition xml:lang="en">A legal or contractual commitment to some cash flows in the future.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-cle;ContractualTransactionObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualObligation"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-cle;REATransactionObligation"/>
-		<rdfs:label xml:lang="en">contractual transaction obligation</rdfs:label>
-		<skos:definition xml:lang="en">An obligation which is one perspective on a commitment which is both a contractual commitment and a transaction-related economic commitment.</skos:definition>
-		<skos:editorialNote xml:lang="en">REA supports the definition of transactions both within and between distinct legal entities or persons. This element forms part of the definition of REA transaction concepts which are between entities.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-cle;DebtClaim">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;REAClaim"/>
-		<rdfs:label xml:lang="en">debt claim</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-cle;EquityClaim">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;REAClaim"/>
-		<rdfs:label xml:lang="en">equity claim</rdfs:label>
-		<skos:definition xml:lang="en">Needs to be unpicked Equity represents ownership in some venture. You own a piece of the assets of the venture, which gives you a claim on those assets. there is parallel to the discharging of obligations and rights in a transaction, in there here, the obligation/right continues to exist until or unless the venture is wound up.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-cle;REATransactionObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-		<rdfs:label xml:lang="en">r e a transaction obligation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-cle;REATransactionRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-		<rdfs:label xml:lang="en">r e a transaction right</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;asReportedBy">
-		<rdfs:label xml:lang="en">as reported by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;Claim"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-cle;AccountingReportingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;asSeenBy">
-		<rdfs:label>as seen by</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;definedOnThePartOf">
-		<rdfs:label xml:lang="en">defined on the part of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;REAClaim"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-cle;AccountingReportingParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;hasEnd">
-		<rdfs:label xml:lang="en">has end</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-ev;DischargingEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;hasStart">
-		<rdfs:label xml:lang="en">has start</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-ev;TransactionUndertaking"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;REAClaim">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
+buxmlns:fibo-fnd-txn-cle="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/"
+buxmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-txnx="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">REAClaimsEvents</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology provides a conceptual view of the REA notion of Claims along with a treatment of commitments according to their aspects of commitments and obligations and the extension of REA claims to debt and equity as concepts.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-cle;AccountingReportingParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-cle;AspectViewingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accounting reporting party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party, from the perspective of which economic facts are defined.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These include the definitions of rights versus obligations, and the Claim as imbalance between those.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-cle;AspectViewingParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">aspect viewing party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party from the perspective of which the aspect is defined.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-cle;CashflowCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-txnx;ContractuallyDefinedBenefit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cashflow commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A legal or contractual commitment to some cash flows in the future.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-cle;ContractualTransactionObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualObligation"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-cle;REATransactionObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual transaction obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An obligation which is one perspective on a commitment which is both a contractual commitment and a transaction-related economic commitment.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">REA supports the definition of transactions both within and between distinct legal entities or persons. This element forms part of the definition of REA transaction concepts which are between entities.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-cle;DebtClaim">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;REAClaim"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt claim</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-cle;EquityClaim">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;REAClaim"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity claim</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Needs to be unpicked Equity represents ownership in some venture. You own a piece of the assets of the venture, which gives you a claim on those assets. there is parallel to the discharging of obligations and rights in a transaction, in there here, the obligation/right continues to exist until or unless the venture is wound up.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-cle;REATransactionObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">r e a transaction obligation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-cle;REATransactionRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">r e a transaction right</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;asReportedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">as reported by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-soc-asp;Claim"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-cle;AccountingReportingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;asSeenBy">
+bubu<rdfs:label>as seen by</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;definedOnThePartOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined on the part of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;REAClaim"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-cle;AccountingReportingParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;hasEnd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has end</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-ev;DischargingEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-cle;hasStart">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has start</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-ev;TransactionUndertaking"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;REAClaim">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/REATransactions.rdf
+++ b/fnd/TransactionsExt/REATransactions.rdf
@@ -1,447 +1,451 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/">
-	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
-	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-txn-cle "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/">
-	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-	<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-lei "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/">
+bu<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
+bu<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-txn-cle "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/">
+bu<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bu<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"
-	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
-	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-txn-cle="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/"
-	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-		<rdfs:label xml:lang="en">REATransactions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;ContractualEconomicAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;agreementFormalizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;confersContractualEconomicAgreement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;contractualEconomicAgreementHasParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualTransactionParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractual economic agreement</rdfs:label>
-		<skos:definition xml:lang="en">An economic agreement forming part of a transaction, which has contractual standing as evidenced by a contract between the two parties to the Agreement.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The REA Economic Agreement may or may not be between two distinct legal persons, as the REA scope includes transactions within organizations. For REA based transaction models which are between separate legal entities or persons, the form of agreement in force is this Contractual Economic Agreement, that is the agreement, backed by a written or implied contract, which is in force between the parties to this agreement.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;ContractualEconomicCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;contractualEconomicAgreementConferredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;contractualEconomicCommitmentDescribedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractual economic commitment</rdfs:label>
-		<skos:definition xml:lang="en">Some Commitment, made as part of a transaction (economic) agreement, which has contractual standing.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In REA, transactions may be modeled with or without contractual standing, for example transactions between departments within an organization. For all transactions which are between distinct legal persons or entities, this Contractual Economic Commitment represents the type of commitment which is in force. In an economic transaction there are always two of these, corresponding to the two sides of the transaction (e.g. delivery and payment, or payment of two separate swap streams).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;ContractualTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-		<rdfs:label xml:lang="en">contractual transaction</rdfs:label>
-		<skos:definition xml:lang="en">An economic transaction which has some contractual basis.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is distinct from a transaction between business units within an enterprise. This is the usual sense of &quot;Transaction&quot; and forms the basis for all securities and derivatives transactions, while the parent term &quot;Economic Transaction&quot; may also be used to define internal transactions and transactions that have no legal or contractual basis.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;ContractualTransactionParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;contractualTransactionPartyIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lei;ContractuallyCapableEntity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractual transaction party</rdfs:label>
-		<skos:definition xml:lang="en">That which is party to a transaction which has contractual standing.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In REA, transactions may include those which are not between legal entities,such as for example internal transactions within a business and between business units. This term Contractual Transaction Party forms the basis for all party definitions for transactions which have some formal contractual basis as being between discrete legal entities (legal persons or other contractually capable entities e.g. non incorporated entities). This is the basis for all derivatives transactions, securities market transactions and so on.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;hasPartyInRole"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;confersEconomicCommitment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;economicAgreementGovernsTransaction"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">economic agreement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;MutualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;economicCommitmentIsConferredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;madeBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">economic commitment</rdfs:label>
-		<skos:definition xml:lang="en">Some Commitment which forms part of the subject of some Transaction, being an undertaking by one or other of the parties to the transaction, extended to the other party to that same transaction.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;contractEmbodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">economic contract</rdfs:label>
-		<skos:definition xml:lang="en">A contract relating to and governing an economic transaction between two parties.</skos:definition>
-		<skos:editorialNote xml:lang="en">From REA ontology.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicContractTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;setsOutContractualEconomicCommitment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">economic contract commitment</rdfs:label>
-		<skos:definition xml:lang="en">Terms underlying the contract for a transaction.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicTransaction">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;subject"/>
-				<owl:onClass rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;transactedUnder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">economic transaction</rdfs:label>
-		<skos:definition xml:lang="en">Some exchange of some items of economic value between two parties (economic agents).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;REAClaim">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;isImbalanceIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-lcap;LegalConstruct"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">r e a claim</rdfs:label>
-		<skos:definition xml:lang="en">Some imbalance, at a given point in time, between the respective rights and obligations of two parties with respect to one another.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionBusinessEvent">
-		<rdfs:label xml:lang="en">transaction business event</rdfs:label>
-		<skos:definition xml:lang="en">Occurrence in time that partners to a business transaction wish to monitor or control.</skos:definition>
-		<skos:editorialNote xml:lang="en">Term derived from REA as expressed in ISO 15944-4 Additional notes in ISO 15944-4 itself: NOTE 1 Business events are the workflow tasks that business partners need to accomplish to complete a business transaction among themselves. As business events occur, they cause a business transaction to move through its various phases of planning, identification, negotiation, actualization and post-actualization. NOTE 2 Occurrences in time can either - be internal as mutually agreed to among the parties to a business transaction; and/or, - reference some common publicly available and recognized date/time referencing schema (e.g. one based on using ISO 8601 and/or ISO 19135).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionEvent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-cle;hasEnd"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ev;DischargingEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-cle;hasStart"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ev;TransactionUndertaking"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;hasCorresponding"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">transaction event</rdfs:label>
-		<skos:definition xml:lang="en">The event component of a transaction</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This describes an event. The event may be delivery of something or settlement of monies in payment for something delivered. A Transaction Event will have terms describing the commitment embodied in that side of that transaction.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionEventAspect">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;hasCorrespondingAlternativeAspect"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionEventAspect"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">transaction event aspect</rdfs:label>
-		<skos:definition xml:lang="en">A transaction side as seen from the perspective of one of the parties to the transaction.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This describes one side of one transaction event. The event may be delivery of something or settlement of monies in payment for something delivered. A Transaction Event Side shows that side of that transaction from the perspective of one or other party.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;transactsWith"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">transaction party</rdfs:label>
-		<skos:definition xml:lang="en">Some entity which takes part in some transaction by receiving and/or parting with some item of economic value or some payment or both.</skos:definition>
-		<skos:editorialNote xml:lang="en">Referred to in REA as Economic Agent (in the context of the economic event, known here as transaction).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;confersContractualEconomicAgreement">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agrx-con;confersContractualCommitment"/>
-		<rdfs:label xml:lang="en">confers contractual economic agreement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-		<skos:definition xml:lang="en">A Contractual Commitment forming part of a (Transaction related) Contractual Economic Agreement and which is documented in the Economic Contract which evidences the agreement between the parties in respect of that transaction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;confersEconomicCommitment">
-		<rdfs:label xml:lang="en">confers economic commitment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
-		<skos:definition xml:lang="en">Some Economic Commitment, that is a commitment in respect of an economic transaction, which arises from the Economic Agreement and exists as a result of that Agreement between the parties to the transaction.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be a contractual commitment between two parties or it may be a commitment between two internal entities within an organization, not having legal standing.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;contractualEconomicAgreementConferredBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agrx-ctrx;contractualCommitmentConferredBy"/>
-		<rdfs:label xml:lang="en">contractual economic agreement conferred by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
-		<skos:definition xml:lang="en">That which confers the contractual economic commitment (transaction related commitment), namely some Economic Agreement with contractual standing, and in which the contract between the parties sets out the details of the Commitment.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are two such Commitments to any transaction, each having reciprocality between the parties i.e. the party which has the obligation in respect of one Commitment has the right(s) in respect of the other - for example the obligation to deliver goods and the right to receive payment in settlement.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;contractualEconomicAgreementHasParty">
-		<rdfs:label xml:lang="en">contractual economic agreement has party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualTransactionParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;contractualEconomicCommitmentDescribedIn">
-		<rdfs:label xml:lang="en">contractual economic commitment described in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;contractualTransactionPartyIdentity">
-		<rdfs:label xml:lang="en">contractual transaction party identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualTransactionParty"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lei;ContractuallyCapableEntity"/>
-		<skos:definition xml:lang="en">Transaction Party is identified as some form of Legal Entity in all cases.</skos:definition>
-		<skos:editorialNote xml:lang="en">Follows reviews. Reasons include that transactions always embody some contract. Subsequent thinking (see Review Notes for 27 Oct 2010) - the most general form of &quot;Transaction&quot; should be so general as to also include the &quot;sweet shop&quot; transaction. Also (per REA case studies), transaction parties include those within firms and therefore not between contractually capable entities. To resolve this, we introduced the notion of a Contractual Transaction Party, for transactions which are between entities. This relationship, which originally obtained for Transaction Party, now applies specifically for Contractual Transaction Party.</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;definedInContextOf">
-		<rdfs:label>defined in context of</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;economicAgreementGovernsTransaction">
-		<rdfs:label xml:lang="en">economic agreement governs transaction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-		<skos:definition xml:lang="en">The transaction which is set out by this agreement.</skos:definition>
-		<skos:editorialNote xml:lang="en">From REA ontology.</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;economicCommitmentIsConferredBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
-		<rdfs:label xml:lang="en">economic commitment is conferred by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
-		<skos:definition xml:lang="en">The Economic Commitment, that is some commitment which forms part of a transaction, is conferred by the bilateral Economic Agreement between the parties to the transaction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;embodiesEconomicCommitment">
-		<rdfs:label xml:lang="en">embodies economic commitment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment">
-		<rdfs:label xml:lang="en">establishes contractual economic commitment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-		<skos:definition xml:lang="en">An economic contract sets up some commitment on the part of one or other party to the contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example this may be a commitment to deliver some goods, perform some service or pay some payment in cash or in kind. From REA ontology.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasCorresponding">
-		<rdfs:label xml:lang="en">has corresponding</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasCorrespondingAlternativeAspect">
-		<rdfs:label xml:lang="en">has corresponding alternative aspect</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEventAspect"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionEventAspect"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasPerspective">
-		<rdfs:label xml:lang="en">has perspective</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionEventAspect"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasTransactionComponent">
-		<rdfs:label xml:lang="en">has transaction component</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasTransactionParty">
-		<rdfs:label xml:lang="en">has transaction party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;isImbalanceIn">
-		<rdfs:label xml:lang="en">is imbalance in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;REAClaim"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-lcap;LegalConstruct"/>
-		<skos:definition xml:lang="en">The imbalance in Obligations or Rights (depending on the viewpoint from which it is described) between one party and another.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;setsOutContractualEconomicCommitment">
-		<rdfs:label xml:lang="en">sets out contractual economic commitment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-txn-rea;contractualEconomicCommitmentDescribedIn"/>
-		<skos:definition xml:lang="en">The economic commitment set out in the terms to the contract which formalizes the agreement to the transaction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;subject">
-		<rdfs:label xml:lang="en">subject</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;transactedUnder">
-		<rdfs:label xml:lang="en">transacted under</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement">
-		<rdfs:label xml:lang="en">transaction embodies economic agreement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-txn-rea;economicAgreementGovernsTransaction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;transactionEventFollowsBusinessProcess">
-		<rdfs:label xml:lang="en">transaction event follows business process</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;transactsWith">
-		<rdfs:label xml:lang="en">transacts with</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-lei="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"
+buxmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
+buxmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-txn-cle="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/"
+buxmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
+buxmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">REATransactions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This is the core REA-derived ontology for transactions. A transaction is defined as an exchange of commitments between parties. 
+		Other aspects of REA such as claims and transaction events (commitment lifecycles) are given in separate ontologies in this module.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REAClaimsEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;ContractualEconomicAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualAgreement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;agreementFormalizedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;confersContractualEconomicAgreement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;contractualEconomicAgreementHasParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualTransactionParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual economic agreement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An economic agreement forming part of a transaction, which has contractual standing as evidenced by a contract between the two parties to the Agreement.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The REA Economic Agreement may or may not be between two distinct legal persons, as the REA scope includes transactions within organizations. For REA based transaction models which are between separate legal entities or persons, the form of agreement in force is this Contractual Economic Agreement, that is the agreement, backed by a written or implied contract, which is in force between the parties to this agreement.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;ContractualEconomicCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;contractualEconomicAgreementConferredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;contractualEconomicCommitmentDescribedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual economic commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some Commitment, made as part of a transaction (economic) agreement, which has contractual standing.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In REA, transactions may be modeled with or without contractual standing, for example transactions between departments within an organization. For all transactions which are between distinct legal persons or entities, this Contractual Economic Commitment represents the type of commitment which is in force. In an economic transaction there are always two of these, corresponding to the two sides of the transaction (e.g. delivery and payment, or payment of two separate swap streams).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;ContractualTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An economic transaction which has some contractual basis.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is distinct from a transaction between business units within an enterprise. This is the usual sense of &quot;Transaction&quot; and forms the basis for all securities and derivatives transactions, while the parent term &quot;Economic Transaction&quot; may also be used to define internal transactions and transactions that have no legal or contractual basis.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;ContractualTransactionParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;contractualTransactionPartyIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-lei;ContractuallyCapableEntity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual transaction party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That which is party to a transaction which has contractual standing.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In REA, transactions may include those which are not between legal entities,such as for example internal transactions within a business and between business units. This term Contractual Transaction Party forms the basis for all party definitions for transactions which have some formal contractual basis as being between discrete legal entities (legal persons or other contractually capable entities e.g. non incorporated entities). This is the basis for all derivatives transactions, securities market transactions and so on.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-ptyx-prc;hasPartyInRole"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;confersEconomicCommitment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;economicAgreementGovernsTransaction"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic agreement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;MutualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;economicCommitmentIsConferredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;madeBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some Commitment which forms part of the subject of some Transaction, being an undertaking by one or other of the parties to the transaction, extended to the other party to that same transaction.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;contractEmbodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A contract relating to and governing an economic transaction between two parties.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From REA ontology.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicContractTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;setsOutContractualEconomicCommitment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic contract commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms underlying the contract for a transaction.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;EconomicTransaction">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;subject"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;transactedUnder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some exchange of some items of economic value between two parties (economic agents).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;REAClaim">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;isImbalanceIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-lcap;LegalConstruct"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">r e a claim</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some imbalance, at a given point in time, between the respective rights and obligations of two parties with respect to one another.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionBusinessEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction business event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Occurrence in time that partners to a business transaction wish to monitor or control.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Term derived from REA as expressed in ISO 15944-4 Additional notes in ISO 15944-4 itself: NOTE 1 Business events are the workflow tasks that business partners need to accomplish to complete a business transaction among themselves. As business events occur, they cause a business transaction to move through its various phases of planning, identification, negotiation, actualization and post-actualization. NOTE 2 Occurrences in time can either - be internal as mutually agreed to among the parties to a business transaction; and/or, - reference some common publicly available and recognized date/time referencing schema (e.g. one based on using ISO 8601 and/or ISO 19135).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionEvent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-cle;hasEnd"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ev;DischargingEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-cle;hasStart"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ev;TransactionUndertaking"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;hasCorresponding"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The event component of a transaction</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This describes an event. The event may be delivery of something or settlement of monies in payment for something delivered. A Transaction Event will have terms describing the commitment embodied in that side of that transaction.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionEventAspect">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;hasCorrespondingAlternativeAspect"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionEventAspect"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction event aspect</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction side as seen from the perspective of one of the parties to the transaction.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This describes one side of one transaction event. The event may be delivery of something or settlement of monies in payment for something delivered. A Transaction Event Side shows that side of that transaction from the perspective of one or other party.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;transactsWith"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some entity which takes part in some transaction by receiving and/or parting with some item of economic value or some payment or both.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Referred to in REA as Economic Agent (in the context of the economic event, known here as transaction).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;confersContractualEconomicAgreement">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agrx-con;confersContractualCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers contractual economic agreement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Contractual Commitment forming part of a (Transaction related) Contractual Economic Agreement and which is documented in the Economic Contract which evidences the agreement between the parties in respect of that transaction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;confersEconomicCommitment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers economic commitment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some Economic Commitment, that is a commitment in respect of an economic transaction, which arises from the Economic Agreement and exists as a result of that Agreement between the parties to the transaction.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be a contractual commitment between two parties or it may be a commitment between two internal entities within an organization, not having legal standing.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;contractualEconomicAgreementConferredBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agrx-ctrx;contractualCommitmentConferredBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual economic agreement conferred by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That which confers the contractual economic commitment (transaction related commitment), namely some Economic Agreement with contractual standing, and in which the contract between the parties sets out the details of the Commitment.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There are two such Commitments to any transaction, each having reciprocality between the parties i.e. the party which has the obligation in respect of one Commitment has the right(s) in respect of the other - for example the obligation to deliver goods and the right to receive payment in settlement.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;contractualEconomicAgreementHasParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual economic agreement has party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualTransactionParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;contractualEconomicCommitmentDescribedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual economic commitment described in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;contractualTransactionPartyIdentity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual transaction party identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;ContractualTransactionParty"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-lei;ContractuallyCapableEntity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Transaction Party is identified as some form of Legal Entity in all cases.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Follows reviews. Reasons include that transactions always embody some contract. Subsequent thinking (see Review Notes for 27 Oct 2010) - the most general form of &quot;Transaction&quot; should be so general as to also include the &quot;sweet shop&quot; transaction. Also (per REA case studies), transaction parties include those within firms and therefore not between contractually capable entities. To resolve this, we introduced the notion of a Contractual Transaction Party, for transactions which are between entities. This relationship, which originally obtained for Transaction Party, now applies specifically for Contractual Transaction Party.</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;definedInContextOf">
+bubu<rdfs:label>defined in context of</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;economicAgreementGovernsTransaction">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic agreement governs transaction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The transaction which is set out by this agreement.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From REA ontology.</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;economicCommitmentIsConferredBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic commitment is conferred by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Economic Commitment, that is some commitment which forms part of a transaction, is conferred by the bilateral Economic Agreement between the parties to the transaction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;embodiesEconomicCommitment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies economic commitment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes contractual economic commitment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An economic contract sets up some commitment on the part of one or other party to the contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example this may be a commitment to deliver some goods, perform some service or pay some payment in cash or in kind. From REA ontology.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasCorresponding">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has corresponding</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasCorrespondingAlternativeAspect">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has corresponding alternative aspect</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEventAspect"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionEventAspect"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasPerspective">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has perspective</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionEventAspect"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasTransactionComponent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has transaction component</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;hasTransactionParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has transaction party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;isImbalanceIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is imbalance in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;REAClaim"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-lcap;LegalConstruct"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The imbalance in Obligations or Rights (depending on the viewpoint from which it is described) between one party and another.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;setsOutContractualEconomicCommitment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out contractual economic commitment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;ContractualEconomicCommitment"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-txn-rea;contractualEconomicCommitmentDescribedIn"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The economic commitment set out in the terms to the contract which formalizes the agreement to the transaction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;subject">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subject</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;transactedUnder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transacted under</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction embodies economic agreement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;EconomicTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicAgreement"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-txn-rea;economicAgreementGovernsTransaction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;transactionEventFollowsBusinessProcess">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction event follows business process</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-rea;transactsWith">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transacts with</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/SecuritiesTransactions.rdf
+++ b/fnd/TransactionsExt/SecuritiesTransactions.rdf
@@ -1,161 +1,165 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-txn-mkt "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
-	<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-txn-mkt "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
+bu<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
-	xmlns:fibo-fnd-txn-mkt="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
-	xmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
-		<rdfs:label xml:lang="en">SecuritiesTransactions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sec;FinancialPrimaryMarketTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;follows"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;SettlementProcess"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial primary market transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;consideration"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fnd-txn-sup;NegotiableCash">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;counterparty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionCounterparty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;principal"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionPrincipal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;subject"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial securities secondary market transaction</rdfs:label>
-		<skos:definition xml:lang="en">A Transaction in which some negotiable security is provided in exchange for some Consideration.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sec;SecuritiesTransactionContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;governs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities transaction contract</rdfs:label>
-		<skos:definition xml:lang="en">The contract (written or implied) which governs the transaction of securities in the secondary Market.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is in line with the REA Ontology in which all Transactions are embodied in some Contract, whether written or implied. forms part of future &quot;Transaction&quot; model to be reviewed, but is ancestral to Options contract and transactions model.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sec;SecuritiesTransactionCounterparty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
-		<rdfs:label xml:lang="en">securities transaction counterparty</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sec;SecuritiesTransactionPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;TransactionPrincipal"/>
-		<rdfs:label xml:lang="en">securities transaction principal</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sec;SettlementProcess">
-		<rdfs:label xml:lang="en">settlement process</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sec;WhenIssuedTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
-		<rdfs:label xml:lang="en">when issued transaction</rdfs:label>
-		<skos:definition xml:lang="en">Trading in securities ahead of them being traded.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sec;embodies">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sec;follows">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEventFollowsBusinessProcess"/>
-		<rdfs:label xml:lang="en">follows</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sec;FinancialPrimaryMarketTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-sec;SettlementProcess"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sec;governs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;economicAgreementGovernsTransaction"/>
-		<rdfs:label xml:lang="en">governs</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-txn-sec;embodies"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sec;offsetForWIIssueDate">
-		<rdfs:label xml:lang="en">offset for w i issue date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sec;WhenIssuedTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Used to calculate actual settlement date from given WI issue date. If issue date is unknwn, this determines how many days form the issue date it&apos;s going to settle.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-txn-mkt="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"
+buxmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SecuritiesTransactions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Describes the basic concepts for securities transactions, as an extension of market transactions more generally. Incudes types of securities transactions, parties to the transaction, settlement and the covering contract for the transaction.
+		This ontology would form the basis for more detailed securities transaction concepts that would ideally be derived from the FIX standard.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sec;FinancialPrimaryMarketTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;follows"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;SettlementProcess"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial primary market transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;consideration"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-fnd-txn-sup;NegotiableCash">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;counterparty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionCounterparty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;principal"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionPrincipal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-rea;subject"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;embodies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial securities secondary market transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Transaction in which some negotiable security is provided in exchange for some Consideration.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sec;SecuritiesTransactionContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-sec;governs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities transaction contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The contract (written or implied) which governs the transaction of securities in the secondary Market.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is in line with the REA Ontology in which all Transactions are embodied in some Contract, whether written or implied. forms part of future &quot;Transaction&quot; model to be reviewed, but is ancestral to Options contract and transactions model.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sec;SecuritiesTransactionCounterparty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities transaction counterparty</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sec;SecuritiesTransactionPrincipal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;TransactionPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities transaction principal</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sec;SettlementProcess">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement process</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sec;WhenIssuedTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">when issued transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Trading in securities ahead of them being traded.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sec;embodies">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sec;follows">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEventFollowsBusinessProcess"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">follows</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sec;FinancialPrimaryMarketTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-sec;SettlementProcess"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sec;governs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;economicAgreementGovernsTransaction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governs</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sec;SecuritiesTransactionContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-sec;FinancialSecuritiesSecondaryMarketTransaction"/>
+bubu<owl:inverseOf rdf:resource="&fibo-fnd-txn-sec;embodies"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sec;offsetForWIIssueDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offset for w i issue date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sec;WhenIssuedTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Used to calculate actual settlement date from given WI issue date. If issue date is unknwn, this determines how many days form the issue date it&apos;s going to settle.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/SupplyTransactions.rdf
+++ b/fnd/TransactionsExt/SupplyTransactions.rdf
@@ -1,161 +1,165 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-	<!ENTITY fibo-fnd-txn-mkt "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bu<!ENTITY fibo-fnd-txn-mkt "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-sup "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-txn-mkt="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
-		<rdfs:label xml:lang="en">SupplyTransactions</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sup;BundleOfResources">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-		<rdfs:label xml:lang="en">bundle of resources</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sup;Customer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;customerTransactsWithVendor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;Vendor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">customer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sup;DeliveryTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sup;SupplyTransactionTerms"/>
-		<rdfs:label xml:lang="en">delivery terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sup;NegotiableCash">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isQuantityOf.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Cash"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">negotiable cash</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sup;SupplyTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;consideration"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sup;customer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;Customer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sup;governedByTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;SupplyTransactionTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sup;supply"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;BundleOfResources"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-sup;vendor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;Vendor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">supply transaction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sup;SupplyTransactionTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
-		<rdfs:label xml:lang="en">supply transaction terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-sup;Vendor">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;TransactionPrincipal"/>
-		<rdfs:label xml:lang="en">vendor</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;customer">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-mkt;counterparty"/>
-		<rdfs:label xml:lang="en">customer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;SupplyTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-sup;Customer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;denomination">
-		<rdfs:label xml:lang="en">denomination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the negotiable cash is denominated. This is the currency seen in the &quot;Monetary Amount&quot;.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;governedByTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactedUnder"/>
-		<rdfs:label xml:lang="en">governed by terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;SupplyTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-sup;SupplyTransactionTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-fnd-txn-sup;scheduledDeliveryDate">
-		<rdfs:label xml:lang="en">scheduled delivery date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;DeliveryTerms"/>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;supply">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;subject"/>
-		<rdfs:label xml:lang="en">supply</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;SupplyTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-sup;BundleOfResources"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;vendor">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-mkt;principal"/>
-		<rdfs:label xml:lang="en">vendor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;SupplyTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-sup;Vendor"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
+buxmlns:fibo-fnd-txn-mkt="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-sup="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SupplyTransactions</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the basic concepts in a supply transaction. 
+		This is an extension of the Market Transactions ontology and is included for completeness of those concepts and differentiates other kinds of market transaction from securities transactions. It is not expected that this is referred to in other FIBO ontologies and it may be left out of application ontologies.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/MarketTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SecuritiesTransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/SupplyTransactions/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sup;BundleOfResources">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bundle of resources</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sup;Customer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;TransactionCounterparty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;customerTransactsWithVendor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;Vendor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">customer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sup;DeliveryTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-sup;SupplyTransactionTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delivery terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sup;NegotiableCash">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;isQuantityOf.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Cash"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">negotiable cash</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sup;SupplyTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;MarketTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-mkt;consideration"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-sup;customer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;Customer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-sup;governedByTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;SupplyTransactionTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-sup;supply"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;BundleOfResources"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-sup;vendor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-sup;Vendor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">supply transaction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sup;SupplyTransactionTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;EconomicContractTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">supply transaction terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-sup;Vendor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-mkt;TransactionPrincipal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">vendor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;customer">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-mkt;counterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">customer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;SupplyTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-sup;Customer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;denomination">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;NegotiableCash"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which the negotiable cash is denominated. This is the currency seen in the &quot;Monetary Amount&quot;.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;governedByTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactedUnder"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governed by terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;SupplyTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-sup;SupplyTransactionTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-fnd-txn-sup;scheduledDeliveryDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheduled delivery date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;DeliveryTerms"/>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;supply">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;subject"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">supply</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;SupplyTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-sup;BundleOfResources"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-sup;vendor">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-mkt;principal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">vendor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-sup;SupplyTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-sup;Vendor"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/TransactionAccounting.rdf
+++ b/fnd/TransactionsExt/TransactionAccounting.rdf
@@ -1,86 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-txn-acc "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-txn-acc "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-txn-acc="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/">
-		<rdfs:label xml:lang="en">TransactionAccounting</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionBusinessEvent">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionEvent">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-acc;AccountsLedgerEntry">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-acc;isPartOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">accounts ledger entry</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;amount">
-		<rdfs:label xml:lang="en">amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;isPartOf">
-		<rdfs:label xml:lang="en">is part of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;narrative">
-		<rdfs:label xml:lang="en">narrative</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;reflectedInSome">
-		<rdfs:label xml:lang="en">reflected in some</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;triggers">
-		<rdfs:label xml:lang="en">triggers</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionBusinessEvent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-txn-acc="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">TransactionAccounting</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology introduces the notion of an accounts ledger entry which is referred to in transaction events and workflows.
+		This ontology extends the notion of aspects of a commitment in order to provide the bridge between an REA accounting view of transactions and a general ledger view.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionBusinessEvent">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-rea;TransactionEvent">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-acc;AccountsLedgerEntry">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-acc;isPartOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accounts ledger entry</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;amount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;isPartOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is part of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-acc;LedgerAccount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;narrative">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">narrative</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;reflectedInSome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reflected in some</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-acc;triggers">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">triggers</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-rea;TransactionBusinessEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/TransactionEvents.rdf
+++ b/fnd/TransactionsExt/TransactionEvents.rdf
@@ -1,204 +1,207 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/">
-	<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
-	<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
-	<!ENTITY fibo-fnd-txn-acc "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/">
-	<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/">
+bu<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
+bu<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
+bu<!ENTITY fibo-fnd-txn-acc "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/">
+bu<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
-	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
-	xmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
-	xmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
-	xmlns:fibo-fnd-txn-acc="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/"
-	xmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
-		<rdfs:label xml:lang="en">TransactionEvents</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-ev;ContractualUndertaking">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ev;UndertakingEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;givesRiseTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">contractual undertaking</rdfs:label>
-		<skos:definition xml:lang="en">A commitment, defined in a Contract, in which one Party to that Contract undertakes to do something or to deliver something or make some payment, to the other Party.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">It is often the Principal to the Contract which makes the commitment, however for Transaction contracts, each sides makes a reciprocal commitment to the other. Parties to specific Commitments may be shown where this clarifies the model, else it is simply identified as being a commitment. Orginally REA &quot;Commitment&quot; but separated in order to cover cashflow feature comitments in some options; commitments in Loan contracts (interest and principal repayment) and so on.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-ev;DischargingEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionBusinessEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-acc;triggers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;terminates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">discharging event</rdfs:label>
-		<skos:definition xml:lang="en">The event in which the</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-ev;Revaluation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionBusinessEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-acc;triggers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">revaluation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-ev;TransactionUndertaking">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ev;UndertakingEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;givesRiseTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">transaction undertaking</rdfs:label>
-		<skos:definition xml:lang="en">A contractually defined and established commitment to deliver some goods, perform some service or make some payment in cash or in kind.</skos:definition>
-		<skos:editorialNote xml:lang="en">From REA ontology.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-ev;Undertaking">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;bestows"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;givesRiseTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-agr;MutualCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;isMadeAsPartOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;isUndertakingTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;undertakenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ev;UndertakingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">undertaking</rdfs:label>
-		<skos:definition xml:lang="en">Some undertaking to act.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This could be an undertaking to deliver something, to do something and so on. These correspond to negative and positive pledges in the contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-ev;UndertakingEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionBusinessEvent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-acc;triggers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">undertaking event</rdfs:label>
-		<skos:definition xml:lang="en">Something which occurs at a point in time, at which a party makes some commitment to some other party.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-ev;UndertakingParty">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;isPartyTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">undertaking party</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;bestows">
-		<rdfs:label xml:lang="en">bestows</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
-		<rdfs:range rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;givesRiseTo">
-		<rdfs:label xml:lang="en">gives rise to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-agr;MutualCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;isMadeAsPartOf">
-		<rdfs:label xml:lang="en">is made as part of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;isPartyTo">
-		<rdfs:label xml:lang="en">is party to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;UndertakingParty"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;isUndertakingTo">
-		<rdfs:label xml:lang="en">is undertaking to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
-		<rdfs:range rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;madeBy">
-		<rdfs:label xml:lang="en">made by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;terminates">
-		<rdfs:label xml:lang="en">terminates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;DischargingEvent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;undertakenBy">
-		<rdfs:label xml:lang="en">undertaken by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-ev;UndertakingParty"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"
+buxmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
+buxmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
+buxmlns:fibo-fnd-txn-acc="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/"
+buxmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">TransactionEvents</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology provides the temporal dimension of the transaction events given in REA. Each commitment in a transaction comes into being when the transaction is struck and ceases to exist when that commitment is discharged.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionAccounting/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionEvents/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-ev;ContractualUndertaking">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ev;UndertakingEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;givesRiseTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractual undertaking</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment, defined in a Contract, in which one Party to that Contract undertakes to do something or to deliver something or make some payment, to the other Party.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">It is often the Principal to the Contract which makes the commitment, however for Transaction contracts, each sides makes a reciprocal commitment to the other. Parties to specific Commitments may be shown where this clarifies the model, else it is simply identified as being a commitment. Orginally REA &quot;Commitment&quot; but separated in order to cover cashflow feature comitments in some options; commitments in Loan contracts (interest and principal repayment) and so on.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-ev;DischargingEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionBusinessEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-acc;triggers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;terminates"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">discharging event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The event in which the</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-ev;Revaluation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionBusinessEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-acc;triggers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">revaluation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-ev;TransactionUndertaking">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ev;UndertakingEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;givesRiseTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">transaction undertaking</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A contractually defined and established commitment to deliver some goods, perform some service or make some payment in cash or in kind.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From REA ontology.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-ev;Undertaking">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;bestows"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;givesRiseTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-agr;MutualCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;isMadeAsPartOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;isUndertakingTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;undertakenBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ev;UndertakingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">undertaking</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some undertaking to act.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This could be an undertaking to deliver something, to do something and so on. These correspond to negative and positive pledges in the contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-ev;UndertakingEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;TransactionBusinessEvent"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-acc;triggers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-acc;AccountsLedgerEntry"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">undertaking event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Something which occurs at a point in time, at which a party makes some commitment to some other party.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-ev;UndertakingParty">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;isPartyTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">undertaking party</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;bestows">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bestows</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-soc-asp;ContingentRight"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;givesRiseTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gives rise to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-agr;MutualCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;isMadeAsPartOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is made as part of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;isPartyTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is party to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;UndertakingParty"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-agr;Agreement"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;isUndertakingTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is undertaking to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-soc-asp;ContingentObligation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;madeBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">made by</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;TransactionParty"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;terminates">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">terminates</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;DischargingEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-rea;EconomicCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-ev;undertakenBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">undertaken by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-ev;Undertaking"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-ev;UndertakingParty"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/TransactionsExt/TransactionsExtended.rdf
+++ b/fnd/TransactionsExt/TransactionsExtended.rdf
@@ -1,97 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-derx-ma "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
-	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
-	<!ENTITY fibo-fnd-txn-txnx "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-derx-ma "https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
+bu<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bu<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/">
+bu<!ENTITY fibo-fnd-txn-txnx "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"
-	xmlns:fibo-der-derx-ma="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
-	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
-	xmlns:fibo-fnd-txn-txnx="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/">
-		<rdfs:label xml:lang="en">TransactionsExtended</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-txnx;ContractuallyDefinedBenefit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-		<rdfs:label xml:lang="en">contractually defined benefit</rdfs:label>
-		<skos:definition xml:lang="en">Some benefit from one party to the other party, defined in contractual terms.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This could for example be a contractual promise of future cash flows such as dividends on a specific instrument.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-txnx;CoveredTransaction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransaction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-txnx;governedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-txnx;MasterAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">covered transaction</rdfs:label>
-		<skos:definition xml:lang="en">A transaction covered by some Master Agreement.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The Master Agreement sets out the terms and conditions under which these transactions are to take place between the parties. These are Over the Counter transactions, including OTC Derivatives.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-txn-txnx;MasterAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;mandates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;MasterAgreementObligation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-txn-txnx;governs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractualRelationship"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">master agreement</rdfs:label>
-		<skos:definition xml:lang="en">A legal contract which is deemed to apply to a number of future activities between the parties thereto and having force over future agreements or contracts to be brought into effect between those parties.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-txnx;governedBy">
-		<rdfs:label xml:lang="en">governed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-txnx;CoveredTransaction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-txnx;MasterAgreement"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-txn-txnx;governs">
-		<rdfs:label xml:lang="en">governs</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-txn-txnx;MasterAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractualRelationship"/>
-		<skos:definition xml:lang="en">The contractual relationship defined by the master agreement.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-derx-ma="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
+buxmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
+buxmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"
+buxmlns:fibo-fnd-txn-txnx="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">TransactionsExtended</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology provides further extensions to the REA-derived transaction concepts in this module. These incude master agreements and covered transactions.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContractsExt/OTCDerivativeMasterAgreements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/REATransactions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/TransactionsExtended/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-txnx;ContractuallyDefinedBenefit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractually defined benefit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some benefit from one party to the other party, defined in contractual terms.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This could for example be a contractual promise of future cash flows such as dividends on a specific instrument.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-txnx;CoveredTransaction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-txn-rea;ContractualTransaction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-txnx;governedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-txnx;MasterAgreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">covered transaction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A transaction covered by some Master Agreement.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The Master Agreement sets out the terms and conditions under which these transactions are to take place between the parties. These are Over the Counter transactions, including OTC Derivatives.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-txn-txnx;MasterAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;mandates"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-derx-ma;MasterAgreementObligation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-txn-txnx;governs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-agrx-ctrx;ContractualRelationship"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">master agreement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A legal contract which is deemed to apply to a number of future activities between the parties thereto and having force over future agreements or contracts to be brought into effect between those parties.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-txnx;governedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-txnx;CoveredTransaction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-txnx;MasterAgreement"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-fnd-txn-txnx;governs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governs</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-txn-txnx;MasterAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agrx-ctrx;ContractualRelationship"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The contractual relationship defined by the master agreement.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/fnd/Utilities/Values.rdf
+++ b/fnd/Utilities/Values.rdf
@@ -1,119 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utl-val "https://spec.edmcouncil.org/fibo/FND/Utilities/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utl-val "https://spec.edmcouncil.org/fibo/FND/Utilities/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF
-	xmlns="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utl-val="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/">
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Values Ontology</rdfs:label>
-		<terms:license rdf:datatype="&rdf;langString" xml:lang="en">&amp;sm;MITLicense</terms:license>
-		<sm:copyright rdf:datatype="&rdf;langString" xml:lang="en">Copyright (c) 2015-2017 EDM Council</sm:copyright>
-		<sm:fileAbstract rdf:datatype="&rdf;langString" xml:lang="en">The Values ontology introduces a set of foundational classes that represent “values” as OWL classes where a value is an immutable piece of information without a specific lifetime or identity independent of the properties that have a value as their subject.  Subtypes of Value are intended to include semantic, business relevant classes that are not independent, mediating or relative things. 
+buxmlns="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/"
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utl-val="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Values Ontology</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">The Values ontology introduces a set of foundational classes that represent “values” as OWL classes where a value is an immutable piece of information without a specific lifetime or identity independent of the properties that have a value as their subject.  Subtypes of Value are intended to include semantic, business relevant classes that are not independent, mediating or relative things. 
 While Values as defined here, in some cases, seem to replicate XSD data types they are intended to use, extend and build-on XSD data types for “business meaningful values”. 
 Business meaningful values (which we will call “Business Semantic Values”) are things like amount, name, postal address, mass, duration, currency and metrics – concepts that make sense in the business domain and are the types of properties of business entities, but not they are not business entities in themselves.  These values are the type (range) of properties that represent the qualities and characteristics of the entities in our business domain such as people, places, transactions and financial instruments. In contrast to semantic values, primitive datatypes, such as “Real”, “Integer” or “String”, frequently have no business meaning on their own.
-As the intent of the Value classes is to capture business meaning, the Value classes are not intended to be used directly in domain models. Subclasses of Value classes that capture business semantics are intended for use in domain models. In other languages, such as UML, this intent to only use subclasses is known as an “Abstract” class.</sm:fileAbstract>
-		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/39479.html</rdfs:seeAlso>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/20140801/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-utl-val;FloatingPointValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;NumericValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;double"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>floating point value</rdfs:label>
-		<skos:definition rdf:datatype="&xsd;string">A floating point representation of a number. Note that this class is not intended to be used directly (in these cases use xsd:double) but is intended to be subclassed with values with business semantic intent.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utl-val;IntegerValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;NumericValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;integer"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">integer value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An integer value is a numeric value with that represents an Integer using an xsd:integer. Note that this class is not intended to be used directly (in these cases use xsd:integer) but is intended to be subclassed with values with business semantic intent.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utl-val;NumericRatioValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;NumericValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numeric ratio value</rdfs:label>
-		<skos:definition rdf:datatype="&xsd;string">A numeric value representing a ratio between two other numeric values.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utl-val;NumericValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;SingleValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numeric value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A numeric value is a single value intended to represent any number without restriction as to precision, scale or representation. The number or expression is contained in the hasValue property.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utl-val;PercentageValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;NumericRatioValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A percentage value is a numeric value representing a rate, number, or amount in each hundred.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utl-val;SingleValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;Value"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">single value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A single value is a Value with exactly one distinguished &quot;hasValue&quot; property that represents the primary data element of that value. Other properties of a SingleValue may be defined to qualify hasValue, such as a unit, namespace or defining authority.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utl-val;TextValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;SingleValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;string"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>text value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A text value is a single value representing textural information represented as an xsd:string. Note that this class is not intended to be used directly (in these cases use xsd:string) but is intended to be subclassed with values with business semantic intent.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utl-val;Value">
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Value is an immutable piece of information without a specific lifetime or identity independent of the properties that have such a value as their subject.  Subtypes of Value are intended to include semantic, business relevant types that are not independent, mediating or relative things. Value is not intended to be used directly (a concept known as &quot;abstract&quot; in other languages such as UML), but is intended to have subclasses that are used in domain models.
+As the intent of the Value classes is to capture business meaning, the Value classes are not intended to be used directly in domain models. Subclasses of Value classes that capture business semantics are intended for use in domain models. In other languages, such as UML, this intent to only use subclasses is known as an “Abstract” class.</terms:abstract>
+bubu<terms:license rdf:datatype="&rdf;langString" xml:lang="en">&amp;sm;MITLicense</terms:license>
+bubu<sm:copyright rdf:datatype="&rdf;langString" xml:lang="en">Copyright (c) 2015-2017 EDM Council</sm:copyright>
+bubu<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/39479.html</rdfs:seeAlso>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/20140801/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utl-val;FloatingPointValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;NumericValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utl-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;double"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>floating point value</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">A floating point representation of a number. Note that this class is not intended to be used directly (in these cases use xsd:double) but is intended to be subclassed with values with business semantic intent.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utl-val;IntegerValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;NumericValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utl-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;integer"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">integer value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An integer value is a numeric value with that represents an Integer using an xsd:integer. Note that this class is not intended to be used directly (in these cases use xsd:integer) but is intended to be subclassed with values with business semantic intent.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utl-val;NumericRatioValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;NumericValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numeric ratio value</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">A numeric value representing a ratio between two other numeric values.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utl-val;NumericValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;SingleValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numeric value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A numeric value is a single value intended to represent any number without restriction as to precision, scale or representation. The number or expression is contained in the hasValue property.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utl-val;PercentageValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;NumericRatioValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A percentage value is a numeric value representing a rate, number, or amount in each hundred.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utl-val;SingleValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;Value"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">single value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A single value is a Value with exactly one distinguished &quot;hasValue&quot; property that represents the primary data element of that value. Other properties of a SingleValue may be defined to qualify hasValue, such as a unit, namespace or defining authority.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utl-val;TextValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-val;SingleValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utl-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;string"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>text value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A text value is a single value representing textural information represented as an xsd:string. Note that this class is not intended to be used directly (in these cases use xsd:string) but is intended to be subclassed with values with business semantic intent.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utl-val;Value">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Value is an immutable piece of information without a specific lifetime or identity independent of the properties that have such a value as their subject.  Subtypes of Value are intended to include semantic, business relevant types that are not independent, mediating or relative things. Value is not intended to be used directly (a concept known as &quot;abstract&quot; in other languages such as UML), but is intended to have subclasses that are used in domain models.
 All explicit triples which have a value instance as their subject (with the exception of annotations) are defined as part of the identity of the value instance. The set of such properties should be treated as immutable (not changed once the value is defined). All instances of Value with the same set of properties may be treated as equivalent. Note that while the above is not directly expressible in OWL, the above constraints and semantics of values are asserted by this specification.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&rdf;langString" xml:lang="en">[ISO11404] The identification of members of a datatype family, subtypes of a datatype, and the resulting datatypes of datatype generators may require the syntactic designation of specific values of a datatype.</fibo-fnd-utl-av:adaptedFrom>
-	</owl:Class>
-	
-	<rdf:Description rdf:about="&fibo-fnd-utl-val;hasValue">
-		<rdf:type rdf:resource="&owl;DatatypeProperty"/>
-		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">hasValue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-utl-val;SingleValue"/>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">hasValue is a datatype property of a single value that represents the primary primitive data of that single value. The range of hasValue is unrestricted as it is intended to be restricted in subtypes of SingleValue for a particular purpose with a particular data type.</skos:definition>
-	</rdf:Description>
+bubu<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&rdf;langString" xml:lang="en">[ISO11404] The identification of members of a datatype family, subtypes of a datatype, and the resulting datatypes of datatype generators may require the syntactic designation of specific values of a datatype.</fibo-fnd-utl-av:adaptedFrom>
+bu</owl:Class>
+bu
+bu<rdf:Description rdf:about="&fibo-fnd-utl-val;hasValue">
+bubu<rdf:type rdf:resource="&owl;DatatypeProperty"/>
+bubu<rdf:type rdf:resource="&owl;FunctionalProperty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">hasValue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-utl-val;SingleValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">hasValue is a datatype property of a single value that represents the primary primitive data of that single value. The range of hasValue is unrestricted as it is intended to be restricted in subtypes of SingleValue for a particular purpose with a particular data type.</skos:definition>
+bu</rdf:Description>
 
 </rdf:RDF>

--- a/fnd/UtilitiesExt/Values.rdf
+++ b/fnd/UtilitiesExt/Values.rdf
@@ -1,323 +1,325 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY SpecificationMetadata "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY SpecificationMetadata "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF
-	xmlns="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:SpecificationMetadata="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Values Ontology</rdfs:label>
-		<terms:license rdf:datatype="&rdf;langString" xml:lang="en">&amp;sm;MITLicense</terms:license>
-		<SpecificationMetadata:copyright rdf:datatype="&rdf;langString" xml:lang="en">Copyright (c) 2015-2017 EDM Council</SpecificationMetadata:copyright>
-		<SpecificationMetadata:fileAbstract rdf:datatype="&rdf;langString" xml:lang="en">The Values ontology introduces a set of foundational classes that represent “values” as OWL classes where a value is an immutable piece of information without a specific lifetime or identity independent of the properties that have a value as their subject.  Subtypes of Value are intended to include semantic, business relevant classes that are not independent, mediating or relative things. 
+buxmlns="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:SpecificationMetadata="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Values Ontology</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">The Values ontology introduces a set of foundational classes that represent “values” as OWL classes where a value is an immutable piece of information without a specific lifetime or identity independent of the properties that have a value as their subject.  Subtypes of Value are intended to include semantic, business relevant classes that are not independent, mediating or relative things. 
 While Values as defined here, in some cases, seem to replicate XSD data types they are intended to use, extend and build-on XSD data types for “business meaningful values”. 
 Business meaningful values (which we will call “Business Semantic Values”) are things like amount, name, postal address, mass, duration, currency and metrics – concepts that make sense in the business domain and are the types of properties of business entities, but not they are not business entities in themselves.  These values are the type (range) of properties that represent the qualities and characteristics of the entities in our business domain such as people, places, transactions and financial instruments. In contrast to semantic values, primitive datatypes, such as “Real”, “Integer” or “String”, frequently have no business meaning on their own.
-As the intent of the Value classes is to capture business meaning, the Value classes are not intended to be used directly in domain models. Subclasses of Value classes that capture business semantics are intended for use in domain models. In other languages, such as UML, this intent to only use subclasses is known as an “Abstract” class.</SpecificationMetadata:fileAbstract>
-		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/39479.html</rdfs:seeAlso>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/20140801/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;BasisPointsValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericRatioValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">basis points value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;DateTimeValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TimePointValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;dateTime"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;dateTime"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date and time value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;DateValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TimePointValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;string"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;string"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;DayMonthValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TemporalValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;string"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;string"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">day and month value</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Used for specifying events which may occur on the nth day of a month.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;DecimalValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;decimal"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Number</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Where there are specific business reasons or business knowledge defining numbers with known limitations such as maximum values, positive-only and so on, these will be defined as sub-types of this Type.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;FloatingPointValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&owl;real"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;IntegerValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;integer"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">integer value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An IntegerValue is a SingleValue that represents an Integer using an xsd:integer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;NegativeIntegerValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;negativeInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;negativeInteger"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">negative integer value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;NonNegativeIntegerValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non-negative integer value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;NonNegativeNumber">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non-negative number</rdfs:label>
-		<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This has no corresponding XML datatype.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;NumericRatioValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numeric ratio</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;NumericValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numeric value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A NumericValue is a SingleValue intended to represent any number without restriction as to precision, scale or representation. The number is contained in the hasValue property.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;PercentageValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericRatioValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;PositiveIntegerValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;positiveInteger"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;positiveInteger"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">positive integer value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;SingleValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;Value"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">atomic value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A SingleValue is a Value with exactly one distinguished &quot;hasValue&quot; property that represents the primary data element of that value. Other properties of a SingleValue may be defined to qualify hasValue, such as a unit, namespace or defining authority.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;TemporalValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;TextValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;string"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;string"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">text value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;TimePointValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TemporalValue"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">time point value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;TimeValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TemporalValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;dateTime"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;dateTime"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">time value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;TrueFalseValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;boolean"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;boolean"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Boolean value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;URIValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:allValuesFrom rdf:resource="&xsd;anyURI"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
-				<owl:onDataRange rdf:resource="&xsd;anyURI"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">URI value</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is used in some cases to identify publicly defined schemes (namespaces) for sets of identifiers or other publicly defined codes.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-utlx-val;Value">
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Value</rdfs:label>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Value is an immutable piece of information without a specific lifetime or identity independent of the properties that have such a value as their subject.  Subtypes of Value are intended to include semantic, business relevant types that are not independent, mediating or relative things. Value is not intended to be used directly (a concept known as &quot;abstract&quot; in other languages such as UML), but is intended to have subclasses that are used in domain models.
+As the intent of the Value classes is to capture business meaning, the Value classes are not intended to be used directly in domain models. Subclasses of Value classes that capture business semantics are intended for use in domain models. In other languages, such as UML, this intent to only use subclasses is known as an “Abstract” class.</terms:abstract>
+bubu<terms:license rdf:datatype="&rdf;langString" xml:lang="en">&amp;sm;MITLicense</terms:license>
+bubu<SpecificationMetadata:copyright rdf:datatype="&rdf;langString" xml:lang="en">Copyright (c) 2015-2017 EDM Council</SpecificationMetadata:copyright>
+bubu<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/39479.html</rdfs:seeAlso>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/20140801/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;BasisPointsValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericRatioValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">basis points value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;DateTimeValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TimePointValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;dateTime"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;dateTime"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date and time value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;DateValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TimePointValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;string"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;string"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;DayMonthValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TemporalValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;string"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;string"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">day and month value</rdfs:label>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Used for specifying events which may occur on the nth day of a month.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;DecimalValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;decimal"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Number</rdfs:label>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Where there are specific business reasons or business knowledge defining numbers with known limitations such as maximum values, positive-only and so on, these will be defined as sub-types of this Type.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;FloatingPointValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&owl;real"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;IntegerValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;integer"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">integer value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An IntegerValue is a SingleValue that represents an Integer using an xsd:integer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;NegativeIntegerValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;negativeInteger"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;negativeInteger"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">negative integer value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;NonNegativeIntegerValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;nonNegativeInteger"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;nonNegativeInteger"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non-negative integer value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;NonNegativeNumber">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non-negative number</rdfs:label>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This has no corresponding XML datatype.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;NumericRatioValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numeric ratio</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;NumericValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numeric value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A NumericValue is a SingleValue intended to represent any number without restriction as to precision, scale or representation. The number is contained in the hasValue property.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;PercentageValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;NumericRatioValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;PositiveIntegerValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;positiveInteger"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;positiveInteger"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">positive integer value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;SingleValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;Value"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">atomic value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A SingleValue is a Value with exactly one distinguished &quot;hasValue&quot; property that represents the primary data element of that value. Other properties of a SingleValue may be defined to qualify hasValue, such as a unit, namespace or defining authority.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;TemporalValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">temporal value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;TextValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;string"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;string"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">text value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;TimePointValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TemporalValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">time point value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;TimeValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;TemporalValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;dateTime"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;dateTime"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">time value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;TrueFalseValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;boolean"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;boolean"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Boolean value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;URIValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:allValuesFrom rdf:resource="&xsd;anyURI"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utlx-val;hasValue"/>
+bubububu<owl:onDataRange rdf:resource="&xsd;anyURI"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">URI value</rdfs:label>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is used in some cases to identify publicly defined schemes (namespaces) for sets of identifiers or other publicly defined codes.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-utlx-val;Value">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Value is an immutable piece of information without a specific lifetime or identity independent of the properties that have such a value as their subject.  Subtypes of Value are intended to include semantic, business relevant types that are not independent, mediating or relative things. Value is not intended to be used directly (a concept known as &quot;abstract&quot; in other languages such as UML), but is intended to have subclasses that are used in domain models.
 All properties of a value instance (with the exception of annotations) are defined as part of the identity of the value instance. The set of such properties is immutable. All instances of Value with the same set of properties are equivalent. Note that while the above is not directly expressible in OWL, the above constraints and semantics of values are asserted by this specification.</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&rdf;langString" xml:lang="en">[ISO11404] The identification of members of a datatype family, subtypes of a datatype, and the resulting datatypes of datatype generators may require the syntactic designation of specific values of a datatype.</fibo-fnd-utl-av:adaptedFrom>
-	</owl:Class>
-	
-	<rdf:Description rdf:about="&fibo-fnd-utlx-val;hasValue">
-		<rdf:type rdf:resource="&owl;DatatypeProperty"/>
-		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
-		<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">hasValue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
-		<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">hasValue is a datatype property of a SingleValue that represents the primary primitive data of that SingleValue. The range of hasValue is unrestricted as it is intended to be restricted in subtypes of SingleValue for a particular purpose with a particular data type.</skos:definition>
-	</rdf:Description>
+bubu<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&rdf;langString" xml:lang="en">[ISO11404] The identification of members of a datatype family, subtypes of a datatype, and the resulting datatypes of datatype generators may require the syntactic designation of specific values of a datatype.</fibo-fnd-utl-av:adaptedFrom>
+bu</owl:Class>
+bu
+bu<rdf:Description rdf:about="&fibo-fnd-utlx-val;hasValue">
+bubu<rdf:type rdf:resource="&owl;DatatypeProperty"/>
+bubu<rdf:type rdf:resource="&owl;FunctionalProperty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">hasValue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-utlx-val;SingleValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">hasValue is a datatype property of a SingleValue that represents the primary primitive data of that SingleValue. The range of hasValue is unrestricted as it is intended to be restricted in subtypes of SingleValue for a particular purpose with a particular data type.</skos:definition>
+bu</rdf:Description>
 
 </rdf:RDF>

--- a/ind/IndicatorsExt/IndicatorsValues.rdf
+++ b/ind/IndicatorsExt/IndicatorsValues.rdf
@@ -1,166 +1,170 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-ind-indx-valx "https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-ind-indx-valx "https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-ind-indx-valx="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/">
-		<rdfs:label xml:lang="en">IndicatorsValues</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-ind-indx-valx;EconomicRateQualifiedTimedValue">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;MarketParameterTimedValue"/>
-		<rdfs:label xml:lang="en">economic rate qualified timed value  (please review)</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;ExchangeRateTimedValue"/>
-		<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;InterestRateTimedValue"/>
-		<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-indx-valx;ExchangeRateTimedValue">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;MarketParameterTimedValue"/>
-		<rdfs:label xml:lang="en">exchange rate timed value  (please review)</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;InterestRateTimedValue"/>
-		<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-indx-valx;GDPValue">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;EconomicRateQualifiedTimedValue"/>
-		<rdfs:label xml:lang="en">g d p value  (please review)</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;InflationRateValue"/>
-		<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;UnemploymentRateValue"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-indx-valx;InflationRateValue">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;EconomicRateQualifiedTimedValue"/>
-		<rdfs:label xml:lang="en">inflation rate value  (please review)</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;UnemploymentRateValue"/>
-		<skos:definition xml:lang="en">The inflation rate, as a percentage. This is quoted for a period of time leading up to a specific date or month.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-indx-valx;InterestRateTimedValue">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;MarketParameterTimedValue"/>
-		<rdfs:label xml:lang="en">interest rate timed value  (please review)</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
-		<skos:definition xml:lang="en">The quoted value of the interest rate at the specified time and date. Term agreed; name changed from Interest Rate Value.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-indx-valx;MarketParameterTimedValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-		<rdfs:label xml:lang="en">market parameter timed value  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The actual value (at a point in time) of a parameter.</skos:definition>
-		<skos:editorialNote xml:lang="en">These were modeled in source model as &quot;Referenceable Archetypes&quot; (now deprecated), so there is not a hierarchy of relatjonships to these. Different types of &quot;Value&quot; with different types of qualifying terms are defined here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-indx-valx;ReferenceIndexDatedValue">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;MarketParameterTimedValue"/>
-		<rdfs:label xml:lang="en">reference index dated value  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-indx-valx;UnemploymentRateValue">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;EconomicRateQualifiedTimedValue"/>
-		<rdfs:label xml:lang="en">unemployment rate value  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;applicablePeriod">
-		<rdfs:label xml:lang="en">applicable period  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;UnemploymentRateValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The period to which the stated value of the unemployment rate applies.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;forYear">
-		<rdfs:label xml:lang="en">for year  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;GDPValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Year"/>
-		<skos:definition xml:lang="en">The year for which the GDP figure applies. Further Notes Review whether this needs additional qualifying terms, e.g. the applicable year end for that country.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;hasGDPAmount">
-		<rdfs:label xml:lang="en">has g d p amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;GDPValue"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
-		<skos:definition xml:lang="en">The actual value of the GDP for the applicable period, stated as a monetary amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;hasPercentageValue">
-		<rdfs:label xml:lang="en">has percentage value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;InflationRateValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The actual value of the inflation rate, stated as a percentage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;hasPercentageValue.1">
-		<rdfs:label xml:lang="en">has percentage value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;UnemploymentRateValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The actual value of the unemployment rate, stated as a percentage of the population unemployed for the stated period.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;measurementPeriod">
-		<rdfs:label xml:lang="en">measurement period  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;InflationRateValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-		<skos:definition xml:lang="en">The period of time up to the quoted date, to which the inflation rate applies.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;quotedDate">
-		<rdfs:label xml:lang="en">quoted date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;InflationRateValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date to which the quoted inflation value applies.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;value">
-		<rdfs:label xml:lang="en">value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;ExchangeRateTimedValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The exchange rate as a numerical ratio of the numerator to the denominator currency.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;value.1">
-		<rdfs:label xml:lang="en">value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;InterestRateTimedValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The quoted value of the Interest Rate at the specified time and date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;value.2">
-		<rdfs:label xml:lang="en">value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The value of the benchmark as a number.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-ind-indx-valx="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">IndicatorsValues</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology reflects an earlier conceptual treatment of indices and indicators in which, in common with other temporally sensitive material, the concepts of a parameter and the values which that parameter takes were segregated. 
+		Since the published Release ontologies do not use this approach, this ontology is effectively redundant. Also subsequent to the simplification described above, a new Values ontology has been introduced which would deliver some of the same conceptualization as were in this ontology. Some of the detailed parameters described here may be re-introduced within the framework of that new Values ontology.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-ind-indx-valx;EconomicRateQualifiedTimedValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;MarketParameterTimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">economic rate qualified timed value  (please review)</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;ExchangeRateTimedValue"/>
+bubu<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;InterestRateTimedValue"/>
+bubu<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-indx-valx;ExchangeRateTimedValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;MarketParameterTimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange rate timed value  (please review)</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;InterestRateTimedValue"/>
+bubu<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-indx-valx;GDPValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;EconomicRateQualifiedTimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">g d p value  (please review)</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;InflationRateValue"/>
+bubu<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;UnemploymentRateValue"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-indx-valx;InflationRateValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;EconomicRateQualifiedTimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation rate value  (please review)</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;UnemploymentRateValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The inflation rate, as a percentage. This is quoted for a period of time leading up to a specific date or month.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-indx-valx;InterestRateTimedValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;MarketParameterTimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate timed value  (please review)</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The quoted value of the interest rate at the specified time and date. Term agreed; name changed from Interest Rate Value.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-indx-valx;MarketParameterTimedValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market parameter timed value  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The actual value (at a point in time) of a parameter.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">These were modeled in source model as &quot;Referenceable Archetypes&quot; (now deprecated), so there is not a hierarchy of relatjonships to these. Different types of &quot;Value&quot; with different types of qualifying terms are defined here.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-indx-valx;ReferenceIndexDatedValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;MarketParameterTimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference index dated value  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-indx-valx;UnemploymentRateValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-indx-valx;EconomicRateQualifiedTimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unemployment rate value  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;applicablePeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable period  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;UnemploymentRateValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period to which the stated value of the unemployment rate applies.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;forYear">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">for year  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;GDPValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Year"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The year for which the GDP figure applies. Further Notes Review whether this needs additional qualifying terms, e.g. the applicable year end for that country.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;hasGDPAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has g d p amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;GDPValue"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The actual value of the GDP for the applicable period, stated as a monetary amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;hasPercentageValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has percentage value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;InflationRateValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The actual value of the inflation rate, stated as a percentage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;hasPercentageValue.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has percentage value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;UnemploymentRateValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The actual value of the unemployment rate, stated as a percentage of the population unemployed for the stated period.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;measurementPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">measurement period  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;InflationRateValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period of time up to the quoted date, to which the inflation rate applies.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;quotedDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quoted date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;InflationRateValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date to which the quoted inflation value applies.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;value">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;ExchangeRateTimedValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The exchange rate as a numerical ratio of the numerator to the denominator currency.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;value.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;InterestRateTimedValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The quoted value of the Interest Rate at the specified time and date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-indx-valx;value.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the benchmark as a number.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/ind/MarketIndicesExt/BasketIndexPublishers.rdf
+++ b/ind/MarketIndicesExt/BasketIndexPublishers.rdf
@@ -1,39 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-ind-mkt-pub "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-ind-mkt-pub "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-ind-mkt-pub="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/">
-		<rdfs:label xml:lang="en">BasketIndexPublishers</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-pub;IndexProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
-		<rdfs:label xml:lang="en">index provider</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-ind-mkt-pub="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BasketIndexPublishers</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the notion of the publisher of a basket index, that is of a stock index or other securities based index.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-pub;IndexProvider">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index provider</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/ind/MarketIndicesExt/BasketIndices.rdf
+++ b/ind/MarketIndicesExt/BasketIndices.rdf
@@ -1,112 +1,115 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-ind-indx-valx "https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/">
-	<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
-	<!ENTITY fibo-ind-mkt-pub "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-ind-indx-valx "https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/">
+bu<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
+bu<!ENTITY fibo-ind-mkt-pub "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-ind-indx-valx="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/"
-	xmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"
-	xmlns:fibo-ind-mkt-pub="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
-		<rdfs:label xml:lang="en">BasketIndices</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-bas;EquityIndexConstituent">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-mkt-bas;ReferenceIndexConstituent"/>
-		<rdfs:label xml:lang="en">equity index constituent</rdfs:label>
-		<skos:definition xml:lang="en">A constituent of the Equity Index.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-bas;EquityReferenceIndex">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-mkt-bas;ReferenceIndex"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-mkt-bas;isPriceOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;EquityReferenceIndexBasket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity reference index</rdfs:label>
-		<skos:definition xml:lang="en">A benchmark or reference index the constituents of which are exclusively Equity securities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-bas;EquityReferenceIndexBasket">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-mkt-bas;ReferenceIndexBasket"/>
-		<rdfs:label xml:lang="en">equity reference index basket</rdfs:label>
-		<skos:definition xml:lang="en">The basket of securities which makes up the Equities Reference Index.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the set of securities of which the collective price, when combined as defined for this basket, is the Reference Index value.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-bas;ReferenceIndex">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-pub;IndexProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-mkt-bas;isPriceOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;ReferenceIndexBasket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">reference index</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-bas;ReferenceIndexBasket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities"/>
-		<rdfs:label xml:lang="en">reference index basket</rdfs:label>
-		<skos:definition xml:lang="en">The basket of securities which makes up a published index.</skos:definition>
-		<skos:editorialNote xml:lang="en">For most securities terms all that matters is that the index is a number put out by a publisher, However, we need to also model indices themselves, and there are also certain classes of equity derivative which refer to individual components of an index. Therefore an index is now modeled in terms of the basket of which it is made up. Note: Not to be confused with a Basket Of Indices, which would be a basket whose constituents are indices. By contrast, this term is the basket of securities which makes up a basket of securities.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-bas;ReferenceIndexConstituent">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/SecuritiesBasketConstituent"/>
-		<rdfs:label xml:lang="en">reference index constituent</rdfs:label>
-		<skos:definition xml:lang="en">A security which makes up part of a Reference Index.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Reference Index as defined in this model is an index of securities, and therefore does not include credit indices, economic indicators or any other kind of index. Therefore this kind of thing which is a Reference Index Constituent is a kind of Securities Basket Constituent, i.e. a security with some composition information and current pricing.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-bas;isPriceOf">
-		<rdfs:label xml:lang="en">is price of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-bas;ReferenceIndex"/>
-		<rdfs:range rdf:resource="&fibo-ind-mkt-bas;ReferenceIndexBasket"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-bas;value">
-		<rdfs:label xml:lang="en">value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-bas;ReferenceIndex"/>
-		<rdfs:range rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
-		<skos:definition xml:lang="en">The value of the benchmark at the stated date or time.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-ind-indx-valx="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/"
+buxmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"
+buxmlns:fibo-ind-mkt-pub="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BasketIndices</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the kinds of reference index that are created from baskets of securities.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/IndicatorsExt/IndicatorsValues/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndexPublishers/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-bas;EquityIndexConstituent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-mkt-bas;ReferenceIndexConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity index constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A constituent of the Equity Index.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-bas;EquityReferenceIndex">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-mkt-bas;ReferenceIndex"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-ind-mkt-bas;isPriceOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;EquityReferenceIndexBasket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity reference index</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A benchmark or reference index the constituents of which are exclusively Equity securities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-bas;EquityReferenceIndexBasket">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-mkt-bas;ReferenceIndexBasket"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity reference index basket</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The basket of securities which makes up the Equities Reference Index.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the set of securities of which the collective price, when combined as defined for this basket, is the Reference Index value.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-bas;ReferenceIndex">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-pub;IndexProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-ind-mkt-bas;isPriceOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-bas;ReferenceIndexBasket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference index</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-bas;ReferenceIndexBasket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/BasketOfSecurities"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference index basket</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The basket of securities which makes up a published index.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">For most securities terms all that matters is that the index is a number put out by a publisher, However, we need to also model indices themselves, and there are also certain classes of equity derivative which refer to individual components of an index. Therefore an index is now modeled in terms of the basket of which it is made up. Note: Not to be confused with a Basket Of Indices, which would be a basket whose constituents are indices. By contrast, this term is the basket of securities which makes up a basket of securities.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-bas;ReferenceIndexConstituent">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Baskets/SecuritiesBasketConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference index constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security which makes up part of a Reference Index.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A Reference Index as defined in this model is an index of securities, and therefore does not include credit indices, economic indicators or any other kind of index. Therefore this kind of thing which is a Reference Index Constituent is a kind of Securities Basket Constituent, i.e. a security with some composition information and current pricing.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-bas;isPriceOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is price of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-bas;ReferenceIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-ind-mkt-bas;ReferenceIndexBasket"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-bas;value">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-bas;ReferenceIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-ind-indx-valx;ReferenceIndexDatedValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the benchmark at the stated date or time.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/ind/MarketIndicesExt/CreditIndices.rdf
+++ b/ind/MarketIndicesExt/CreditIndices.rdf
@@ -1,217 +1,220 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-ind-mkt-cri "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/">
-	<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-ind-mkt-cri "https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/">
+bu<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-ind-mkt-cri="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"
-	xmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/">
-		<rdfs:label xml:lang="en">CreditIndices</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-cri;BasketOfCreditRisks">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/Basket"/>
-		<rdfs:label xml:lang="en">basket of credit risks  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A basket of securities and / or legal entities, collected for the purpose of identifying risk.</skos:definition>
-		<skos:editorialNote xml:lang="en">From OTPP: Variety: Criteria for constituent entities is based on sectors (emerging market, financial, sovereign, etc), spread range (investment grade, non-investment grade), or asset type (loan, bond, mortgage-backed, asset-backed), second criteria is based on maturity of protection (2,3,5,7,10 yrs). As a result, I&apos;m aware of over 2000 CDS indexes that Markit manages. Constituents can be on multiple indexes, based on maturity, etc. Because the indexes are maturity specific, it makes sense to have an entity AND an instrument with the corresponding maturity (or close to it) to measure the credit-risk of default. Premiums are standard and set depending on the composite spread at the initiation of the index, with upfront-fees to get into a deal thereafter depending on changes in the MTM of the spread. The payout per constituent credit-event is ~ Notional x weight. Modeling notes: Whereas this may be a basket of securities just like a &quot;Basket&quot; in the sense used in reference indices and in derivatives with basket underlyers, in this instance the constituents of the basket are collected, and are defined as constituents, in the context of the credit risks that they represent and not in the context of their market price as securities.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-cri;CreditIndex">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-mkt-cri;representsRiskOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-cri;BasketOfCreditRisks"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit index  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">An index that is a function of credit events. These are Credit events occurring that change the value of an underlying portfolio.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review session notes: Q: How does this differ from a basket of debt securities? A: Basket is defined as part of the contract. Whereas, with the Index, you don&apos;t reference the components. The index is based on a basket of risks (not a basket of debt instruments as such). So this is an indirection not a circularity as it is not an index of CDS contracts but of credit events as these effect a notional portfolio. In could be some form of valuation of underlying CDS (real or imagined). However this &quot;is&quot; the Reference Entity in the sense that it is what you refer to in order to determine the status of the portfolio, Contrast two types of CDS: Single Name and non singlename. With single name CDS: it&apos;s a binary process; if there&apos;s a default it&apos;s all over, as the contingent transaction kicks in. With indices if the index changes there would be partial payouts but the contract continues in existence,. It would pay out a portion of its value. The index indicates that some proportion has defaulted. Would deal with multi names. ALSO Index is not always a static portfolio, there may be proivisions for replacing defaulted securities. Need further research on the details. However, we only need to know them as something with a number and a publisher in order to model the CDS terms. See also: Credit Basket. This is locally defined and does form part of the CDS contract terms, but will have similar details to the index. SME Feedback - details of this term from OTPP: Because the indexes are maturity specific, it makes sense to have an entity AND an instrument with the corresponding maturity (or close to it) to measure the credit-risk of default. Premiums are standard and set depending on the composite spread at the initiation of the index, with upfront-fees to get into a deal thereafter depending on changes in the MTM of the spread. The payout per constituent credit-event is ~ Notional x weight. (cont&apos;d - examples from OTPP): Credit-events and Payouts - Similar to single-name, and triggered by a constituent. The constituent is removed, the Notional*weight is paid, the remaining notional lowered, and the weighting re-balanced. Can be physical or cash settled. Looks like cash settled is becoming more popular. Notionals can be large but the payouts are small because of the small weights. Eg. $250MM Notional, 125 entities, weight is 1/125 for a defaulting entity = $2MM (simplified) transfer.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/BasketConstituent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-mkt-cri;isConstituentOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-cri;BasketOfCreditRisks"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-ind-mkt-cri;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit index reference constituent  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A constituent of a basket of credit risks, such as that used in a credit index.</skos:definition>
-		<skos:editorialNote xml:lang="en">OTPP Note:: There will be a specific reference entity and a specific instrument per index - and only one instrument per entity, per index. note that a credi index constituent may be in principal also be loans (as with CDS also), in which case some of the terms here would not apply (specifically, the reference security identity if the Reference Entity has not also issued any such), however it&apos;s not clear how this would be treated.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;assetType">
-		<rdfs:label xml:lang="en">asset type  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The types of asset which make up the index. Further notes: There is a variety of indices build around different common creiteria, of which this is one. Variety: asset type (loan, bond, mortgage-backed, asset-backed).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;currency">
-		<rdfs:label xml:lang="en">currency  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the reference instrument is denominated.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;currentNotionalValue">
-		<rdfs:label xml:lang="en">current notional value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
-		<skos:definition xml:lang="en">The notional amount of the index at the present time or at a defined point in the past.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;debtRanking">
-		<rdfs:label xml:lang="en">debt ranking  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">An indication of the ranking of this debt.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;indexConstituentID">
-		<rdfs:label xml:lang="en">index constituent i d  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">An identifier for this constituent of this index, published by the index provider. Further notes: Example: Markit REDCODE reference entity ID</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;indexName">
-		<rdfs:label xml:lang="en">index name  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The formal name of the index.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;isConstituentOf">
-		<rdfs:label xml:lang="en">is constituent of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
-		<rdfs:range rdf:resource="&fibo-ind-mkt-cri;BasketOfCreditRisks"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;maturity">
-		<rdfs:label xml:lang="en">maturity  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownDateDuration"/>
-		<skos:definition xml:lang="en">The maturity of protection represented by the index as a length of time (dated duration specification).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;maturity.1">
-		<rdfs:label xml:lang="en">maturity  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedDurationSpecification"/>
-		<skos:definition xml:lang="en">The maturity of the instrument, specified as a length of time (dated duration specification). This is a specified duration, denominated in calendar units.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;originalNotional">
-		<rdfs:label xml:lang="en">original notional  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The notional amount represented by the index when it is first constituted.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;premium">
-		<rdfs:label xml:lang="en">premium  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A premium payable for a contract based on the index.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;refersTo">
-		<rdfs:label xml:lang="en">refers to  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;representsRiskOf">
-		<rdfs:label xml:lang="en">represents risk of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-ind-mkt-cri;BasketOfCreditRisks"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;sector">
-		<rdfs:label xml:lang="en">sector  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The sector from which constituents of the index are all drawn.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;spreadRange">
-		<rdfs:label xml:lang="en">spread range  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The range of credit spread for the constituents of the index.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;tCM">
-		<rdfs:label xml:lang="en">t c m  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Description of the reference instrument in TCM format (ticker-coupon-maturity).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;ticker">
-		<rdfs:label xml:lang="en">ticker  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">A local ticker identifier for the index constituent.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;upFrontFee">
-		<rdfs:label xml:lang="en">up front fee  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A fee payanle by any party that wishes to participate in a contract based on the index after the start of its life.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;weight">
-		<rdfs:label xml:lang="en">weight  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The percentage weight of this constituent in relation to the index as a whole.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-ind-mkt-cri="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"
+buxmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CreditIndices</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Published indices which reflect the performance of a basket of credit risks.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-cri;BasketOfCreditRisks">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/Basket"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">basket of credit risks  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A basket of securities and / or legal entities, collected for the purpose of identifying risk.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From OTPP: Variety: Criteria for constituent entities is based on sectors (emerging market, financial, sovereign, etc), spread range (investment grade, non-investment grade), or asset type (loan, bond, mortgage-backed, asset-backed), second criteria is based on maturity of protection (2,3,5,7,10 yrs). As a result, I&apos;m aware of over 2000 CDS indexes that Markit manages. Constituents can be on multiple indexes, based on maturity, etc. Because the indexes are maturity specific, it makes sense to have an entity AND an instrument with the corresponding maturity (or close to it) to measure the credit-risk of default. Premiums are standard and set depending on the composite spread at the initiation of the index, with upfront-fees to get into a deal thereafter depending on changes in the MTM of the spread. The payout per constituent credit-event is ~ Notional x weight. Modeling notes: Whereas this may be a basket of securities just like a &quot;Basket&quot; in the sense used in reference indices and in derivatives with basket underlyers, in this instance the constituents of the basket are collected, and are defined as constituents, in the context of the credit risks that they represent and not in the context of their market price as securities.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-cri;CreditIndex">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-ind-mkt-cri;representsRiskOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-cri;BasketOfCreditRisks"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit index  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An index that is a function of credit events. These are Credit events occurring that change the value of an underlying portfolio.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review session notes: Q: How does this differ from a basket of debt securities? A: Basket is defined as part of the contract. Whereas, with the Index, you don&apos;t reference the components. The index is based on a basket of risks (not a basket of debt instruments as such). So this is an indirection not a circularity as it is not an index of CDS contracts but of credit events as these effect a notional portfolio. In could be some form of valuation of underlying CDS (real or imagined). However this &quot;is&quot; the Reference Entity in the sense that it is what you refer to in order to determine the status of the portfolio, Contrast two types of CDS: Single Name and non singlename. With single name CDS: it&apos;s a binary process; if there&apos;s a default it&apos;s all over, as the contingent transaction kicks in. With indices if the index changes there would be partial payouts but the contract continues in existence,. It would pay out a portion of its value. The index indicates that some proportion has defaulted. Would deal with multi names. ALSO Index is not always a static portfolio, there may be proivisions for replacing defaulted securities. Need further research on the details. However, we only need to know them as something with a number and a publisher in order to model the CDS terms. See also: Credit Basket. This is locally defined and does form part of the CDS contract terms, but will have similar details to the index. SME Feedback - details of this term from OTPP: Because the indexes are maturity specific, it makes sense to have an entity AND an instrument with the corresponding maturity (or close to it) to measure the credit-risk of default. Premiums are standard and set depending on the composite spread at the initiation of the index, with upfront-fees to get into a deal thereafter depending on changes in the MTM of the spread. The payout per constituent credit-event is ~ Notional x weight. (cont&apos;d - examples from OTPP): Credit-events and Payouts - Similar to single-name, and triggered by a constituent. The constituent is removed, the Notional*weight is paid, the remaining notional lowered, and the weighting re-balanced. Can be physical or cash settled. Looks like cash settled is becoming more popular. Notionals can be large but the payouts are small because of the small weights. Eg. $250MM Notional, 125 entities, weight is 1/125 for a defaulting entity = $2MM (simplified) transfer.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/BasketConstituent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-ind-mkt-cri;isConstituentOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-ind-mkt-cri;BasketOfCreditRisks"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-ind-mkt-cri;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit index reference constituent  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A constituent of a basket of credit risks, such as that used in a credit index.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">OTPP Note:: There will be a specific reference entity and a specific instrument per index - and only one instrument per entity, per index. note that a credi index constituent may be in principal also be loans (as with CDS also), in which case some of the terms here would not apply (specifically, the reference security identity if the Reference Entity has not also issued any such), however it&apos;s not clear how this would be treated.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;assetType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset type  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The types of asset which make up the index. Further notes: There is a variety of indices build around different common creiteria, of which this is one. Variety: asset type (loan, bond, mortgage-backed, asset-backed).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;currency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">currency  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which the reference instrument is denominated.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;currentNotionalValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current notional value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The notional amount of the index at the present time or at a defined point in the past.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;debtRanking">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt ranking  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An indication of the ranking of this debt.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;indexConstituentID">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index constituent i d  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An identifier for this constituent of this index, published by the index provider. Further notes: Example: Markit REDCODE reference entity ID</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;indexName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index name  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formal name of the index.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;isConstituentOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is constituent of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-ind-mkt-cri;BasketOfCreditRisks"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;maturity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownDateDuration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The maturity of protection represented by the index as a length of time (dated duration specification).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;maturity.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The maturity of the instrument, specified as a length of time (dated duration specification). This is a specified duration, denominated in calendar units.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;originalNotional">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">original notional  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The notional amount represented by the index when it is first constituted.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;premium">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">premium  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A premium payable for a contract based on the index.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;refersTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;representsRiskOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">represents risk of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-ind-mkt-cri;BasketOfCreditRisks"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;sector">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sector  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The sector from which constituents of the index are all drawn.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;spreadRange">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spread range  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The range of credit spread for the constituents of the index.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;tCM">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">t c m  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Description of the reference instrument in TCM format (ticker-coupon-maturity).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;ticker">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ticker  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A local ticker identifier for the index constituent.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;upFrontFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">up front fee  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndex"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A fee payanle by any party that wishes to participate in a contract based on the index after the start of its life.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-ind-mkt-cri;weight">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">weight  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-ind-mkt-cri;CreditIndexReferenceConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage weight of this constituent in relation to the index as a whole.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoanTypes/CommercialLoans.rdf
+++ b/loan/LoanTypes/CommercialLoans.rdf
@@ -1,101 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-typ-com "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-typ-com "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-typ-com="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/">
-		<rdfs:label xml:lang="en">CommercialLoans</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-le-lp;NaturalPerson">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-com;CommercialLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;drawnDownBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-com;CommercialLoanBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commercial loan</rdfs:label>
-		<skos:definition xml:lang="en">Loan extended for a commercial purpose. Further notes: Commercial Loans: Talk about property like office building. Borrower is a small business or corporation. Meanings: Loan extended for a commercial purpose versus Loan extended to a corporate entity Example: Aus: Nature of security e.g. private property versus commercial property being pledged as security, as there are different requirements on these. Also legislation on commercial lending by governments (business strategy etc.).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-com;CommercialLoanBorrower">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-pty;identity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-le-lp;NaturalPerson">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commercial loan borrower</rdfs:label>
-		<skos:definition xml:lang="en">The borrower of a Commercial Loan</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be a Corporation, or one or more adult human beings. This is because a commercial loan may be extended to sole trader or partnership.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-com;CorporateBorrower">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-pty;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">corporate borrower</rdfs:label>
-		<skos:definition xml:lang="en">A borrower which is a Corporation.</skos:definition>
-		<skos:editorialNote xml:lang="en">Classifying loans by the type of borrower is less common than classifying it by things like collaterial (mortgagees) and so on. So the kind of borrower is not usually the main feature by which we try to classify the loan. So this exists but is not so often referred to.</skos:editorialNote>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-typ-com="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CommercialLoans</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Commercial loans are loans where the loan purpose is some commercial purpose. Note that these are distinguished by the loan purpose not by the borrower type – borrowers may be corporate or personal, though in the majority of cases they would also be corporate loans that is loans with a corporate borrower.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-lp;NaturalPerson">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-com;CommercialLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;drawnDownBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-com;CommercialLoanBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commercial loan</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Loan extended for a commercial purpose. Further notes: Commercial Loans: Talk about property like office building. Borrower is a small business or corporation. Meanings: Loan extended for a commercial purpose versus Loan extended to a corporate entity Example: Aus: Nature of security e.g. private property versus commercial property being pledged as security, as there are different requirements on these. Also legislation on commercial lending by governments (business strategy etc.).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-com;CommercialLoanBorrower">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-pty;identity"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-be-le-lp;NaturalPerson">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commercial loan borrower</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The borrower of a Commercial Loan</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be a Corporation, or one or more adult human beings. This is because a commercial loan may be extended to sole trader or partnership.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-com;CorporateBorrower">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-pty;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate borrower</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A borrower which is a Corporation.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Classifying loans by the type of borrower is less common than classifying it by things like collaterial (mortgagees) and so on. So the kind of borrower is not usually the main feature by which we try to classify the loan. So this exists but is not so often referred to.</skos:editorialNote>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/loan/LoanTypes/ConstructionLoans.rdf
+++ b/loan/LoanTypes/ConstructionLoans.rdf
@@ -1,204 +1,131 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fbc-dae-crf "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-tem-cl "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/">
-	<!ENTITY fibo-loan-tem-sta "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
-	<!ENTITY fibo-loan-typ-cl "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/ConstructionLoans/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fbc-dae-crf "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-tem-cl "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/">
+bu<!ENTITY fibo-loan-tem-sta "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
+bu<!ENTITY fibo-loan-typ-cl "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/ConstructionLoans/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
 <rdf:RDF
-	xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/ConstructionLoans/"
-	xmlns:fibo-fbc-dae-crf="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-tem-cl="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/"
-	xmlns:fibo-loan-tem-sta="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"
-	xmlns:fibo-loan-typ-cl="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/ConstructionLoans/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology
-		rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/ConstructionLoans/">
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">ConstructionLoans</rdfs:label>
-		<owl:imports
-			rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports
-			rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
-		<owl:imports
-			rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports
-			rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports
-			rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports
-			rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports
-			rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/"/>
-		<owl:imports
-			rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"/>
-		<owl:versionIRI
-			rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/ConstructionLoans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel
-			rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class
-		rdf:about="&fibo-loan-typ-cl;ConstructionLoan">
-		<rdfs:subClassOf
-			rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty
-					rdf:resource="&fibo-loan-tem-sta;hasSnapshot"/>
-				<owl:someValuesFrom
-					rdf:resource="&fibo-loan-tem-cl;ConstructionLoanSnapshot"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">construction loan</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class
-		rdf:about="&fibo-loan-typ-cl;ConstructionLoanContract">
-		<rdfs:subClassOf
-			rdf:resource="&fibo-fbc-dae-crf;CreditFacilityAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty
-					rdf:resource="&fibo-fbc-dae-crf;setsOutCommitmentTo"/>
-				<owl:someValuesFrom
-					rdf:resource="&fibo-loan-typ-cl;ConstructionLoanCreditFacilityTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty
-					rdf:resource="&fibo-loan-typ-cl;hasMilestoneTerm"/>
-				<owl:someValuesFrom
-					rdf:resource="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">construction loan contract  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class
-		rdf:about="&fibo-loan-typ-cl;ConstructionLoanCreditFacilityTranche">
-		<rdfs:subClassOf
-			rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacilityTranche"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty
-					rdf:resource="&fibo-fbc-dae-crf;issuedAs"/>
-				<owl:someValuesFrom
-					rdf:resource="&fibo-loan-typ-cl;ConstructionLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">construction loan credit facility tranche  (please review)</rdfs:label>
-		<skos:definition
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">A loan taken out for construction purposes. Further notes: These are a temporary loan. when the construction is finished then that loan is transformed to another loan, which would be a permanent loan. Information to follow on what the new permanent loan would be. Terms are adjusted in the new loan, since in construction loans the rates are significantly higher. This is an incentive to complete the construction works. Notes from PoC reviews, discussing Maximum Balance concept: In a Construction Loan you agree a maximum amount that you could draw. As you progress with the construction you continue to draw more and more. So you start with the minimum. Example: for purpose of construction of a house you could need to borrow up to 500K and the bank establishes the milestones at which certain amounts are made availalbe and can be drawn. For instance prior to start you might draw 10%, (50K); the next 50K would be available to draw only once the foundations are laid. And so on. Milestones may include &quot;Frame standing&quot; (for American-style frame based houses). Each stage requires inspection on behalf of the bank. So you are starting with no more than 10% (in this example) of what is allowable, and could arrive to the full 500K by the end of ths construction but it is not mandated that you arrive to that. What differentiates a Construction Loan is that there si a max amount specified and there are Milestones specified in which the amounts for each milestone can be advanced.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class
-		rdf:about="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet">
-		<rdfs:subClassOf
-			rdf:resource="&fibo-fbc-dae-crf;LoanPrecedentConditions"/>
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">construction loan milestone terms set  (please review)</rdfs:label>
-		<skos:definition
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">An agreed point at which an amount is advanced to the lender on completion of some pre-agreed scope of works on the construction.</skos:definition>
-		<skos:editorialNote
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">from review of a separate question, where we identified the need for this term:</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty
-		rdf:about="&fibo-loan-typ-cl;hasMilestoneTerm">
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">has milestone term  (please review)</rdfs:label>
-		<rdfs:domain
-			rdf:resource="&fibo-loan-typ-cl;ConstructionLoanContract"/>
-		<rdfs:range
-			rdf:resource="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty
-		rdf:about="&fibo-loan-typ-cl;maximumAllowedBalance">
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">maximum allowed balance  (please review)</rdfs:label>
-		<rdfs:domain
-			rdf:resource="&fibo-loan-typ-cl;ConstructionLoanContract"/>
-		<rdfs:range
-			rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">Maximum balance - For loans with flexible re-draw facilities, the maximum loan amount that could potentially be outstanding</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty
-		rdf:about="&fibo-loan-typ-cl;maximumAnticipatedBalance">
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">maximum anticipated balance  (please review)</rdfs:label>
-		<rdfs:domain
-			rdf:resource="&fibo-loan-typ-cl;ConstructionLoanCreditFacilityTranche"/>
-		<rdfs:range
-			rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">Maximum balance - For loans with flexible re-draw facilities, the maximum loan amount that could potentially be outstanding</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty
-		rdf:about="&fibo-loan-typ-cl;milestoneDescription">
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">milestone description  (please review)</rdfs:label>
-		<rdfs:domain
-			rdf:resource="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet"/>
-		<rdfs:range
-			rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">A textual description of the point at which it is legally recognized that the construction milestone has been reached.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty
-		rdf:about="&fibo-loan-typ-cl;milestoneMaximumDrawdownAmount">
-		<rdfs:label
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">milestone maximum drawdown amount  (please review)</rdfs:label>
-		<rdfs:domain
-			rdf:resource="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet"/>
-		<rdfs:range
-			rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition
-			rdf:datatype="&rdf;langString"
-			xml:lang="en">The maximum amount of the loan that can be drawn by the Borrower on completion of this Milestone.</skos:definition>
-	</owl:ObjectProperty>
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fbc-dae-crf="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-tem-cl="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/"
+buxmlns:fibo-loan-tem-sta="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"
+buxmlns:fibo-loan-typ-cl="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/ConstructionLoans/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/ConstructionLoans/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ConstructionLoans</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Construction loans are loans in name only, in that the concept referred to as a construction loan is effectively a credit facility, with separate draw-downs (loans as defined in these ontologies) being enabled upon evidence of completion of agreed stages of the construction project, 
+		Note that for completion this ontology will need to be extended with a number of project management concepts describing the parameters of the construction project that are referred to in the contract for this facility. Some basic project management terms such as milestones are already included but will need framing within more foundational concepts for project management.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/ConstructionLoans/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cl;ConstructionLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-sta;hasSnapshot"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-cl;ConstructionLoanSnapshot"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">construction loan</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cl;ConstructionLoanContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;setsOutCommitmentTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cl;ConstructionLoanCreditFacilityTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-cl;hasMilestoneTerm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">construction loan contract  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cl;ConstructionLoanCreditFacilityTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacilityTranche"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;issuedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cl;ConstructionLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">construction loan credit facility tranche  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan taken out for construction purposes. Further notes: These are a temporary loan. when the construction is finished then that loan is transformed to another loan, which would be a permanent loan. Information to follow on what the new permanent loan would be. Terms are adjusted in the new loan, since in construction loans the rates are significantly higher. This is an incentive to complete the construction works. Notes from PoC reviews, discussing Maximum Balance concept: In a Construction Loan you agree a maximum amount that you could draw. As you progress with the construction you continue to draw more and more. So you start with the minimum. Example: for purpose of construction of a house you could need to borrow up to 500K and the bank establishes the milestones at which certain amounts are made availalbe and can be drawn. For instance prior to start you might draw 10%, (50K); the next 50K would be available to draw only once the foundations are laid. And so on. Milestones may include &quot;Frame standing&quot; (for American-style frame based houses). Each stage requires inspection on behalf of the bank. So you are starting with no more than 10% (in this example) of what is allowable, and could arrive to the full 500K by the end of ths construction but it is not mandated that you arrive to that. What differentiates a Construction Loan is that there si a max amount specified and there are Milestones specified in which the amounts for each milestone can be advanced.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;LoanPrecedentConditions"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">construction loan milestone terms set  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An agreed point at which an amount is advanced to the lender on completion of some pre-agreed scope of works on the construction.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">from review of a separate question, where we identified the need for this term:</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-cl;hasMilestoneTerm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has milestone term  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-cl;ConstructionLoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-cl;maximumAllowedBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum allowed balance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-cl;ConstructionLoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum balance - For loans with flexible re-draw facilities, the maximum loan amount that could potentially be outstanding</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-cl;maximumAnticipatedBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum anticipated balance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-cl;ConstructionLoanCreditFacilityTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum balance - For loans with flexible re-draw facilities, the maximum loan amount that could potentially be outstanding</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-cl;milestoneDescription">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">milestone description  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A textual description of the point at which it is legally recognized that the construction milestone has been reached.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-cl;milestoneMaximumDrawdownAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">milestone maximum drawdown amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-cl;ConstructionLoanMilestoneTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The maximum amount of the loan that can be drawn by the Borrower on completion of this Milestone.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoanTypes/CreditProducts.rdf
+++ b/loan/LoanTypes/CreditProducts.rdf
@@ -1,125 +1,128 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fbc-dae-crf "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
-	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-typ-cr "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fbc-dae-crf "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
+bu<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-typ-cr "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/"
-	xmlns:fibo-fbc-dae-crf="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"
-	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-typ-cr="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/">
-		<rdfs:label xml:lang="en">CreditProducts</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-cr;CreditCard">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacilityTranche"/>
-		<rdfs:label xml:lang="en">credit card facility</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-cr;HomeEquityLineOfCredit">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCredit"/>
-		<rdfs:label xml:lang="en">home equity line of credit</rdfs:label>
-		<skos:definition xml:lang="en">A credit line on a house or other property, that can be drawn down and/or paid back by the borrower.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is both a revolving line of credit and a mortgage, in that the collateral for the revolving line of credit in this case is some real estate, which is a defining fact for a mortgage. This form of product can either have an increase or decrease in principal, according to the actions of the borrower. These may also be used in the formation of asset pools for asset backed securities, though a specific named type of security has not been identified with these as underlying.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-cr;HomeEquityLineOfCreditContract">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-cr;RevolvingCreditContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;setsOutCommitmentTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cr;HomeEquityLineOfCreditTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">home equity line of credit contract</rdfs:label>
-		<skos:definition xml:lang="en">A credit line on a house or other property, that can be drawn down and/or paid back by the borrower.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-cr;HomeEquityLineOfCreditTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCreditTranche"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-cr;becomesRevolvingLineOfCredit"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cr;HomeEquityLineOfCredit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">home equity line of credit tranche</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-cr;RevolvingCreditContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;setsOutCommitmentTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCreditTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">revolving credit contract</rdfs:label>
-		<skos:definition xml:lang="en">Contract which embodies and defines the terms and conditions for a credit line based on some collaterial, which can be drawn down and/or paid back by the borrower.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-cr;RevolvingLineOfCredit">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Debt"/>
-		<rdfs:label xml:lang="en">revolving line of credit</rdfs:label>
-		<skos:definition xml:lang="en">A credit line based on some collateral, that can be drawn down and/or paid back by the borrower.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This form of product can either have an increase or decrease in principal, according to the actions of the borrower.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-cr;RevolvingLineOfCreditTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacilityTranche"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-cr;becomesRevolvingLineOfCredit"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCredit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">revolving line of credit tranche</rdfs:label>
-		<skos:definition xml:lang="en">A contractually committed line of credit which is issued as a revolving line of credit which can be drawn upon and has collateral</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-cr;becomesRevolvingLineOfCredit">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-dae-crf;issuedAs"/>
-		<rdfs:label xml:lang="en">becomes revolving line of credit</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCreditTranche"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCredit"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-cr;maximumAllowedBalance">
-		<rdfs:label xml:lang="en">maximum allowed balance  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-cr;RevolvingCreditContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The maximum loan amount that is allowed to be outstanding as defined in this loan contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-cr;maximumAnticipatedBalance">
-		<rdfs:label xml:lang="en">maximum anticipated balance  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCredit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The maximum loan amount that could potentially be outstanding.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fbc-dae-crf="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"
+buxmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-typ-cr="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CreditProducts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Terms specific to the existence and extension of credit. Includes terms like home equity lines of credit which may be referenced in asset backed securities. Also includes credit card facilities.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cr;CreditCard">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacilityTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit card facility</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cr;HomeEquityLineOfCredit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCredit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">home equity line of credit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A credit line on a house or other property, that can be drawn down and/or paid back by the borrower.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is both a revolving line of credit and a mortgage, in that the collateral for the revolving line of credit in this case is some real estate, which is a defining fact for a mortgage. This form of product can either have an increase or decrease in principal, according to the actions of the borrower. These may also be used in the formation of asset pools for asset backed securities, though a specific named type of security has not been identified with these as underlying.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cr;HomeEquityLineOfCreditContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-cr;RevolvingCreditContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;setsOutCommitmentTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cr;HomeEquityLineOfCreditTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">home equity line of credit contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A credit line on a house or other property, that can be drawn down and/or paid back by the borrower.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cr;HomeEquityLineOfCreditTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCreditTranche"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-cr;becomesRevolvingLineOfCredit"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cr;HomeEquityLineOfCredit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">home equity line of credit tranche</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cr;RevolvingCreditContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-dae-crf;setsOutCommitmentTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCreditTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">revolving credit contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contract which embodies and defines the terms and conditions for a credit line based on some collaterial, which can be drawn down and/or paid back by the borrower.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cr;RevolvingLineOfCredit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;Debt"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">revolving line of credit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A credit line based on some collateral, that can be drawn down and/or paid back by the borrower.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This form of product can either have an increase or decrease in principal, according to the actions of the borrower.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-cr;RevolvingLineOfCreditTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CommittedCreditFacilityTranche"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-cr;becomesRevolvingLineOfCredit"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCredit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">revolving line of credit tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A contractually committed line of credit which is issued as a revolving line of credit which can be drawn upon and has collateral</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-cr;becomesRevolvingLineOfCredit">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fbc-dae-crf;issuedAs"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes revolving line of credit</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCreditTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCredit"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-cr;maximumAllowedBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum allowed balance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-cr;RevolvingCreditContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The maximum loan amount that is allowed to be outstanding as defined in this loan contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-cr;maximumAnticipatedBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum anticipated balance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-cr;RevolvingLineOfCredit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The maximum loan amount that could potentially be outstanding.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoanTypes/GeneralLoans.rdf
+++ b/loan/LoanTypes/GeneralLoans.rdf
@@ -1,97 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-typ-gen "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/GeneralLoans/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-typ-gen "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/GeneralLoans/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/GeneralLoans/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-typ-gen="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/GeneralLoans/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/GeneralLoans/">
-		<rdfs:label xml:lang="en">GeneralLoans</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/GeneralLoans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-gen;AutoLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:label xml:lang="en">auto loan  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A loan specifically for the purpose of automobile purchase.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-gen;AutoLoanContract">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-gen;AutoLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">auto loan contract  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-gen;MarineFinance">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:label xml:lang="en">marine finance  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A loan for the purchase of a boat or other vessel.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-gen;MarineFinanceContract">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">marine finance contract  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Contract embodying the terms under which a loan is advanced for marine finance.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-gen;boatHeldAsChattel">
-		<rdfs:label xml:lang="en">boat held as chattel  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the vessel is to be held in ownership as a form of chattel by the lender during the period of the loan.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-gen;mooredAt">
-		<rdfs:label xml:lang="en">moored at  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Textual description (name etc.) of where the vessel is to be moored if it has a permanent mooring place.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-gen;percentageAdvanced">
-		<rdfs:label xml:lang="en">percentage advanced  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The percentage of the purchase price advanced as the loan.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-gen;residential">
-		<rdfs:label xml:lang="en">residential  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the boat is intended to be used and is legally able to be used as a place of residence.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-typ-gen="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/GeneralLoans/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/GeneralLoans/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">GeneralLoans</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology is for different kinds of general loan such as motor loans and marine finance.
+		Other types of general loan such as those for motorhomes or other specified purposes would also go in this ontology, which is not complete.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/GeneralLoans/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-gen;AutoLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">auto loan  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan specifically for the purpose of automobile purchase.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-gen;AutoLoanContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-gen;AutoLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">auto loan contract  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-gen;MarineFinance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">marine finance  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan for the purchase of a boat or other vessel.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-gen;MarineFinanceContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">marine finance contract  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contract embodying the terms under which a loan is advanced for marine finance.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-gen;boatHeldAsChattel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">boat held as chattel  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the vessel is to be held in ownership as a form of chattel by the lender during the period of the loan.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-gen;mooredAt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">moored at  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Textual description (name etc.) of where the vessel is to be moored if it has a permanent mooring place.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-gen;percentageAdvanced">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage advanced  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage of the purchase price advanced as the loan.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-gen;residential">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">residential  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-gen;MarineFinance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the boat is intended to be used and is legally able to be used as a place of residence.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoanTypes/LoanProducts.rdf
+++ b/loan/LoanTypes/LoanProducts.rdf
@@ -1,128 +1,132 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-loan-reg "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/">
-	<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
-	<!ENTITY fibo-loan-typ-prod "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-loan-reg "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/">
+bu<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
+bu<!ENTITY fibo-loan-typ-prod "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-loan-reg="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/"
-	xmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
-	xmlns:fibo-loan-typ-prod="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/">
-		<rdfs:label xml:lang="en">LoanProducts</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-prod;LoanProduct">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/FinancialProduct"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/isEmbodiedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-prod;hasPreconditions"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/LoanPrecedentConditions"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-prod;isTemplateFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-prod;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan product</rdfs:label>
-		<skos:definition xml:lang="en">A pre-packed business offering, which can be instantiated as a Loan, in which the lender would lend an amount of money to a potential customer under agreed terms, which terms would be a formal contract expressing the terms defined in this Product and any other terms agreed bilaterally between the parties when the Product is instantiated.</skos:definition>
-		<skos:editorialNote xml:lang="en">property &apos;becomes&apos; (now &apos;realized as&apos;): If accepted by a potential borrower, the Loan Product is embodied as an actual loan on a given date and under given conditions.</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is defined in terms of a &quot;Product&quot;, that is it is not itself the loan but is the pre-packaging of a possible loan product that might be made available by a given lender. See &quot;Loan&quot; for the actual loan which comes into effect at the point at which it is drawn down (draw down date). This term Loan Product defines only the packaging of possible loans as products made available by a lender (similar to insurance products made available by a retail insurance company, which are not the same as the policy or the underwriting of a specific instance of that policy). Note that the draft definition here replaces one that was a carbon copy of the &quot;Loan&quot; definition. Loan Product is not for a specific amount i.e. the amount is agreed as part of negotiating a specific Loan Contract between lender and borrower, based on the terms contained in this Loan Product definition.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-prod;LoanProductDisclosureRight">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ProductDisclosureRight"/>
-		<rdfs:label xml:lang="en">loan product disclosure right  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Right to fair representation of the facts about Loan products before entrering into agreements for same.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-prod;MortgageProduct">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-prod;LoanProduct"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/isEmbodiedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-prod;isTemplateFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-prod;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage product  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-prod;hasPreconditions">
-		<rdfs:label xml:lang="en">has preconditions  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-prod;LoanProduct"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/LoanPrecedentConditions"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-prod;isAbout">
-		<rdfs:label>is about</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-prod;isTemplateFor">
-		<rdfs:label xml:lang="en">is template for</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/Product"/>
-		<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-prod;specifies">
-		<rdfs:label xml:lang="en">specifies  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-prod;LoanProduct"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-loan-reg="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/"
+buxmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
+buxmlns:fibo-loan-typ-prod="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoanProducts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology describes loan and mortgage loan products. A product as defined here is something marketed and offered for sale, in this case a loan, such that when a customer takes on the product, they become signatories to a corresponding loan contract. A loan product in this sense is a contractual , off-the-shelf product with terms corresponding to those in the actual contract when it is signed.
+		Note that considerable work has been done on products to support a separate loan product concept in the HMDA-derived Loan Contracts module, so this work now needs integrating with that or deprecating</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-prod;LoanProduct">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/FinancialProduct"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/isEmbodiedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-prod;hasPreconditions"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/LoanPrecedentConditions"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-prod;isTemplateFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-prod;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan product</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pre-packed business offering, which can be instantiated as a Loan, in which the lender would lend an amount of money to a potential customer under agreed terms, which terms would be a formal contract expressing the terms defined in this Product and any other terms agreed bilaterally between the parties when the Product is instantiated.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">property &apos;becomes&apos; (now &apos;realized as&apos;): If accepted by a potential borrower, the Loan Product is embodied as an actual loan on a given date and under given conditions.</skos:editorialNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is defined in terms of a &quot;Product&quot;, that is it is not itself the loan but is the pre-packaging of a possible loan product that might be made available by a given lender. See &quot;Loan&quot; for the actual loan which comes into effect at the point at which it is drawn down (draw down date). This term Loan Product defines only the packaging of possible loans as products made available by a lender (similar to insurance products made available by a retail insurance company, which are not the same as the policy or the underwriting of a specific instance of that policy). Note that the draft definition here replaces one that was a carbon copy of the &quot;Loan&quot; definition. Loan Product is not for a specific amount i.e. the amount is agreed as part of negotiating a specific Loan Contract between lender and borrower, based on the terms contained in this Loan Product definition.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-prod;LoanProductDisclosureRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ProductDisclosureRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan product disclosure right  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Right to fair representation of the facts about Loan products before entrering into agreements for same.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-prod;MortgageProduct">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-prod;LoanProduct"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/isEmbodiedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-prod;isTemplateFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-prod;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage product  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-prod;hasPreconditions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has preconditions  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-prod;LoanProduct"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/LoanPrecedentConditions"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-prod;isAbout">
+bubu<rdfs:label>is about</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-prod;isTemplateFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is template for</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/Product"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-prod;specifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-prod;LoanProduct"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoanTypes/MortgageLoans.rdf
+++ b/loan/LoanTypes/MortgageLoans.rdf
@@ -1,273 +1,277 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
-	<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
-	<!ENTITY fibo-loan-typ-sec "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
+bu<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
+bu<!ENTITY fibo-loan-typ-sec "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
-	xmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
-	xmlns:fibo-loan-typ-sec="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
-		<rdfs:label xml:lang="en">MortgageLoans</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;CombinationMortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Combination Mortgage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;Construction">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Construction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;DebtConsolidation">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Debt Consolidation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;EquityRelease">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Equity Release</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;GovernmentSponsoredLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Government Sponsored Loan</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;InvestmentHomeLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-		<rdfs:label xml:lang="en">investment home loan  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A loan for a second or subsequent property which is taken out for investment purposes.</skos:definition>
-		<skos:editorialNote xml:lang="en">[formal definition to come from participants] The purpose for this is prospecitve income rather than personal use</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;InvestmentHomeLoanContract">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
-		<rdfs:label xml:lang="en">investment home loan contract  (please review)</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-loan-typ-mtg;SecondHomeLoanContract"/>
-		<skos:definition xml:lang="en">A loan for a second or subsequent property which is taken out for investment purposes.</skos:definition>
-		<skos:editorialNote xml:lang="en">[formal definition to come from participants] The purpose for this is prospecitve income rather than personal use</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;InvestmentMortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Investment Mortgage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageBorrower">
-		<rdfs:label xml:lang="en">mortgage borrower  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLender">
-		<rdfs:label xml:lang="en">mortgage lender  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;hasBorrowingParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;hasLendingParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLender"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;hasMIGProvider"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanMIGProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;hasParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage loan  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A loan securitized against some real estate.</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition probably incomplete. Mortgage is not only securitized on the real estate but is used to fund the purchase of that real estate. Not sure of the best form of wording.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLoanBorrowerInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:label xml:lang="en">mortgage loan borrower information  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLoanContract">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage loan contract  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A mortgage loan contract setting out the terms and conditions for a mortgage.</skos:definition>
-		<skos:editorialNote xml:lang="en">IMP PoC notes: Loan purpose. Permissible answers: Purchase Re-mortgage Renovation Equity release Construction Debt consolidation Other (to provide details, if applicable) Re-mortgage with Equity Release Re-mortgage on Different Terms Combination Mortgage Investment Mortgage Right to Buy Government Sponsored Loan No data - these have now been defined as a selectable list of loan purposes which are specific to mortgage loans.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLoanPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">mortgage loan purpose</rdfs:label>
-		<skos:definition xml:lang="en">A purpose for which a Mortgage Loan may be taken out.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;Purchase">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Purchase</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;Remortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Remortgage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;RemortgageOnDifferentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;Remortgage"/>
-		<rdfs:label xml:lang="en">Remortgage On Different Terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;RemortgageWithEquityRelease">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;Remortgage"/>
-		<rdfs:label xml:lang="en">Remortgage With Equity Release</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;Renovation">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Renovation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;ReverseMortgage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-		<rdfs:label xml:lang="en">reverse mortgage  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Designed for senior citizens who want to borrow against the equity of house. The house has been paid for. How is it different?: Scenario based. If you have someone who is asset rich but cash poor then a traditional view of the mortgage wqould say yoiu must have th ecash to repay the loan, which would not apply in this case: we actually don&apos;t anticipate that you would repay it, maybe not even regular amounts on the loan, but when the loan expires, e.g. when you die, we will recover on the asset in the normal course of events. Not seen as a default but is an expectation that we will recover our funds. See Wikipedia. AKA Lifetime morgtage, seniores (age xxx or older) to release the home equity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;RightToBuy">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<rdfs:label xml:lang="en">Right To Buy</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;SecondHomeLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-		<rdfs:label xml:lang="en">second home loan  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A loan which may be used for a vacation home or second home used for personal reasons.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-mtg;SecondHomeLoanContract">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
-		<rdfs:label xml:lang="en">second home loan contract  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;domiciled">
-		<rdfs:label xml:lang="en">domiciled  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoanBorrowerInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether borrower is a resident of the jurisdiction where the property is located. Corporate: Where registered / whether registered in this jurisdiction? Where it pays taxes. Review 07 April: notes for &quot;Domicile&quot; are about the new term &quot;Domicile&quot;. Corporate can be &quot;resident&quot; in a location. can be regarded sa resident for tax purposes, which seems to be the thing we refer to as &quot;Registration&quot; (new term added today for Incorporated Company). So we have for example the Registered Address determines your residency? In the US most companies are incorporeated in Delaware because they have more lenient requirements. Place of Incorporation is usually their &quot;Place of REsidence&quot; but they may register in various states for various reasons, and in other foreign countries (except where this is a separate leagel entity presumably? MB). So: Is &quot;Resident&quot; the term we generally use for all legal entities or only for natural persons? Domicile is a better word, and is used in the context of corporations as well as natural persons. Examples: in Aus, someone nameless may have changed their place of residence due to issues around aspextos. Similar casinos incorporated in obscure countries.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;hasBorrowingParty">
-		<rdfs:label xml:lang="en">has borrowing party  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageBorrower"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;hasLendingParty">
-		<rdfs:label xml:lang="en">has lending party  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLender"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;hasMIGProvider">
-		<rdfs:label xml:lang="en">has m i g provider  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-gty;LoanMIGProvider"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;hasParty">
-		<rdfs:label xml:lang="en">has party  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;isLienOn">
-		<rdfs:label>is lien on</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;loanMortgageMandateAmount">
-		<rdfs:label xml:lang="en">loan mortgage mandate amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Mortgage Mandate - Amount of mortgage mandate that can be converted into a proper mortgage at a later stage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;maturity">
-		<rdfs:label xml:lang="en">maturity  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-		<skos:definition xml:lang="en">The length of time from the present until the maturity of the mortgage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;maturityDate">
-		<rdfs:label xml:lang="en">maturity date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The date at which the mortgage is due to have been paid off in full. This is the date when the final principal is paid off along with any remaining interest.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;mortgagePurpose">
-		<rdfs:label xml:lang="en">mortgage purpose  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
-		<skos:definition xml:lang="en">The purpose for which the Mortgage Loan has been taken out.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
+buxmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
+buxmlns:fibo-loan-typ-sec="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">MortgageLoans</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Loans which have collateral posted as security and where that collateral is real estate, and the real estate which makes up the collateral is purchased with the funds loaned. This ontology covers a range of mortgage concepts and parties, along with catewgories of mortgage loan purpose (remortgage, second home etc.)
+		Note that much of the material in this ontology will also have been covered in the separate Loan Contracts module, and is to be integrated. The terms here are not intended not be specific to US mortgage loans or HMDA reporting but are more general.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;CombinationMortgage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Combination Mortgage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;Construction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Construction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;DebtConsolidation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Debt Consolidation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;EquityRelease">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Equity Release</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;GovernmentSponsoredLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Government Sponsored Loan</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;InvestmentHomeLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment home loan  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan for a second or subsequent property which is taken out for investment purposes.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">[formal definition to come from participants] The purpose for this is prospecitve income rather than personal use</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;InvestmentHomeLoanContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment home loan contract  (please review)</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-loan-typ-mtg;SecondHomeLoanContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan for a second or subsequent property which is taken out for investment purposes.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">[formal definition to come from participants] The purpose for this is prospecitve income rather than personal use</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;InvestmentMortgage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Investment Mortgage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageBorrower">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage borrower  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLender">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage lender  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;hasBorrowingParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;hasLendingParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLender"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;hasMIGProvider"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanMIGProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;hasParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage loan  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan securitized against some real estate.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Definition probably incomplete. Mortgage is not only securitized on the real estate but is used to fund the purchase of that real estate. Not sure of the best form of wording.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLoanBorrowerInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage loan borrower information  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLoanContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage loan contract  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A mortgage loan contract setting out the terms and conditions for a mortgage.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">IMP PoC notes: Loan purpose. Permissible answers: Purchase Re-mortgage Renovation Equity release Construction Debt consolidation Other (to provide details, if applicable) Re-mortgage with Equity Release Re-mortgage on Different Terms Combination Mortgage Investment Mortgage Right to Buy Government Sponsored Loan No data - these have now been defined as a selectable list of loan purposes which are specific to mortgage loans.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;MortgageLoanPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage loan purpose</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A purpose for which a Mortgage Loan may be taken out.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;Purchase">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Purchase</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;Remortgage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Remortgage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;RemortgageOnDifferentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;Remortgage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Remortgage On Different Terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;RemortgageWithEquityRelease">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;Remortgage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Remortgage With Equity Release</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;Renovation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Renovation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;ReverseMortgage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reverse mortgage  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Designed for senior citizens who want to borrow against the equity of house. The house has been paid for. How is it different?: Scenario based. If you have someone who is asset rich but cash poor then a traditional view of the mortgage wqould say yoiu must have th ecash to repay the loan, which would not apply in this case: we actually don&apos;t anticipate that you would repay it, maybe not even regular amounts on the loan, but when the loan expires, e.g. when you die, we will recover on the asset in the normal course of events. Not seen as a default but is an expectation that we will recover our funds. See Wikipedia. AKA Lifetime morgtage, seniores (age xxx or older) to release the home equity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;RightToBuy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Right To Buy</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;SecondHomeLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">second home loan  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan which may be used for a vacation home or second home used for personal reasons.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-mtg;SecondHomeLoanContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">second home loan contract  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;domiciled">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">domiciled  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoanBorrowerInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether borrower is a resident of the jurisdiction where the property is located. Corporate: Where registered / whether registered in this jurisdiction? Where it pays taxes. Review 07 April: notes for &quot;Domicile&quot; are about the new term &quot;Domicile&quot;. Corporate can be &quot;resident&quot; in a location. can be regarded sa resident for tax purposes, which seems to be the thing we refer to as &quot;Registration&quot; (new term added today for Incorporated Company). So we have for example the Registered Address determines your residency? In the US most companies are incorporeated in Delaware because they have more lenient requirements. Place of Incorporation is usually their &quot;Place of REsidence&quot; but they may register in various states for various reasons, and in other foreign countries (except where this is a separate leagel entity presumably? MB). So: Is &quot;Resident&quot; the term we generally use for all legal entities or only for natural persons? Domicile is a better word, and is used in the context of corporations as well as natural persons. Examples: in Aus, someone nameless may have changed their place of residence due to issues around aspextos. Similar casinos incorporated in obscure countries.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;hasBorrowingParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has borrowing party  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageBorrower"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;hasLendingParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has lending party  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLender"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;hasMIGProvider">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has m i g provider  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-gty;LoanMIGProvider"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;hasParty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has party  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;isLienOn">
+bubu<rdfs:label>is lien on</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;loanMortgageMandateAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan mortgage mandate amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mortgage Mandate - Amount of mortgage mandate that can be converted into a proper mortgage at a later stage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;maturity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The length of time from the present until the maturity of the mortgage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;maturityDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the mortgage is due to have been paid off in full. This is the date when the final principal is paid off along with any remaining interest.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-mtg;mortgagePurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage purpose  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-mtg;MortgageLoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-mtg;MortgageLoanPurpose"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The purpose for which the Mortgage Loan has been taken out.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoanTypes/PersonalLoans.rdf
+++ b/loan/LoanTypes/PersonalLoans.rdf
@@ -1,86 +1,89 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-typ-per "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-typ-per "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-typ-per="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/">
-		<rdfs:label xml:lang="en">PersonalLoans</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-per;PersonalLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;drawnDownBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-per;PersonalLoanBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">personal loan  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Consumer Loan: The recipient (borrower) is an end consumer. Types: Home Mortgage</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-per;PersonalLoanBorrower">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-pty;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;NaturalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">personal loan borrower  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-per;PersonalLoanContract">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasBorrower"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-per;PersonalLoanBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-per;PersonalLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">personal loan contract  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The contract for a loan which is advanced to an individual human beings or two more individual human beings in their personal capacities.</skos:definition>
-		<skos:editorialNote xml:lang="en">This originates from the terms in the PoC Semantic Data Model, which did not distinguish between personal and business loans, but for which a good number of the terms defined for &quot;Loan&quot; apply uniquely to personal loans and not to corporate loans, i.e. information about the borrower which can only be information about an individual. Therefore a separate class of Personal Loan Contract, and Personal Loan, have been defined here so that these facts may be applied at the level at which they are meaningful and relevant. In the case of loans to more than one individual, there is a &quot;Co-borrower&quot;. It should be assumed that the two or more parties are jointly and severally liable for any liabillities incurred under the terms of this Contract.</skos:editorialNote>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-typ-per="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">PersonalLoans</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Loans where the borrower is a natural person.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-per;PersonalLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;drawnDownBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-per;PersonalLoanBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">personal loan  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Consumer Loan: The recipient (borrower) is an end consumer. Types: Home Mortgage</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-per;PersonalLoanBorrower">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-pty;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;NaturalPerson"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">personal loan borrower  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-per;PersonalLoanContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasBorrower"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-per;PersonalLoanBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-per;PersonalLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">personal loan contract  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The contract for a loan which is advanced to an individual human beings or two more individual human beings in their personal capacities.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This originates from the terms in the PoC Semantic Data Model, which did not distinguish between personal and business loans, but for which a good number of the terms defined for &quot;Loan&quot; apply uniquely to personal loans and not to corporate loans, i.e. information about the borrower which can only be information about an individual. Therefore a separate class of Personal Loan Contract, and Personal Loan, have been defined here so that these facts may be applied at the level at which they are meaningful and relevant. In the case of loans to more than one individual, there is a &quot;Co-borrower&quot;. It should be assumed that the two or more parties are jointly and severally liable for any liabillities incurred under the terms of this Contract.</skos:editorialNote>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/loan/LoanTypes/SecuredLoans.rdf
+++ b/loan/LoanTypes/SecuredLoans.rdf
@@ -1,129 +1,133 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
-	<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-typ-sec "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/">
-	<!ENTITY fibo-loan-typ-uns "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
+bu<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-typ-sec "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/">
+bu<!ENTITY fibo-loan-typ-uns "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
-	xmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-typ-sec="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"
-	xmlns:fibo-loan-typ-uns="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/">
-		<rdfs:label xml:lang="en">SecuredLoans</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-sec;CollateralizedSecuredLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;SecuredLoan"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-sec;coveredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-col;LoanCollateralAgreement"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-sec;howSecured.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-sec;SecuredByCollateral"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">collateralized secured loan</rdfs:label>
-		<skos:definition xml:lang="en">Loan in which some asset is provided as collateral to the loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-sec;GuaranteedLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;SecuredLoan"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-sec;howSecured.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-sec;SecuredByGuaranty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-gty;guaranteedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">guaranteed loan</rdfs:label>
-		<skos:definition xml:lang="en">Loan secured by guaranty.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-sec;LoanSecuritizationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">loan securitization method</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-sec;SecuredByCollateral">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;LoanSecuritizationMethod"/>
-		<rdfs:label xml:lang="en">secured by collateral</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-sec;SecuredByGuaranty">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;LoanSecuritizationMethod"/>
-		<rdfs:label xml:lang="en">secured by guaranty</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-sec;SecuredLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:label xml:lang="en">secured loan</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-loan-typ-uns;UnsecuredLoan"/>
-		<skos:definition xml:lang="en">A loan which is secured by some security in the form either of collateral or of guaranty.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">All loans are either secured or unsecured All secured loans are secured by some asset or some guaranty Guaranties have various forms. Guaranties have a guarantor. The guarantor may or may not elect to introduce some collateral of their own. Guarantor may or may not be Co-borrower. Linguistic clues: Collateral Agreement: Side agreement (co - lateral) giving the lender acccess to those assets. Set of terms existing the contract. &quot;Security Interest&quot;.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-sec;coveredBy">
-		<rdfs:label xml:lang="en">covered by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanCollateralAgreement"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-sec;howSecured.2">
-		<rdfs:label xml:lang="en">how secured  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-sec;SecuredLoan"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-sec;LoanSecuritizationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-sec;secured">
-		<rdfs:label xml:lang="en">secured  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-sec;secured.1">
-		<rdfs:label xml:lang="en">secured  (please review)</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
+buxmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-typ-sec="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"
+buxmlns:fibo-loan-typ-uns="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SecuredLoans</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology provides concepts relating to secured loans. All loans are either secured or unsecured, and secured loans are secured either by collateral or by guaranty. 
+		This ontology covers these core concepts, so that mortgage loans, where the collateral is more specific, can be built on to of this. These concepts may not be needed for stand-along application-specific ontologies for mortgage lending as the concepts here provide the abstractions for definition of mortgage loan concepts and differentiates them from other categories of loan. These intermediate abstracations may or may not be presented in the separate Loan Contracts module for mortgage loans.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-sec;CollateralizedSecuredLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;SecuredLoan"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-sec;coveredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-col;LoanCollateralAgreement"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-sec;howSecured.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-sec;SecuredByCollateral"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateralized secured loan</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Loan in which some asset is provided as collateral to the loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-sec;GuaranteedLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;SecuredLoan"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-sec;howSecured.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-sec;SecuredByGuaranty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-gty;guaranteedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">guaranteed loan</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Loan secured by guaranty.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-sec;LoanSecuritizationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan securitization method</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-sec;SecuredByCollateral">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;LoanSecuritizationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secured by collateral</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-sec;SecuredByGuaranty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-sec;LoanSecuritizationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secured by guaranty</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-sec;SecuredLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secured loan</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-loan-typ-uns;UnsecuredLoan"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan which is secured by some security in the form either of collateral or of guaranty.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">All loans are either secured or unsecured All secured loans are secured by some asset or some guaranty Guaranties have various forms. Guaranties have a guarantor. The guarantor may or may not elect to introduce some collateral of their own. Guarantor may or may not be Co-borrower. Linguistic clues: Collateral Agreement: Side agreement (co - lateral) giving the lender acccess to those assets. Set of terms existing the contract. &quot;Security Interest&quot;.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-sec;coveredBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">covered by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanCollateralAgreement"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-sec;howSecured.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">how secured  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-sec;SecuredLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-sec;LoanSecuritizationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-sec;secured">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secured  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-sec;secured.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secured  (please review)</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoanTypes/StudentLoans.rdf
+++ b/loan/LoanTypes/StudentLoans.rdf
@@ -1,58 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-typ-per "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/">
-	<!ENTITY fibo-loan-typ-stu "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-typ-per "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/">
+bu<!ENTITY fibo-loan-typ-stu "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-typ-per="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"
-	xmlns:fibo-loan-typ-stu="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/">
-		<rdfs:label xml:lang="en">StudentLoans</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-stu;StudentBorrower">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-typ-per;PersonalLoanBorrower"/>
-		<rdfs:label xml:lang="en">student borrower  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-stu;StudentLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:label xml:lang="en">student loan</rdfs:label>
-		<skos:definition xml:lang="en">A loan provided for the purposes of education.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Also loans which are Bridge Loan between education and professional certification, e.g. between Law School and Bar Exam. These are considered Student Loans also. So this adds to the list of types of Student Loan and the facts thereof. Also Resident and Relocation e.g. Med students, e..g when doing internship. Provide money for that purpose. Also considered a student loan. Implications: There are different crieteria in making the loan, for each of these, e.g. whether you have graduated. If residentcy and relocation aplication: would have to be completing Med raining and getting ready to go into internship. So there are liufecycle (phase) terms about the Borrower (student). In these the borrower is alwways the student.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-stu;StudentLoanContract">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-stu;StudentLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">student loan contract  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The contract for a Student Loan.</skos:definition>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-typ-per="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"
+buxmlns:fibo-loan-typ-stu="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">StudentLoans</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">A loan or series of loans made for the purposes of study at some institution of learning.
+		This ontology and much of the common supporting information on loan applications are based on extensive review and input from Sallie Mae in the US and there may be other variants of student loans that are not covered here. For example in principle a student loan may be framed as a credit facility in some arrangements and as a single loan with separate payment phases in others.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-stu;StudentBorrower">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-typ-per;PersonalLoanBorrower"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">student borrower  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-stu;StudentLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">student loan</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan provided for the purposes of education.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Also loans which are Bridge Loan between education and professional certification, e.g. between Law School and Bar Exam. These are considered Student Loans also. So this adds to the list of types of Student Loan and the facts thereof. Also Resident and Relocation e.g. Med students, e..g when doing internship. Provide money for that purpose. Also considered a student loan. Implications: There are different crieteria in making the loan, for each of these, e.g. whether you have graduated. If residentcy and relocation aplication: would have to be completing Med raining and getting ready to go into internship. So there are liufecycle (phase) terms about the Borrower (student). In these the borrower is alwways the student.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-stu;StudentLoanContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-stu;StudentLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">student loan contract  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The contract for a Student Loan.</skos:definition>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/loan/LoanTypes/UnsecuredLoans.rdf
+++ b/loan/LoanTypes/UnsecuredLoans.rdf
@@ -1,45 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-typ-uns "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-typ-uns "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-typ-uns="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/">
-		<rdfs:label xml:lang="en">UnsecuredLoans</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-uns;UnsecuredLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:label xml:lang="en">unsecured loan  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-typ-uns;secured">
-		<rdfs:label xml:lang="en">secured  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-typ-uns;UnsecuredLoan"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-typ-uns="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">UnsecuredLoans</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology is a companion to the Secured Loans ontology, and defines loans for which there is no security, either as guaranty or as collateral. 
+		Note that for most applications this ontology would not be needed. It is provided in order to provide a conceptually complete account of the kinds of loans there might be. While most people would not lend on this basis, the concept still exists.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/UnsecuredLoans/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-uns;UnsecuredLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unsecured loan  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-typ-uns;secured">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secured  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-typ-uns;UnsecuredLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/Loans/LoanBasicTerms.rdf
+++ b/loan/Loans/LoanBasicTerms.rdf
@@ -1,982 +1,985 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
-	<!ENTITY fibo-fnd-agrx-ele "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/">
-	<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
-	<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-tem-ph "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY fibo-sec-dbt-dbt-fin "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-ctrx "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/">
+bu<!ENTITY fibo-fnd-agrx-ele "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/">
+bu<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-ptyx-ptyx "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
+bu<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-tem-ph "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY fibo-sec-dbt-dbt-fin "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
-	xmlns:fibo-fnd-agrx-ele="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"
-	xmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
-	xmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-tem-ph="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:fibo-sec-dbt-dbt-fin="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-		<rdfs:label xml:lang="en">LoanBasicTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;AutoLoanPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">auto loan purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;BridgingLoanPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">bridging loan purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;ConstructionLoanPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">construction loan purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;CreditCardReceivablePurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">credit card receivable purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;CurrentPrincipalBalanceApplicability">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability"/>
-		<rdfs:label xml:lang="en">current principal balance applicability</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;CurtailmentAmountApplicability">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability"/>
-		<rdfs:label xml:lang="en">curtailment amount applicability</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;DrawingRightsPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">drawing rights purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;HomeEquityLoanPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">home equity loan purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanBorrowerCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;acceptedBy"/>
-				<owl:onClass rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan borrower commitment</rdfs:label>
-		<skos:definition xml:lang="en">The commitment of a given borrower to be a borrower and to repay this loan.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is in the sense of a commitment as defined in a Contract. The Loan Contract between Lender and Borrower(s) would define these commitments. Includes commitments to pay principal, commitment to pay interest, and other covenants or conditions agreed upon. There is also a status of a commitment prior to the loan, in relation to the credit facility. This is not the same as what is modeled here, where I now have it as a parent of the legal commitments made by the borrower when they sign the loan. On the above, see also &quot;Loan Precedent Conditions&quot; which covers the conditions to be met before the loan may be initiated (approved). PoC Review comment: Not needed in data model. Renamed from &quot;Loan Borrower Association&quot; in logical model. PoC Review comments on original term (renamed and re-interpreted since): This should just be Loan borrower, i.e. it defines which borrower is associated with each loan. It represents the commitment of this borrower to be a borrower and to repay this loan. IBM Notes: Unique identifier per borrower (not showing the real name) - to enable borrowers with multiple loans in the pool to be identified (e.g. further advances / second liens are shown as separate entries). Should not change over the life of the transaction By storing this identifier in the loan Borrower commitment a separate value is available for each loan borrower Modeling Note: The original PoC SDM term described above fulfilled the dual role of being an intermediate table between borrower and loan, and have the name and meaning of &quot;Commitment&quot;. The Semantic Model defines commitments already (e.g. for transaction models), and so we have chosen to model the commitments of the borrower in terms of their relationship to the contract and terms for interest and principal, which would need to be modeled anyway. The PoC notes above are of little relevance to the semantics of this term.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanConditions">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/DebtTerms"/>
-		<rdfs:label xml:lang="en">loan conditions</rdfs:label>
-		<skos:definition xml:lang="en">Conditions which must be met by the Borrower during the course of the loan. Breach of these conditions will have predetermined consequences.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanContract">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasInterestTerms"/>
-				<owl:onClass rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;hasProvisions"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanTerminationProvisions"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;establishes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;establishes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasBorrower"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasConditions"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanConditions"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasLender"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanLender"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasPaymentSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPaymentSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasPrepaymentTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPrepaymentTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasPrincipalTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan contract</rdfs:label>
-		<skos:definition xml:lang="en">The Contract which embodies a loan from one party (the Lender) to another party (the Borrower).</skos:definition>
-		<skos:editorialNote xml:lang="en">Reiew notes from PoC review sessions: A contract is set up on a loan, and there are additional aspects that pertain to each party on that loan. See: Loan borrower Association (the action term) Proposal: Use the entity of Contract (specialized for loan contracts). Rationale: Most of these terms are similar to those for a Bond, which is a securitry and as such is a Contract. Would then identify facts about the contract as a contract e.g. maturity) and also sets of contractual terms such as interst payment trerms and principal repayment terms. Conclusion: modeled this as a Contract. Extensively re-built the archetypal &quot;Debt&quot; model to distinguish between Debt (an amount owed) and Debt Finance (an amount extended by one party to another at a point in time, which is then a debt). Original notes from PoC: Unique identifier for each loan. The loan ID should not change through the life of the transaction. If the original loan ID canot be maintained in this field enter the original ID followed by the new ID, comma delimited ( We handle this as an attribute of mortgage loan rether than loan - since ensuring uniqueness and stability will be handled across the class of mortgage loans before attempting this across any broader class of general loans )</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanDrawdown">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-gty;guaranteedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;loanSubsidyAmount"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;maturity"/>
-				<owl:onClass rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;drawnDownBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-pty;hasLoanThirdParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-pty;originatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanOriginator"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-pty;servicedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan drawdown</rdfs:label>
-		<skos:definition xml:lang="en">An amount of money, drawn down by one party (the borrower) from a credit tranche made available by another party (the lender) at a specific point in time. Formal terms for the loan are defined in a Loan Contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is not the amount owed at a specific point in time (that is the Loan Balance) but rather the amount drawn down as a loan. The balance of the loan changes over time as principal is paid off, and the balance of monies between the lender and the borrower is further impacted by interest payments, interest due and fees.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanEarlyPrepaymentHardPenaltyTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
-		<rdfs:label xml:lang="en">loan early prepayment hard penalty terms</rdfs:label>
-		<skos:definition xml:lang="en">Early repayment penalty in the event of the loan being paid off without any refinancing with the same lender.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These terms cover prepayment penalty period, penalty amount and whether or not there is provision for waiver of the penalty, all inherited from the parent term.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanEarlyPrepaymentSoftPenaltyTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
-		<rdfs:label xml:lang="en">loan early prepayment soft penalty terms</rdfs:label>
-		<skos:definition xml:lang="en">Early repayment penalty in the event of the loan being paid off in order to refinance with the same lender.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These terms cover prepayment penalty period, penalty amount and whether or not there is provision for waiver of the penalty, all inherited from the parent term.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPrepaymentTermsSet"/>
-		<rdfs:label xml:lang="en">loan early prepayment terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing the prepayment in full of a loan early in the life of that loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanFixedInterestPaymentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-		<rdfs:label xml:lang="en">loan fixed interest payment terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanFloatingInterestPaymentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasBaseRate"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan floating interest payment terms set</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanIdentificationScheme">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/IdentificationScheme"/>
-		<rdfs:label xml:lang="en">loan identification scheme</rdfs:label>
-		<skos:definition xml:lang="en">A scheme for formal identification of loans. Further notes: May be a published, public scheme or an internal scheme. MAy not be a database-specific key.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanIdentifier">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/Identifier"/>
-		<rdfs:label xml:lang="en">loan identifier</rdfs:label>
-		<skos:definition xml:lang="en">A formal identification code allocated to loans.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Not an internal database key but a published identifier. May be published internally in the absence of public (e.g. ISO) standard.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanInterestPaymentCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;governedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan interest payment commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment by the borrower of a loan to pay interest on that loan or on amounts of that loan.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is established by a Loan Contract, and described in Loan Interest Payment Terms of that contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/InterestPaymentTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;loanInterestRateCap"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasBaseRate.1"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan interest payment terms</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms governing the payment of interest on the loan.</skos:definition>
-		<skos:editorialNote xml:lang="en">Contains similar terms to debt securities interest payment terms, but defined separately here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanOngoingPrepaymentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPrepaymentTermsSet"/>
-		<rdfs:label xml:lang="en">loan ongoing prepayment terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing prepayments of the principal on a loan by the borrower throughout the life of the loan.</skos:definition>
-		<skos:editorialNote xml:lang="en">Comment: Determine whether this is mortgage-specific or applicable to all types of loan. Some definitions are mortgage specific but there must in principle be terms governing early payments on other types of loan. This also governs an important collective metric in loan pools (Loan prepayment speed) which would suggest these are terms applicable to other loan types.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanOriginator">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;mayBecome"/>
-				<owl:allValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanLender"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan originator</rdfs:label>
-		<skos:definition xml:lang="en">The party which finds the lender for the loan, for the borrower.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Similar to mortgages: the originator may be a bank but the person able to lend the money may be some other party. In other instances the originator will become the lender.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">loan party</rdfs:label>
-		<skos:definition xml:lang="en">A Party to the Loan.</skos:definition>
-		<skos:editorialNote xml:lang="en">This covers the principals to the Loan contract (Loan Borrower and Loan Lender) as well as third parties, including Loan Originator. Transformation notes: In the PoC SDM the sub-classes of Loan Third Party will not be articulated as separate parties but defined via a selection list under &quot;Loan Party&quot; or &quot;Loan Third Party&quot;.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPaymentSchedule">
-		<rdfs:label xml:lang="en">loan payment schedule</rdfs:label>
-		<skos:definition xml:lang="en">The schedule for payments made by the borrower.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is calculated to ensure that a constant amount is paid but the amount is applied differently each time to principal and interest. This is called a Credit Foncier. TERMS TO ADD Payment Identifier: A unique identifier for this individual scheduloed payment. this is used to track what payments made by the borrower, are made against this specific scheduled payment. Also known as Coupon Identifier. ACTION: Put this term in the Explicit Schedule listings.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPrepaymentTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
-		<rdfs:label xml:lang="en">loan prepayment terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing prepayments of the principal on a loan by the borrower.</skos:definition>
-		<skos:editorialNote xml:lang="en">Terms so far are mortgage specific but there must in principle be terms governing early payments on other types of loan. This also governs an important collective metric in loan pools (Loan speed).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPrincipalRepaymentCommitment">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;governedBy.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan principal repayment commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment by a borrower to repay the principal on a loan under the terms described.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is established by a Loan Contract, and described in the Loan Principal Repayment Terms of that contract</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
-		<rdfs:label xml:lang="en">loan principal repayment terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms governing the repayment of principal of the loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPurposeSelection">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
-		<rdfs:label xml:lang="en">loan purpose</rdfs:label>
-		<skos:definition xml:lang="en">A selection of different types of loan purpose, being the purpose for which and manner in which loan (credit) draw-down amounts are to be used. This shows the purpose for which credit is to be used, and implies certain kinds of fact that relate to that specific type of loan e.g. mortgages. These are also identified as tranche types in tranches of a credit facility.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanRetainedAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<rdfs:label xml:lang="en">loan retained amount</rdfs:label>
-		<skos:definition xml:lang="en">Retained amount, an amount the Issuer will be obliged to fund to the borrower at a later date, for example construction deposit.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is a monetary amount by descent from the Monetary Amount term in the taxonomy of kinds of amount. Hence it does not have a monetary amount attribute because it is one.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanStandardizationDocumentation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:label xml:lang="en">loan standardization documentation</rdfs:label>
-		<skos:definition xml:lang="en">Very specific categorization of documentation obtained by the lender at the time of origination to qualify a borrower. Documentation Types vary from lender to lender and need to be completely understood. takes a code list in the data world see eg S&amp;P codes of these. not exhaustive? example tax returns etc. categorize as hi low or medium type of doc risk there are also &apos;no doc&apos; mtges</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanTerminationProvisions">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;TerminationProvisions"/>
-		<rdfs:label xml:lang="en">loan termination provisions</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanVariableInterestPaymentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-		<rdfs:label xml:lang="en">loan variable interest payment terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;MotorhomeLoanPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">motorhome loan purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;OrdinaryLoanPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">ordinary loan purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;OriginalBalanceApplicability">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability"/>
-		<rdfs:label xml:lang="en">original balance applicability</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;OverdraftFacilityPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">overdraft facility purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;PaymentArrangementTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
-		<rdfs:label xml:lang="en">payment arrangement terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms covering other arrangements for payments such as paying scheduled payments early to be applied on the scheduled payment dates.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">penalty interest balance applicability</rdfs:label>
-		<skos:definition xml:lang="en">Selection of types of balance to which pre-payment interest penalties may be applied.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;ResidentialHouseboatLoanPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">residential houseboat loan purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;StudentLoanPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">student loan purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;WorkingCapitalPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<rdfs:label xml:lang="en">working capital purpose</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;aRMConvertible">
-		<rdfs:label xml:lang="en">a r m convertible  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the Loan can be converted into an ARM.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;acceptedBy">
-		<rdfs:label xml:lang="en">accepted by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;accepts">
-		<rdfs:label xml:lang="en">accepts  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
-		<owl:inverseOf rdf:resource="&fibo-loan-loan-loan;acceptedBy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;applicableToSameLenderRefinance">
-		<rdfs:label xml:lang="en">applicable to same lender refinance  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentHardPenaltyTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the penalty is specified as being for the loan being paid off in the event of a refinance with same lender. No = these terms relate to penalties where the loan is not so refinanced.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;applicableToSameLenderRefinance.1">
-		<rdfs:label xml:lang="en">applicable to same lender refinance  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentSoftPenaltyTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the penalty is specified as being for the loan being paid off in the event of a refinance with same lender. Yes = these terms define the penalty payable when the debt is refinanced by arrangement with the same lender.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;applicableToSameLenderRefinance.2">
-		<rdfs:label xml:lang="en">applicable to same lender refinance  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the penalty is specified as being for the loan being paid off in the event of a refinance with same lender.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;assumable">
-		<rdfs:label xml:lang="en">assumable  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whethre another borrower may take ownership of the property and assume the payments on this loan.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;baloon">
-		<rdfs:label xml:lang="en">baloon  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the loan will or will not amortize the loan balance fully by the maturity date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;borrows">
-		<rdfs:label xml:lang="en">borrows</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;buydownExists">
-		<rdfs:label xml:lang="en">buydown exists  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether a third party (usually a builder) is making payments to subsize a borrower.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;docType">
-		<rdfs:label xml:lang="en">doc type  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanStandardizationDocumentation"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-gen;LoanStandarizationDocumentType"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;drawDownDate">
-		<rdfs:label xml:lang="en">draw down date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<skos:definition xml:lang="en">The date on which the funds are drawn down, that define the start of the loan.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;drawnDownBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbt-fin;hasBorrowingParty"/>
-		<rdfs:label xml:lang="en">drawn down by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<owl:inverseOf rdf:resource="&fibo-loan-loan-loan;borrows"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;earlyPrepaymentPenalty">
-		<rdfs:label xml:lang="en">early prepayment penalty  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount to be paid as a penalty in the event of early payment of the loan.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;escrowApplicable">
-		<rdfs:label xml:lang="en">escrow applicable  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the servicer is contractually responsible for maintaining an escrow against the account for payment of txes and insurance.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;establishes">
-		<rdfs:label xml:lang="en">establishes  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;establishes.1">
-		<rdfs:label xml:lang="en">establishes  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;governedBy">
-		<rdfs:label xml:lang="en">governed by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentCommitment"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;governedBy.1">
-		<rdfs:label xml:lang="en">governed by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentCommitment"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;gracePeriod">
-		<rdfs:label xml:lang="en">grace period  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanTerminationProvisions"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The period of time after any due date that the borrower has to fulfil its obligations before a a default (failure to pay) is deemed to have occurred.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasBaseRate">
-		<rdfs:label xml:lang="en">has base rate  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanFloatingInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasBaseRate.1">
-		<rdfs:label xml:lang="en">has base rate  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasBorrower">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-		<rdfs:label xml:lang="en">has borrower</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasConditions">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has conditions  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanConditions"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasInterestTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has interest terms  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasLender">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbt-fin;hasLendingParty"/>
-		<rdfs:label xml:lang="en">has lender</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanLender"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasLoanPhase">
-		<rdfs:label xml:lang="en">has loan phase</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ph;LoanPhase"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasPaymentSchedule">
-		<rdfs:label xml:lang="en">has payment schedule  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPaymentSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasPrepaymentTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has prepayment terms  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPrepaymentTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasPrincipalTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has principal terms  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanAmortizationPaymentsNumber">
-		<rdfs:label xml:lang="en">loan amortization payments number  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The number of payments contractually required at origination to repay the loan. For monthly paying loans this is the number of months from the contractual first payment date to the maturity date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanAmortizationPeriod">
-		<rdfs:label xml:lang="en">loan amortization period  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">Loan Term, that is the original contractual term of the loan, in months.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanAnnualPrePaymentsRate">
-		<rdfs:label xml:lang="en">loan annual pre payments rate  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Percentage amount of pre-payments allowed (without penalty ) under the loan contract in any given year</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanDenominationCurrency">
-		<rdfs:label xml:lang="en">loan denomination currency  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which the loan is denominated.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanFurtherAdvancesAllowed">
-		<rdfs:label xml:lang="en">loan further advances allowed  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the lender allows the borrower the possibility to have further advances i.e. advances above the original loan balance.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanGuaranteeInsuredPoint">
-		<rdfs:label xml:lang="en">loan guarantee insured point  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Loan to Value percentage above which losses are insured.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanGuarantorType">
-		<rdfs:label xml:lang="en">loan guarantor type  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<skos:definition xml:lang="en">The type of guarantee provider, if applicable. Actiojn: Move down th eGuaranteed Loan.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanIdentifier">
-		<rdfs:label xml:lang="en">loan identifier  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanIdentifier"/>
-		<skos:definition xml:lang="en">Unique identifier for the loan. Further notes: This is an information construct. It is internal rather than a publicly available ID (like ISIN) but is included since it is a fundamental &quot;fact&quot; about the loan regardless of the fact that it exists only as a data model construct. The loan ID should not change through the life of the transaction. Data model note (not applicable to semantic model): If the original loan ID cannot be maintained in this field enter the original ID followed by the new ID, comma delimited</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanInterestPaymentFrequency">
-		<rdfs:label xml:lang="en">loan interest payment frequency  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">Payment Frequency - Frequency of payments due, i.e. number of months between payments.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanInterestRateCap">
-		<rdfs:label xml:lang="en">loan interest rate cap  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The cap on the interest rate chargeable, if there is one.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanInterestRateType">
-		<rdfs:label xml:lang="en">loan interest rate type  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-		<skos:definition xml:lang="en">Loan Interest Rate Type.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanInterestResetInterval">
-		<rdfs:label xml:lang="en">loan interest reset interval  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-		<skos:definition xml:lang="en">Interest Rate Reset interval - The interval in months at which the interest rate is adjusted (for floating loans)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanMaximumAllowedBalance">
-		<rdfs:label xml:lang="en">loan maximum allowed balance  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Maximum balance - For loans with flexible re-draw facilities, the maximum loan amount that could potentially be outstanding</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanOriginalAdvanceAmount">
-		<rdfs:label xml:lang="en">loan original advance amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The Original Balance of the loan, that is the amount advanced under this loan. Further notes: PoC workings: Original balance (inclusive of fees)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanOriginalAdvanceDate">
-		<rdfs:label xml:lang="en">loan original advance date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<skos:definition xml:lang="en">Loan origination date, that is the date of original loan advance.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanOriginationChannelType">
-		<rdfs:label xml:lang="en">loan origination channel type  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<skos:definition xml:lang="en">The type of bank, division or organization which was responsible for arranging the loan.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanPaymentFrequency">
-		<rdfs:label xml:lang="en">loan payment frequency  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">Payment Frequency - Frequency of payments due, i.e. number of months between payments. Further notes: This is defined as a frequency, i.e. the reciprocal of a period of time. Corresponding Data model entries: Monthly Quarterly Semi annually Annual Bullet Other (to provide details, if applicable) No data Note that not all of these correspond to frequency. Therefore one possibility is that this term is not present. Arrangements such as bullet payments are part of the principal and interest payment terms. This term is retained as a fact about the Loan Contract because the lender may be contractually obliged to make payments with this regularity, which combine interest, principal and other amounts (Tax, ESCROW etc.).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanPeriodicPayment">
-		<rdfs:label xml:lang="en">loan periodic payment  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Periodic contractual payment due (the payment due if there are no other payment arrangements in force)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanPeriodicPaymentType">
-		<rdfs:label xml:lang="en">loan periodic payment type  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<skos:definition xml:lang="en">Periodic payment type. May combine interst and principal amounts. See selection of values. May also be principal interest and ESCROW.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanPhase">
-		<rdfs:label xml:lang="en">loan phase  (please review)</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanPurpose">
-		<rdfs:label xml:lang="en">loan purpose  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<skos:definition xml:lang="en">The purpose for which the loan has been advanced.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanRetainedAmount">
-		<rdfs:label xml:lang="en">loan retained amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Retained amount, this is an amount the Issuer will be obliged to fund to the borrower at a later date, for example construction deposit.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanRetainedAmountDate">
-		<rdfs:label xml:lang="en">loan retained amount date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<skos:definition xml:lang="en">Date when the retained amount is to be drawn by.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanSubsidyAmount">
-		<rdfs:label xml:lang="en">loan subsidy amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Loan Subsidy Received - Amount of subsidy received from government by borrower.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;maturity">
-		<rdfs:label xml:lang="en">maturity  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-		<skos:definition xml:lang="en">The period of time before which the loan is to be repaid or the credit facility expires, if any.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;maturityDate">
-		<rdfs:label xml:lang="en">maturity date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<skos:definition xml:lang="en">The date when the loan matures and is due to be repaid.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;mayBecome">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
-		<rdfs:label xml:lang="en">may become</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanOriginator"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanLender"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;mayHave">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
-		<rdfs:label xml:lang="en">may have  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanStandardizationDocumentation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;penaltyInterestAppliedTo">
-		<rdfs:label xml:lang="en">penalty interest applied to  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanOngoingPrepaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability"/>
-		<skos:definition xml:lang="en">The balance to which the penalty interest is to be applied.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;preArrangedPaymentFee">
-		<rdfs:label xml:lang="en">pre arranged payment fee  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;PaymentArrangementTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The Handling Fee that would be payable in the event of the borrower wishing to make funds available early for application on the schedule due dates (so they are not principal prepayments).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;prepaymentPenaltyInterest">
-		<rdfs:label xml:lang="en">prepayment penalty interest  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanOngoingPrepaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Prepayment Penalty Interest.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;prepaymentPenaltyPeriod">
-		<rdfs:label xml:lang="en">prepayment penalty period  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-		<skos:definition xml:lang="en">Period during which penalities are incurred for partial or full principal repayment prior to loan maturity. MISMO definition: &quot;Information specific to calculation of penalities for partial or full principal repayment prior to loan maturity. &quot; There is a penalty for this as well, perhaps as a monetary amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;prepaymentPenaltyWaiver">
-		<rdfs:label xml:lang="en">prepayment penalty waiver  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the Loan Contract includes a provision for the lender to waive the prepayment penalty at their discretion.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;prepaymentThreshold">
-		<rdfs:label xml:lang="en">prepayment threshold  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanOngoingPrepaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Percentage amount of pre-payments allowed under the product per year. This is for mortgages that allow a certain threshold of pre-payments (ie 10%) before charges are incurred.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;recourseLoan">
-		<rdfs:label xml:lang="en">recourse loan  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The only way you get the money back in the event of default is the security. Recourse is where you still have the opportunity to go back to the borrower for the rest of the money.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;renegotiable">
-		<rdfs:label xml:lang="en">renegotiable  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the terms for payment of interest can be renegotiated during the life of the loan.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;renegotiable.1">
-		<rdfs:label xml:lang="en">renegotiable  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanVariableInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;retainedUntil">
-		<rdfs:label xml:lang="en">retained until  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanRetainedAmount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Date when the retained amount is to be drawn by.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;riskLevel">
-		<rdfs:label xml:lang="en">risk level  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanStandardizationDocumentation"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-gen;LoanDocumentRiskLevel"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;secured">
-		<rdfs:label xml:lang="en">secured  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the loan is secured. Further Details: All loans are either secured or unsecured All secured loans are secured by some asset or some guaranty Guaranties have various forms. Guaranties have a guarantor. The guarantor may or may not elect to introduce some collateral of their own. Guarantor may or may not be Co-borrower.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;setsOutTermsFor">
-		<rdfs:label xml:lang="en">sets out terms for  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<skos:definition xml:lang="en">Extended credit (debt or Credit depending on the Viewpoint) has terms set out in a Contract, governing the terms fo extension of the cerdit, payment of interest, principal repayment and any other required clauses defining conditions of the loan or credit. Note feb 2010: term created in Sept 2008 as part of upper ontology. Review and perhaps specialise the kind of contract this relationship comes from.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;specifies">
-		<rdfs:label xml:lang="en">specifies  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanRetainedAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;spread">
-		<rdfs:label xml:lang="en">spread  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanFloatingInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The percentage of interest added to the base rate.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;subsidyPeriodEndDate">
-		<rdfs:label xml:lang="en">subsidy period end date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<skos:definition xml:lang="en">Subsidy Period - date at which subsidy period ends</skos:definition>
-	</owl:DatatypeProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-ctrx="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"
+buxmlns:fibo-fnd-agrx-ele="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"
+buxmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-ptyx-ptyx="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
+buxmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-tem-ph="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:fibo-sec-dbt-dbt-fin="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoanBasicTerms</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This is the core ontology for loans concepts. These include loan purposes, loan payment terms and parties.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractElements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractsExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;AutoLoanPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">auto loan purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;BridgingLoanPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bridging loan purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;ConstructionLoanPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">construction loan purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;CreditCardReceivablePurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit card receivable purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;CurrentPrincipalBalanceApplicability">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current principal balance applicability</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;CurtailmentAmountApplicability">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">curtailment amount applicability</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;DrawingRightsPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">drawing rights purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;HomeEquityLoanPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">home equity loan purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanBorrowerCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ctrx;ContractuallyConferredCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;acceptedBy"/>
+bubububu<owl:onClass rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan borrower commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The commitment of a given borrower to be a borrower and to repay this loan.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is in the sense of a commitment as defined in a Contract. The Loan Contract between Lender and Borrower(s) would define these commitments. Includes commitments to pay principal, commitment to pay interest, and other covenants or conditions agreed upon. There is also a status of a commitment prior to the loan, in relation to the credit facility. This is not the same as what is modeled here, where I now have it as a parent of the legal commitments made by the borrower when they sign the loan. On the above, see also &quot;Loan Precedent Conditions&quot; which covers the conditions to be met before the loan may be initiated (approved). PoC Review comment: Not needed in data model. Renamed from &quot;Loan Borrower Association&quot; in logical model. PoC Review comments on original term (renamed and re-interpreted since): This should just be Loan borrower, i.e. it defines which borrower is associated with each loan. It represents the commitment of this borrower to be a borrower and to repay this loan. IBM Notes: Unique identifier per borrower (not showing the real name) - to enable borrowers with multiple loans in the pool to be identified (e.g. further advances / second liens are shown as separate entries). Should not change over the life of the transaction By storing this identifier in the loan Borrower commitment a separate value is available for each loan borrower Modeling Note: The original PoC SDM term described above fulfilled the dual role of being an intermediate table between borrower and loan, and have the name and meaning of &quot;Commitment&quot;. The Semantic Model defines commitments already (e.g. for transaction models), and so we have chosen to model the commitments of the borrower in terms of their relationship to the contract and terms for interest and principal, which would need to be modeled anyway. The PoC notes above are of little relevance to the semantics of this term.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanConditions">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/DebtTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan conditions</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Conditions which must be met by the Borrower during the course of the loan. Breach of these conditions will have predetermined consequences.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanContract">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasInterestTerms"/>
+bubububu<owl:onClass rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-ele;hasProvisions"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanTerminationProvisions"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;establishes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;establishes.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasBorrower"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasConditions"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanConditions"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasLender"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanLender"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasPaymentSchedule"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPaymentSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasPrepaymentTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPrepaymentTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasPrincipalTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;setsOutTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan contract</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Contract which embodies a loan from one party (the Lender) to another party (the Borrower).</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Reiew notes from PoC review sessions: A contract is set up on a loan, and there are additional aspects that pertain to each party on that loan. See: Loan borrower Association (the action term) Proposal: Use the entity of Contract (specialized for loan contracts). Rationale: Most of these terms are similar to those for a Bond, which is a securitry and as such is a Contract. Would then identify facts about the contract as a contract e.g. maturity) and also sets of contractual terms such as interst payment trerms and principal repayment terms. Conclusion: modeled this as a Contract. Extensively re-built the archetypal &quot;Debt&quot; model to distinguish between Debt (an amount owed) and Debt Finance (an amount extended by one party to another at a point in time, which is then a debt). Original notes from PoC: Unique identifier for each loan. The loan ID should not change through the life of the transaction. If the original loan ID canot be maintained in this field enter the original ID followed by the new ID, comma delimited ( We handle this as an attribute of mortgage loan rether than loan - since ensuring uniqueness and stability will be handled across the class of mortgage loans before attempting this across any broader class of general loans )</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanDrawdown">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-gty;guaranteedBy"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;loanSubsidyAmount"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;maturity"/>
+bubububu<owl:onClass rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;drawnDownBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-pty;hasLoanThirdParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-pty;originatedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanOriginator"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-pty;servicedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan drawdown</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An amount of money, drawn down by one party (the borrower) from a credit tranche made available by another party (the lender) at a specific point in time. Formal terms for the loan are defined in a Loan Contract.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is not the amount owed at a specific point in time (that is the Loan Balance) but rather the amount drawn down as a loan. The balance of the loan changes over time as principal is paid off, and the balance of monies between the lender and the borrower is further impacted by interest payments, interest due and fees.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanEarlyPrepaymentHardPenaltyTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan early prepayment hard penalty terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Early repayment penalty in the event of the loan being paid off without any refinancing with the same lender.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These terms cover prepayment penalty period, penalty amount and whether or not there is provision for waiver of the penalty, all inherited from the parent term.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanEarlyPrepaymentSoftPenaltyTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan early prepayment soft penalty terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Early repayment penalty in the event of the loan being paid off in order to refinance with the same lender.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These terms cover prepayment penalty period, penalty amount and whether or not there is provision for waiver of the penalty, all inherited from the parent term.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPrepaymentTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan early prepayment terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms governing the prepayment in full of a loan early in the life of that loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanFixedInterestPaymentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan fixed interest payment terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanFloatingInterestPaymentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasBaseRate"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan floating interest payment terms set</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanIdentificationScheme">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/IdentificationScheme"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan identification scheme</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A scheme for formal identification of loans. Further notes: May be a published, public scheme or an internal scheme. MAy not be a database-specific key.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanIdentifier">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/Identifier"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan identifier</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formal identification code allocated to loans.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Not an internal database key but a published identifier. May be published internally in the absence of public (e.g. ISO) standard.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanInterestPaymentCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;governedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest payment commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment by the borrower of a loan to pay interest on that loan or on amounts of that loan.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is established by a Loan Contract, and described in Loan Interest Payment Terms of that contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/InterestPaymentTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;loanInterestRateCap"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasBaseRate.1"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest payment terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms governing the payment of interest on the loan.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Contains similar terms to debt securities interest payment terms, but defined separately here.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanOngoingPrepaymentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPrepaymentTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan ongoing prepayment terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms governing prepayments of the principal on a loan by the borrower throughout the life of the loan.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Comment: Determine whether this is mortgage-specific or applicable to all types of loan. Some definitions are mortgage specific but there must in principle be terms governing early payments on other types of loan. This also governs an important collective metric in loan pools (Loan prepayment speed) which would suggest these are terms applicable to other loan types.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanOriginator">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;mayBecome"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanLender"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan originator</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which finds the lender for the loan, for the borrower.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Similar to mortgages: the originator may be a bank but the person able to lend the money may be some other party. In other instances the originator will become the lender.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Party to the Loan.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This covers the principals to the Loan contract (Loan Borrower and Loan Lender) as well as third parties, including Loan Originator. Transformation notes: In the PoC SDM the sub-classes of Loan Third Party will not be articulated as separate parties but defined via a selection list under &quot;Loan Party&quot; or &quot;Loan Third Party&quot;.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPaymentSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan payment schedule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The schedule for payments made by the borrower.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is calculated to ensure that a constant amount is paid but the amount is applied differently each time to principal and interest. This is called a Credit Foncier. TERMS TO ADD Payment Identifier: A unique identifier for this individual scheduloed payment. this is used to track what payments made by the borrower, are made against this specific scheduled payment. Also known as Coupon Identifier. ACTION: Put this term in the Explicit Schedule listings.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPrepaymentTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan prepayment terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms governing prepayments of the principal on a loan by the borrower.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Terms so far are mortgage specific but there must in principle be terms governing early payments on other types of loan. This also governs an important collective metric in loan pools (Loan speed).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPrincipalRepaymentCommitment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;governedBy.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan principal repayment commitment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A commitment by a borrower to repay the principal on a loan under the terms described.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is established by a Loan Contract, and described in the Loan Principal Repayment Terms of that contract</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan principal repayment terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms governing the repayment of principal of the loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanPurposeSelection">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan purpose</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A selection of different types of loan purpose, being the purpose for which and manner in which loan (credit) draw-down amounts are to be used. This shows the purpose for which credit is to be used, and implies certain kinds of fact that relate to that specific type of loan e.g. mortgages. These are also identified as tranche types in tranches of a credit facility.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanRetainedAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan retained amount</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Retained amount, an amount the Issuer will be obliged to fund to the borrower at a later date, for example construction deposit.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is a monetary amount by descent from the Monetary Amount term in the taxonomy of kinds of amount. Hence it does not have a monetary amount attribute because it is one.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanStandardizationDocumentation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan standardization documentation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Very specific categorization of documentation obtained by the lender at the time of origination to qualify a borrower. Documentation Types vary from lender to lender and need to be completely understood. takes a code list in the data world see eg S&amp;P codes of these. not exhaustive? example tax returns etc. categorize as hi low or medium type of doc risk there are also &apos;no doc&apos; mtges</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanTerminationProvisions">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-ele;TerminationProvisions"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan termination provisions</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanVariableInterestPaymentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan variable interest payment terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;MotorhomeLoanPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">motorhome loan purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;OrdinaryLoanPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ordinary loan purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;OriginalBalanceApplicability">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">original balance applicability</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;OverdraftFacilityPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">overdraft facility purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;PaymentArrangementTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment arrangement terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms covering other arrangements for payments such as paying scheduled payments early to be applied on the scheduled payment dates.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">penalty interest balance applicability</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Selection of types of balance to which pre-payment interest penalties may be applied.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;ResidentialHouseboatLoanPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">residential houseboat loan purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;StudentLoanPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">student loan purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;WorkingCapitalPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">working capital purpose</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;aRMConvertible">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">a r m convertible  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Loan can be converted into an ARM.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;acceptedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accepted by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;accepts">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accepts  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
+bubu<owl:inverseOf rdf:resource="&fibo-loan-loan-loan;acceptedBy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;applicableToSameLenderRefinance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable to same lender refinance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentHardPenaltyTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the penalty is specified as being for the loan being paid off in the event of a refinance with same lender. No = these terms relate to penalties where the loan is not so refinanced.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;applicableToSameLenderRefinance.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable to same lender refinance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentSoftPenaltyTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the penalty is specified as being for the loan being paid off in the event of a refinance with same lender. Yes = these terms define the penalty payable when the debt is refinanced by arrangement with the same lender.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;applicableToSameLenderRefinance.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable to same lender refinance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the penalty is specified as being for the loan being paid off in the event of a refinance with same lender.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;assumable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assumable  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whethre another borrower may take ownership of the property and assume the payments on this loan.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;baloon">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">baloon  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the loan will or will not amortize the loan balance fully by the maturity date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;borrows">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrows</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;buydownExists">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">buydown exists  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether a third party (usually a builder) is making payments to subsize a borrower.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;docType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">doc type  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanStandardizationDocumentation"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-gen;LoanStandarizationDocumentType"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;drawDownDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">draw down date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date on which the funds are drawn down, that define the start of the loan.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;drawnDownBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbt-fin;hasBorrowingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">drawn down by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<owl:inverseOf rdf:resource="&fibo-loan-loan-loan;borrows"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;earlyPrepaymentPenalty">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">early prepayment penalty  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount to be paid as a penalty in the event of early payment of the loan.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;escrowApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">escrow applicable  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the servicer is contractually responsible for maintaining an escrow against the account for payment of txes and insurance.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;establishes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;establishes.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">establishes  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentCommitment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;governedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governed by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;governedBy.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governed by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentCommitment"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;gracePeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">grace period  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanTerminationProvisions"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period of time after any due date that the borrower has to fulfil its obligations before a a default (failure to pay) is deemed to have occurred.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasBaseRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has base rate  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanFloatingInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasBaseRate.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has base rate  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasBorrower">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has borrower</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasConditions">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has conditions  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanConditions"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasInterestTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has interest terms  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasLender">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbt-fin;hasLendingParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has lender</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanLender"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasLoanPhase">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has loan phase</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ph;LoanPhase"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasPaymentSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has payment schedule  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPaymentSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasPrepaymentTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has prepayment terms  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPrepaymentTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;hasPrincipalTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has principal terms  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPrincipalRepaymentTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanAmortizationPaymentsNumber">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan amortization payments number  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of payments contractually required at origination to repay the loan. For monthly paying loans this is the number of months from the contractual first payment date to the maturity date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanAmortizationPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan amortization period  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Loan Term, that is the original contractual term of the loan, in months.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanAnnualPrePaymentsRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan annual pre payments rate  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Percentage amount of pre-payments allowed (without penalty ) under the loan contract in any given year</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanDenominationCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan denomination currency  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which the loan is denominated.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanFurtherAdvancesAllowed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan further advances allowed  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the lender allows the borrower the possibility to have further advances i.e. advances above the original loan balance.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanGuaranteeInsuredPoint">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan guarantee insured point  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Loan to Value percentage above which losses are insured.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanGuarantorType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan guarantor type  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of guarantee provider, if applicable. Actiojn: Move down th eGuaranteed Loan.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanIdentifier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan identifier  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanIdentifier"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Unique identifier for the loan. Further notes: This is an information construct. It is internal rather than a publicly available ID (like ISIN) but is included since it is a fundamental &quot;fact&quot; about the loan regardless of the fact that it exists only as a data model construct. The loan ID should not change through the life of the transaction. Data model note (not applicable to semantic model): If the original loan ID cannot be maintained in this field enter the original ID followed by the new ID, comma delimited</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanInterestPaymentFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest payment frequency  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Payment Frequency - Frequency of payments due, i.e. number of months between payments.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanInterestRateCap">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest rate cap  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The cap on the interest rate chargeable, if there is one.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanInterestRateType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest rate type  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Loan Interest Rate Type.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanInterestResetInterval">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest reset interval  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Interest Rate Reset interval - The interval in months at which the interest rate is adjusted (for floating loans)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanMaximumAllowedBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan maximum allowed balance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Maximum balance - For loans with flexible re-draw facilities, the maximum loan amount that could potentially be outstanding</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanOriginalAdvanceAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan original advance amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Original Balance of the loan, that is the amount advanced under this loan. Further notes: PoC workings: Original balance (inclusive of fees)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanOriginalAdvanceDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan original advance date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Loan origination date, that is the date of original loan advance.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanOriginationChannelType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan origination channel type  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of bank, division or organization which was responsible for arranging the loan.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanPaymentFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan payment frequency  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Payment Frequency - Frequency of payments due, i.e. number of months between payments. Further notes: This is defined as a frequency, i.e. the reciprocal of a period of time. Corresponding Data model entries: Monthly Quarterly Semi annually Annual Bullet Other (to provide details, if applicable) No data Note that not all of these correspond to frequency. Therefore one possibility is that this term is not present. Arrangements such as bullet payments are part of the principal and interest payment terms. This term is retained as a fact about the Loan Contract because the lender may be contractually obliged to make payments with this regularity, which combine interest, principal and other amounts (Tax, ESCROW etc.).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanPeriodicPayment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan periodic payment  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Periodic contractual payment due (the payment due if there are no other payment arrangements in force)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanPeriodicPaymentType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan periodic payment type  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Periodic payment type. May combine interst and principal amounts. See selection of values. May also be principal interest and ESCROW.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanPhase">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan phase  (please review)</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanPurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan purpose  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The purpose for which the loan has been advanced.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanRetainedAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan retained amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Retained amount, this is an amount the Issuer will be obliged to fund to the borrower at a later date, for example construction deposit.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;loanRetainedAmountDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan retained amount date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date when the retained amount is to be drawn by.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;loanSubsidyAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan subsidy amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Loan Subsidy Received - Amount of subsidy received from government by borrower.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;maturity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period of time before which the loan is to be repaid or the credit facility expires, if any.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;maturityDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date when the loan matures and is due to be repaid.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;mayBecome">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-ptyx;becomesParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may become</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanOriginator"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanLender"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;mayHave">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may have  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanStandardizationDocumentation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;penaltyInterestAppliedTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">penalty interest applied to  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanOngoingPrepaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;PenaltyInterestBalanceApplicability"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The balance to which the penalty interest is to be applied.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;preArrangedPaymentFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pre arranged payment fee  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;PaymentArrangementTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Handling Fee that would be payable in the event of the borrower wishing to make funds available early for application on the schedule due dates (so they are not principal prepayments).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;prepaymentPenaltyInterest">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prepayment penalty interest  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanOngoingPrepaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Prepayment Penalty Interest.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;prepaymentPenaltyPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prepayment penalty period  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Period during which penalities are incurred for partial or full principal repayment prior to loan maturity. MISMO definition: &quot;Information specific to calculation of penalities for partial or full principal repayment prior to loan maturity. &quot; There is a penalty for this as well, perhaps as a monetary amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;prepaymentPenaltyWaiver">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prepayment penalty waiver  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanEarlyPrepaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Loan Contract includes a provision for the lender to waive the prepayment penalty at their discretion.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;prepaymentThreshold">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prepayment threshold  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanOngoingPrepaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Percentage amount of pre-payments allowed under the product per year. This is for mortgages that allow a certain threshold of pre-payments (ie 10%) before charges are incurred.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;recourseLoan">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">recourse loan  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The only way you get the money back in the event of default is the security. Recourse is where you still have the opportunity to go back to the borrower for the rest of the money.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;renegotiable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">renegotiable  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanInterestPaymentTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the terms for payment of interest can be renegotiated during the life of the loan.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;renegotiable.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">renegotiable  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanVariableInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;retainedUntil">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">retained until  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanRetainedAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date when the retained amount is to be drawn by.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;riskLevel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">risk level  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanStandardizationDocumentation"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-gen;LoanDocumentRiskLevel"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;secured">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secured  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the loan is secured. Further Details: All loans are either secured or unsecured All secured loans are secured by some asset or some guaranty Guaranties have various forms. Guaranties have a guarantor. The guarantor may or may not elect to introduce some collateral of their own. Guarantor may or may not be Co-borrower.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;setsOutTermsFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out terms for  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Extended credit (debt or Credit depending on the Viewpoint) has terms set out in a Contract, governing the terms fo extension of the cerdit, payment of interest, principal repayment and any other required clauses defining conditions of the loan or credit. Note feb 2010: term created in Sept 2008 as part of upper ontology. Review and perhaps specialise the kind of contract this relationship comes from.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;specifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanRetainedAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-loan;spread">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spread  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanFloatingInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage of interest added to the base rate.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-loan;subsidyPeriodEndDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subsidy period end date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Subsidy Period - date at which subsidy period ends</skos:definition>
+bu</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/loan/Loans/LoansCollateral.rdf
+++ b/loan/Loans/LoansCollateral.rdf
@@ -1,191 +1,194 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-accx-assx "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-tem-ev "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
-	<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
-	<!ENTITY fibo-loan-typ-sec "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-accx-assx "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-tem-ev "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
+bu<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
+bu<!ENTITY fibo-loan-typ-sec "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-accx-assx="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-tem-ev="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"
-	xmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
-	xmlns:fibo-loan-typ-sec="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
-		<rdfs:label xml:lang="en">LoansCollateral</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-col;LoanCollateral">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Collateral"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-col;pledgedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;CollateralProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-col;supports"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan collateral  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Assets pledged to a lender until a loan is repaid. Further notes: This provides one means by which some extension of finance (such as a loan, debt or equity issue) is under-written. PoC equivalent term definition and note: Collateral is property collateral or additional collateral associated with a loan or mortgage loan (PoC data note) There are foreign key attributes of collateral coupling it to collateral provider and to loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-col;LoanCollateralAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:label xml:lang="en">loan collateral agreement  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Contract in which the borrower of a collateralized securied loan agrees the terms on which the collateral is made available to the Lender.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-col;LoanPropertyCollateral">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;takesFormOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-assx;PropertyAsset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;isLienOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-col;lien"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan property collateral  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Property Assets pledged to a lender until a loan is repaid. Further notes: This provides one means by which some extension of finance (such as a loan, debt or equity issue) is under-written.</skos:definition>
-	</owl:Class>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-col;collateralType">
-		<rdfs:label xml:lang="en">collateral type  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
-		<skos:definition xml:lang="en">Type of additional collateral.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;collateralValue">
-		<rdfs:label xml:lang="en">collateral value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Additional Collateral value - Value of additional collateral</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;hasValuation">
-		<rdfs:label xml:lang="en">has valuation  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
-		<owl:inverseOf rdf:resource="&fibo-loan-loan-col;isOf"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;isLien">
-		<rdfs:label xml:lang="en">is lien  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;isOf">
-		<rdfs:label xml:lang="en">is of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;lien">
-		<rdfs:label xml:lang="en">represents lien on  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;pledgedBy">
-		<rdfs:label xml:lang="en">pledged by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;CollateralProvider"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;propertyCollateralDSCRate">
-		<rdfs:label xml:lang="en">property collateral d s c rate  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Debt Service Coverage Rate (DSC)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-col;propertyCollateralLienSeniority">
-		<rdfs:label xml:lang="en">property collateral lien seniority  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-		<skos:definition xml:lang="en">Seniority on liquidation of property.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;propertyCollateralTransferable">
-		<rdfs:label xml:lang="en">property collateral transferable  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Is property Transferability limited? For Spanish VPO loans, whether the property transferability is limited.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-col;propertyCollateralVPODeclassificationDate">
-		<rdfs:label xml:lang="en">property collateral v p o declassification date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-		<skos:definition xml:lang="en">Time Until Declassification - For Spanish VPO loans, time (in months) until property will be declassified as VPO property Further notes: PoC SDM Data note: Converted to date for declassification to avoid dirty data (AO )</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;providedBy">
-		<rdfs:label>provided by</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;supports">
-		<rdfs:label xml:lang="en">supports  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
-		<rdfs:range rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
-		<skos:definition xml:lang="en">A loan which is supported by the Collateral</skos:definition>
-		<skos:editorialNote xml:lang="en">Relationship introduced in PoC work, as inverse of another relationship already in model (&quot;collateraized by&quot;).</skos:editorialNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-accx-assx="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-tem-ev="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"
+buxmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
+buxmlns:fibo-loan-typ-sec="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansCollateral</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology describes the concept of loan collateral and loan property collateral in the context of collateralized securitized loans.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AssetExtensions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-col;LoanCollateral">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Collateral"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-col;pledgedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;CollateralProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-col;supports"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan collateral  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Assets pledged to a lender until a loan is repaid. Further notes: This provides one means by which some extension of finance (such as a loan, debt or equity issue) is under-written. PoC equivalent term definition and note: Collateral is property collateral or additional collateral associated with a loan or mortgage loan (PoC data note) There are foreign key attributes of collateral coupling it to collateral provider and to loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-col;LoanCollateralAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan collateral agreement  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contract in which the borrower of a collateralized securied loan agrees the terms on which the collateral is made available to the Lender.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-col;LoanPropertyCollateral">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;takesFormOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-assx;PropertyAsset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-mtg;isLienOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-col;lien"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan property collateral  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Property Assets pledged to a lender until a loan is repaid. Further notes: This provides one means by which some extension of finance (such as a loan, debt or equity issue) is under-written.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-col;collateralType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateral type  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Type of additional collateral.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;collateralValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateral value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Additional Collateral value - Value of additional collateral</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;hasValuation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has valuation  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
+bubu<owl:inverseOf rdf:resource="&fibo-loan-loan-col;isOf"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;isLien">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is lien  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;isOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;lien">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">represents lien on  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;pledgedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pledged by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;CollateralProvider"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;propertyCollateralDSCRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property collateral d s c rate  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Debt Service Coverage Rate (DSC)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-col;propertyCollateralLienSeniority">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property collateral lien seniority  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Seniority on liquidation of property.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;propertyCollateralTransferable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property collateral transferable  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Is property Transferability limited? For Spanish VPO loans, whether the property transferability is limited.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-col;propertyCollateralVPODeclassificationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property collateral v p o declassification date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Time Until Declassification - For Spanish VPO loans, time (in months) until property will be declassified as VPO property Further notes: PoC SDM Data note: Converted to date for declassification to avoid dirty data (AO )</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;providedBy">
+bubu<rdfs:label>provided by</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-col;supports">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">supports  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-typ-sec;CollateralizedSecuredLoan"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan which is supported by the Collateral</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Relationship introduced in PoC work, as inverse of another relationship already in model (&quot;collateraized by&quot;).</skos:editorialNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/Loans/LoansGeneral.rdf
+++ b/loan/Loans/LoansGeneral.rdf
@@ -1,58 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
-		<rdfs:label xml:lang="en">LoansGeneral</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gen;IncomeVerificationMethodSelection">
-		<rdfs:label xml:lang="en">IncomeVerificationMethodSelection  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Selection of possible methods by which borrower&apos;s income was determined.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gen;LoanDocumentRiskLevel">
-		<rdfs:label xml:lang="en">LoanDocumentRiskLevel  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gen;LoanStandarizationDocumentType">
-		<rdfs:label xml:lang="en">LoanStandarizationDocumentType  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Financial Institution defined categorization of documentation type. This is interpreted from information provided by the seller on both the data file and in their underwriting quidelines. See attached Translation tables. needs work These are (from CDDOCTYPE enumeration in MAT-CODES): Unknown Other Full Full or Alternate Alternative Lite Low - ACTION make sure this isn&apos;t Risk Level in other list Limited Reduced Partial Streamline No Documentation No Ratio No Income Verifier No Income Qualifier Stated Documentation ACTION: Make sure these are all mutually exclusive, then implement as selection list entries.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gen;UnsubscribedDebt">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
-		<rdfs:label xml:lang="en">unsubscribed debt  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-gen;domiciled">
-		<rdfs:label xml:lang="en">domiciled  (please review)</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansGeneral</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology contains a small amount of additional general terms about loans. These are mainly based on lists of values such as income verification methods, risk levels and documentation types, as referred to in the loan application process.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gen;IncomeVerificationMethodSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">IncomeVerificationMethodSelection  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Selection of possible methods by which borrower&apos;s income was determined.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gen;LoanDocumentRiskLevel">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoanDocumentRiskLevel  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gen;LoanStandarizationDocumentType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoanStandarizationDocumentType  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Financial Institution defined categorization of documentation type. This is interpreted from information provided by the seller on both the data file and in their underwriting quidelines. See attached Translation tables. needs work These are (from CDDOCTYPE enumeration in MAT-CODES): Unknown Other Full Full or Alternate Alternative Lite Low - ACTION make sure this isn&apos;t Risk Level in other list Limited Reduced Partial Streamline No Documentation No Ratio No Income Verifier No Income Qualifier Stated Documentation ACTION: Make sure these are all mutually exclusive, then implement as selection list entries.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gen;UnsubscribedDebt">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unsubscribed debt  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-gen;domiciled">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">domiciled  (please review)</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/Loans/LoansGuaranties.rdf
+++ b/loan/Loans/LoansGuaranties.rdf
@@ -1,124 +1,127 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
-		<rdfs:label xml:lang="en">LoansGuaranties</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gty;LimitedGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:label xml:lang="en">limited guaranty  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A guaranty which is given up to a given amount or proportion of the loan. Generally specified as a monetary amount and is specified by the lender, so the bank may say 75% of valuation and they only have 60% of valuation available, to an additional limited guaranty would cover the missing 15% up to the point where the primary borrower&apos;s equity would meet the standard conditions of the loan. At that point the limited guaranty ceases.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example in the case of a joint guaranty between school and lender, the school is offering a limited guaranty, i.e. it onlky covers the loan up to a proportion. See alsl (in Aus) family Loan has Family Guaranty. So borrower might provide limited guaranty up to a given amount, for instance primary borrower needs a 100K deposit, only has 50K so the co-borrower (guarantor) would guaranty the deposito but not the whole house. time limit - would come to an end at some point, defined in the contract. This would possibly be defined in the contract terms, not as a defined time but you would contact the bank and ask to be exempted from the stated conditions at such a time as the primary has now met the status to be a borrower i their own right.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gty;LoanGuarantor">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
-		<rdfs:label xml:lang="en">loan guarantor  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Guarantor, that is the party which provides some guaranty for the loan.</skos:definition>
-		<skos:editorialNote xml:lang="en">This means that the person who is the guarantor is going to guarantee payments to the lender in the event that the borrower does not pay. PoC data original definition: &quot;Name of Mortgage Indemnity Guarantee (MIG) provider if applicable OR Name of (other) guarantee provider.&quot; This definition does not apply to this term any more - see detailed review notes which identify that MIG is provided by a different kind of party, to a different party, for different reasons. Implementation: MIG Provider is now a separate field in the combined SDM spreadsheet, and modeled as such, as Loan MIG Provider.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gty;LoanGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/isGuaranteedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan guaranty  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A guaranty given by some party in respect of some loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gty;LoanMIGProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
-		<rdfs:label xml:lang="en">loan m i g provider party  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Mortgage Indemnity Guaranty (MIG) provider. Further notes: SME Review notes 16 Sept: Guaranty - mortgage insurance e.g. insure up to 80% exposure. When you get into indemnification, then for instance if the product doesn&apos;t meet the investor&apos;s requirement such that if it doesn&apos;t get paid then the lender steps in and takes the hit for the loan - this is usually a precondition for securitizing (issuing) the loan in a pool. If the loan is not going to be sold on the secondary market there would be no need to indemnify that loan so this term would not apply. Indemnification is insurance for the investor, while the lender is the one providing that indemnification.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gty;MortgageIndemnityGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/isGuaranteedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanMIGProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;MortgageIndemnityInsurancePolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage indemnity guaranty  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Mortgage Indemnity Guaranty (MIG).</skos:definition>
-		<skos:editorialNote xml:lang="en">See notes from SME Review and in MIG Provider. Applies to securitized pool, insures the lender. Additional note (IBM): there is a further application of this. When a lender takes a loan which is a where the value of the loan is greater than 80% of the value of the property, at that point it is required for the lender to also get a private mortgage insurance, so they are paying separately for the mortgage insurance so that if the borrower defaults above 80% then the mortgage insurance pays the loss. In the Loan Party Insurer (new &quot;Party&quot; type) you have Loan Party Insured Ratio (e.g. the 80% in the example above). These are different situations but the same principle. So this needs to be modeled for both. 30 June: Is this Lender or Borrower? since you have one lender and one borrower in a single loan, but multiple lenders in the case of packaging this up for a security - there are then multiple lenders and multiple borrowers. A similar kind of insurance exists in the one lender one borrower scenario i.e. the mortgage loan itself. There are two concepts here. the MIG thing was for bundling these. the MIG might apply across multiple contracts, but still be a fact about &quot;the&quot; contract? The notes about 80% above (IBM) are about the individual loan. ACTION: Tidy this up.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-gty;MortgageIndemnityInsurancePolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;InsurancePolicy"/>
-		<rdfs:label xml:lang="en">mortgage indemnity insurance policy  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The physical policy for the Mortgage Indemnity Guaranty.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-gty;guaranteedBy">
-		<rdfs:label>guaranteed by</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-gty;hasLimitedGuarantyAmount">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/hasGuaranteedAmount"/>
-		<rdfs:label xml:lang="en">has limited guaranty amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-gty;LimitedGuaranty"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount to which the guaranty is limited.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-gty;mIGApplicable">
-		<rdfs:label xml:lang="en">m i g applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">FNP flag yes/No is this gurantor a MIG ( Mortgage Indemnity Guarantee) or other</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansGuaranties</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines various kinds of guaranty for different kinds of loans, along with the concept of a loan guarantor. These include mortgage loan related guaranty terms.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gty;LimitedGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">limited guaranty  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A guaranty which is given up to a given amount or proportion of the loan. Generally specified as a monetary amount and is specified by the lender, so the bank may say 75% of valuation and they only have 60% of valuation available, to an additional limited guaranty would cover the missing 15% up to the point where the primary borrower&apos;s equity would meet the standard conditions of the loan. At that point the limited guaranty ceases.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example in the case of a joint guaranty between school and lender, the school is offering a limited guaranty, i.e. it onlky covers the loan up to a proportion. See alsl (in Aus) family Loan has Family Guaranty. So borrower might provide limited guaranty up to a given amount, for instance primary borrower needs a 100K deposit, only has 50K so the co-borrower (guarantor) would guaranty the deposito but not the whole house. time limit - would come to an end at some point, defined in the contract. This would possibly be defined in the contract terms, not as a defined time but you would contact the bank and ask to be exempted from the stated conditions at such a time as the primary has now met the status to be a borrower i their own right.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gty;LoanGuarantor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan guarantor  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Guarantor, that is the party which provides some guaranty for the loan.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This means that the person who is the guarantor is going to guarantee payments to the lender in the event that the borrower does not pay. PoC data original definition: &quot;Name of Mortgage Indemnity Guarantee (MIG) provider if applicable OR Name of (other) guarantee provider.&quot; This definition does not apply to this term any more - see detailed review notes which identify that MIG is provided by a different kind of party, to a different party, for different reasons. Implementation: MIG Provider is now a separate field in the combined SDM spreadsheet, and modeled as such, as Loan MIG Provider.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gty;LoanGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/isGuaranteedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan guaranty  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A guaranty given by some party in respect of some loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gty;LoanMIGProvider">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan m i g provider party  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mortgage Indemnity Guaranty (MIG) provider. Further notes: SME Review notes 16 Sept: Guaranty - mortgage insurance e.g. insure up to 80% exposure. When you get into indemnification, then for instance if the product doesn&apos;t meet the investor&apos;s requirement such that if it doesn&apos;t get paid then the lender steps in and takes the hit for the loan - this is usually a precondition for securitizing (issuing) the loan in a pool. If the loan is not going to be sold on the secondary market there would be no need to indemnify that loan so this term would not apply. Indemnification is insurance for the investor, while the lender is the one providing that indemnification.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gty;MortgageIndemnityGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/isGuaranteedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanMIGProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;MortgageIndemnityInsurancePolicy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage indemnity guaranty  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mortgage Indemnity Guaranty (MIG).</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">See notes from SME Review and in MIG Provider. Applies to securitized pool, insures the lender. Additional note (IBM): there is a further application of this. When a lender takes a loan which is a where the value of the loan is greater than 80% of the value of the property, at that point it is required for the lender to also get a private mortgage insurance, so they are paying separately for the mortgage insurance so that if the borrower defaults above 80% then the mortgage insurance pays the loss. In the Loan Party Insurer (new &quot;Party&quot; type) you have Loan Party Insured Ratio (e.g. the 80% in the example above). These are different situations but the same principle. So this needs to be modeled for both. 30 June: Is this Lender or Borrower? since you have one lender and one borrower in a single loan, but multiple lenders in the case of packaging this up for a security - there are then multiple lenders and multiple borrowers. A similar kind of insurance exists in the one lender one borrower scenario i.e. the mortgage loan itself. There are two concepts here. the MIG thing was for bundling these. the MIG might apply across multiple contracts, but still be a fact about &quot;the&quot; contract? The notes about 80% above (IBM) are about the individual loan. ACTION: Tidy this up.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-gty;MortgageIndemnityInsurancePolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;InsurancePolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage indemnity insurance policy  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The physical policy for the Mortgage Indemnity Guaranty.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-gty;guaranteedBy">
+bubu<rdfs:label>guaranteed by</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-gty;hasLimitedGuarantyAmount">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/hasGuaranteedAmount"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has limited guaranty amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-gty;LimitedGuaranty"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount to which the guaranty is limited.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-gty;mIGApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m i g applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">FNP flag yes/No is this gurantor a MIG ( Mortgage Indemnity Guarantee) or other</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/Loans/LoansParties.rdf
+++ b/loan/Loans/LoansParties.rdf
@@ -1,208 +1,211 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
-	<!ENTITY fibo-loan-tem-apr "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-loan-gty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
+bu<!ENTITY fibo-loan-tem-apr "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
-	xmlns:fibo-loan-tem-apr="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-		<rdfs:label xml:lang="en">LoansParties</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;AVMProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
-		<rdfs:label xml:lang="en">a v m provider  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Party which is the Provider of an AVM Valuation.</skos:definition>
-		<skos:editorialNote xml:lang="en">PoC Data element definition and documentation (note inclusion of business / data rules with these): Provider of original AVM valuation - Name of AVM provider if original valuation method is AVM (RR 108 ) Provider of current AVM valuation - Name of AVM provider if current valuation method is AVM ( RR 114) Property Valuation Provider ( party) -id (end of PoC data notes) Semantic Model notes: This does not include a definition of or reference to what AVM is. Need to add this, and get a meaningful definition. Also if there are &quot;Original&quot; and &quot;Current&quot; AVM valutions these need to be identified and dealt with.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;CollateralProvider">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
-		<rdfs:label xml:lang="en">collateral provider  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Party which provides collateral for the Loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;Cosigner">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-pty;borrows.1"/>
-				<owl:onClass rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-pty;mayBe"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-app;hasAssessmentInformation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-apr;mayBecome"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cosigner  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Someone who commits to fulfil the obligations of the Borrower in the event that the Borrower defaults on the loan.</skos:definition>
-		<skos:editorialNote xml:lang="en">A co-borrower is different than a cosigner in that a cosigner takes responsibility for the debt should the borrower default, but does not have ownership in the property. Co-borrowers are frequently spouses or partners who use their combined income to qualify for a larger mortgage than could be obtained singularly, and are willing to share the risk of default on the mortgage and the general risks of homeownership. Review session notes 19 May 2011 usually identified by some identifier such as SSN, whether individual or a corporation. Contact information is at legal entity level. co-borrower or co-signer. Are these synonymous? Sometimes. Also have a concept of &quot;Joint Borrower&quot; e.g. a married couple. The legal entity which is the Co-borrower may become the Borrower under certain circumstances. Student Loans: The student may be the borrower, or the parent may be the borrower on behalf of the student. Student would not normally be a co-borrower but in theory it could. The co-borrower is someone with more established credit. Other factors: legal age - you need ot be of legal age in order to sign the Loan Contract, this is because you have to be a Legal Entity. so then the adult is simply the Borrower. Also potentially have references on the loan. These would come in handy later. These may be related to the student or the borrower.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;JointBorrower">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:label xml:lang="en">joint borrower  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Any additional borrower(s) whose name(s) appear on loan documents and whose income and credit history are used to qualify for the loan. Under this arrangement, all parties involved have an obligation to repay the loan. For mortgages, the names of applicable joint borrowers also appear on the property&apos;s title.</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition sourced in SME Review by Steve Smith. Quiting from a source, http://www.investopedia.com/terms/c/co_borrowers.asp</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;LoanBorrower">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Borrower"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;accepts"/>
-				<owl:allValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;borrows"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-pty;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan borrower</rdfs:label>
-		<skos:definition xml:lang="en">The Borrower of the Loan. This is the party which draws down the offered credit in the form of a loan under conditions agreed in the Loan Contract to which the Borrower is party.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The Party &quot;Loan Borrower&quot; is both party to the Loan as the party which borrows and owes the money, and party to the Loan Contract which sets out the agreed conditions between the Borrower and the Lender for the loan and for the repayment thereof.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;LoanLender">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Lender"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanParty"/>
-		<rdfs:label xml:lang="en">loan lender  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;LoanServicer.1">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
-		<rdfs:label xml:lang="en">loan servicer  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The party which is the Loan Servicer. Further notes: The Loan Servicer may be the original lender or it may be someone else. For instance, if the bank is sold by Bank A, it may be given to some third party for servicing. Servicing is either done by the original lender or by someone else. Idea: Look at a data model from one of the main agencies. See Fannie Mae enterprise common data model. In progress. More precise definition needed for what it is to service a loan, i.e. what activities this party participates in and what facts apply. Some of these are defined in the facts which are emerging from these reviews. There seem to be several functions which may or may not be combined.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;LoanThirdParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanParty"/>
-		<rdfs:label xml:lang="en">loan third party  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A party which, by virtue of being a third party to the Loan Contract, performs some role directly in relation to the Loan.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These can be thought of as third parties to the Loan Contract or to the Loan itself, i.e. the money advanced by the lender to the borrower. These are all modeled as parties to the loan directly, but by virtue of their being third parties to the loan contract, that is, the Loan third Party itself are identified as contract third party.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;PrimaryBorrower">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:label xml:lang="en">primary borrower</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-pty;SecondaryBorrower">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:label xml:lang="en">secondary borrower</rdfs:label>
-	</owl:Class>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-loan-pty;assessmentDate">
-		<rdfs:label xml:lang="en">assessment date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;borrows.1">
-		<rdfs:label xml:lang="en">borrows  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-pty;Cosigner"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<owl:inverseOf rdf:resource="&fibo-loan-loan-pty;hasCoBorower"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;hasCoBorower">
-		<rdfs:label xml:lang="en">has co borower  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;Cosigner"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;hasLoanThirdParty">
-		<rdfs:label>has loan third party</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;identity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">borrower identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-		<skos:definition xml:lang="en">The borrower of the loan is a legal entity of some type.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;mayBe">
-		<rdfs:label xml:lang="en">may be  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-pty;Cosigner"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;originatedBy">
-		<rdfs:label>originated by</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;servicedBy">
-		<rdfs:label>serviced by</rdfs:label>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-loan-gty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
+buxmlns:fibo-loan-tem-apr="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansParties</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the parties to a loan, including borrowers and third parties such as collateral providers and loan servicers.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGuaranties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;AVMProvider">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">a v m provider  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Party which is the Provider of an AVM Valuation.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">PoC Data element definition and documentation (note inclusion of business / data rules with these): Provider of original AVM valuation - Name of AVM provider if original valuation method is AVM (RR 108 ) Provider of current AVM valuation - Name of AVM provider if current valuation method is AVM ( RR 114) Property Valuation Provider ( party) -id (end of PoC data notes) Semantic Model notes: This does not include a definition of or reference to what AVM is. Need to add this, and get a meaningful definition. Also if there are &quot;Original&quot; and &quot;Current&quot; AVM valutions these need to be identified and dealt with.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;CollateralProvider">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateral provider  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Party which provides collateral for the Loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;Cosigner">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-pty;borrows.1"/>
+bubububu<owl:onClass rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-pty;mayBe"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-app;hasAssessmentInformation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-apr;mayBecome"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cosigner  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Someone who commits to fulfil the obligations of the Borrower in the event that the Borrower defaults on the loan.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">A co-borrower is different than a cosigner in that a cosigner takes responsibility for the debt should the borrower default, but does not have ownership in the property. Co-borrowers are frequently spouses or partners who use their combined income to qualify for a larger mortgage than could be obtained singularly, and are willing to share the risk of default on the mortgage and the general risks of homeownership. Review session notes 19 May 2011 usually identified by some identifier such as SSN, whether individual or a corporation. Contact information is at legal entity level. co-borrower or co-signer. Are these synonymous? Sometimes. Also have a concept of &quot;Joint Borrower&quot; e.g. a married couple. The legal entity which is the Co-borrower may become the Borrower under certain circumstances. Student Loans: The student may be the borrower, or the parent may be the borrower on behalf of the student. Student would not normally be a co-borrower but in theory it could. The co-borrower is someone with more established credit. Other factors: legal age - you need ot be of legal age in order to sign the Loan Contract, this is because you have to be a Legal Entity. so then the adult is simply the Borrower. Also potentially have references on the loan. These would come in handy later. These may be related to the student or the borrower.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;JointBorrower">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">joint borrower  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any additional borrower(s) whose name(s) appear on loan documents and whose income and credit history are used to qualify for the loan. Under this arrangement, all parties involved have an obligation to repay the loan. For mortgages, the names of applicable joint borrowers also appear on the property&apos;s title.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Definition sourced in SME Review by Steve Smith. Quiting from a source, http://www.investopedia.com/terms/c/co_borrowers.asp</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;LoanBorrower">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Borrower"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractCounterparty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanParty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;accepts"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanBorrowerCommitment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;borrows"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-pty;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan borrower</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Borrower of the Loan. This is the party which draws down the offered credit in the form of a loan under conditions agreed in the Loan Contract to which the Borrower is party.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The Party &quot;Loan Borrower&quot; is both party to the Loan as the party which borrows and owes the money, and party to the Loan Contract which sets out the agreed conditions between the Borrower and the Lender for the loan and for the repayment thereof.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;LoanLender">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Lender"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractPrincipal"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan lender  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;LoanServicer.1">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan servicer  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is the Loan Servicer. Further notes: The Loan Servicer may be the original lender or it may be someone else. For instance, if the bank is sold by Bank A, it may be given to some third party for servicing. Servicing is either done by the original lender or by someone else. Idea: Look at a data model from one of the main agencies. See Fannie Mae enterprise common data model. In progress. More precise definition needed for what it is to service a loan, i.e. what activities this party participates in and what facts apply. Some of these are defined in the facts which are emerging from these reviews. There seem to be several functions which may or may not be combined.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;LoanThirdParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan third party  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which, by virtue of being a third party to the Loan Contract, performs some role directly in relation to the Loan.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These can be thought of as third parties to the Loan Contract or to the Loan itself, i.e. the money advanced by the lender to the borrower. These are all modeled as parties to the loan directly, but by virtue of their being third parties to the loan contract, that is, the Loan third Party itself are identified as contract third party.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;PrimaryBorrower">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary borrower</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-pty;SecondaryBorrower">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secondary borrower</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-loan-pty;assessmentDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assessment date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;borrows.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrows  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-pty;Cosigner"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<owl:inverseOf rdf:resource="&fibo-loan-loan-pty;hasCoBorower"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;hasCoBorower">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has co borower  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanContract"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;Cosigner"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;hasLoanThirdParty">
+bubu<rdfs:label>has loan third party</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;identity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The borrower of the loan is a legal entity of some type.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;mayBe">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-pty;Cosigner"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-gty;LoanGuarantor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;originatedBy">
+bubu<rdfs:label>originated by</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-pty;servicedBy">
+bubu<rdfs:label>serviced by</rdfs:label>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/Loans/LoansRegulatory.rdf
+++ b/loan/Loans/LoansRegulatory.rdf
@@ -1,351 +1,354 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-bp-reg-req "https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
-	<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-loan-reg "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/">
-	<!ENTITY fibo-loan-tem-bor "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/">
-	<!ENTITY fibo-loan-typ-prod "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-bp-reg-req "https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
+bu<!ENTITY fibo-fnd-soc-asp "https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-loan-reg "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/">
+bu<!ENTITY fibo-loan-tem-bor "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/">
+bu<!ENTITY fibo-loan-typ-prod "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-bp-reg-req="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
-	xmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-loan-reg="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/"
-	xmlns:fibo-loan-tem-bor="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"
-	xmlns:fibo-loan-typ-prod="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/">
-		<rdfs:label xml:lang="en">LoansRegulatory</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;BorrowerDataProtectionRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;DataProtectionRequirement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;governsTheActivitiesOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;ConsumerCreditReferenceAgency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">borrower data protection requirement  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;BorrowerDisclosureRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;DisclosureRequirement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-prod;LoanProductDisclosureRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;governs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">borrower disclosure requirement  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;BorrowerRight">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerRight"/>
-		<rdfs:label xml:lang="en">borrower right  (please review)</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">example the right not to have a home reposessed. Example: RESPA Real Estate Setetlement Procedures Act (promulgated by HUD to govern real estate practices and disclosures Provisions of good faith estimate (GFE) of loan settlement costs. GFE would be when you apply - you get a GFE back from the lender telling you what it would cost if you close the loan.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerCreditEqualTreatmentRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerCreditRequirement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;EqualTreatmentRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">consumer credit equal treatment requirement  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerCreditProtectionLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerProtectionLaw"/>
-		<rdfs:label xml:lang="en">consumer credit protection law  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerCreditReferenceAgency">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:label xml:lang="en">consumer credit reference agency  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Applicable regulations: vary by jurisdiciton. for example, only being allowed ot divulge actual judgements against a party, but not things that are not substantiated by judgements. For example, slow payments which are not covered by some judgement against the party. There will be different regulatory requirments about: 1. What the CR Agency can hold 2. Who they can divulge it to 3. What information they must provide the borrower at his/her request Some of the third thing there is covered in the EU the Data Protection Directive and local acts that implement this.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerCreditRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;ConsumerRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;overseenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;ConsumerProtectionAgency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">consumer credit requirement  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Requirement set out on the lender about how they must treat the appliction to a loan</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">e..g being able to see and challenge information about them held by the credit agency or lender. e.g. can&apos;t publish opinions only facts, etc.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerProtectionAgency">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/RegulatoryAgency"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/hasJurisdiction"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">consumer protection agency  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Some agency tasked with regulating consumer protection in some jurisdiction.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that this is consumer protection, and not other regulatory requirements such as systemic risk. an instance of this is the Consumer Financial Protection Bureau in the US. This is wide rthan just lending, but also covers lender rights.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerProtectionLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-		<rdfs:label xml:lang="en">consumer protection law  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;LegalRight"/>
-		<rdfs:label xml:lang="en">consumer right  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;CreditReferenceAgencyRequirements">
-		<rdfs:label xml:lang="en">credit reference agency requirements  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">REquirements other than data protection, governing what a credit reference agency can or cannot do.</skos:definition>
-		<skos:editorialNote xml:lang="en">Example might include legislation about whether a consumer can be given a bad rating for no good reason; must presumably be some audit requirements about how ratings are arrived at (llogically - no one knows of this; may be addressed simply by the indivbidual&apos;s right to see what&apos;s said. Additional right (not in DP): The right to have something struck from the record of the individual. - see sub term here (Right Or Credit Record Correction). Question: are there additional regulations, rights around not being badly assessed, or is the right of correction (and the access to knowledge) all that there is? May also be rights under common law about the information provided to the agencies.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;DataProtectionRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;LegalRequirement"/>
-		<rdfs:label xml:lang="en">data protection requirement  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Requirements defining how data about individuals is held. Example is the EU DA directive and laws, which make the data the property of the individual that data is about. Covers - what information i sheld - who information can be divulged to. - the individual&apos;s rights in respect of that information Privacy regulations cover most of this. EU defines &quot;Personal Data&quot; and &quot;Sensitive Personal Data&quot;. For credit reference agencies the latter would be covered. More detail about whether they can divulge facts which are not subject to formal judgements etc.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;DisclosureRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerCreditRequirement"/>
-		<rdfs:label xml:lang="en">disclosure requirement  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Requirement for disclosure to borrowers or potential borrowers. There are two kinds of disclosure requirement: 1. Disclosure about the information held on the borrower 2. Disclsure about the product.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;EqualTreatmentRight">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;BorrowerRight"/>
-		<rdfs:label xml:lang="en">equal treatment right  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The right to equal treatment under the law.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;GoodFaithEstimate">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;LoanProductRepresentations"/>
-		<rdfs:label xml:lang="en">good faith estimate  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">GFE - representation by the lender on the costs and implications of settlement (early termination) of the loan.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Provided in a timely way. Also associated with cooling off periods</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;InformationRight">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;BorrowerRight"/>
-		<rdfs:label xml:lang="en">information right  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The right to some information in some context, for example when purchasing some product. The right to full and fair disclosure of</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;LenderRight">
-		<rdfs:label xml:lang="en">lender right  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Rights on the lender to protect them against loss. furthe rNtoes: Logically, considering the two parties, they both have protecxtion mechanisms. so while the lender has protecxtion mechanisms through mortgage insurance, and the consumer has protextion mechanisms such as good faith estimates. also the agencies (see Consumer Protection Agency), an instance of which is the CFPB in the US (just set up). Lender rights are: - expressed in the Contract Consumer protection develops becaues the contract is written by the potential Lender. So the rights are introcued to rectify the imbalance between the two parties. Same goes for insurance. consumer protection laws (governe dby the relevant consumer protection agency. So the lender protexts itself as it writes th contract AND does the things it needs to do to protext itself, but on the approval process, and with later instruments such as insurance. Interestingly., it is the Borrower who pays for this by paying for credit reports etc. So the borrower protects itself by other mechanisms. Caveat emptor - displaced by regulation (the buyer is protected by regulation). Uberimae Fidae - in the utmost good faith. Mortgage Insurance is an additional means of mitigating the risk, that the lended may have., so if the information assessed is not accurate, or if the borrower&apos;s situation changes for the worse. then the risk rating may go down. So the Mortgage Insurance is a further strategy which mitigates any shortfall in the Lender Righrs that you may have - ie someone guarantees. In the US you can also avoid that by having paid a deposit. PIMI: Principal, Interst and Morgage Insurance. So the Borrower pays towards the MI, esxcept if they have paid a given amount as deposit. there are 2 types of MI: 1. protects the lender in the event of borrower degault 2. Insurance for &quot;Incapacity to pay the mortage&quot; (these can be bought off the shelf - can combine health, unemployment etc.). - this is the Borrower mitigating their own risk. Prevents foreclosure. Similar to general sickness etc. Where the lender charges for MI, the cost is passed onto the Borrower. e.g. if there is a % valuation (e.g. 70% in Aus, 80% in US for example) then no insurance is required.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;LoanProductRepresentations">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;Representation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-typ-prod;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-prod;LoanProduct"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan product representations  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Representations about the loan product and the appropriateness of this for the borrower.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Covers responsible lending, consumer credit laws. See Aus Consumer Creti; US Reg Z and so on. In detail, this will include things like the representations about rates of interest, what people can or can&apos;t say when offering a product to a customer. Reg Z: Promoting the informed use of consumer credit by .. implictions and cost Also right to cancel a lien on a consumer&apos;s dwelling.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;LoanRegulatoryRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-reg-req;mandatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;ConsumerCreditProtectionLaw"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;administeredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;Regulator"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;regulates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan regulatory requirement  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A regulatory requirement defined in regulations by a comsumer credit act or other legislation.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Presence of a loan regulatory requirement associated with a loan indicates that the loan is regulated by the UK Consumer credit act or the equivalent in continental Europe.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;ProductDisclosureRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;DisclosureRequirement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;governs.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;LoanProductRepresentations"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-reg;governsTimelinessOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;GoodFaithEstimate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">product disclosure requirement  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A requirement governing what representations can be made about a product, as it affects the consumer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are also rules which encompass limitations on how you might attach loans and liens to principle dwellings, e.g. when or whether you can foreclose on someone&apos;s principal dwelling with impunity; what rights the consumer has - this last will be a separate kind of regulation.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;ProductDisclosureRight">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;InformationRight"/>
-		<rdfs:label xml:lang="en">product disclosure right  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The right to information about products at the point of purchasing these.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Includes retail, insurance and financial product disclosures</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;RegB">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerCreditEqualTreatmentRequirement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;DisclosureRequirement"/>
-		<rdfs:label xml:lang="en">reg b  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">US regulation concerning &quot;Equal credit opportunity act&quot; Electronic delivery of disclosures</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Timing and delivery of electronic disclosures. Applications must have equal opportunity to follow. All applications for credit to be evaluated equally and not discriminiated against. This is disclosures about the Borrower.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;RegZ">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ProductDisclosureRequirement"/>
-		<rdfs:label xml:lang="en">reg z  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">US Fed regulation &quot;Truth in Lending Act&quot; uniform standards for electronic delivery of disclosures</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Creditors may delivery disclosures electronic if they obtain consumer&apos;s consent. Also relate to international, and foreign languages. This is disclosures about the Product.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;Regulator">
-		<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-		<rdfs:label xml:lang="en">regulator  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;Representation">
-		<rdfs:label xml:lang="en">representation  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-reg;RightOfCreditRecordCorrection">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;CreditReferenceAgencyRequirements"/>
-		<rdfs:label xml:lang="en">right of credit record correction  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The right to have a credit record corrected.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;administeredBy">
-		<rdfs:label xml:lang="en">administered by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;LoanRegulatoryRequirement"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-reg;Regulator"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;confers">
-		<rdfs:label xml:lang="en">confers  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;ConsumerCreditRequirement"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-reg;ConsumerRight"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;governs">
-		<rdfs:label xml:lang="en">governs  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;BorrowerDisclosureRequirement"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;governs.1">
-		<rdfs:label xml:lang="en">governs  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;ProductDisclosureRequirement"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-reg;LoanProductRepresentations"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;governsTheActivitiesOf">
-		<rdfs:label xml:lang="en">governs the activities of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;BorrowerDataProtectionRequirement"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-reg;ConsumerCreditReferenceAgency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;governsTimelinessOf">
-		<rdfs:label xml:lang="en">governs timeliness of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;ProductDisclosureRequirement"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-reg;GoodFaithEstimate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;overseenBy">
-		<rdfs:label xml:lang="en">overseen by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;ConsumerCreditRequirement"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-reg;ConsumerProtectionAgency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;regulates">
-		<rdfs:label xml:lang="en">regulates  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;LoanRegulatoryRequirement"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;requirementActReference">
-		<rdfs:label xml:lang="en">requirement act reference  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;LoanRegulatoryRequirement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;requirementSectionAndParagraph">
-		<rdfs:label xml:lang="en">requirement section and paragraph  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-reg;LoanRegulatoryRequirement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-bp-reg-req="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
+buxmlns:fibo-fnd-soc-asp="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-loan-reg="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/"
+buxmlns:fibo-loan-tem-bor="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"
+buxmlns:fibo-loan-typ-prod="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansRegulatory</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology contains concepts relating to regulatory requirements around loans, including disclosure rights and a small number of regulation-specific concepts. These include definitions of rights conferred on borrowers under consumer protection law, rights to equal treatment and the like.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/SocialConstructsExt/ConstructAspects/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/LoanProducts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansRegulatory/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;BorrowerDataProtectionRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;DataProtectionRequirement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;governsTheActivitiesOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;ConsumerCreditReferenceAgency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower data protection requirement  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;BorrowerDisclosureRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;DisclosureRequirement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;confers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-prod;LoanProductDisclosureRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;governs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower disclosure requirement  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;BorrowerRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower right  (please review)</rdfs:label>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">example the right not to have a home reposessed. Example: RESPA Real Estate Setetlement Procedures Act (promulgated by HUD to govern real estate practices and disclosures Provisions of good faith estimate (GFE) of loan settlement costs. GFE would be when you apply - you get a GFE back from the lender telling you what it would cost if you close the loan.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerCreditEqualTreatmentRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerCreditRequirement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;confers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;EqualTreatmentRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consumer credit equal treatment requirement  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerCreditProtectionLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerProtectionLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consumer credit protection law  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerCreditReferenceAgency">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consumer credit reference agency  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Applicable regulations: vary by jurisdiciton. for example, only being allowed ot divulge actual judgements against a party, but not things that are not substantiated by judgements. For example, slow payments which are not covered by some judgement against the party. There will be different regulatory requirments about: 1. What the CR Agency can hold 2. Who they can divulge it to 3. What information they must provide the borrower at his/her request Some of the third thing there is covered in the EU the Data Protection Directive and local acts that implement this.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerCreditRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;confers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;ConsumerRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;overseenBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;ConsumerProtectionAgency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consumer credit requirement  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Requirement set out on the lender about how they must treat the appliction to a loan</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">e..g being able to see and challenge information about them held by the credit agency or lender. e.g. can&apos;t publish opinions only facts, etc.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerProtectionAgency">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/RegulatoryAgency"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegulatoryAgencies/hasJurisdiction"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consumer protection agency  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some agency tasked with regulating consumer protection in some jurisdiction.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note that this is consumer protection, and not other regulatory requirements such as systemic risk. an instance of this is the Consumer Financial Protection Bureau in the US. This is wide rthan just lending, but also covers lender rights.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerProtectionLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consumer protection law  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;ConsumerRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-soc-asp;LegalRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">consumer right  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;CreditReferenceAgencyRequirements">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit reference agency requirements  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">REquirements other than data protection, governing what a credit reference agency can or cannot do.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Example might include legislation about whether a consumer can be given a bad rating for no good reason; must presumably be some audit requirements about how ratings are arrived at (llogically - no one knows of this; may be addressed simply by the indivbidual&apos;s right to see what&apos;s said. Additional right (not in DP): The right to have something struck from the record of the individual. - see sub term here (Right Or Credit Record Correction). Question: are there additional regulations, rights around not being badly assessed, or is the right of correction (and the access to knowledge) all that there is? May also be rights under common law about the information provided to the agencies.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;DataProtectionRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-reg-req;LegalRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">data protection requirement  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Requirements defining how data about individuals is held. Example is the EU DA directive and laws, which make the data the property of the individual that data is about. Covers - what information i sheld - who information can be divulged to. - the individual&apos;s rights in respect of that information Privacy regulations cover most of this. EU defines &quot;Personal Data&quot; and &quot;Sensitive Personal Data&quot;. For credit reference agencies the latter would be covered. More detail about whether they can divulge facts which are not subject to formal judgements etc.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;DisclosureRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerCreditRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">disclosure requirement  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Requirement for disclosure to borrowers or potential borrowers. There are two kinds of disclosure requirement: 1. Disclosure about the information held on the borrower 2. Disclsure about the product.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;EqualTreatmentRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;BorrowerRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equal treatment right  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right to equal treatment under the law.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;GoodFaithEstimate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;LoanProductRepresentations"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">good faith estimate  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">GFE - representation by the lender on the costs and implications of settlement (early termination) of the loan.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Provided in a timely way. Also associated with cooling off periods</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;InformationRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;BorrowerRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">information right  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right to some information in some context, for example when purchasing some product. The right to full and fair disclosure of</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;LenderRight">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lender right  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Rights on the lender to protect them against loss. furthe rNtoes: Logically, considering the two parties, they both have protecxtion mechanisms. so while the lender has protecxtion mechanisms through mortgage insurance, and the consumer has protextion mechanisms such as good faith estimates. also the agencies (see Consumer Protection Agency), an instance of which is the CFPB in the US (just set up). Lender rights are: - expressed in the Contract Consumer protection develops becaues the contract is written by the potential Lender. So the rights are introcued to rectify the imbalance between the two parties. Same goes for insurance. consumer protection laws (governe dby the relevant consumer protection agency. So the lender protexts itself as it writes th contract AND does the things it needs to do to protext itself, but on the approval process, and with later instruments such as insurance. Interestingly., it is the Borrower who pays for this by paying for credit reports etc. So the borrower protects itself by other mechanisms. Caveat emptor - displaced by regulation (the buyer is protected by regulation). Uberimae Fidae - in the utmost good faith. Mortgage Insurance is an additional means of mitigating the risk, that the lended may have., so if the information assessed is not accurate, or if the borrower&apos;s situation changes for the worse. then the risk rating may go down. So the Mortgage Insurance is a further strategy which mitigates any shortfall in the Lender Righrs that you may have - ie someone guarantees. In the US you can also avoid that by having paid a deposit. PIMI: Principal, Interst and Morgage Insurance. So the Borrower pays towards the MI, esxcept if they have paid a given amount as deposit. there are 2 types of MI: 1. protects the lender in the event of borrower degault 2. Insurance for &quot;Incapacity to pay the mortage&quot; (these can be bought off the shelf - can combine health, unemployment etc.). - this is the Borrower mitigating their own risk. Prevents foreclosure. Similar to general sickness etc. Where the lender charges for MI, the cost is passed onto the Borrower. e.g. if there is a % valuation (e.g. 70% in Aus, 80% in US for example) then no insurance is required.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;LoanProductRepresentations">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;Representation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-typ-prod;isAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-prod;LoanProduct"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan product representations  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Representations about the loan product and the appropriateness of this for the borrower.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Covers responsible lending, consumer credit laws. See Aus Consumer Creti; US Reg Z and so on. In detail, this will include things like the representations about rates of interest, what people can or can&apos;t say when offering a product to a customer. Reg Z: Promoting the informed use of consumer credit by .. implictions and cost Also right to cancel a lien on a consumer&apos;s dwelling.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;LoanRegulatoryRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-reg-req;mandatedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;ConsumerCreditProtectionLaw"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;administeredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;Regulator"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;regulates"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan regulatory requirement  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A regulatory requirement defined in regulations by a comsumer credit act or other legislation.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Presence of a loan regulatory requirement associated with a loan indicates that the loan is regulated by the UK Consumer credit act or the equivalent in continental Europe.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;ProductDisclosureRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;DisclosureRequirement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;governs.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;LoanProductRepresentations"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-reg;governsTimelinessOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-reg;GoodFaithEstimate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">product disclosure requirement  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A requirement governing what representations can be made about a product, as it affects the consumer.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There are also rules which encompass limitations on how you might attach loans and liens to principle dwellings, e.g. when or whether you can foreclose on someone&apos;s principal dwelling with impunity; what rights the consumer has - this last will be a separate kind of regulation.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;ProductDisclosureRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;InformationRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">product disclosure right  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right to information about products at the point of purchasing these.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Includes retail, insurance and financial product disclosures</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;RegB">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ConsumerCreditEqualTreatmentRequirement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;DisclosureRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reg b  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">US regulation concerning &quot;Equal credit opportunity act&quot; Electronic delivery of disclosures</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Timing and delivery of electronic disclosures. Applications must have equal opportunity to follow. All applications for credit to be evaluated equally and not discriminiated against. This is disclosures about the Borrower.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;RegZ">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;ProductDisclosureRequirement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reg z  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">US Fed regulation &quot;Truth in Lending Act&quot; uniform standards for electronic delivery of disclosures</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Creditors may delivery disclosures electronic if they obtain consumer&apos;s consent. Also relate to international, and foreign languages. This is disclosures about the Product.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;Regulator">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regulator  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;Representation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">representation  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-reg;RightOfCreditRecordCorrection">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-reg;CreditReferenceAgencyRequirements"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">right of credit record correction  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right to have a credit record corrected.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;administeredBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">administered by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;LoanRegulatoryRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-reg;Regulator"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;confers">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;ConsumerCreditRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-reg;ConsumerRight"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;governs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governs  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;BorrowerDisclosureRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;governs.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governs  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;ProductDisclosureRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-reg;LoanProductRepresentations"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;governsTheActivitiesOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governs the activities of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;BorrowerDataProtectionRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-reg;ConsumerCreditReferenceAgency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;governsTimelinessOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">governs timeliness of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;ProductDisclosureRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-reg;GoodFaithEstimate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;overseenBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">overseen by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;ConsumerCreditRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-reg;ConsumerProtectionAgency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;regulates">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regulates  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;LoanRegulatoryRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;requirementActReference">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requirement act reference  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;LoanRegulatoryRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-loan-reg;requirementSectionAndParagraph">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">requirement section and paragraph  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-reg;LoanRegulatoryRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/ConstructionLoansTemporal.rdf
+++ b/loan/LoansTemporal/ConstructionLoansTemporal.rdf
@@ -1,48 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-tem-cl "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/">
-	<!ENTITY fibo-loan-tem-sta "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-tem-cl "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/">
+bu<!ENTITY fibo-loan-tem-sta "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-tem-cl="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/"
-	xmlns:fibo-loan-tem-sta="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/">
-		<rdfs:label xml:lang="en">ConstructionLoansTemporal</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-cl;ConstructionLoanSnapshot">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
-		<rdfs:label xml:lang="en">construction loan snapshot</rdfs:label>
-		<skos:definition xml:lang="en">Information at a point in time, specific to a Construction Loan.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This covers the &quot;Loan advance to date&quot; amount, which will have a current value on any given day and which will vary over time, as milestones are passed and additional advances drawn down.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-cl;loanAdvanceToDate">
-		<rdfs:label xml:lang="en">loan advance to date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-cl;ConstructionLoanSnapshot"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount of principal advanced to date.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-tem-cl="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/"
+buxmlns:fibo-loan-tem-sta="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ConstructionLoansTemporal</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Temporally sensitive concepts relating to construction loans. 
+		At present this ontology simply defines the basic concept of a snapshot in time for a construction loan. Additional details will need to be added.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/ConstructionLoansTemporal/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-cl;ConstructionLoanSnapshot">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">construction loan snapshot</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information at a point in time, specific to a Construction Loan.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This covers the &quot;Loan advance to date&quot; amount, which will have a current value on any given day and which will vary over time, as milestones are passed and additional advances drawn down.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-cl;loanAdvanceToDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan advance to date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-cl;ConstructionLoanSnapshot"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of principal advanced to date.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/LoanApplicationsTemporal.rdf
+++ b/loan/LoansTemporal/LoanApplicationsTemporal.rdf
@@ -1,299 +1,303 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-msg "https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
-	<!ENTITY fibo-loan-tem-bor "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/">
-	<!ENTITY fibo-loan-tem-ph "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
-	<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
-	<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-msg "https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
+bu<!ENTITY fibo-loan-tem-bor "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/">
+bu<!ENTITY fibo-loan-tem-ph "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
+bu<!ENTITY fibo-loan-typ-mtg "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/">
+bu<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-msg="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
-	xmlns:fibo-loan-tem-bor="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"
-	xmlns:fibo-loan-tem-ph="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"
-	xmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
-	xmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
-		<rdfs:label xml:lang="en">LoanApplicationsTemporal</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicant">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;Applicant"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-app;mayBecome"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan applicant</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplication">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;ApplicationInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;madeBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanApplicant"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-app;appraisedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanAppraiser"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-app;mayBecome.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan application</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-		<owl:disjointWith rdf:resource="&fibo-loan-tem-ph;RepaidLoan"/>
-		<skos:definition xml:lang="en">A loan which is being applied for and has not yet been disbursed.</skos:definition>
-		<skos:editorialNote xml:lang="en">There are several statuses applicable to the application. Application embeds the Assessment Information. then: &quot;Application&quot; (v) &quot;Application&quot; (n) we could add the verb? document supports the application. Application (noun derived from a verb)</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationAtAgreementStage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationStatus"/>
-		<rdfs:label xml:lang="en">loan application at agreement stage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationAtDisbursementStage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationStatus"/>
-		<rdfs:label xml:lang="en">loan application at disbursement stage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-app;refersToValueOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;IndividualCreditRating"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;appraisedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanAppraiser"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;includes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-bor;PersonalAssessmentFactsAtApproval"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan application borrower assessment information</rdfs:label>
-		<skos:definition xml:lang="en">Information about the borrower in relation to the loan. Specifically this is a bundle of information whose purpose is to identify the borrower and to assess their ability to pay (credit worthiness etc.)</skos:definition>
-		<skos:editorialNote xml:lang="en">Originates from MBS PoC terms, where this was a data table for &quot;Borrower&quot; which on further investigation was really borrower information as at the time of the loan. Additional terms moved elsewhere. PoC review / working Notes: These are really terms of the &quot;Borrower&quot;. This separate class only added to make this information visible. Some of the terms form &quot;Commitment&quot; likely belong here as they describe the Loan Borrower relationship not the commitment per se. More process related terms to model about the details of the application process.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationPhase">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Phase"/>
-		<rdfs:label xml:lang="en">loan application phase</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">loan application status</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;LoanAppraiser">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
-		<rdfs:label xml:lang="en">loan appraiser</rdfs:label>
-		<skos:definition xml:lang="en">That party which appraises the borrower for the purposes of the loan.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Hired by the underwriter to give the market value of the property.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;LoanAtApplicationStage">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationStatus"/>
-		<rdfs:label xml:lang="en">loan at application stage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;MortgageLoanApplication">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-app;appraisedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;MortgageLoanAppraiser"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-app;mayBecome.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage loan application</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-app;MortgageLoanAppraiser">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanAppraiser"/>
-		<rdfs:label xml:lang="en">mortgage loan appraiser</rdfs:label>
-		<skos:definition xml:lang="en">That party which appraises the borrower for the purposes of the loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;applicationDate">
-		<rdfs:label xml:lang="en">application date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;applicationPhase">
-		<rdfs:label xml:lang="en">application phase  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-app;LoanApplicationPhase"/>
-		<skos:definition xml:lang="en">The phase within the application lifecycle, that this Loan Application is at,</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;appraisedBy">
-		<rdfs:label xml:lang="en">appraised by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-app;LoanAppraiser"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;assessmentDate">
-		<rdfs:label xml:lang="en">assessment date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Date at which Borrower income, credit quality, verification, first time status etc were assessed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;borrowerCreditRatingAtApproval">
-		<rdfs:label xml:lang="en">borrower credit rating at approval  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Borrower Credit Quality at the time of the loan approval.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;domicile">
-		<rdfs:label xml:lang="en">domicile  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">this will really be a relationship fact. This is synonymous with Residence. synonym:Residency</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;grossIncome">
-		<rdfs:label xml:lang="en">gross income  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Primary borrower underwritten gross income (not rent)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;hasAssessmentInformation">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
-		<rdfs:label xml:lang="en">has assessment information  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;incomeVerificationMethod">
-		<rdfs:label xml:lang="en">income verification method  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-gen;IncomeVerificationMethodSelection"/>
-		<skos:definition xml:lang="en">REVIEW Is there something like this for corporates? Credit Review Check would apply to corporates as well as persons. This is not so miuch income but their credit record. There could be both.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;intendedLoanPurpose">
-		<rdfs:label xml:lang="en">intended loan purpose  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The purpose to which the loaned funds are to be put.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;mayBecome">
-		<rdfs:label xml:lang="en">may become  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicant"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;mayBecome.1">
-		<rdfs:label xml:lang="en">may become  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;originalLoanDTI">
-		<rdfs:label xml:lang="en">original loan d t i  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">Original Debt to Income (DTI) ratio when the loan was advanced. For combined income.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;refersToValueOf">
-		<rdfs:label xml:lang="en">refers to value of  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-crr;IndividualCreditRating"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;repossessionHistory">
-		<rdfs:label xml:lang="en">repossession history  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the potential borrower has a history of repossession.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-msg="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
+buxmlns:fibo-loan-tem-bor="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"
+buxmlns:fibo-loan-tem-ph="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"
+buxmlns:fibo-loan-typ-mtg="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"
+buxmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoanApplicationsTemporal</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines concepts for the loan application process, including the temporally sensitive concept of loan phases, along with kinds of loan application and the parties thereto. 
+		These concepts include mortgage loan applications, which will need to be integrated with the HMDA-based work in LoanContracts.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Messaging/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/MortgageLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;Applicant"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-app;mayBecome"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan applicant</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplication">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-msg;ApplicationInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-msg;madeBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanApplicant"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-app;appraisedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanAppraiser"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-app;mayBecome.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan application</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bubu<owl:disjointWith rdf:resource="&fibo-loan-tem-ph;RepaidLoan"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan which is being applied for and has not yet been disbursed.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">There are several statuses applicable to the application. Application embeds the Assessment Information. then: &quot;Application&quot; (v) &quot;Application&quot; (n) we could add the verb? document supports the application. Application (noun derived from a verb)</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationAtAgreementStage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan application at agreement stage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationAtDisbursementStage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan application at disbursement stage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-app;refersToValueOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;IndividualCreditRating"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;appraisedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanAppraiser"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;includes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-bor;PersonalAssessmentFactsAtApproval"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan application borrower assessment information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the borrower in relation to the loan. Specifically this is a bundle of information whose purpose is to identify the borrower and to assess their ability to pay (credit worthiness etc.)</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Originates from MBS PoC terms, where this was a data table for &quot;Borrower&quot; which on further investigation was really borrower information as at the time of the loan. Additional terms moved elsewhere. PoC review / working Notes: These are really terms of the &quot;Borrower&quot;. This separate class only added to make this information visible. Some of the terms form &quot;Commitment&quot; likely belong here as they describe the Loan Borrower relationship not the commitment per se. More process related terms to model about the details of the application process.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationPhase">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Phase"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan application phase</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;LoanApplicationStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan application status</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;LoanAppraiser">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-pty;LoanThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan appraiser</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That party which appraises the borrower for the purposes of the loan.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Hired by the underwriter to give the market value of the property.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;LoanAtApplicationStage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan at application stage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;MortgageLoanApplication">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-app;appraisedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;MortgageLoanAppraiser"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-app;mayBecome.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-mtg;MortgageLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage loan application</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-app;MortgageLoanAppraiser">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanAppraiser"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage loan appraiser</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">That party which appraises the borrower for the purposes of the loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;applicationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">application date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;applicationPhase">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">application phase  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-app;LoanApplicationPhase"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The phase within the application lifecycle, that this Loan Application is at,</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;appraisedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">appraised by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-app;LoanAppraiser"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;assessmentDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assessment date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date at which Borrower income, credit quality, verification, first time status etc were assessed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;borrowerCreditRatingAtApproval">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower credit rating at approval  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Borrower Credit Quality at the time of the loan approval.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;domicile">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">domicile  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">this will really be a relationship fact. This is synonymous with Residence. synonym:Residency</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;grossIncome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gross income  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Primary borrower underwritten gross income (not rent)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;hasAssessmentInformation">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has assessment information  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;incomeVerificationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">income verification method  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-gen;IncomeVerificationMethodSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">REVIEW Is there something like this for corporates? Credit Review Check would apply to corporates as well as persons. This is not so miuch income but their credit record. There could be both.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;intendedLoanPurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">intended loan purpose  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The purpose to which the loaned funds are to be put.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;mayBecome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may become  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicant"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;mayBecome.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may become  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplication"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;originalLoanDTI">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">original loan d t i  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Original Debt to Income (DTI) ratio when the loan was advanced. For combined income.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;refersToValueOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to value of  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-crr;IndividualCreditRating"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-app;repossessionHistory">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repossession history  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the potential borrower has a history of repossession.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/LoanBorrowersTemporal.rdf
+++ b/loan/LoansTemporal/LoanBorrowersTemporal.rdf
@@ -1,384 +1,387 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
-	<!ENTITY fibo-loan-tem-apr "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
-	<!ENTITY fibo-loan-tem-bor "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/">
-	<!ENTITY fibo-loan-tem-ph "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
-	<!ENTITY fibo-loan-typ-com "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/">
-	<!ENTITY fibo-loan-typ-per "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/">
-	<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-gen "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
+bu<!ENTITY fibo-loan-tem-apr "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
+bu<!ENTITY fibo-loan-tem-bor "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/">
+bu<!ENTITY fibo-loan-tem-ph "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
+bu<!ENTITY fibo-loan-typ-com "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/">
+bu<!ENTITY fibo-loan-typ-per "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/">
+bu<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"
-	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
-	xmlns:fibo-loan-tem-apr="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"
-	xmlns:fibo-loan-tem-bor="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"
-	xmlns:fibo-loan-tem-ph="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"
-	xmlns:fibo-loan-typ-com="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"
-	xmlns:fibo-loan-typ-per="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"
-	xmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/">
-		<rdfs:label xml:lang="en">LoanBorrowersTemporal</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;ArrearsPaymentHistory">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-		<rdfs:label xml:lang="en">arrears payment history  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Historical information about payment of arrears by the entity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that refers to all arrears payments generally for the person / organization, not just to arrears on a specific loan. when referred to in assessment for a given loan, this would refer to arrears on other loans in the past. Note that there is some possible interest in whether these arrears are in the past 6 months or more than 6 months ago. This may be an articifial or context-specific cut-off.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;appraisedBy.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">borrower ongoing dated facts  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Ongoing information about the borrower.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Includes credit rating information. Ongoing assessment reports both good and bad credit rating information. In the US, by regulation, lender is required to respot person&apos;s payment history on a monthly basis. This is the basis on which peope&apos;s score is changed. So the lender&apos;s reporting to the credit bureau may affect that person&apos;s credit rating. this may give rise to credit disputes. Also there is a scenario where the borrower may contact the lender and ask for some change. For student loans, they can apply for a deferment payment based on change in circumstances e.g. if losing job, or becoming disabled, then there are specific programs which they can apply for. can defer paymen for a time, and if proven eligible (e.g. also if in military, being deployed), then if they subbut the relevant document, they approve and change their repayment term, perhaps temporarily and then revert to the previously agreed terms. This results from the borrower contacting the lender.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;CorporateDatedFacts">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-		<rdfs:label xml:lang="en">corporate dated facts  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;CorporateLoanBorrowerAssessmentInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-com;CorporateBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">corporate loan borrower assessment information  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;DelinquencyBorrowerFacts">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ph;DelinquentLoan"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">delinquency borrower facts  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Facts about the borroewr in the event of some delinquency.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;EmploymentStatus">
-		<rdfs:label xml:lang="en">employment status</rdfs:label>
-		<skos:definition xml:lang="en">Possible employment statuses for adult human beings.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;IndividualPersonCreditRating">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;IndividualCreditRating"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crr;issuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;CreditRatingIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">individual person credit rating  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">was Borrower Credit Rating</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;PersonalAssessmentFactsAtApproval">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-gen;domiciled"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">personal assessment facts at approval  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Pertinent economic facts about an individual person at the time a given loan was approved.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are the same dated economic facts that may be assessed about a person at any time, but with the time of assessment being the time that the loan in quesiton was approved. This term therefore also has a relationship to the loan and the assessment activity for that loan.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;PersonalDatedFacts">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;includes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-bor;ArrearsPaymentHistory"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">personal dated facts  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Facts about a natural person. These are facts that are true as at a given time.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are assessed by the servicer on a regular basis. For example monthly. the Loan servicer assesses information about the borrower once a month or... If payment is once a month, then once a month you make the payment, the information goes to the Servicer (whether or not thi is the originating bank). They keep a running total. they decrement the principal and so on. So this is monthly because the payments are monthly. They have the reports of the monies received and so on. All this is provided to the Conservatorships (where this happens) ,and are kept as individual records there AND are aggregated for accounting and risk management purposes. For securities, need to go down to the quality level of the individual loans when they put then in the pools. Further to this: this is for dynamic MBS / ABS securities (dynmaic versus static loan pools and securities based on these). If it&apos;s fixed and is in place and being serviced, there is no way to change the terms of the security. If it defaults, then the original contract is defective. with dynmaci, similar to managed CDO in that the content of the pool can be changed. Earlier note Fannie Mae: the initial assessment of the borrower in terms of Credit worthiness and financial status. taken by the broker organization. the financial status of the borrower, as well as down payment, credit rating etc. is taken into account by &quot;Pre-approval&quot;. Preappoval means the broker is submitting the loan to Fannie Mae with the idea that it would meet the criteria to be purchasable by Fannie Mae. When all this is verified these are sent to Fannie Mae and then we have &quot;agreements&quot; or &quot;commitments&quot; that are in the pipeline - in the process of being processed or closed, then there are x many fixed, variable and so on. Then Fannie Mae will estimate how many loans it will be purchasing by aggregating all those. Meanwhile: Loan servicing - if this identified late payments or missed payments, then there may be another assessment of the borrower&apos;s credit worthiness. If going into foreclosure, would be another assessment. Once the loans are purchased, the concerns are simply calculating LTV (on property side, for a mortgage), which changes with payment and market value. Gets aggregated for various kinds of risk assessment and exposure assessment. The reporting by the servicer is monthly regardless of the payment frequency of the loan. Corporate versus Personal: Are the same kinds of facts assessed? Is the assessment still monthly? Agency (conservatorship): as above, once the loan is in a pool, the servicer reports to them. ALSO: If the loan is transferred from one pool etc. to another. Meanwhile: Borrower may be any Legal Entity, even for agency loans. they capture the party role, the relationship between the party and a security, and the relationship between a party and a pool of loans. Allows for a range of kinds of party. See tables of info on loan pools. 35 logical tables about the loan itself. Borrower (in old common data model in Fannie) for Borrower, has credit, per loan the mortgage insurer, the originator of the loan (bank, underwriter, brokerage etc.), the appraiser (of the property i.e. real estate, for mortgage), and for Loan borrower, the Borrower Type Code, whether ever bankrupt, amount of doan payment, borrower details, depth (Borrower v Borrower Liabilities); business expenses, Review notes: Identify the things about corporations that extend to persons and vice versa. Also static versus dated terms e.g. birth date v date of incorporation.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-typ-per;PersonalLoanBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-apr;obtainedFrom"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-ppl;Person"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">personal loan borrower assessment information  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-bor;PersonalMortgageLoanBorrowerAssessmentInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-apr;MortgageLoanBorrowerAssessmentInformation"/>
-		<rdfs:label xml:lang="en">personal mortgage loan borrower assessment information  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;annualProfitAndLoss">
-		<rdfs:label xml:lang="en">annual profit and loss  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;CorporateDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Primary borrower underwritten gross income (not rent), as per most recent Profit and Loss posting.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;appraisedBy">
-		<rdfs:label>appraised by</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;appraisedBy.1">
-		<rdfs:label xml:lang="en">appraised by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;assessmentDate">
-		<rdfs:label xml:lang="en">assessment date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Date at which Borrower income, credit quality, verification, first time status etc were last assessed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingArrearsSelection">
-		<rdfs:label xml:lang="en">borrower rating arrears selection  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: BKR 1 - 10 Arrears code &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; ArrearscodeaccordingtothecodingofBureauKredietRegistratie(Hollandonly) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; ( AO 34, RR 30 ) &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingCreditAmount">
-		<rdfs:label xml:lang="en">borrower rating credit amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: Credit agency rating of Amount&amp;nbsp;of&amp;nbsp;the&amp;nbsp;credit&amp;nbsp;(Holland&amp;nbsp;only) &lt;/p&gt; &lt;p&gt; (AO 35 , RR 31 ) &lt;/p&gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingCreditSelection">
-		<rdfs:label xml:lang="en">borrower rating credit selection  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: BKR 1-10 Credit type &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; CredittypeaccordingtothecodingofBureauKredietRegistratie(Hollandonly) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 33 - Agency Rating code , RR 29 ) &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingCuredDate">
-		<rdfs:label xml:lang="en">borrower rating cured date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: Is the coding with BKR cured? (Holland only) &lt;/p&gt; &lt;p&gt; If the coding is cured, number of months since it is cured (Holland only) &lt;/p&gt; &lt;p&gt; Represented as a non dirty date if cured &lt;/p&gt;&lt;br /&gt; &lt;p&gt; ( AO 36-37, RR 32- 33 )&amp;nbsp; year month date &lt;/p&gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingDate">
-		<rdfs:label xml:lang="en">borrower rating date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: The&amp;nbsp;date&amp;nbsp;of&amp;nbsp;the&amp;nbsp;bureau&amp;nbsp;score&amp;nbsp;for&amp;nbsp;this&amp;nbsp;borrower &lt;/p&gt; &lt;p&gt; (AO 40. RR 36 ) &lt;/p&gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingScoreSelection">
-		<rdfs:label xml:lang="en">borrower rating score selection  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: Bureau Score Value - Borrower&apos;s Score. &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; &amp;gt;0 Regular Score&amp;lt;br /&amp;gt; -999 CAIS for mortgage not available&amp;lt;br /&amp;gt; -998 Notice of Correction or Notice of Dispute&amp;lt;br /&amp;gt; 0 Bankruptcy Restriction Order or Bankruptcy Restriction Undertaking &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 41, RR 37 ) &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingScoreTypeSelection">
-		<rdfs:label xml:lang="en">borrower rating score type selection  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: This is partially expressed by party id of the issuing agency &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; But some of these scores are also methods ( internal / Other ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Who has provided the score. For continental Europe give name of provider. &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Callcredit (1)&amp;lt;br /&amp;gt; Experian (2)&amp;lt;br /&amp;gt; Equifax (3)&amp;lt;br /&amp;gt; Schufa (4)&amp;lt;br /&amp;gt; BKR (5)&amp;lt;br /&amp;gt; Internal Score (6)&amp;lt;br /&amp;gt; Other (7) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; ( AO 38 - originally Party id , RR 34 )&amp;lt;br /&amp;gt; No data (ND) &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingTypeSelection">
-		<rdfs:label xml:lang="en">borrower rating type selection  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: Bureau Score Type - Type of scorecard provided. &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Generation 8 B&amp;amp;F AAM - DCM (Experian) (1)&amp;lt;br /&amp;gt; Generation 8 B&amp;amp;F CRS - DCM (Experian) (2)&amp;lt;br /&amp;gt; Generation 7 Mortgage PD Score - DCM (Experian) (3)&amp;lt;br /&amp;gt; FSC109 - Risk Navigator (Equifax) (4)&amp;lt;br /&amp;gt; RNILF02 - Risk Navigator (Equifax) (5)&amp;lt;br /&amp;gt; RNISF02 - Risk Navigator (Equifax) (6)&amp;lt;br /&amp;gt; Internal Scorecard (7)&amp;lt;br /&amp;gt; Other (provide details) (8)&amp;lt;br /&amp;gt; No data (ND) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; ( AO 39, RR 35 ) &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;dateOfIncorporation">
-		<rdfs:label xml:lang="en">date of incorporation  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;CorporateLoanBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date of incorporation of the Corporation.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;grossIncome">
-		<rdfs:label xml:lang="en">gross income  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Primary borrower underwritten personal gross income (not rent)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;history1-6MArrearsPayments">
-		<rdfs:label xml:lang="en">history 1-6 m arrears payments  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">History - use timed status values and timed status information entity which has present and past values.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;history6PlusMArrearsPayments">
-		<rdfs:label xml:lang="en">history 6 plus m arrears payments  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">As above History of payments missed on previous mortgage(s) with months &amp;gt; 6M in arrears &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; RR has count of payments missed - but the form here with associated dates will mean that entered data remains valid over time dirty data &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; History of (non) payments6+ months in arrears on preceding mortgages &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Data form is a list with dates and indicated event ( OK / arrears 6+ Mo ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 24, RR 40 ) &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;includes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
-		<rdfs:label xml:lang="en">includes  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;incomeVerificationMethod">
-		<rdfs:label xml:lang="en">income verification method  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-gen;IncomeVerificationMethodSelection"/>
-		<skos:definition xml:lang="en">Income verification method for borrowers income.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;isAbout">
-		<rdfs:label xml:lang="en">is about  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;isAbout.1">
-		<rdfs:label>is about</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;isAbout.2">
-		<rdfs:label xml:lang="en">is about borrower  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;paymentsMissedInPastSixMonths">
-		<rdfs:label xml:lang="en">payments missed in past six months  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;ArrearsPaymentHistory"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">History of payments missed on previous mortgage in the prior 0-6 months (information as at underwriting).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;recordsEmploymentStatusAs">
-		<rdfs:label xml:lang="en">records employment status as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-bor;EmploymentStatus"/>
-		<skos:definition xml:lang="en">The employment status of the person applying for the loan, e.g. employed, self-employed, unemployed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;referenceContactInformation">
-		<rdfs:label xml:lang="en">reference contact information  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">contact information on file for the references taken up on the potential borrower(s).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;relatesEmploymentStatus">
-		<rdfs:label xml:lang="en">relates employment status</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-bor;EmploymentStatus"/>
-		<skos:definition xml:lang="en">Employment Status; Employment status of (the primary) applicant.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;repossessionHistory">
-		<rdfs:label xml:lang="en">repossession history  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">If yes: Will be more facts to be determined.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;repossessionHistory.1">
-		<rdfs:label xml:lang="en">repossession history  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether there is a history of prior repossessions resulting from the borrower defaulting on a previous mortgage loan.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;residencyPeriod">
-		<rdfs:label xml:lang="en">residency period  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-		<skos:definition xml:lang="en">Period in which borrower is resident of the country - where the loan property is located.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-gen="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
+buxmlns:fibo-loan-tem-apr="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"
+buxmlns:fibo-loan-tem-bor="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"
+buxmlns:fibo-loan-tem-ph="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"
+buxmlns:fibo-loan-typ-com="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"
+buxmlns:fibo-loan-typ-per="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"
+buxmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoanBorrowersTemporal</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology provides temporally sensitive concepts elating to loan borrowers themselves, including such concepts for different kinds of borrower (corporate and personal). These include things like credit statuses, payment history, and facts about the borrower at assessment and at other times.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CommercialLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/PersonalLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansGeneral/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;ArrearsPaymentHistory">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">arrears payment history  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Historical information about payment of arrears by the entity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note that refers to all arrears payments generally for the person / organization, not just to arrears on a specific loan. when referred to in assessment for a given loan, this would refer to arrears on other loans in the past. Note that there is some possible interest in whether these arrears are in the past 6 months or more than 6 months ago. This may be an articifial or context-specific cut-off.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;appraisedBy.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower ongoing dated facts  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Ongoing information about the borrower.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Includes credit rating information. Ongoing assessment reports both good and bad credit rating information. In the US, by regulation, lender is required to respot person&apos;s payment history on a monthly basis. This is the basis on which peope&apos;s score is changed. So the lender&apos;s reporting to the credit bureau may affect that person&apos;s credit rating. this may give rise to credit disputes. Also there is a scenario where the borrower may contact the lender and ask for some change. For student loans, they can apply for a deferment payment based on change in circumstances e.g. if losing job, or becoming disabled, then there are specific programs which they can apply for. can defer paymen for a time, and if proven eligible (e.g. also if in military, being deployed), then if they subbut the relevant document, they approve and change their repayment term, perhaps temporarily and then revert to the previously agreed terms. This results from the borrower contacting the lender.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;CorporateDatedFacts">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate dated facts  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;CorporateLoanBorrowerAssessmentInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-com;CorporateBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate loan borrower assessment information  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;DelinquencyBorrowerFacts">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ph;DelinquentLoan"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delinquency borrower facts  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Facts about the borroewr in the event of some delinquency.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;EmploymentStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">employment status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Possible employment statuses for adult human beings.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;IndividualPersonCreditRating">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;IndividualCreditRating"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crr;issuedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;CreditRatingIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">individual person credit rating  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">was Borrower Credit Rating</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;PersonalAssessmentFactsAtApproval">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-gen;domiciled"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">personal assessment facts at approval  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Pertinent economic facts about an individual person at the time a given loan was approved.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are the same dated economic facts that may be assessed about a person at any time, but with the time of assessment being the time that the loan in quesiton was approved. This term therefore also has a relationship to the loan and the assessment activity for that loan.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;PersonalDatedFacts">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;includes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-bor;ArrearsPaymentHistory"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">personal dated facts  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Facts about a natural person. These are facts that are true as at a given time.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are assessed by the servicer on a regular basis. For example monthly. the Loan servicer assesses information about the borrower once a month or... If payment is once a month, then once a month you make the payment, the information goes to the Servicer (whether or not thi is the originating bank). They keep a running total. they decrement the principal and so on. So this is monthly because the payments are monthly. They have the reports of the monies received and so on. All this is provided to the Conservatorships (where this happens) ,and are kept as individual records there AND are aggregated for accounting and risk management purposes. For securities, need to go down to the quality level of the individual loans when they put then in the pools. Further to this: this is for dynamic MBS / ABS securities (dynmaic versus static loan pools and securities based on these). If it&apos;s fixed and is in place and being serviced, there is no way to change the terms of the security. If it defaults, then the original contract is defective. with dynmaci, similar to managed CDO in that the content of the pool can be changed. Earlier note Fannie Mae: the initial assessment of the borrower in terms of Credit worthiness and financial status. taken by the broker organization. the financial status of the borrower, as well as down payment, credit rating etc. is taken into account by &quot;Pre-approval&quot;. Preappoval means the broker is submitting the loan to Fannie Mae with the idea that it would meet the criteria to be purchasable by Fannie Mae. When all this is verified these are sent to Fannie Mae and then we have &quot;agreements&quot; or &quot;commitments&quot; that are in the pipeline - in the process of being processed or closed, then there are x many fixed, variable and so on. Then Fannie Mae will estimate how many loans it will be purchasing by aggregating all those. Meanwhile: Loan servicing - if this identified late payments or missed payments, then there may be another assessment of the borrower&apos;s credit worthiness. If going into foreclosure, would be another assessment. Once the loans are purchased, the concerns are simply calculating LTV (on property side, for a mortgage), which changes with payment and market value. Gets aggregated for various kinds of risk assessment and exposure assessment. The reporting by the servicer is monthly regardless of the payment frequency of the loan. Corporate versus Personal: Are the same kinds of facts assessed? Is the assessment still monthly? Agency (conservatorship): as above, once the loan is in a pool, the servicer reports to them. ALSO: If the loan is transferred from one pool etc. to another. Meanwhile: Borrower may be any Legal Entity, even for agency loans. they capture the party role, the relationship between the party and a security, and the relationship between a party and a pool of loans. Allows for a range of kinds of party. See tables of info on loan pools. 35 logical tables about the loan itself. Borrower (in old common data model in Fannie) for Borrower, has credit, per loan the mortgage insurer, the originator of the loan (bank, underwriter, brokerage etc.), the appraiser (of the property i.e. real estate, for mortgage), and for Loan borrower, the Borrower Type Code, whether ever bankrupt, amount of doan payment, borrower details, depth (Borrower v Borrower Liabilities); business expenses, Review notes: Identify the things about corporations that extend to persons and vice versa. Also static versus dated terms e.g. birth date v date of incorporation.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-bor;isAbout.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-typ-per;PersonalLoanBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-apr;obtainedFrom"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-aap-ppl;Person"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">personal loan borrower assessment information  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-bor;PersonalMortgageLoanBorrowerAssessmentInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-apr;MortgageLoanBorrowerAssessmentInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">personal mortgage loan borrower assessment information  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;annualProfitAndLoss">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">annual profit and loss  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;CorporateDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Primary borrower underwritten gross income (not rent), as per most recent Profit and Loss posting.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;appraisedBy">
+bubu<rdfs:label>appraised by</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;appraisedBy.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">appraised by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;assessmentDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assessment date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date at which Borrower income, credit quality, verification, first time status etc were last assessed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingArrearsSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower rating arrears selection  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: BKR 1 - 10 Arrears code &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; ArrearscodeaccordingtothecodingofBureauKredietRegistratie(Hollandonly) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; ( AO 34, RR 30 ) &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingCreditAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower rating credit amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: Credit agency rating of Amount&amp;nbsp;of&amp;nbsp;the&amp;nbsp;credit&amp;nbsp;(Holland&amp;nbsp;only) &lt;/p&gt; &lt;p&gt; (AO 35 , RR 31 ) &lt;/p&gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingCreditSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower rating credit selection  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: BKR 1-10 Credit type &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; CredittypeaccordingtothecodingofBureauKredietRegistratie(Hollandonly) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 33 - Agency Rating code , RR 29 ) &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingCuredDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower rating cured date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: Is the coding with BKR cured? (Holland only) &lt;/p&gt; &lt;p&gt; If the coding is cured, number of months since it is cured (Holland only) &lt;/p&gt; &lt;p&gt; Represented as a non dirty date if cured &lt;/p&gt;&lt;br /&gt; &lt;p&gt; ( AO 36-37, RR 32- 33 )&amp;nbsp; year month date &lt;/p&gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower rating date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: The&amp;nbsp;date&amp;nbsp;of&amp;nbsp;the&amp;nbsp;bureau&amp;nbsp;score&amp;nbsp;for&amp;nbsp;this&amp;nbsp;borrower &lt;/p&gt; &lt;p&gt; (AO 40. RR 36 ) &lt;/p&gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingScoreSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower rating score selection  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: Bureau Score Value - Borrower&apos;s Score. &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; &amp;gt;0 Regular Score&amp;lt;br /&amp;gt; -999 CAIS for mortgage not available&amp;lt;br /&amp;gt; -998 Notice of Correction or Notice of Dispute&amp;lt;br /&amp;gt; 0 Bankruptcy Restriction Order or Bankruptcy Restriction Undertaking &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 41, RR 37 ) &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingScoreTypeSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower rating score type selection  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: This is partially expressed by party id of the issuing agency &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; But some of these scores are also methods ( internal / Other ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Who has provided the score. For continental Europe give name of provider. &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Callcredit (1)&amp;lt;br /&amp;gt; Experian (2)&amp;lt;br /&amp;gt; Equifax (3)&amp;lt;br /&amp;gt; Schufa (4)&amp;lt;br /&amp;gt; BKR (5)&amp;lt;br /&amp;gt; Internal Score (6)&amp;lt;br /&amp;gt; Other (7) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; ( AO 38 - originally Party id , RR 34 )&amp;lt;br /&amp;gt; No data (ND) &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;borrowerRatingTypeSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower rating type selection  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;IndividualPersonCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: Bureau Score Type - Type of scorecard provided. &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Generation 8 B&amp;amp;F AAM - DCM (Experian) (1)&amp;lt;br /&amp;gt; Generation 8 B&amp;amp;F CRS - DCM (Experian) (2)&amp;lt;br /&amp;gt; Generation 7 Mortgage PD Score - DCM (Experian) (3)&amp;lt;br /&amp;gt; FSC109 - Risk Navigator (Equifax) (4)&amp;lt;br /&amp;gt; RNILF02 - Risk Navigator (Equifax) (5)&amp;lt;br /&amp;gt; RNISF02 - Risk Navigator (Equifax) (6)&amp;lt;br /&amp;gt; Internal Scorecard (7)&amp;lt;br /&amp;gt; Other (provide details) (8)&amp;lt;br /&amp;gt; No data (ND) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; ( AO 39, RR 35 ) &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;dateOfIncorporation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">date of incorporation  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;CorporateLoanBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date of incorporation of the Corporation.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;grossIncome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gross income  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Primary borrower underwritten personal gross income (not rent)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;history1-6MArrearsPayments">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">history 1-6 m arrears payments  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">History - use timed status values and timed status information entity which has present and past values.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;history6PlusMArrearsPayments">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">history 6 plus m arrears payments  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">As above History of payments missed on previous mortgage(s) with months &amp;gt; 6M in arrears &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; RR has count of payments missed - but the form here with associated dates will mean that entered data remains valid over time dirty data &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; History of (non) payments6+ months in arrears on preceding mortgages &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Data form is a list with dates and indicated event ( OK / arrears 6+ Mo ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 24, RR 40 ) &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;includes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;incomeVerificationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">income verification method  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-gen;IncomeVerificationMethodSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Income verification method for borrowers income.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;isAbout">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is about  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;isAbout.1">
+bubu<rdfs:label>is about</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;isAbout.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is about borrower  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;paymentsMissedInPastSixMonths">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payments missed in past six months  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;ArrearsPaymentHistory"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">History of payments missed on previous mortgage in the prior 0-6 months (information as at underwriting).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;recordsEmploymentStatusAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">records employment status as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-bor;EmploymentStatus"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The employment status of the person applying for the loan, e.g. employed, self-employed, unemployed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;referenceContactInformation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference contact information  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">contact information on file for the references taken up on the potential borrower(s).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;relatesEmploymentStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relates employment status</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-bor;EmploymentStatus"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Employment Status; Employment status of (the primary) applicant.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;repossessionHistory">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repossession history  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;BorrowerOngoingDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">If yes: Will be more facts to be determined.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;repossessionHistory.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repossession history  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether there is a history of prior repossessions resulting from the borrower defaulting on a previous mortgage loan.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-bor;residencyPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">residency period  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-bor;PersonalLoanBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Period in which borrower is resident of the country - where the loan property is located.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/LoanCollateralTemporal.rdf
+++ b/loan/LoansTemporal/LoanCollateralTemporal.rdf
@@ -1,71 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-tem-apr "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
-	<!ENTITY fibo-loan-tem-col "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-tem-apr "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
+bu<!ENTITY fibo-loan-tem-col "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-tem-apr="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"
-	xmlns:fibo-loan-tem-col="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/">
-		<rdfs:label xml:lang="en">LoanCollateralTemporal</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-col;CollateralDatedFacts">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-col;SecurityInterestDatedFacts"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-col;isAboutLoanCollateral"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">collateral dated facts  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">What information is kept about different kinds of asset? Example: HJouse: Building structure, the land (these are non date facts), quality of the title. If car, information, identify (registration, VIN etc.); insurance and so on. Insurance is a dated fact. If a car is collateral., you would collect updated information on an ongoing basis. this happens though registering an interest in the vehicle. Insurance companies undertake not to cancel insutrance without notifying lender if there is a lein. so they regfister an interest in a motor vehicle. so some of this event driven, some is dated, some is static. Also: Flood plain risk, flood insurance on the asset.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-col;SecurityInterestDatedFacts">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-apr;appraisedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security interest dated facts  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-col;isAboutLoanCollateral">
-		<rdfs:label xml:lang="en">is about loan collateral  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-col;CollateralDatedFacts"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-col;isOf">
-		<rdfs:label xml:lang="en">is of  (please review)</rdfs:label>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-tem-apr="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"
+buxmlns:fibo-loan-tem-col="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoanCollateralTemporal</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology covers date-sensitive facts about the collateral provided for a collateralized loan, including security collateral.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-col;CollateralDatedFacts">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-col;SecurityInterestDatedFacts"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-col;isAboutLoanCollateral"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateral dated facts  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">What information is kept about different kinds of asset? Example: HJouse: Building structure, the land (these are non date facts), quality of the title. If car, information, identify (registration, VIN etc.); insurance and so on. Insurance is a dated fact. If a car is collateral., you would collect updated information on an ongoing basis. this happens though registering an interest in the vehicle. Insurance companies undertake not to cancel insutrance without notifying lender if there is a lein. so they regfister an interest in a motor vehicle. so some of this event driven, some is dated, some is static. Also: Flood plain risk, flood insurance on the asset.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-col;SecurityInterestDatedFacts">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-apr;appraisedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security interest dated facts  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-col;isAboutLoanCollateral">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is about loan collateral  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-col;CollateralDatedFacts"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-col;LoanCollateral"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-col;isOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is of  (please review)</rdfs:label>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/LoanPhases.rdf
+++ b/loan/LoansTemporal/LoanPhases.rdf
@@ -1,168 +1,172 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-tem-ph "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
-	<!ENTITY fibo-loan-tem-sta "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-tem-ph "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
+bu<!ENTITY fibo-loan-tem-sta "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-tem-ph="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"
-	xmlns:fibo-loan-tem-sta="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
-		<rdfs:label xml:lang="en">LoanPhases</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ph;DeferredLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-		<rdfs:label xml:lang="en">deferred loan</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ph;DelinquentLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ph;hasStatus"/>
-				<owl:allValuesFrom rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">delinquent loan</rdfs:label>
-		<skos:definition xml:lang="en">A loan which is an active loan (in Repayment phase), which is in default.</skos:definition>
-		<skos:editorialNote xml:lang="en">Possible outcomes including settlement where the loan is not paid off in full but a settlement is arrived at in which this is considered to be closed. Legal Proceedings may undertaken be in relation to Loan Defaults. Default versus Arrears? There are states within the space of being in arrears where it is not yet in default unless the borrower has not paid within a given period of time. For instance a decision is made after e.g. 3 months, when it is decided they are in default - a &quot;Notice of Default&quot; is then served, leading into the set of legal events we see in the Loan Default Proceedings.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ph;DisbursedLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasLoanPhase"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ph;RepaymentPhase"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ph;hasStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-sta;LoanPaymentStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">disbursed loan</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-loan-tem-ph;RepaidLoan"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ph;InDefaultLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;DelinquentLoan"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ph;inDefaultLoanIncludes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-sta;LoanDefaultProceedingStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">in default loan</rdfs:label>
-		<skos:definition xml:lang="en">Formal notice served.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ph;LoanPaidInFull">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;LoanPhase"/>
-		<rdfs:label xml:lang="en">loan paid in full</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ph;LoanPhase">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Phase"/>
-		<rdfs:label xml:lang="en">loan phase</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ph;RepaidLoan">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasLoanPhase"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ph;LoanPaidInFull"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">repaid loan</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ph;RepaymentPhase">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;LoanPhase"/>
-		<rdfs:label xml:lang="en">repayment phase</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;deferred">
-		<rdfs:label xml:lang="en">deferred</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DeferredLoan"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;disbursementDate">
-		<rdfs:label xml:lang="en">disbursement date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;hasStatus">
-		<rdfs:label xml:lang="en">has status</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanPaymentStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;inDefault">
-		<rdfs:label xml:lang="en">in default</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the loan is in default.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;inDefaultLoanIncludes">
-		<rdfs:label xml:lang="en">in default loan includes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ph;InDefaultLoan"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanDefaultProceedingStatus"/>
-		<skos:definition xml:lang="en">The status of any legal proceedings, as a part of this status information at a given point in time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;isDeferred">
-		<rdfs:label xml:lang="en">is deferred</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;loanStatus">
-		<rdfs:label xml:lang="en">loan status</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;repaymentDate">
-		<rdfs:label xml:lang="en">repayment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ph;RepaidLoan"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The date the loan was deemed to be repaid.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-tem-ph="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"
+buxmlns:fibo-loan-tem-sta="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoanPhases</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the phases in the life of a loan, including delinquent loans, up to the point where the loan is repaid. 
+		Future integration of this work should be based on the lifecycle concept, in the same way as product lifecycles.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanPhases/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ph;DeferredLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deferred loan</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ph;DelinquentLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ph;hasStatus"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delinquent loan</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan which is an active loan (in Repayment phase), which is in default.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Possible outcomes including settlement where the loan is not paid off in full but a settlement is arrived at in which this is considered to be closed. Legal Proceedings may undertaken be in relation to Loan Defaults. Default versus Arrears? There are states within the space of being in arrears where it is not yet in default unless the borrower has not paid within a given period of time. For instance a decision is made after e.g. 3 months, when it is decided they are in default - a &quot;Notice of Default&quot; is then served, leading into the set of legal events we see in the Loan Default Proceedings.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ph;DisbursedLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasLoanPhase"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ph;RepaymentPhase"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ph;hasStatus"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-sta;LoanPaymentStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">disbursed loan</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-loan-tem-ph;RepaidLoan"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ph;InDefaultLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;DelinquentLoan"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ph;inDefaultLoanIncludes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-sta;LoanDefaultProceedingStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in default loan</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal notice served.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ph;LoanPaidInFull">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;LoanPhase"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan paid in full</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ph;LoanPhase">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Phase"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan phase</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ph;RepaidLoan">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-loan;hasLoanPhase"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ph;LoanPaidInFull"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repaid loan</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ph;RepaymentPhase">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ph;LoanPhase"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repayment phase</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;deferred">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deferred</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DeferredLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;disbursementDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">disbursement date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;hasStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has status</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanPaymentStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;inDefault">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in default</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the loan is in default.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;inDefaultLoanIncludes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in default loan includes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ph;InDefaultLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanDefaultProceedingStatus"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of any legal proceedings, as a part of this status information at a given point in time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;isDeferred">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is deferred</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;loanStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan status</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ph;DisbursedLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ph;repaymentDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repayment date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ph;RepaidLoan"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date the loan was deemed to be repaid.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/LoansAppraisal.rdf
+++ b/loan/LoansTemporal/LoansAppraisal.rdf
@@ -1,84 +1,87 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
-	<!ENTITY fibo-loan-tem-apr "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-aap-ppl "https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
+bu<!ENTITY fibo-loan-tem-apr "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"
-	xmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
-	xmlns:fibo-loan-tem-apr="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
-		<rdfs:label xml:lang="en">LoansAppraisal</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-apr;MortgageLoanBorrowerAssessmentInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/appraisedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;MortgageLoanAppraiser"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/isAbout.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;MortgageLoanApplication"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage loan borrower assessment information  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-apr;RepossessionHistory">
-		<rdfs:label xml:lang="en">repossession history  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Information about an entity which has a history of repossessions, about those repossessions.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-apr;appraisedBy">
-		<rdfs:label xml:lang="en">appraised by  (please review)</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-apr;firstTimeBuyer">
-		<rdfs:label xml:lang="en">first time buyer  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-apr;MortgageLoanBorrowerAssessmentInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the borrower is a first time buyer.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-apr;mayBecome">
-		<rdfs:label xml:lang="en">may become  (please review)</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-apr;obtainedFrom">
-		<rdfs:label xml:lang="en">obtained from  (please review)</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-ppl;Person"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-aap-ppl="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
+buxmlns:fibo-loan-tem-apr="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansAppraisal</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts relating to the appraisal of a loan, including mortgage borrower assessment information and repossession history.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansAppraisal/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-apr;MortgageLoanBorrowerAssessmentInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-app;LoanApplicationBorrowerAssessmentInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/appraisedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;MortgageLoanAppraiser"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanBorrowersTemporal/isAbout.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;MortgageLoanApplication"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage loan borrower assessment information  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-apr;RepossessionHistory">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repossession history  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about an entity which has a history of repossessions, about those repossessions.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-apr;appraisedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">appraised by  (please review)</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanServicer.1"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-apr;firstTimeBuyer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first time buyer  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-apr;MortgageLoanBorrowerAssessmentInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the borrower is a first time buyer.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-apr;mayBecome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may become  (please review)</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-pty;LoanBorrower"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-apr;obtainedFrom">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obtained from  (please review)</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-fnd-aap-ppl;Person"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/LoansEvents.rdf
+++ b/loan/LoansTemporal/LoansEvents.rdf
@@ -1,425 +1,429 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
-	<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
-	<!ENTITY fibo-loan-tem-col "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/">
-	<!ENTITY fibo-loan-tem-ev "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
-	<!ENTITY fibo-loan-tem-ltv "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-law-cor "https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-col "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/">
+bu<!ENTITY fibo-loan-loan-pty "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/">
+bu<!ENTITY fibo-loan-tem-col "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/">
+bu<!ENTITY fibo-loan-tem-ev "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
+bu<!ENTITY fibo-loan-tem-ltv "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"
-	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
-	xmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
-	xmlns:fibo-loan-tem-col="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/"
-	xmlns:fibo-loan-tem-ev="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"
-	xmlns:fibo-loan-tem-ltv="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
-		<rdfs:label xml:lang="en">LoansEvents</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;CountyCourt">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-cor;CourtOfLaw"/>
-		<rdfs:label xml:lang="en">county court  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;CountyCourtActor">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">county court actor  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;CountyCourtJudgment">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;deliveredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isAgainst"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">county court judgment  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Satisfaction code associated with a county court judgement can have values satisfied/unsatisfied. This is a value changing event.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;DefaultProceedingTypeSelection">
-		<rdfs:label xml:lang="en">default proceeding type selection</rdfs:label>
-		<skos:definition xml:lang="en">(1) Default amount (2) Property Sale (3) Loss amount (4) Recoveries (5) Professional Negligence</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;InformativeEvent">
-		<rdfs:label xml:lang="en">informative event  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">An event which reflects some change in information about something.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is not an event which has any impact on any economic facts. Example: A change of name of a corporation is an informative event. Court proceedings that impose restricitons on paying any further advance on a loan is an informative event.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;LegalProceeding">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isAgainst"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;takesPlaceUnder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">legal proceeding  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;LoanDefaultProceeding">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
-		<rdfs:label xml:lang="en">loan default proceeding  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">[no definition] Further Review This is typically part of mortgagte servicing. THere would typically be a whole department dealing with this. Dealing with default, helping borrowers make payment Collections Default admin Foreclosure Reselling All dealt with by several sub departments. This requires subject matter experts in this area. 1. scoping Identify default as a possible state. This hands off to other business processes. Once you get into the default scenario we are talking about a proces that is going to fall into place over a period of time. The bank works out what to do with the default scenario, e.g. whether it restructures, forecloses, seeks restitution from the security (collateral). It does nto help us to understand the structure of the loan, rather tha consequences of the loan. If we were to further explore the default detail we would bring in other SMEs. And we would have to model a process flow. 1.1 impact on the pool of an MBS Loan Default Proceeding (special ase of legal thing) is an aspect of Default Management / Administratoin. there is also the State of the Loan. Sale / something / fulfilment / fiunduing / approved = servicing mode. Something happens (non payment) =&amp;gt; Default Grace Period followed by negotiation. Some threshold whereby after a given amount of delinquency it needs to go into some other process moving towards foreclosure. Do State Diagram. Stages of loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;MortgageLending">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;PropertyRelatedActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;determines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ltv;OriginalLTV"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage lending  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;NonPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isNot"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;Payment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">non payment  (please review)</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-loan-tem-ev;Payment"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;NonValueChangingActivity">
-		<rdfs:label xml:lang="en">non value changing activity  (please review)</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;Payment">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
-		<rdfs:label xml:lang="en">payment  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">An activity in which one actor makes a payment to another actor for some reason.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;Prepayment">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
-		<rdfs:label xml:lang="en">prepayment  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyBuyer">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;PropertyPurchaseAndSale"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">property buyer  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyCollateralValuation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-col;isOf"/>
-				<owl:allValuesFrom rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-loan-col;providedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;AVMProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">property collateral valuation  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">A valuation of the collateral Real Property to support the Property collateral Arrangement</skos:definition>
-		<skos:editorialNote xml:lang="en">Review archetype in light of non typical relationships. Valuation has some formal, financial and legal standing over and above being an Activity. Hence parties etc. also then relate to the valuation aactivity (see adjacent).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyLendersValuationTypeSelection">
-		<rdfs:label xml:lang="en">property lenders valuation type selection</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyPurchaseAndSale">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;PropertyRelatedActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;resultsIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;PurchasePrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">property purchase and sale  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The sale and purchase of real estate.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyRelatedActivity">
-		<rdfs:label xml:lang="en">property related activity  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">not sure if this is useful as a common class. Used for grouping of new activity terms around mortgage lending and propery purchase for now</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyValuation">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;PropertyRelatedActivity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;resultsIn.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">property valuation  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The activity whereby some real estats is valued by some agent, for some purpose (for example, for the purpose of granting or denoying a loan).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The activity of valuation of the propetry, which is carried out prior to setting up the loan, gives rise to &quot;Property Valuation&quot; information which is retained through the life of the loan.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-col;isOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">property valuation historical information  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Valuation of the property at some point in time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyValuer">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;carriesOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;PropertyValuation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">property valuer  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The party which carries out the valluation of the property for the purpose of a mortgage loan. Further notes: Also: See Event State Analysis at Fannie Mae, for core processes, as partof the enterprise data architecture transformation, e.g. ESA for single family and multi family loans.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;PurchasePrice">
-		<rdfs:label xml:lang="en">purchase price  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ev;ValueChangingActivity">
-		<rdfs:label xml:lang="en">value changing activity  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Some event or activity which changes the value of something. Examples: A value changing event can be for instance (in securities), a declaration of a dividend. This is an event which changes the value of something. CAE that are in FIBIM are value changing events. Changes to principal on any loan is a value changing event.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;borrowerCCJudgementDate">
-		<rdfs:label xml:lang="en">borrower c c judgement date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtJudgment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: Date this CCJ or equivalent was registered against the associated borrower regardless of satisfied or not</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;borrowerCCJudgementSatisfaction">
-		<rdfs:label xml:lang="en">borrower c c judgement satisfaction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtJudgment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: Satisfaction codes: 1 = this borrower County Court judgment was satisfied at time of underwriting; 2 = this borrower County Court judgment was unsatisfied at time of underwriting; Required that number of satisfied and unsatisfied CCJ&apos;s for a borrower can be determined from this data.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;borrowerCCJudgementValueAmount">
-		<rdfs:label xml:lang="en">borrower c c judgement value amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtJudgment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: Total value of CCJs or equivalent recorded against the primary borrower that were satisfied / unsatsified (at time of underwriting ) is computed by selecting the satisfaction code value of interest and aggregating against all borrower CC Judgements &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;carriesOut">
-		<rdfs:label xml:lang="en">carries out  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyValuer"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyValuation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;courtName">
-		<rdfs:label xml:lang="en">court name  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The formal name of the court.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;deliveredBy">
-		<rdfs:label xml:lang="en">delivered by  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtJudgment"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;determines">
-		<rdfs:label xml:lang="en">determines  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;MortgageLending"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ltv;OriginalLTV"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;identity">
-		<rdfs:label xml:lang="en">identity  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtActor"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;isAgainst">
-		<rdfs:label xml:lang="en">is against  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;isBuyer">
-		<rdfs:label xml:lang="en">is buyer  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyBuyer"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyPurchaseAndSale"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;isNot">
-		<rdfs:label xml:lang="en">is not  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;NonPayment"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;Payment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;isStatusOf">
-		<rdfs:label>is status of</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;loanDefaultProceedingAmount">
-		<rdfs:label xml:lang="en">loan default proceeding amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;LoanDefaultProceeding"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: Default or Foreclosure amount - Total default amount before the application of sale proceeds and recoveries.&amp;nbsp; (AO 146, RR 135) Loan Default Proceeding_cd= (1) Default amount &lt;/p&gt; &lt;p&gt; Sale price - Price achieved on sale of property ( AO 147, RR 137 )&amp;nbsp; Loan Default Proceeding_cd= (2) Property Sale &lt;/p&gt; &lt;p&gt; Loss on Sale&amp;nbsp;&amp;nbsp; Total loss net of fees, accrued interest etc. after application of sale proceeds (excluding prepayment charge if subordinate to principal recoveries). Show any gain on sale as a negative number (AO 148, RR 138 )&amp;nbsp; Loan Default Proceeding_cd = (3) Loss amount &lt;/p&gt; &lt;p&gt; Cumulative Reocveries - ony relevant for cases with losses&amp;nbsp; ( AO 149, RR 139 )&amp;nbsp; Loan Default Proceeding_cd =&amp;nbsp; (4) Recoveries &lt;/p&gt; &lt;p&gt; Professional Negligence Recoveries - Any amounts received in settlement or as a result of professional negligence claims against surveyors, solicitors etc. net of any fees / costs ( AO 150, RR 140 )&amp;nbsp; Loan Default Proceeding_cd = (5) Professional Negligence &lt;/p&gt;&lt;br /&gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;loanDefaultProceedingType">
-		<rdfs:label xml:lang="en">loan default proceeding type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;LoanDefaultProceeding"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;DefaultProceedingTypeSelection"/>
-		<skos:definition xml:lang="en">The type of default proceeding.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyAVMConfidenceInterval_cd">
-		<rdfs:label xml:lang="en">property a v m confidence interval_cd  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">&amp;lt;p&amp;gt; Confidence Interval for original AVM valuation -Confidence interval for original valuation if valuation method is AVM (RR 107 ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Confidence interval for current AVM valuation - List the AVM supplier&apos;s confidence value for the most recent valuation ( RR 113) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Property AVM confidence interval cd ( AO 126 - 127) values to be defined &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyLTV_rt">
-		<rdfs:label xml:lang="en">property l t v_rt  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">&amp;lt;p&amp;gt; OriginalLTV-Originator’soriginalunderwrittenLoanToValueratio(LTV).For2ndlienloansthisshouldbethe&amp;lt;br /&amp;gt; combinedortotalLTV. ( RR 103 ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Originator’s current Loan to Value ratio (LTV). For 2nd lien loans this should be the combined or total LTV (RR 109 ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Both supported as dated instances of a property Collateral valuation avoiding dirty data -Dt from ( AO 124, 125) &amp;lt;/p&amp;gt;&amp;lt;br /&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyLendersValuationType">
-		<rdfs:label xml:lang="en">property lenders valuation type  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyLendersValuationTypeSelection"/>
-		<skos:definition xml:lang="en">The type of valuation performed at origination.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyLendersValuation_at">
-		<rdfs:label xml:lang="en">property lenders valuation_at  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">&amp;lt;p&amp;gt; Original Valuation amount - Property value as of date of latest loan advance prior to a securitisation. Valuation amounts should be in the same currency as the loan (field 114) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Current Valuation Amount - Most recent valuation amount (if e.g. at repossession there were multiple valuations, this should reflect the lowest). If no update, leave blank. Valuation amounts should be in the same currency as the loan (field 114) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Property value at time of lastest loan advance - Property value at the time of the last advance. Valuation amounts should be in the same currency as the loan (field 114) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 119 - 121 ) &amp;lt;/p&amp;gt;&amp;lt;br /&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyLendersValuation_dt">
-		<rdfs:label xml:lang="en">property lenders valuation_dt  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">&amp;lt;p&amp;gt; Original valuation date - Date of latest property valuation at time of latest loan advance prior to a securitisation (RR 106) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Current valuation date - The date of most recent valuation ( (RR 112 ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 124-125) &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;purchaseAmount">
-		<rdfs:label xml:lang="en">purchase amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PurchasePrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;purchaseDate">
-		<rdfs:label xml:lang="en">purchase date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PurchasePrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;resultsIn">
-		<rdfs:label xml:lang="en">results in  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyPurchaseAndSale"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;PurchasePrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;resultsIn.1">
-		<rdfs:label xml:lang="en">results in  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyValuation"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;takesPlaceUnder">
-		<rdfs:label xml:lang="en">takes place under  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;valuationDate">
-		<rdfs:label xml:lang="en">valuation date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;value">
-		<rdfs:label xml:lang="en">value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-law-cor="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-col="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"
+buxmlns:fibo-loan-loan-pty="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"
+buxmlns:fibo-loan-tem-col="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/"
+buxmlns:fibo-loan-tem-ev="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"
+buxmlns:fibo-loan-tem-ltv="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansEvents</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines a wide range of events relating to loans. These include legal proceedings, prepayments, events affecting the collateral such as valuation, purchase and sale and details of many of these concepts. 
+		Note that most of this material was derived from an earlier activity with IBM Research, and are substantively based on a logical data model from that exercise.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanCollateralTemporal/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;CountyCourt">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-cor;CourtOfLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">county court  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;CountyCourtActor">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">county court actor  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;CountyCourtJudgment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;deliveredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isAgainst"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">county court judgment  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Satisfaction code associated with a county court judgement can have values satisfied/unsatisfied. This is a value changing event.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;DefaultProceedingTypeSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default proceeding type selection</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">(1) Default amount (2) Property Sale (3) Loss amount (4) Recoveries (5) Professional Negligence</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;InformativeEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">informative event  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event which reflects some change in information about something.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is not an event which has any impact on any economic facts. Example: A change of name of a corporation is an informative event. Court proceedings that impose restricitons on paying any further advance on a loan is an informative event.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;LegalProceeding">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isAgainst"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;takesPlaceUnder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal proceeding  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;LoanDefaultProceeding">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan default proceeding  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">[no definition] Further Review This is typically part of mortgagte servicing. THere would typically be a whole department dealing with this. Dealing with default, helping borrowers make payment Collections Default admin Foreclosure Reselling All dealt with by several sub departments. This requires subject matter experts in this area. 1. scoping Identify default as a possible state. This hands off to other business processes. Once you get into the default scenario we are talking about a proces that is going to fall into place over a period of time. The bank works out what to do with the default scenario, e.g. whether it restructures, forecloses, seeks restitution from the security (collateral). It does nto help us to understand the structure of the loan, rather tha consequences of the loan. If we were to further explore the default detail we would bring in other SMEs. And we would have to model a process flow. 1.1 impact on the pool of an MBS Loan Default Proceeding (special ase of legal thing) is an aspect of Default Management / Administratoin. there is also the State of the Loan. Sale / something / fulfilment / fiunduing / approved = servicing mode. Something happens (non payment) =&amp;gt; Default Grace Period followed by negotiation. Some threshold whereby after a given amount of delinquency it needs to go into some other process moving towards foreclosure. Do State Diagram. Stages of loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;MortgageLending">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;PropertyRelatedActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;determines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ltv;OriginalLTV"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage lending  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;NonPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isNot"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;Payment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non payment  (please review)</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-loan-tem-ev;Payment"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;NonValueChangingActivity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non value changing activity  (please review)</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;Payment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An activity in which one actor makes a payment to another actor for some reason.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;Prepayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;ValueChangingActivity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prepayment  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyBuyer">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isBuyer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;PropertyPurchaseAndSale"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property buyer  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyCollateralValuation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-col;isOf"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-loan-loan-col;LoanPropertyCollateral"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-loan-col;providedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-pty;AVMProvider"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property collateral valuation  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A valuation of the collateral Real Property to support the Property collateral Arrangement</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review archetype in light of non typical relationships. Valuation has some formal, financial and legal standing over and above being an Activity. Hence parties etc. also then relate to the valuation aactivity (see adjacent).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyLendersValuationTypeSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property lenders valuation type selection</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyPurchaseAndSale">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;PropertyRelatedActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;resultsIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;PurchasePrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property purchase and sale  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The sale and purchase of real estate.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyRelatedActivity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property related activity  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">not sure if this is useful as a common class. Used for grouping of new activity terms around mortgage lending and propery purchase for now</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyValuation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;PropertyRelatedActivity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;resultsIn.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property valuation  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The activity whereby some real estats is valued by some agent, for some purpose (for example, for the purpose of granting or denoying a loan).</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The activity of valuation of the propetry, which is carried out prior to setting up the loan, gives rise to &quot;Property Valuation&quot; information which is retained through the life of the loan.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-col;isOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property valuation historical information  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Valuation of the property at some point in time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;PropertyValuer">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;carriesOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;PropertyValuation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property valuer  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which carries out the valluation of the property for the purpose of a mortgage loan. Further notes: Also: See Event State Analysis at Fannie Mae, for core processes, as partof the enterprise data architecture transformation, e.g. ESA for single family and multi family loans.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;PurchasePrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase price  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ev;ValueChangingActivity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value changing activity  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some event or activity which changes the value of something. Examples: A value changing event can be for instance (in securities), a declaration of a dividend. This is an event which changes the value of something. CAE that are in FIBIM are value changing events. Changes to principal on any loan is a value changing event.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;borrowerCCJudgementDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower c c judgement date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtJudgment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: Date this CCJ or equivalent was registered against the associated borrower regardless of satisfied or not</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;borrowerCCJudgementSatisfaction">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower c c judgement satisfaction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtJudgment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: Satisfaction codes: 1 = this borrower County Court judgment was satisfied at time of underwriting; 2 = this borrower County Court judgment was unsatisfied at time of underwriting; Required that number of satisfied and unsatisfied CCJ&apos;s for a borrower can be determined from this data.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;borrowerCCJudgementValueAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower c c judgement value amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtJudgment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: Total value of CCJs or equivalent recorded against the primary borrower that were satisfied / unsatsified (at time of underwriting ) is computed by selecting the satisfaction code value of interest and aggregating against all borrower CC Judgements &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;carriesOut">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">carries out  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyValuer"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyValuation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;courtName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">court name  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formal name of the court.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;deliveredBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delivered by  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtJudgment"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;determines">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determines  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;MortgageLending"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ltv;OriginalLTV"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;identity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;CountyCourtActor"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;CountyCourt"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;isAgainst">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is against  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;isBuyer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is buyer  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyBuyer"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyPurchaseAndSale"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;isNot">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is not  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;NonPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;Payment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;isStatusOf">
+bubu<rdfs:label>is status of</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;loanDefaultProceedingAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan default proceeding amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;LoanDefaultProceeding"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: Default or Foreclosure amount - Total default amount before the application of sale proceeds and recoveries.&amp;nbsp; (AO 146, RR 135) Loan Default Proceeding_cd= (1) Default amount &lt;/p&gt; &lt;p&gt; Sale price - Price achieved on sale of property ( AO 147, RR 137 )&amp;nbsp; Loan Default Proceeding_cd= (2) Property Sale &lt;/p&gt; &lt;p&gt; Loss on Sale&amp;nbsp;&amp;nbsp; Total loss net of fees, accrued interest etc. after application of sale proceeds (excluding prepayment charge if subordinate to principal recoveries). Show any gain on sale as a negative number (AO 148, RR 138 )&amp;nbsp; Loan Default Proceeding_cd = (3) Loss amount &lt;/p&gt; &lt;p&gt; Cumulative Reocveries - ony relevant for cases with losses&amp;nbsp; ( AO 149, RR 139 )&amp;nbsp; Loan Default Proceeding_cd =&amp;nbsp; (4) Recoveries &lt;/p&gt; &lt;p&gt; Professional Negligence Recoveries - Any amounts received in settlement or as a result of professional negligence claims against surveyors, solicitors etc. net of any fees / costs ( AO 150, RR 140 )&amp;nbsp; Loan Default Proceeding_cd = (5) Professional Negligence &lt;/p&gt;&lt;br /&gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;loanDefaultProceedingType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan default proceeding type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;LoanDefaultProceeding"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;DefaultProceedingTypeSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of default proceeding.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyAVMConfidenceInterval_cd">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property a v m confidence interval_cd  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&amp;lt;p&amp;gt; Confidence Interval for original AVM valuation -Confidence interval for original valuation if valuation method is AVM (RR 107 ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Confidence interval for current AVM valuation - List the AVM supplier&apos;s confidence value for the most recent valuation ( RR 113) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Property AVM confidence interval cd ( AO 126 - 127) values to be defined &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyLTV_rt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property l t v_rt  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&amp;lt;p&amp;gt; OriginalLTV-Originator’soriginalunderwrittenLoanToValueratio(LTV).For2ndlienloansthisshouldbethe&amp;lt;br /&amp;gt; combinedortotalLTV. ( RR 103 ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Originator’s current Loan to Value ratio (LTV). For 2nd lien loans this should be the combined or total LTV (RR 109 ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Both supported as dated instances of a property Collateral valuation avoiding dirty data -Dt from ( AO 124, 125) &amp;lt;/p&amp;gt;&amp;lt;br /&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyLendersValuationType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property lenders valuation type  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyLendersValuationTypeSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of valuation performed at origination.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyLendersValuation_at">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property lenders valuation_at  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&amp;lt;p&amp;gt; Original Valuation amount - Property value as of date of latest loan advance prior to a securitisation. Valuation amounts should be in the same currency as the loan (field 114) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Current Valuation Amount - Most recent valuation amount (if e.g. at repossession there were multiple valuations, this should reflect the lowest). If no update, leave blank. Valuation amounts should be in the same currency as the loan (field 114) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Property value at time of lastest loan advance - Property value at the time of the last advance. Valuation amounts should be in the same currency as the loan (field 114) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 119 - 121 ) &amp;lt;/p&amp;gt;&amp;lt;br /&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;propertyLendersValuation_dt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">property lenders valuation_dt  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyCollateralValuation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&amp;lt;p&amp;gt; Original valuation date - Date of latest property valuation at time of latest loan advance prior to a securitisation (RR 106) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; Current valuation date - The date of most recent valuation ( (RR 112 ) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; (AO 124-125) &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;purchaseAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PurchasePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;purchaseDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">purchase date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PurchasePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;resultsIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyPurchaseAndSale"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;PurchasePrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;resultsIn.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">results in  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyValuation"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;takesPlaceUnder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes place under  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;valuationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ev;value">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ev;PropertyValuationHistoricalInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/LoansLTV.rdf
+++ b/loan/LoansTemporal/LoansLTV.rdf
@@ -1,63 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-tem-ltv "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-tem-ltv "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-tem-ltv="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/">
-		<rdfs:label xml:lang="en">LoansLTV</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ltv;CurrentLTV">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ltv;LoanToValueRatio"/>
-		<rdfs:label xml:lang="en">current l t v  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ltv;LoanToValueRatio">
-		<rdfs:label xml:lang="en">loan to value ratio  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-ltv;OriginalLTV">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ltv;LoanToValueRatio"/>
-		<rdfs:label xml:lang="en">original l t v  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-tem-ltv;informationDate">
-		<rdfs:label xml:lang="en">information date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ltv;CurrentLTV"/>
-		<skos:definition xml:lang="en">The date at which this valuation was carried out.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-tem-ltv;valuationDate">
-		<rdfs:label xml:lang="en">valuation date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ltv;OriginalLTV"/>
-		<skos:definition xml:lang="en">The date the valuation was carried out. This is the date the valuaton was carried out as part of the original mortgage valuation.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-ltv;value">
-		<rdfs:label xml:lang="en">value  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-ltv;LoanToValueRatio"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-tem-ltv="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansLTV</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the concept of a loan to value (LTV) ratio, including both the original LTV at application and the same concept as a variable over time.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansLTV/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ltv;CurrentLTV">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ltv;LoanToValueRatio"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current l t v  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ltv;LoanToValueRatio">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan to value ratio  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-ltv;OriginalLTV">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ltv;LoanToValueRatio"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">original l t v  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-tem-ltv;informationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">information date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ltv;CurrentLTV"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which this valuation was carried out.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-tem-ltv;valuationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ltv;OriginalLTV"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date the valuation was carried out. This is the date the valuaton was carried out as part of the original mortgage valuation.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-ltv;value">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-ltv;LoanToValueRatio"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/LoansStatus.rdf
+++ b/loan/LoansTemporal/LoansStatus.rdf
@@ -1,370 +1,373 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
-	<!ENTITY fibo-loan-tem-ev "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
-	<!ENTITY fibo-loan-tem-sta "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
-	<!ENTITY fibo-loan-typ-stu "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-tem-app "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/">
+bu<!ENTITY fibo-loan-tem-ev "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
+bu<!ENTITY fibo-loan-tem-sta "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
+bu<!ENTITY fibo-loan-typ-stu "https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
-	xmlns:fibo-loan-tem-ev="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"
-	xmlns:fibo-loan-tem-sta="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"
-	xmlns:fibo-loan-typ-stu="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
-		<rdfs:label xml:lang="en">LoansStatus</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-typ-stu;StudentLoan">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-sta;hasActiveStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-sta;StudentLoanActiveStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanDrawdown">
-		<owl:equivalentClass rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;ActiveLoanStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanLifecycleStatus"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-sta;hasLoanApplicationStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanApplicationAtDisbursementStage"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">active loan status</rdfs:label>
-		<skos:definition xml:lang="en">Status of a Loan which is in the Disbursement phase.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LegalProceedingStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isStatusOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">legal proceeding status  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The status of some legal proceeding at some point in time.</skos:definition>
-		<skos:editorialNote xml:lang="en">The precise terms for such proceedings will vary on a type of proceeding to type of proceeding basis and so none are articulated here. Review: Maybe in fact there are some common status that apply to all legal proceedings, e.g. None, Imminent, In progress, Closed.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LegalProceedingsStatusSelection">
-		<rdfs:label xml:lang="en">legal proceedings status selection</rdfs:label>
-		<skos:definition xml:lang="en">The status of any legal proceedings.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanArrearsStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanPaymentStatus"/>
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
-		<rdfs:label xml:lang="en">loan arrears status  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Arrears describes the whole period where a loan is either delinquent or in default. [mixed bag of types of Status] formerly Loan Status. Now: The status of arrears performance at any given time in the life of the loan (e.g. present, series of dated past values).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanDefaultProceedingStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LegalProceedingStatus"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isStatusOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;LoanDefaultProceeding"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan default proceeding status  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The status of loan default legal proceeding at some point in time.</skos:definition>
-		<skos:editorialNote xml:lang="en">Added to enhance Proof of Concept model, which has an aggregation relation from Loan Status to Loan Proceeding. That would not be literally correct as it would make a proceeding (and activity) part of a status. Rather, it must be the status of that proceeding, which is part of this status information set and is reported on at the point in time that the other loan status information may be reported on. Action: Although this &quot;is of&quot; a defined kind of activity called Loan Proceeding, that does not satisfy the need for a dated set of statuses. Need a selection list, based on facts about the Loan Default Proceedings, e.g. Imminent, Pending, Ongoing, Closed. Mabe some of those should be part of a wider list of common terms about all legal proceedings statuses.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanLifecycleStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">loan lifecycle status</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPayment">
-		<rdfs:label xml:lang="en">loan payment  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Add in here the terms on payment history related terms which are in the &quot;Loan Contract&quot; set.</skos:definition>
-		<skos:editorialNote xml:lang="en">The above terms all seemed to relate to pre-payment not payment. Do we also need a set of history terms about payment per se? If not, delete this class as prepayment history already modeled.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPaymentStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">loan payment status  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPerformanceStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
-		<rdfs:label xml:lang="en">loan performance status  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The current performance of the loan, as one of a list of possible statuses.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Relates to the performance in terms of whether the customer is paying in time or is in default, and more generally in terms of meeting their obligations in terms of principal or interest payment or any other obligations defined in the Loan Contract (agreement).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPerformanceStatusSelection">
-		<rdfs:label xml:lang="en">loan performance status selection  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPrepaymentStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
-		<rdfs:label xml:lang="en">loan prepayment status  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Information about prepayments of the loan, at a given point in time.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is dated information. Discussion: Payment ahead of the loan Payments ahead of schedule</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanSnapshotOrStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">loan snapshot or status  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Information applicable to a loan at a given date.</skos:definition>
-		<skos:editorialNote xml:lang="en">In the model you have Loan Balance, Loan DTI, ALSO ADD: Loan Default Proceeding should be referenced from Loan Snapshot as well. Combine Balance and Status, leave Rate and ?? out...</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;LoanStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">loan status  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Statuses which occur for a period of time, relating to a loan.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The status applies at a period of time, and is applicable across all phases.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;StudentLoanActiveStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;ActiveLoanStatus"/>
-		<rdfs:label xml:lang="en">student loan active status  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The status of the Student Loan at a given point in time, during the phase where it is active (the disbursement phase).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-sta;StudentLoanActiveStatusSelection">
-		<rdfs:label xml:lang="en">student loan active status selection</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;allocationToFees">
-		<rdfs:label xml:lang="en">allocation to fees  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount of the payment which is allocated to other fees.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;allocationToInterest">
-		<rdfs:label xml:lang="en">allocation to interest  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount allocated to Interest</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;allocationToPrincipal">
-		<rdfs:label xml:lang="en">allocation to principal  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount of the information allocated to Principal</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;anticipatedMaturityDate">
-		<rdfs:label xml:lang="en">anticipated maturity date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date when the loan is expected to mature.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;cumulativePrepaidAmount">
-		<rdfs:label xml:lang="en">cumulative prepaid amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPrepaymentStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The cumulative amount that has been pre paid.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;currentLoanRate">
-		<rdfs:label xml:lang="en">current loan rate  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The rate payable on the loan at this point in time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;delinquent">
-		<rdfs:label xml:lang="en">delinquent  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;delinquent.1">
-		<rdfs:label xml:lang="en">delinquent  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPaymentStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;hasActiveStatus">
-		<rdfs:label xml:lang="en">has active status  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-sta;ActiveLoanStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;hasLifecycleStatus">
-		<rdfs:label xml:lang="en">has lifecycle status  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanLifecycleStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;hasLoanApplicationStatus">
-		<rdfs:label xml:lang="en">has loan application status</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanLifecycleStatus"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-app;LoanApplicationStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;hasSnapshot">
-		<rdfs:label xml:lang="en">has snapshot  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;informationDate">
-		<rdfs:label xml:lang="en">information date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPrepaymentStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date on which this information applies.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;informationDate.1">
-		<rdfs:label xml:lang="en">information date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date on which these facts are or were applicable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-tem-sta;loanApplicationStatus">
-		<rdfs:label xml:lang="en">loan application status  (please review)</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanDebtToIncomeRatio">
-		<rdfs:label xml:lang="en">loan debt to income ratio  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition xml:lang="en">The debt to income ratio of the borrower or borrowers.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanInterestOnlyTemporaryProvision">
-		<rdfs:label xml:lang="en">loan interest only temporary provision  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether payments currently pay interest due but no principal on the loan.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanLastPrepaymentAmount">
-		<rdfs:label xml:lang="en">loan last prepayment amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPrepaymentStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Last pre-payment amount. This is the amount pre-paid most recently as at the Information Date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanLitigationUnderWay">
-		<rdfs:label xml:lang="en">loan litigation under way  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether Litigation proceedings are currently under way.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanPaymentInformationDate">
-		<rdfs:label xml:lang="en">loan payment information date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The actual date on which the payment was made.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanPerformanceStatus">
-		<rdfs:label xml:lang="en">loan performance status  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPerformanceStatus"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanPerformanceStatusSelection"/>
-		<skos:definition xml:lang="en">The current performance of the loan, as one of a list of possible statuses. Relates to the performance in terms of whether the customer is paying in time or is in default, and more generally in terms of meeting their obligations in terms of principal or interest payment or any other obligations defined in the Loan Contract (agreement). Performing Arrears Default or Foreclosure Redeemed Repurchased by Seller Review notes Differs from Account Status which would be Open, Closed, etc. There may be other covenants that might need to be met for example in terms of credit rating. Student Loans addtional statuses In school [status of the student, that impacts the loan] Implication is that they don&apos;t have to pay it back while they are still in school. so this can impact the loan status but does not always Grace [no longer in school but there is a grace period before they have to go into repayment] This is a phase Repayment Repaid in full Student Loan phases include: Pre-disbursement - this crosses phase [others may exist] (no default or foreclose) Not the same as Origination or Application status. Then there are sub-statuses. E.g. in the &quot;!Repayment&quot; status, there may be a set of sub-statuses e.g. charge-off, settlement, resell. Similarly in the origination / application statuses, there are multiple sub statuses. Industry standards would have these terms, e.g. MISMP and others. See e.g. for electronic transmission of student loan data. See notes to be received. These were originally derived from the Sallie Mae statuses. Are very similar. (earlier IBM notes) RR 126 Date Last Current - If the borrower is in arrears, the date they were last current&amp;nbsp; Loan Status.Loan Status_dt = where Loan Status.Loan Status Performance_cd ^= arrears RR 133 Date on which account redeemed Loan Status. Loan Status_dt = Where Loan Status.LOan Status Performance_cd = Redeemed</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanPrepaymentPenaltiesCumulativePaidAmount">
-		<rdfs:label xml:lang="en">loan prepayment penalties cumulative paid amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPrepaymentStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Pre-Payment Penalties - Cumulative amount of pre-payment penalties paid to date</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanStatusArrearsBalance">
-		<rdfs:label xml:lang="en">loan status arrears balance  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Arrears Balance as at the Status Date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanStatusArrearsDuration">
-		<rdfs:label xml:lang="en">loan status arrears duration  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-		<skos:definition xml:lang="en">The length of time that the loan has been in arrears.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanStatusPerformanceArrangementDate">
-		<rdfs:label xml:lang="en">loan status performance arrangement date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date when the borrower had an arrangement put in place to reduce the balance of any arrears whilst maintaining their current payment.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;paymentAmount">
-		<rdfs:label xml:lang="en">payment amount  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount paid by the borrower at the information date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;paymentIdentifier">
-		<rdfs:label xml:lang="en">payment identifier  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">A unique identifier which identifies which scheduled payment this payment is made against.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;status">
-		<rdfs:label xml:lang="en">status  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LegalProceedingStatus"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-sta;LegalProceedingsStatusSelection"/>
-		<skos:definition xml:lang="en">The status of the proceedings in question.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;studentLoanStatus">
-		<rdfs:label xml:lang="en">student loan status  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-sta;StudentLoanActiveStatus"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-sta;StudentLoanActiveStatusSelection"/>
-		<skos:definition xml:lang="en">The status of the Student Loan at a given point in time, during the phase where it is active (the disbursement phase).</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-tem-app="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"
+buxmlns:fibo-loan-tem-ev="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"
+buxmlns:fibo-loan-tem-sta="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"
+buxmlns:fibo-loan-typ-stu="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansStatus</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the kinds of status that a loan may be in at various stages in its lifecycle, based on the more general temporal concept of statuses. These include the statuses of legal proceedings, of loan performance, of prepayment and of the loan itself e.g. active or in arrears.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/StudentLoans/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoanApplicationsTemporal/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansStatus/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-typ-stu;StudentLoan">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-sta;hasActiveStatus"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-sta;StudentLoanActiveStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanDrawdown">
+bubu<owl:equivalentClass rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;ActiveLoanStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanLifecycleStatus"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-sta;hasLoanApplicationStatus"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-app;LoanApplicationAtDisbursementStage"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">active loan status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Status of a Loan which is in the Disbursement phase.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LegalProceedingStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isStatusOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;LegalProceeding"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal proceeding status  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of some legal proceeding at some point in time.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The precise terms for such proceedings will vary on a type of proceeding to type of proceeding basis and so none are articulated here. Review: Maybe in fact there are some common status that apply to all legal proceedings, e.g. None, Imminent, In progress, Closed.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LegalProceedingsStatusSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal proceedings status selection</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of any legal proceedings.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanArrearsStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanPaymentStatus"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan arrears status  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Arrears describes the whole period where a loan is either delinquent or in default. [mixed bag of types of Status] formerly Loan Status. Now: The status of arrears performance at any given time in the life of the loan (e.g. present, series of dated past values).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanDefaultProceedingStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LegalProceedingStatus"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-ev;isStatusOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;LoanDefaultProceeding"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan default proceeding status  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of loan default legal proceeding at some point in time.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Added to enhance Proof of Concept model, which has an aggregation relation from Loan Status to Loan Proceeding. That would not be literally correct as it would make a proceeding (and activity) part of a status. Rather, it must be the status of that proceeding, which is part of this status information set and is reported on at the point in time that the other loan status information may be reported on. Action: Although this &quot;is of&quot; a defined kind of activity called Loan Proceeding, that does not satisfy the need for a dated set of statuses. Need a selection list, based on facts about the Loan Default Proceedings, e.g. Imminent, Pending, Ongoing, Closed. Mabe some of those should be part of a wider list of common terms about all legal proceedings statuses.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanLifecycleStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan lifecycle status</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPayment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan payment  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Add in here the terms on payment history related terms which are in the &quot;Loan Contract&quot; set.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The above terms all seemed to relate to pre-payment not payment. Do we also need a set of history terms about payment per se? If not, delete this class as prepayment history already modeled.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPaymentStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan payment status  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPerformanceStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan performance status  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The current performance of the loan, as one of a list of possible statuses.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Relates to the performance in terms of whether the customer is paying in time or is in default, and more generally in terms of meeting their obligations in terms of principal or interest payment or any other obligations defined in the Loan Contract (agreement).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPerformanceStatusSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan performance status selection  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanPrepaymentStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan prepayment status  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about prepayments of the loan, at a given point in time.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is dated information. Discussion: Payment ahead of the loan Payments ahead of schedule</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanSnapshotOrStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan snapshot or status  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information applicable to a loan at a given date.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">In the model you have Loan Balance, Loan DTI, ALSO ADD: Loan Default Proceeding should be referenced from Loan Snapshot as well. Combine Balance and Status, leave Rate and ?? out...</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;LoanStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan status  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Statuses which occur for a period of time, relating to a loan.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The status applies at a period of time, and is applicable across all phases.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;StudentLoanActiveStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-sta;ActiveLoanStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">student loan active status  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of the Student Loan at a given point in time, during the phase where it is active (the disbursement phase).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-sta;StudentLoanActiveStatusSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">student loan active status selection</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;allocationToFees">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocation to fees  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of the payment which is allocated to other fees.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;allocationToInterest">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocation to interest  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount allocated to Interest</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;allocationToPrincipal">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allocation to principal  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of the information allocated to Principal</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;anticipatedMaturityDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">anticipated maturity date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date when the loan is expected to mature.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;cumulativePrepaidAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cumulative prepaid amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPrepaymentStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The cumulative amount that has been pre paid.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;currentLoanRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current loan rate  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rate payable on the loan at this point in time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;delinquent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delinquent  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;delinquent.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delinquent  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPaymentStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;hasActiveStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has active status  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-sta;ActiveLoanStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;hasLifecycleStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has lifecycle status  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanLifecycleStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;hasLoanApplicationStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has loan application status</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanLifecycleStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-app;LoanApplicationStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;hasSnapshot">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has snapshot  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;informationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">information date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPrepaymentStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date on which this information applies.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;informationDate.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">information date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date on which these facts are or were applicable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-tem-sta;loanApplicationStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan application status  (please review)</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanDebtToIncomeRatio">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan debt to income ratio  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanSnapshotOrStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The debt to income ratio of the borrower or borrowers.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanInterestOnlyTemporaryProvision">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest only temporary provision  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether payments currently pay interest due but no principal on the loan.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanLastPrepaymentAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan last prepayment amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPrepaymentStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Last pre-payment amount. This is the amount pre-paid most recently as at the Information Date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanLitigationUnderWay">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan litigation under way  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether Litigation proceedings are currently under way.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanPaymentInformationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan payment information date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The actual date on which the payment was made.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanPerformanceStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan performance status  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPerformanceStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-sta;LoanPerformanceStatusSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The current performance of the loan, as one of a list of possible statuses. Relates to the performance in terms of whether the customer is paying in time or is in default, and more generally in terms of meeting their obligations in terms of principal or interest payment or any other obligations defined in the Loan Contract (agreement). Performing Arrears Default or Foreclosure Redeemed Repurchased by Seller Review notes Differs from Account Status which would be Open, Closed, etc. There may be other covenants that might need to be met for example in terms of credit rating. Student Loans addtional statuses In school [status of the student, that impacts the loan] Implication is that they don&apos;t have to pay it back while they are still in school. so this can impact the loan status but does not always Grace [no longer in school but there is a grace period before they have to go into repayment] This is a phase Repayment Repaid in full Student Loan phases include: Pre-disbursement - this crosses phase [others may exist] (no default or foreclose) Not the same as Origination or Application status. Then there are sub-statuses. E.g. in the &quot;!Repayment&quot; status, there may be a set of sub-statuses e.g. charge-off, settlement, resell. Similarly in the origination / application statuses, there are multiple sub statuses. Industry standards would have these terms, e.g. MISMP and others. See e.g. for electronic transmission of student loan data. See notes to be received. These were originally derived from the Sallie Mae statuses. Are very similar. (earlier IBM notes) RR 126 Date Last Current - If the borrower is in arrears, the date they were last current&amp;nbsp; Loan Status.Loan Status_dt = where Loan Status.Loan Status Performance_cd ^= arrears RR 133 Date on which account redeemed Loan Status. Loan Status_dt = Where Loan Status.LOan Status Performance_cd = Redeemed</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanPrepaymentPenaltiesCumulativePaidAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan prepayment penalties cumulative paid amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPrepaymentStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Pre-Payment Penalties - Cumulative amount of pre-payment penalties paid to date</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanStatusArrearsBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan status arrears balance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Arrears Balance as at the Status Date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanStatusArrearsDuration">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan status arrears duration  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The length of time that the loan has been in arrears.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;loanStatusPerformanceArrangementDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan status performance arrangement date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanArrearsStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date when the borrower had an arrangement put in place to reduce the balance of any arrears whilst maintaining their current payment.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;paymentAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment amount  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount paid by the borrower at the information date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;paymentIdentifier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment identifier  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LoanPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A unique identifier which identifies which scheduled payment this payment is made against.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;status">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">status  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;LegalProceedingStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-sta;LegalProceedingsStatusSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of the proceedings in question.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-sta;studentLoanStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">student loan status  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-sta;StudentLoanActiveStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-sta;StudentLoanActiveStatusSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of the Student Loan at a given point in time, during the phase where it is active (the disbursement phase).</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/loan/LoansTemporal/LoansTemporal.rdf
+++ b/loan/LoansTemporal/LoansTemporal.rdf
@@ -1,161 +1,164 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-loan-tem-tem "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansTemporal/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-loan-tem-tem "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansTemporal/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansTemporal/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-loan-tem-tem="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansTemporal/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansTemporal/">
-		<rdfs:label xml:lang="en">LoansTemporal</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansTemporal/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<rdfs:Datatype rdf:about="&xsd;string">
-	</rdfs:Datatype>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanDrawdown">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-tem;LoanBalance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;DatedBalance"/>
-		<rdfs:label xml:lang="en">loan balance  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The outstanding balance on a loan at a particular point in time.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is the latest outstanding principal balance as at the date for which this is indicated. This also has a present value and a time series of possible past values. The time at which the amount is indicated forms part of the concept &quot;Dated monetary Amount&quot; PoC SDM Term Notes: Balance includes amount outstanding and fees In particular may record the balance outstanding at the time this loan was incorporated into some loan pool So each loan may have a number of balances associated with it recorded at different times. The loan may have been moved into and out of one or more pools. Some of the recorded ballences may be associated with the exact time and balance while this loan enters or exists a particulat pool. Other loan balances may be at different times not associated with a pool entry or exit event. Conesnsus:Review</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-tem;LoanBalanceDetermination">
-		<rdfs:label xml:lang="en">loan balance determination  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-tem;LoanBalanceRecord">
-		<rdfs:label xml:lang="en">loan balance record  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-tem;LoanDeterminer">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-tem;determines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-tem;LoanRateDetermination"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan determiner  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-tem;LoanInterestRate">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-tem;isAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan interest rate  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">This is also a timed variable with a present value and a time series of past values. What is it? A record of the rates that may have been charged in a variable rate loan. Therefore, this variable is the &quot;Interest Rate&quot; of the loan. It is a &quot;Dated Parameter&quot; - dates are taken care of in the upper mode of Variable Parameters.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-loan-tem-tem;LoanRateDetermination">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-loan-tem-tem;givesRiseTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan rate determination  (please review)</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;determines">
-		<rdfs:label xml:lang="en">determines  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanDeterminer"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-tem;LoanRateDetermination"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;givesRiseTo">
-		<rdfs:label xml:lang="en">gives rise to  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanRateDetermination"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;hasBalance">
-		<rdfs:label xml:lang="en">has balance  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-tem;LoanBalance"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;hasRateRecord">
-		<rdfs:label xml:lang="en">has rate record  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;isAbout">
-		<rdfs:label xml:lang="en">is about  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<owl:inverseOf rdf:resource="&fibo-loan-tem-tem;hasRateRecord"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;loanBalance">
-		<rdfs:label xml:lang="en">loan balance  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanBalance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Current Balance of the loan at the stated date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;loanBalanceAsAt">
-		<rdfs:label xml:lang="en">loan balance as at  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanBalance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">Date for which current loan balance is defined. Term reduntant since Dated Monetary Amount is a dated value and so has a date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;loanInterestMarginRate">
-		<rdfs:label xml:lang="en">loan interest margin rate  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Remove it. But add a fact about time history of amounts on those loans where the interest amount can be change by the lender. Undefined PoC SDM Notes: Currentinterestratemargin(forfixedrateloansthisisthesameasthecurrentinterestrate,forfloatingrateloans&amp;lt;br /&amp;gt; thisisthemarginover(orunderifinputasanegative)theindexrate. &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; allows derivation of (93) Date interest rate next changes (e.g. discount margin changes, fixed period ends, loan re-fixed etc. this is not the next LIBOR reset date) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; using : (Loan Rate.)Loan Interest Margin_rt where (loan Rate.)LoanRate_dt &amp;gt; today AND &amp;lt; any other date in the set &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; allows derivation of (94) The margin for the loan at the final step date &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; using: (Loan Rate.)Loan Interest Margin_rt where where (Loan Rate.)LoanRate_dt &amp;gt; any other date in the set &amp;lt;/p&amp;gt;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;loanInterestRate">
-		<rdfs:label xml:lang="en">loan interest rate  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Undefined PoC SDM Notes: Requirement to derive&amp;nbsp; (85) Current interest rate (%) is satisfied by: ( Loan Rate.) Loan Intrest_rt where ; (Loan Rate. )LoanRate_dt &gt;= today AND &gt; any other date in the set Requirement to derive (92) &amp;nbsp;Next Interest Rate satisfied by: ( Loan Rate.) Loan Intrest_rt where&amp;nbsp; (Loan Rate. )LoanRate_dt ; &gt; today AND &lt; any other date in the set</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-loan-tem-tem;poolMembershipSelection">
-		<rdfs:label xml:lang="en">pool membership selection  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanBalance"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">Member loan Balance code indicates whether this is a &quot;plain&quot; balance (1) with no pool membership change associated with it NOTE: THis is an unreviewed and unchanged Data Model term. or alternatively whether it is a balanceassociated with this mortgage (2) entering or (3) leaving the mortgage pool, or whether (4) this is a balance of a mortgage not associated with any pool Will not be in Semantic Model. Would be separate classes with a time line component.</skos:definition>
-	</owl:DatatypeProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-loan-tem-tem="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansTemporal/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansTemporal/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoansTemporal</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Loan concepts with a date or time component. For example, amounts outstanding, loan balances and interest rates at a given point in time.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansTemporal/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<rdfs:Datatype rdf:about="&xsd;string">
+bu</rdfs:Datatype>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanDrawdown">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-tem;LoanBalance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;DatedBalance"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan balance  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The outstanding balance on a loan at a particular point in time.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is the latest outstanding principal balance as at the date for which this is indicated. This also has a present value and a time series of possible past values. The time at which the amount is indicated forms part of the concept &quot;Dated monetary Amount&quot; PoC SDM Term Notes: Balance includes amount outstanding and fees In particular may record the balance outstanding at the time this loan was incorporated into some loan pool So each loan may have a number of balances associated with it recorded at different times. The loan may have been moved into and out of one or more pools. Some of the recorded ballences may be associated with the exact time and balance while this loan enters or exists a particulat pool. Other loan balances may be at different times not associated with a pool entry or exit event. Conesnsus:Review</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-tem;LoanBalanceDetermination">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan balance determination  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-tem;LoanBalanceRecord">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan balance record  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-tem;LoanDeterminer">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-tem;determines"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-tem;LoanRateDetermination"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan determiner  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-tem;LoanInterestRate">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-tem;isAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest rate  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">This is also a timed variable with a present value and a time series of past values. What is it? A record of the rates that may have been charged in a variable rate loan. Therefore, this variable is the &quot;Interest Rate&quot; of the loan. It is a &quot;Dated Parameter&quot; - dates are taken care of in the upper mode of Variable Parameters.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-loan-tem-tem;LoanRateDetermination">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-loan-tem-tem;givesRiseTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan rate determination  (please review)</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;determines">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determines  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanDeterminer"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-tem;LoanRateDetermination"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;givesRiseTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">gives rise to  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanRateDetermination"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;hasBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has balance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-tem;LoanBalance"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;hasRateRecord">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has rate record  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;isAbout">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is about  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<owl:inverseOf rdf:resource="&fibo-loan-tem-tem;hasRateRecord"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;loanBalance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan balance  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanBalance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Current Balance of the loan at the stated date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;loanBalanceAsAt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan balance as at  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanBalance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date for which current loan balance is defined. Term reduntant since Dated Monetary Amount is a dated value and so has a date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;loanInterestMarginRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest margin rate  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Remove it. But add a fact about time history of amounts on those loans where the interest amount can be change by the lender. Undefined PoC SDM Notes: Currentinterestratemargin(forfixedrateloansthisisthesameasthecurrentinterestrate,forfloatingrateloans&amp;lt;br /&amp;gt; thisisthemarginover(orunderifinputasanegative)theindexrate. &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; allows derivation of (93) Date interest rate next changes (e.g. discount margin changes, fixed period ends, loan re-fixed etc. this is not the next LIBOR reset date) &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; using : (Loan Rate.)Loan Interest Margin_rt where (loan Rate.)LoanRate_dt &amp;gt; today AND &amp;lt; any other date in the set &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; allows derivation of (94) The margin for the loan at the final step date &amp;lt;/p&amp;gt; &amp;lt;p&amp;gt; using: (Loan Rate.)Loan Interest Margin_rt where where (Loan Rate.)LoanRate_dt &amp;gt; any other date in the set &amp;lt;/p&amp;gt;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-loan-tem-tem;loanInterestRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan interest rate  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanInterestRate"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Undefined PoC SDM Notes: Requirement to derive&amp;nbsp; (85) Current interest rate (%) is satisfied by: ( Loan Rate.) Loan Intrest_rt where ; (Loan Rate. )LoanRate_dt &gt;= today AND &gt; any other date in the set Requirement to derive (92) &amp;nbsp;Next Interest Rate satisfied by: ( Loan Rate.) Loan Intrest_rt where&amp;nbsp; (Loan Rate. )LoanRate_dt ; &gt; today AND &lt; any other date in the set</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-loan-tem-tem;poolMembershipSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool membership selection  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-tem-tem;LoanBalance"/>
+bubu<rdfs:range rdf:resource="&xsd;string"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Member loan Balance code indicates whether this is a &quot;plain&quot; balance (1) with no pool membership change associated with it NOTE: THis is an unreviewed and unchanged Data Model term. or alternatively whether it is a balanceassociated with this mortgage (2) entering or (3) leaving the mortgage pool, or whether (4) this is a balance of a mortgage not associated with any pool Will not be in Semantic Model. Would be separate classes with a time line component.</skos:definition>
+bu</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/md/CIVTemporal/FundsTemporal.rdf
+++ b/md/CIVTemporal/FundsTemporal.rdf
@@ -1,224 +1,227 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-civx-fun "https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-civ-fnd-civ "https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-md-civx-fun "https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/"
-	xmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-civx-fun="https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/">
-		<rdfs:label xml:lang="en">FundsTemporal</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<rdfs:Datatype rdf:about="&xsd;string">
-	</rdfs:Datatype>
-	
-	<rdfs:Datatype rdf:about="&xsd;dateTime">
-	</rdfs:Datatype>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;Fund">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestor">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPortfolio">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnit">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;AccruedFees">
-		<rdfs:label xml:lang="en">accrued fees</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;AccruedIncome">
-		<rdfs:label xml:lang="en">accrued income</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;AccruedTaxes">
-		<rdfs:label xml:lang="en">accrued taxes</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;BidPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:label xml:lang="en">bid price</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-civx-fun;mutuallyExclusive"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;FeePayable">
-		<rdfs:label xml:lang="en">fee payable</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;FundPrice">
-		<rdfs:label xml:lang="en">fund price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;FundUnitPerformance">
-		<rdfs:label xml:lang="en">fund unit performance</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;FundsTax">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-civx-fun;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">funds tax</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;NetAssetValue">
-		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:label xml:lang="en">net asset value</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;RedemptionPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:label xml:lang="en">redemption price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;SigmaValueOfHoldings">
-		<rdfs:label xml:lang="en">sigma value of holdings</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;Swing">
-		<rdfs:label xml:lang="en">swing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;SwingPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:label xml:lang="en">swing price</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;appliesTo">
-		<rdfs:label xml:lang="en">applies to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundsTax"/>
-		<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
-		<owl:inverseOf rdf:resource="&fibo-md-civx-fun;incursTax"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;declarationTime">
-		<rdfs:label xml:lang="en">declaration time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;NetAssetValue"/>
-		<rdfs:range rdf:resource="&xsd;dateTime"/>
-		<skos:definition xml:lang="en">Time of the net asset value publication. Further Notes REVIEW: time of day, year or what?</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationDate">
-		<rdfs:label xml:lang="en">determination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The date when the price is determined. and time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationDate.1">
-		<rdfs:label xml:lang="en">determination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationPeriod">
-		<rdfs:label xml:lang="en">determination period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">THe period for which the performance is determined</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determines">
-		<rdfs:label xml:lang="en">determines</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;hasPerformance">
-		<rdfs:label xml:lang="en">has performance</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;hasPrice">
-		<rdfs:label xml:lang="en">has price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incurs">
-		<rdfs:label xml:lang="en">incurs</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FundsTax"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursFees">
-		<rdfs:label xml:lang="en">incurs fees</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursFees.1">
-		<rdfs:label xml:lang="en">incurs fees</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursTax">
-		<rdfs:label xml:lang="en">incurs tax</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FundsTax"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursTax.1">
-		<rdfs:label xml:lang="en">incurs tax</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FundsTax"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursTransactionFee">
-		<rdfs:label xml:lang="en">incurs transaction fee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-md-civx-fun;mutuallyExclusive">
-		<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
-		<rdfs:label xml:lang="en">offer price</rdfs:label>
-	</owl:Class>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;netOrGrossOfFees">
-		<rdfs:label xml:lang="en">net or gross of fees</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;valuationTime">
-		<rdfs:label xml:lang="en">valuation time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-civx-fun;NetAssetValue"/>
-		<rdfs:range rdf:resource="&xsd;dateTime"/>
-		<skos:definition xml:lang="en">Time of the price valuation for the investment fund/fund class.</skos:definition>
-	</owl:DatatypeProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-civ-fnd-civ="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-md-civx-fun="https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FundsTemporal</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Terms which have a time component (either real time, intra-day or dated terms). These include Net Present Value (NPV) and related analytics.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<rdfs:Datatype rdf:about="&xsd;dateTime">
+bu</rdfs:Datatype>
+bu
+bu<rdfs:Datatype rdf:about="&xsd;string">
+bu</rdfs:Datatype>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;Fund">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundInvestor">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundPortfolio">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-civ-fnd-civ;FundUnit">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;AccruedFees">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accrued fees</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;AccruedIncome">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accrued income</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;AccruedTaxes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accrued taxes</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;BidPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bid price</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-civx-fun;mutuallyExclusive"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;FeePayable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fee payable</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;FundPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;FundUnitPerformance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fund unit performance</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;FundsTax">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-civx-fun;appliesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funds tax</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;NetAssetValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">net asset value</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;RedemptionPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;SigmaValueOfHoldings">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sigma value of holdings</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;Swing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">swing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;SwingPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">swing price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;appliesTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applies to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundsTax"/>
+bubu<rdfs:range rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+bubu<owl:inverseOf rdf:resource="&fibo-md-civx-fun;incursTax"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;declarationTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">declaration time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-civx-fun;NetAssetValue"/>
+bubu<rdfs:range rdf:resource="&xsd;dateTime"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Time of the net asset value publication. Further Notes REVIEW: time of day, year or what?</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determination date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date when the price is determined. and time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationDate.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determination date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determinationPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determination period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">THe period for which the performance is determined</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;determines">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determines</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;Fund"/>
+bubu<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;hasPerformance">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has performance</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;hasPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-md-civx-fun;FundPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incurs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incurs</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-md-civx-fun;FundsTax"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursFees">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incurs fees</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+bubu<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursFees.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incurs fees</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursTax">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incurs tax</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundInvestor"/>
+bubu<rdfs:range rdf:resource="&fibo-md-civx-fun;FundsTax"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursTax.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incurs tax</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-md-civx-fun;FundsTax"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-civx-fun;incursTransactionFee">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">incurs transaction fee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-civ-fnd-civ;FundPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-md-civx-fun;FeePayable"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-md-civx-fun;mutuallyExclusive">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-civx-fun;FundPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offer price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;netOrGrossOfFees">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">net or gross of fees</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-civx-fun;FundUnitPerformance"/>
+bubu<rdfs:range rdf:resource="&xsd;string"/>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-civx-fun;valuationTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-civx-fun;NetAssetValue"/>
+bubu<rdfs:range rdf:resource="&xsd;dateTime"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Time of the price valuation for the investment fund/fund class.</skos:definition>
+bu</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/md/DebtTemporal/DebtAnalytics.rdf
+++ b/md/DebtTemporal/DebtAnalytics.rdf
@@ -1,609 +1,612 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
-	<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
+bu<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
-	xmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
-		<rdfs:label xml:lang="en">DebtAnalytics</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;AverageLife">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;LifeAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;takesIntoAccount"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">average life</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
-		<skos:definition xml:lang="en">An estimate of the number of terms to maturity, taking the possibility of early payments into account. Average life is calculated using the weighted average time to the receipt of all future cash flows.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Where it refers to pre-payment above, if the bond does not include prepayment then this is not included. However, analytics that refer to this e.g. Yield to Average Life, then this figure is relevant. It is not relevant for other types of bond where e.g. you would use yield to next call, yield to worst etc. Average Life used in place of Maturity for Yield Calculation. This is not only used for Yield calculations though. It is referred to as an analytic figure in its own right. Average Life uses one of a number of standard pre-payment models (for structured finance at least). For MBS, the average life includes some calculations to take account of pre-payments on the underlying mortgages. This takes account of the possibillity of borrowers paying early. This has to be modeled or forecast (not given) as it&apos;s a function of market conditions and interest rate. You would not see this in a market data feed. When you model MBS you calculate Average Life as part of the model i.e. you estimate the percentage of prepayment in the next x length of time and factor this into the Average Life. Refers to Weighted Average Time to receipt of future cash flows. For MBS, early payments will shorten the Average Life. For Student Loans, Credit Card, Loan etc, i.e. all Pool Backed (any bond that has securitized debt). Other bonds: Sinking Funds etc., also Early Payment - partial Call for a corporate / regular bond. Early Payment for pass through has the same effect. Sinking Fund: Each payment is part principal and part interest, this is implicit in the overall definition of &quot;Early payment&quot;.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;AverageLifeAtIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
-		<rdfs:label xml:lang="en">average life at issue</rdfs:label>
-		<skos:definition xml:lang="en">The Average Life analytic at the time the security was issued.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtConvexityAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;CurveConvexity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;definedInRelationTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;isRateOfChangeOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt convexity analytic</rdfs:label>
-		<skos:definition xml:lang="en">The second derivative of a security&apos;s price with respect to its yield, divided by the security&apos;s price. A security exhibits positive convexity when its price rises more for a downward move in its yield than its price declines for an equal upward move in its yield. Further notes: A measure of the change in price for a given change in Modified Duration. This always (necessarily) refers to Modified Duration. This is used as another risk measurement. Numerator is always (a) duration - either MacCaulays or Modified. Always rate of change of (one of the) Duration against some other parameter. The other paramater can be characterised as a Yield (it may be the Price, but that has a relationship to the Yield in any case). REVIEW: Inconsistency in the above - is it always necessarily Modified Duration that is referred to, or &quot;any&quot; Duration measure (Macaulays and.or Modified)? notes 9 Dec A measure of the sensitivity of the price with reference to interest rates. This is normally determined with reference to maturity, but since there are different maturity dates, this figure gives an estimate of the equitvalent if you had a homogenous portfolio, i.e. this is an estimate based on a pure equivalent, homogenous portfolio. Convexity of instrument versus portfolio. Sees instrument in terms of the set of cashflows. The term Convexity can be applied either to a bond or to a portfolio. More notes: When you get Convexit in MD, it will tell you what Duration it is refrfering to, along with Redemption Date (logically). Also if there is Option Adjusted Yield, there is a third set of analytics. What are they? i.e. OA Convexity, Duration Yield and the rest. Conclusions: Agreed to revisit this in OTC.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;providesAnalysisAbout"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt instrument analytical parameter</rdfs:label>
-		<skos:definition xml:lang="en">Parameter describing some aspect of the behaviour of a debt instrument, that may vary over time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtInstrumentPoolAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:label xml:lang="en">debt instrument pool analytic</rdfs:label>
-		<skos:definition xml:lang="en">A measure of some aspect of the behaviour or a pool of securitized debt i.e. a pool of debt instruments. Futher Notes: Nothing defined under this yet. We have analytics for pools of individual debt products (mortgages, loans, auto loans), but not the equivalent sorts of terms implied for a securitixed debt pool. Presumably these would be aggregate terms similar or equivalent to analytics for debt instruments, such as yield, average live, convixity and so on. As such these would be similar to porfolio analytics (not modeled).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtPool">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasAnalytic"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasFactor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PoolAnalyticalParameter"/>
-		<rdfs:label xml:lang="en">debt pool analytical parameter</rdfs:label>
-		<skos:definition xml:lang="en">A measure of some aspect of some pool of debt, such as a pool of loans or a pool of securitized debt products.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;DurationAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">duration analytic</rdfs:label>
-		<skos:definition xml:lang="en">Weighted average time to receipt of all the payments.</skos:definition>
-		<skos:editorialNote xml:lang="en">Duration in general is a measure of % price change for a given change in yield. See definition from BMB The duration on a traditional bond will be much shorter than the duration relative to the maturity. Duration is the first derivative of the curve between Price and Yield. There are multiple types of duration, all of which are variants of this. So Duration is the first derivative and the different type of duration measure are different ways of measuring this, for example a &quot;quick and dirty&quot; measure of duration or one which.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;EffectiveDuration">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
-		<rdfs:label xml:lang="en">effective duration</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;EquivalentLifeAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;LifeAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;derivedUsing"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PartialCallsEstimationModel"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;refersTo.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;BondWithPartialCall"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equivalent life analytic</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;EquivalentYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;RelativeYieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;isDefaultIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;BondMarket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equivalent yield calculation method</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;FFIECDown300PrepaySpeed">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-		<rdfs:label xml:lang="en">f f i e c down 300 prepay speed</rdfs:label>
-		<skos:definition xml:lang="en">Public Securities Association (PSA) speed used for the underlying collateral for cash-flow calculations in the &quot;down 300&quot; scenario.</skos:definition>
-		<skos:editorialNote xml:lang="en">Detailed parameters to follow, but basically these three PSA terms are differentiated by the fact that they reference 3 different prepayment models, so each of these will refer to a sub-type of the term &quot;Loan Pool Prepayment Model&quot;. For now the semantics are defined only in this written definition. Add model variants and terms in a future version.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;FFIECUp300PrepaySpeed">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-		<rdfs:label xml:lang="en">f f i e c up 300 prepay speed</rdfs:label>
-		<skos:definition xml:lang="en">Public Securities Association (PSA) speed used for the underlying collateral for cash-flow calculations in the &quot;up 300&quot; scenario.</skos:definition>
-		<skos:editorialNote xml:lang="en">Detailed parameters to follow, but basically these three PSA terms are differentiated by the fact that they reference 3 different prepayment models, so each of these will refer to a sub-type of the term &quot;Loan Pool Prepayment Model&quot;. For now the semantics are defined only in this written definition. Add model variants and terms in a future version.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;ICMAYieldFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationFormula"/>
-		<rdfs:label xml:lang="en">i c m a yield formula</rdfs:label>
-		<skos:definition xml:lang="en">The calculation method specified by ICMA (formerly ISMA) for determination of yield for fixed-rate bonds.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This basic formula is used across many markets, including the US and most of Europe. While individual markets may have different flavors (French round their bonds to 5 decimals, UK Gilts have ex-div), the formula is still the same. This would be the formula used by &quot;Wall Street Yield&quot;, &quot;US Treasury Yield&quot;, &quot;Corporate Bond Yield&quot; etc. Notes Origin:Fidessa</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;ImpliedForwardRate">
-		<rdfs:label xml:lang="en">implied forward rate</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;isAggregateOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">instrument aggregate loan analytic</rdfs:label>
-		<skos:definition xml:lang="en">Parameters that describe some feature of loan pools or mortgage pools, aggregated and defined at the level of the instrument (i.e. the tranche or class of security within the issue).</skos:definition>
-		<skos:editorialNote xml:lang="en">for some of these there may also be a similar aggregated figure at the level of the issue (i.e. for a whole MBS issue) and for some there would not. To be determined</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;aggregateOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageLoanAge"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">instrument weighted average loan age</rdfs:label>
-		<skos:definition xml:lang="en">A dollar-weighted average measuring the age of the individual loans in a mortgage pass-through or pooled security, such as Ginnie Mae or a Freddie Mac security. The WALA is measured as the time in months since the origination of the loans, with the weighting based on each loan&apos;s size in proportion to the aggregate total of the pool.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is defined by the issuer. WALA is more official, not an analysis from a vendor. This changes but the values are relayed by the issuer on an ongoing basis. Investopedia explains Weighted Average Loan Age - WALA The weighted average age will change over time as some mortgages get paid off faster than others. Based on the issuer of the mortgage-backed securities (MBS), the WALA may be weighted on the remaining principal balance dollar figure, or the beginning notional value of the loan. The flip side of the WALA is the weighted average maturity (WAM), which is a dollar-weighted measure of the months remaining until the principal amounts are completely repaid on each loan in the pool.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;aggregateOf.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageRemainingMaturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">instrument weighted average remaining maturity</rdfs:label>
-		<skos:definition xml:lang="en">The weighted average of the time until all maturities on loans in a mortgage-backed or asset backed security. The higher the weighted average to maturity of the loans, the longer the loans in the security have until maturity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;InternallyDeterminedPriceSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPriceSpread"/>
-		<rdfs:label xml:lang="en">internally determined price spread</rdfs:label>
-		<skos:definition xml:lang="en">The spread determined internally within the organisation from information available at their own trading desks. Further Notes Internal prices within a bank would be determined by surveying their own traders. So e.g. corporate desk trades these 30 bonds, get the daily spreads on those at the end of the day and calculate the price. The traders determine the pricing during the based on market movements. (this is all for OTC traded bonds, not exchange traded bonds).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;KeyRateDuration">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
-		<rdfs:label xml:lang="en">key rate duration</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;LifeAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
-		<rdfs:label xml:lang="en">life analytic</rdfs:label>
-		<skos:definition xml:lang="en">Some measure of the life of a security, other than the actual time to maturity itself. This is a derived figure, based on certain parameters as appropriate to that type of instrument, to give a figure that is equivalent to and similar to the basic maturity of the instrument, for the purposes of analysing that security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;MaturityEquivalentPSA">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-		<rdfs:label xml:lang="en">maturity equivalent p s a</rdfs:label>
-		<skos:definition xml:lang="en">Prepayment speed that results in the same average life as that computed for the Collateralized Mortgage Obligation (CMO), Asset Backed Securities (ABS) or Mortgage Backed Securities (MBS) using the Maturity Prepay Model.</skos:definition>
-		<skos:editorialNote xml:lang="en">Detailed parameters to follow, but basically these three PSA terms are differentiated by the fact that they reference 3 different prepayment models, so each of these will refer to a sub-type of the term &quot;Loan Pool Prepayment Model&quot;. For now the semantics are defined only in this written definition. Add model variants and terms in a future version.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;ModifiedDurationAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;refersTo.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">modified duration analytic</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic"/>
-		<skos:definition xml:lang="en">The percentage price change of a security for a given change in yield. The higher the modified duration of a security, the higher its risk. Ad/ModDuration = [duration / {1 + (IRR/M)}]; where IRR is the internal rate of return and M is the number of compounding periods per year.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The higher the MD the greater the change in price for a given change in yield.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
-		<rdfs:label xml:lang="en">mortgage instrument weighted average remaining maturity</rdfs:label>
-		<skos:definition xml:lang="en">The weighted average of the time until all maturities on mortgages in a mortgage-backed security (MBS). The higher the weighted average to maturity, the longer the mortgages in the security have until maturity.</skos:definition>
-		<skos:editorialNote xml:lang="en">Synonym (if this is the same term): Also known as &quot;average effective maturity&quot;. Investopedia explains Weighted Average Maturity - WAM The measure is calculated by totaling each mortgage value represented by the MBS. The weights of each mortgage is found by dividing the value of each into the total of all. To arrive at the WAM number the weight of each security is multiplied by the time until maturity of each mortgage, and then all the values are added together. For example say an MBS has three mortgages valued at $1,000, $2,000 and $3,000 (a total of $6,000) and mature in one, two and three years respectively. The weights of these are 1/6 (1,000/6,000), 1/3 (2,000/6,000) and 1/2 (3,000/6,000). The WAM is 2 1/3 years (1/6 x 1 year + 1/3 x 2 years + 1/2 x 3 years). Analysis: this investopedia decription does not take account of there being more than one Pool behind the MBS.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PVBP">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;definedInRelationTo.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">p v b p</rdfs:label>
-		<skos:definition xml:lang="en">Sensitivity of the price for one basis point change in yield, defined as the difference in price given 1 bp change in yield.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Price value of Basis Point Definition: The difference in price given 1 bp change in yield. This is like Duration but normalized to 1 basis point. Synonym DV01</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PartialCallsEstimationModel">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticsCalculationModel"/>
-		<rdfs:label xml:lang="en">partial calls estimation model</rdfs:label>
-		<skos:definition xml:lang="en">A model of how the early partial calls are estimated.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolAnalyticalParameter">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
-		<rdfs:label xml:lang="en">pool analytical parameter</rdfs:label>
-		<skos:definition xml:lang="en">Paramater that describes some aspect of the behaviour of some kind of pool.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolFactor">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ReferenceFactor"/>
-		<rdfs:label xml:lang="en">pool factor</rdfs:label>
-		<skos:definition xml:lang="en">How much of the original pool is still outstanding. This is a number below one. Expressed as percentage.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Would multiply the factor by the starting value of the pool. This determines how much it is paying down. Would take the form of a 10 digit decimal factor showing how much of the pool is outstanding. You get Factor information every month or so which includes the WAM figure (and the WALA and WAC). The rate can be derived from this. that would be the rate at which the pool is paying down. These all come from the issuer.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolPaydownRate">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;derivedFrom.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool paydown rate</rdfs:label>
-		<skos:definition xml:lang="en">The rate at which the pool is paying down. This is based on observed factor. CPR, SMM, etc. etc. Measured differently for different kinds of security. CBO might have a prepayment rate for example if the underlying bond is callable. with a non agency mortgge dela, defualts will effect this. so for instance there is principal is no lnger inthe pool because the mortgagee defaults. With agency these are not taken out in the case of default but for non agency these mortgages are removed from the pool if and when a mortgagee defualts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolWeightedAverageLoanAge">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;derivedFrom"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanAge"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool weighted average loan age</rdfs:label>
-		<skos:definition xml:lang="en">A dollar-weighted average measuring the age of the individual loans in a mortgage pass-through or pooled security, such as Ginnie Mae or a Freddie Mac security. The WALA is measured as the time in months since the origination of the loans, with the weighting based on each loan&apos;s size in proportion to the aggregate total of the pool.</skos:definition>
-		<skos:editorialNote xml:lang="en">Adaptation taken from the instrument level figure. This definition looks as though it may already be defined with reference to the Loan Pool. Note also that this figure is specific to Pass Through securities. These are mutually exclusive with Tranched securities (static model update to come).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolWeightedAverageRemainingMaturity">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;derivedFrom.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool weighted average remaining maturity</rdfs:label>
-		<skos:definition xml:lang="en">The weighted average of the time until all maturities on loans in a pool. The higher the weighted average to maturity of the loans, the longer the loans in the pool have until maturity. REVIEW: Adapted from instrument specific definition from Investopedia. Review of 23 September identified that certain figures exist for pool and for instrument, whereas Investopedia definition was for Instrument (tranche, class etc.).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PrepaymentSpeed">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;determinedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanPoolPrepaymentModel"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">prepayment speed</rdfs:label>
-		<skos:definition xml:lang="en">The rate at which the pool is paying down.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is a model. Includes other factors such as homogeniety. Earlier notes: Same as Payment. Curtailment. Paydown is normally scheduled payments of the mortgage. Prepayment is when someone pays off the mortgage early I may send in 1500 when my monthly amount is 1000 a month. So the 500 is a prepayment. Scheduled principal payment. More notes 25 nov: Also factor in changes to the pool constituents where this is allowed for that kind of MBS. So we make estimates of how face value will will change. face value won&apos;t change but the underlying value of the Pf changes, so eg. the current mortgage factor. Model update note June 2010: Detailed types of &quot;Prepayment Speed&quot; analytic received from thomson Reuters, now modeled as sub types of this term. So term origin is PSA by extension, since this is the common super class of 3 specific prepayment speed analytic types defined by PSA. PSA stands for Public Securities Association. Type: PSA gives this as numeric, however definitions imply percentage, so defined as dated percentage for now. Many data models use numbers which are interpreted later as percentages so this may be the case here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-aly;PriceAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;MarketData"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;derivedFrom"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Price"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">price analytic</rdfs:label>
-		<skos:definition xml:lang="en">Information that is about prices, rather than actually being a price.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;aggregateOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-aly;isAggregateOf"/>
-		<rdfs:label xml:lang="en">aggregate of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageLoanAge"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;aggregateOf.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-aly;isAggregateOf"/>
-		<rdfs:label xml:lang="en">aggregate of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageRemainingMaturity"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-aly;averageLifeDateAtIssue">
-		<rdfs:label xml:lang="en">average life date at issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;AverageLifeAtIssue"/>
-		<skos:definition xml:lang="en">The date equivalent to the Average Life figure, as measured at Issue Date.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;averageLifeValue">
-		<rdfs:label xml:lang="en">average life value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-		<skos:definition xml:lang="en">The value of the Average Life analytic at some time in the past or at the present. For MBS this would be expressed as a month eg 50 months.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;averageLifeValue.1">
-		<rdfs:label xml:lang="en">average life value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;AverageLifeAtIssue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateSpecification"/>
-		<skos:definition xml:lang="en">The value of the Average Life analytic at the time the security was issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;decimalPlaces">
-		<rdfs:label xml:lang="en">decimal places</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of decimal places used in the publication of the factor value.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;definedInRelationTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
-		<rdfs:label xml:lang="en">defined in relation to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtConvexityAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;definedInRelationTo.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
-		<rdfs:label xml:lang="en">defined in relation to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PVBP"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;derivedUsing">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;derivedFrom"/>
-		<rdfs:label xml:lang="en">derived using</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PartialCallsEstimationModel"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;determinedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;derivedFrom"/>
-		<rdfs:label xml:lang="en">determined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;LoanPoolPrepaymentModel"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;equivalentLifeValue">
-		<rdfs:label xml:lang="en">equivalent life value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-		<skos:definition xml:lang="en">The Equivalent Life in years at the stated date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;factorValue">
-		<rdfs:label xml:lang="en">factor value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The factor, expressed as a numeric amount in the past or present.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;has.1">
-		<rdfs:label xml:lang="en">has instrument analytic</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasAnalytic">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
-		<rdfs:label xml:lang="en">has analytic</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtPool"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasFactor">
-		<rdfs:label xml:lang="en">has factor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtPool"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasMeasure">
-		<rdfs:label xml:lang="en">has measure</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;isAggregateOf">
-		<rdfs:label xml:lang="en">is aggregate of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;isDefaultIn">
-		<rdfs:label xml:lang="en">is default in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;EquivalentYieldCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;BondMarket"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;isRateOfChangeOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;analyzes"/>
-		<rdfs:label xml:lang="en">is rate of change of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtConvexityAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;modifiedDurationValue">
-		<rdfs:label xml:lang="en">modified duration value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;ModifiedDurationAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-		<skos:definition xml:lang="en">The Modified Duration in Years.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;prepaymentSpeedValue">
-		<rdfs:label xml:lang="en">prepayment speed value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedPercentage"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;refersTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;analyzes"/>
-		<rdfs:label xml:lang="en">makes reference to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;refersTo.1">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;BondWithPartialCall"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;refersTo.2">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;ModifiedDurationAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;takesIntoAccount">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
-		<rdfs:label xml:lang="en">takes into account</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;value">
-		<rdfs:label xml:lang="en">value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtConvexityAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
-		<skos:definition xml:lang="en">The numeric value of the Convexity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;value.2">
-		<rdfs:label xml:lang="en">value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PVBP"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The value of the PVBP expressed as a price change, with price denominated in percentage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;wALAValue">
-		<rdfs:label xml:lang="en">w a l a value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-		<skos:definition xml:lang="en">The weighted average loan age, at some point in the past or present.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;wARMValue">
-		<rdfs:label xml:lang="en">w a r m value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-		<skos:definition xml:lang="en">The amount of the WARM in the past or present.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasMeasure"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;has.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;has.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
+buxmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtAnalytics</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology covers an extensive range of analytical measures for debt instruments and pools of debt instruments. These cover the well-known concepts of convexity, duration and life, as well as weighted average loan ages and maturities, prepayments speeds etc. for debt pools. Most of the widely referenced variants of these are included, for example modified duration. Some yield related concepts (e.g. for equivalent yield) are also included.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;AverageLife">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;LifeAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;takesIntoAccount"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">average life</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An estimate of the number of terms to maturity, taking the possibility of early payments into account. Average life is calculated using the weighted average time to the receipt of all future cash flows.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Where it refers to pre-payment above, if the bond does not include prepayment then this is not included. However, analytics that refer to this e.g. Yield to Average Life, then this figure is relevant. It is not relevant for other types of bond where e.g. you would use yield to next call, yield to worst etc. Average Life used in place of Maturity for Yield Calculation. This is not only used for Yield calculations though. It is referred to as an analytic figure in its own right. Average Life uses one of a number of standard pre-payment models (for structured finance at least). For MBS, the average life includes some calculations to take account of pre-payments on the underlying mortgages. This takes account of the possibillity of borrowers paying early. This has to be modeled or forecast (not given) as it&apos;s a function of market conditions and interest rate. You would not see this in a market data feed. When you model MBS you calculate Average Life as part of the model i.e. you estimate the percentage of prepayment in the next x length of time and factor this into the Average Life. Refers to Weighted Average Time to receipt of future cash flows. For MBS, early payments will shorten the Average Life. For Student Loans, Credit Card, Loan etc, i.e. all Pool Backed (any bond that has securitized debt). Other bonds: Sinking Funds etc., also Early Payment - partial Call for a corporate / regular bond. Early Payment for pass through has the same effect. Sinking Fund: Each payment is part principal and part interest, this is implicit in the overall definition of &quot;Early payment&quot;.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;AverageLifeAtIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">average life at issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Average Life analytic at the time the security was issued.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtConvexityAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;CurveConvexity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;definedInRelationTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;isRateOfChangeOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt convexity analytic</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The second derivative of a security&apos;s price with respect to its yield, divided by the security&apos;s price. A security exhibits positive convexity when its price rises more for a downward move in its yield than its price declines for an equal upward move in its yield. Further notes: A measure of the change in price for a given change in Modified Duration. This always (necessarily) refers to Modified Duration. This is used as another risk measurement. Numerator is always (a) duration - either MacCaulays or Modified. Always rate of change of (one of the) Duration against some other parameter. The other paramater can be characterised as a Yield (it may be the Price, but that has a relationship to the Yield in any case). REVIEW: Inconsistency in the above - is it always necessarily Modified Duration that is referred to, or &quot;any&quot; Duration measure (Macaulays and.or Modified)? notes 9 Dec A measure of the sensitivity of the price with reference to interest rates. This is normally determined with reference to maturity, but since there are different maturity dates, this figure gives an estimate of the equitvalent if you had a homogenous portfolio, i.e. this is an estimate based on a pure equivalent, homogenous portfolio. Convexity of instrument versus portfolio. Sees instrument in terms of the set of cashflows. The term Convexity can be applied either to a bond or to a portfolio. More notes: When you get Convexit in MD, it will tell you what Duration it is refrfering to, along with Redemption Date (logically). Also if there is Option Adjusted Yield, there is a third set of analytics. What are they? i.e. OA Convexity, Duration Yield and the rest. Conclusions: Agreed to revisit this in OTC.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;providesAnalysisAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt instrument analytical parameter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Parameter describing some aspect of the behaviour of a debt instrument, that may vary over time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtInstrumentPoolAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt instrument pool analytic</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure of some aspect of the behaviour or a pool of securitized debt i.e. a pool of debt instruments. Futher Notes: Nothing defined under this yet. We have analytics for pools of individual debt products (mortgages, loans, auto loans), but not the equivalent sorts of terms implied for a securitixed debt pool. Presumably these would be aggregate terms similar or equivalent to analytics for debt instruments, such as yield, average live, convixity and so on. As such these would be similar to porfolio analytics (not modeled).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtPool">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasAnalytic"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasFactor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PoolAnalyticalParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt pool analytical parameter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure of some aspect of some pool of debt, such as a pool of loans or a pool of securitized debt products.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;DurationAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">duration analytic</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Weighted average time to receipt of all the payments.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Duration in general is a measure of % price change for a given change in yield. See definition from BMB The duration on a traditional bond will be much shorter than the duration relative to the maturity. Duration is the first derivative of the curve between Price and Yield. There are multiple types of duration, all of which are variants of this. So Duration is the first derivative and the different type of duration measure are different ways of measuring this, for example a &quot;quick and dirty&quot; measure of duration or one which.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;EffectiveDuration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effective duration</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;EquivalentLifeAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;LifeAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;derivedUsing"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PartialCallsEstimationModel"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;refersTo.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;BondWithPartialCall"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equivalent life analytic</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;EquivalentYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;RelativeYieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;isDefaultIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;BondMarket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equivalent yield calculation method</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;FFIECDown300PrepaySpeed">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">f f i e c down 300 prepay speed</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Public Securities Association (PSA) speed used for the underlying collateral for cash-flow calculations in the &quot;down 300&quot; scenario.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Detailed parameters to follow, but basically these three PSA terms are differentiated by the fact that they reference 3 different prepayment models, so each of these will refer to a sub-type of the term &quot;Loan Pool Prepayment Model&quot;. For now the semantics are defined only in this written definition. Add model variants and terms in a future version.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;FFIECUp300PrepaySpeed">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">f f i e c up 300 prepay speed</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Public Securities Association (PSA) speed used for the underlying collateral for cash-flow calculations in the &quot;up 300&quot; scenario.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Detailed parameters to follow, but basically these three PSA terms are differentiated by the fact that they reference 3 different prepayment models, so each of these will refer to a sub-type of the term &quot;Loan Pool Prepayment Model&quot;. For now the semantics are defined only in this written definition. Add model variants and terms in a future version.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;ICMAYieldFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationFormula"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i c m a yield formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The calculation method specified by ICMA (formerly ISMA) for determination of yield for fixed-rate bonds.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This basic formula is used across many markets, including the US and most of Europe. While individual markets may have different flavors (French round their bonds to 5 decimals, UK Gilts have ex-div), the formula is still the same. This would be the formula used by &quot;Wall Street Yield&quot;, &quot;US Treasury Yield&quot;, &quot;Corporate Bond Yield&quot; etc. Notes Origin:Fidessa</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;ImpliedForwardRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">implied forward rate</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;isAggregateOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instrument aggregate loan analytic</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Parameters that describe some feature of loan pools or mortgage pools, aggregated and defined at the level of the instrument (i.e. the tranche or class of security within the issue).</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">for some of these there may also be a similar aggregated figure at the level of the issue (i.e. for a whole MBS issue) and for some there would not. To be determined</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;aggregateOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageLoanAge"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instrument weighted average loan age</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A dollar-weighted average measuring the age of the individual loans in a mortgage pass-through or pooled security, such as Ginnie Mae or a Freddie Mac security. The WALA is measured as the time in months since the origination of the loans, with the weighting based on each loan&apos;s size in proportion to the aggregate total of the pool.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is defined by the issuer. WALA is more official, not an analysis from a vendor. This changes but the values are relayed by the issuer on an ongoing basis. Investopedia explains Weighted Average Loan Age - WALA The weighted average age will change over time as some mortgages get paid off faster than others. Based on the issuer of the mortgage-backed securities (MBS), the WALA may be weighted on the remaining principal balance dollar figure, or the beginning notional value of the loan. The flip side of the WALA is the weighted average maturity (WAM), which is a dollar-weighted measure of the months remaining until the principal amounts are completely repaid on each loan in the pool.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;aggregateOf.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageRemainingMaturity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instrument weighted average remaining maturity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The weighted average of the time until all maturities on loans in a mortgage-backed or asset backed security. The higher the weighted average to maturity of the loans, the longer the loans in the security have until maturity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;InternallyDeterminedPriceSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPriceSpread"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">internally determined price spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The spread determined internally within the organisation from information available at their own trading desks. Further Notes Internal prices within a bank would be determined by surveying their own traders. So e.g. corporate desk trades these 30 bonds, get the daily spreads on those at the end of the day and calculate the price. The traders determine the pricing during the based on market movements. (this is all for OTC traded bonds, not exchange traded bonds).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;KeyRateDuration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">key rate duration</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;LifeAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">life analytic</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some measure of the life of a security, other than the actual time to maturity itself. This is a derived figure, based on certain parameters as appropriate to that type of instrument, to give a figure that is equivalent to and similar to the basic maturity of the instrument, for the purposes of analysing that security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;MaturityEquivalentPSA">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity equivalent p s a</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Prepayment speed that results in the same average life as that computed for the Collateralized Mortgage Obligation (CMO), Asset Backed Securities (ABS) or Mortgage Backed Securities (MBS) using the Maturity Prepay Model.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Detailed parameters to follow, but basically these three PSA terms are differentiated by the fact that they reference 3 different prepayment models, so each of these will refer to a sub-type of the term &quot;Loan Pool Prepayment Model&quot;. For now the semantics are defined only in this written definition. Add model variants and terms in a future version.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;ModifiedDurationAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;refersTo.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">modified duration analytic</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage price change of a security for a given change in yield. The higher the modified duration of a security, the higher its risk. Ad/ModDuration = [duration / {1 + (IRR/M)}]; where IRR is the internal rate of return and M is the number of compounding periods per year.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The higher the MD the greater the change in price for a given change in yield.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage instrument weighted average remaining maturity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The weighted average of the time until all maturities on mortgages in a mortgage-backed security (MBS). The higher the weighted average to maturity, the longer the mortgages in the security have until maturity.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Synonym (if this is the same term): Also known as &quot;average effective maturity&quot;. Investopedia explains Weighted Average Maturity - WAM The measure is calculated by totaling each mortgage value represented by the MBS. The weights of each mortgage is found by dividing the value of each into the total of all. To arrive at the WAM number the weight of each security is multiplied by the time until maturity of each mortgage, and then all the values are added together. For example say an MBS has three mortgages valued at $1,000, $2,000 and $3,000 (a total of $6,000) and mature in one, two and three years respectively. The weights of these are 1/6 (1,000/6,000), 1/3 (2,000/6,000) and 1/2 (3,000/6,000). The WAM is 2 1/3 years (1/6 x 1 year + 1/3 x 2 years + 1/2 x 3 years). Analysis: this investopedia decription does not take account of there being more than one Pool behind the MBS.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;PVBP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;definedInRelationTo.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">p v b p</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Sensitivity of the price for one basis point change in yield, defined as the difference in price given 1 bp change in yield.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Price value of Basis Point Definition: The difference in price given 1 bp change in yield. This is like Duration but normalized to 1 basis point. Synonym DV01</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;PartialCallsEstimationModel">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticsCalculationModel"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partial calls estimation model</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A model of how the early partial calls are estimated.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolAnalyticalParameter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool analytical parameter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Paramater that describes some aspect of the behaviour of some kind of pool.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolFactor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ReferenceFactor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool factor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How much of the original pool is still outstanding. This is a number below one. Expressed as percentage.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Would multiply the factor by the starting value of the pool. This determines how much it is paying down. Would take the form of a 10 digit decimal factor showing how much of the pool is outstanding. You get Factor information every month or so which includes the WAM figure (and the WALA and WAC). The rate can be derived from this. that would be the rate at which the pool is paying down. These all come from the issuer.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolPaydownRate">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;derivedFrom.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool paydown rate</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rate at which the pool is paying down. This is based on observed factor. CPR, SMM, etc. etc. Measured differently for different kinds of security. CBO might have a prepayment rate for example if the underlying bond is callable. with a non agency mortgge dela, defualts will effect this. so for instance there is principal is no lnger inthe pool because the mortgagee defaults. With agency these are not taken out in the case of default but for non agency these mortgages are removed from the pool if and when a mortgagee defualts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolWeightedAverageLoanAge">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;derivedFrom"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanAge"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool weighted average loan age</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A dollar-weighted average measuring the age of the individual loans in a mortgage pass-through or pooled security, such as Ginnie Mae or a Freddie Mac security. The WALA is measured as the time in months since the origination of the loans, with the weighting based on each loan&apos;s size in proportion to the aggregate total of the pool.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Adaptation taken from the instrument level figure. This definition looks as though it may already be defined with reference to the Loan Pool. Note also that this figure is specific to Pass Through securities. These are mutually exclusive with Tranched securities (static model update to come).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;PoolWeightedAverageRemainingMaturity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;derivedFrom.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool weighted average remaining maturity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The weighted average of the time until all maturities on loans in a pool. The higher the weighted average to maturity of the loans, the longer the loans in the pool have until maturity. REVIEW: Adapted from instrument specific definition from Investopedia. Review of 23 September identified that certain figures exist for pool and for instrument, whereas Investopedia definition was for Instrument (tranche, class etc.).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;PrepaymentSpeed">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;determinedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanPoolPrepaymentModel"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prepayment speed</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rate at which the pool is paying down.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is a model. Includes other factors such as homogeniety. Earlier notes: Same as Payment. Curtailment. Paydown is normally scheduled payments of the mortgage. Prepayment is when someone pays off the mortgage early I may send in 1500 when my monthly amount is 1000 a month. So the 500 is a prepayment. Scheduled principal payment. More notes 25 nov: Also factor in changes to the pool constituents where this is allowed for that kind of MBS. So we make estimates of how face value will will change. face value won&apos;t change but the underlying value of the Pf changes, so eg. the current mortgage factor. Model update note June 2010: Detailed types of &quot;Prepayment Speed&quot; analytic received from thomson Reuters, now modeled as sub types of this term. So term origin is PSA by extension, since this is the common super class of 3 specific prepayment speed analytic types defined by PSA. PSA stands for Public Securities Association. Type: PSA gives this as numeric, however definitions imply percentage, so defined as dated percentage for now. Many data models use numbers which are interpreted later as percentages so this may be the case here.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-aly;PriceAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;MarketData"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;derivedFrom"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Price"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price analytic</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information that is about prices, rather than actually being a price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;aggregateOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-aly;isAggregateOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">aggregate of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageLoanAge"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;aggregateOf.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-aly;isAggregateOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">aggregate of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PoolWeightedAverageRemainingMaturity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-aly;averageLifeDateAtIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">average life date at issue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;AverageLifeAtIssue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date equivalent to the Average Life figure, as measured at Issue Date.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;averageLifeValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">average life value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the Average Life analytic at some time in the past or at the present. For MBS this would be expressed as a month eg 50 months.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;averageLifeValue.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">average life value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;AverageLifeAtIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DateSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the Average Life analytic at the time the security was issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;decimalPlaces">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">decimal places</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of decimal places used in the publication of the factor value.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;definedInRelationTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined in relation to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtConvexityAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;definedInRelationTo.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined in relation to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PVBP"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;derivedUsing">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;derivedFrom"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derived using</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PartialCallsEstimationModel"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;determinedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;derivedFrom"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;LoanPoolPrepaymentModel"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;equivalentLifeValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equivalent life value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Equivalent Life in years at the stated date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;factorValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">factor value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The factor, expressed as a numeric amount in the past or present.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;has.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has instrument analytic</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasAnalytic">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has analytic</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtPool"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasFactor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has factor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtPool"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PoolFactor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;hasMeasure">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has measure</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;isAggregateOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is aggregate of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;isDefaultIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is default in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;EquivalentYieldCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;BondMarket"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;isRateOfChangeOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;analyzes"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is rate of change of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtConvexityAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;modifiedDurationValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">modified duration value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;ModifiedDurationAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Modified Duration in Years.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;prepaymentSpeedValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prepayment speed value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedPercentage"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;refersTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;analyzes"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">makes reference to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;refersTo.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;BondWithPartialCall"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;refersTo.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;ModifiedDurationAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;takesIntoAccount">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes into account</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;value">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;DebtConvexityAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The numeric value of the Convexity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;value.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;PVBP"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the PVBP expressed as a price change, with price denominated in percentage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;wALAValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">w a l a value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The weighted average loan age, at some point in the past or present.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-aly;wARMValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">w a r m value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of the WARM in the past or present.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasMeasure"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;PrepaymentSpeed"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;has.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageRemainingMaturity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;has.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;InstrumentWeightedAverageLoanAge"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/md/DebtTemporal/DebtInterestAmounts.rdf
+++ b/md/DebtTemporal/DebtInterestAmounts.rdf
@@ -1,180 +1,184 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
-		<rdfs:label xml:lang="en">DebtInterestAmounts</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;BondCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ContractuallyDefinedNumericalParameter"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;DebtSecurityInterestAmount"/>
-		<rdfs:label xml:lang="en">bond coupon</rdfs:label>
-		<skos:definition xml:lang="en">Mechanism whereby an investor receives income from interest payments, which are usually made periodically.</skos:definition>
-		<fibo-fnd-utl-av:synonym xml:lang="en">bond interest</fibo-fnd-utl-av:synonym>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;BondFixedCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondCoupon"/>
-		<rdfs:label xml:lang="en">bond fixed coupon</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
-		<skos:definition xml:lang="en">Mechanism whereby an investor receives income from interest payments, which are usually made periodically. These are for a fixed amount.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;BondVariableCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondCoupon"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;projectedValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;ProjectedCouponPaymentValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond variable coupon</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;DebtInstrumentReferenceRate">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-		<rdfs:label xml:lang="en">debt instrument reference rate</rdfs:label>
-		<skos:definition xml:lang="en">The interest rate of some debt instrument which is referred to in calculations of some sort.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example a US Treasury Bill interest Rate, used in quoting prices by way of spreads against this instrument. Also potentially an instrument the interest rate of which is used as the Base in a Floating Rate Note or other variable debt coupon formula.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;DebtSecurityInterestAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:label xml:lang="en">debt security interest amount</rdfs:label>
-		<skos:definition xml:lang="en">The amount of interest paid out on a debt security at a given point in time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;FRNCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
-		<rdfs:label xml:lang="en">f r n coupon</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;IndexLinkedCoupon"/>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;InflationBondVariableCoupon"/>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;WACBondCoupon"/>
-		<skos:definition xml:lang="en">Mechanism whereby an investor receives income from interest payments, which are usually made periodically. These are for a variable amount based on a specified Interest rate.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;IndexLinkedCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
-		<rdfs:label xml:lang="en">index linked coupon</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;InflationBondVariableCoupon"/>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;WACBondCoupon"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;InflationBondFactor">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ReferenceFactor"/>
-		<rdfs:label xml:lang="en">inflation bond factor</rdfs:label>
-		<skos:definition xml:lang="en">The factor which is used in determining the principal on an inflation bond. This is used either in calculating the interest payments, in calculating the principal payback or more typically both. Further notes: This is a dated parameter, that is it varies over time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;InflationBondVariableCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
-		<rdfs:label xml:lang="en">inflation bond variable coupon</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;WACBondCoupon"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;ProjectedCouponPaymentValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
-		<rdfs:label xml:lang="en">projected coupon payment value</rdfs:label>
-		<skos:definition xml:lang="en">Projected Coupon amount, along with parameters defining when and how this is projected.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;TreasuryBillInterestRateValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-		<rdfs:label xml:lang="en">treasury bill interest rate value</rdfs:label>
-		<skos:definition xml:lang="en">The value of a government short term debt security, or treasury bill, at a given point in time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;TreasuryBillReferenceRate">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;DebtInstrumentReferenceRate"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;hasInterestRateValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;TreasuryBillInterestRateValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">treasury bill reference rate</rdfs:label>
-		<skos:definition xml:lang="en">The parameter which is the interest rate payable by the T Bill at any point in time. This therefore takes a value at any given time and has historical values in the past.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-int;WACBondCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
-		<rdfs:label xml:lang="en">w a c bond coupon</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;bondHasCoupon">
-		<rdfs:label>bond has coupon</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;couponAmount">
-		<rdfs:label xml:lang="en">coupon amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedPercentage"/>
-		<skos:definition xml:lang="en">The current pr past amount of the bond coupon.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;hasFactor">
-		<rdfs:label>has factor</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;hasInterestRateValue">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
-		<rdfs:label xml:lang="en">has interest rate value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-int;TreasuryBillReferenceRate"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-int;TreasuryBillInterestRateValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;interestRate">
-		<rdfs:label xml:lang="en">interest rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-int;TreasuryBillInterestRateValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The rate of interest payable by the Treasury Bill at a stated time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;projectedCoupon">
-		<rdfs:label xml:lang="en">projected coupon</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-int;ProjectedCouponPaymentValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Anticipated amount of a future (variable) coupon amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;projectedValue">
-		<rdfs:label xml:lang="en">projected value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-int;ProjectedCouponPaymentValue"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtInterestAmounts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines debt interest amounts as they occur at a point in time, including variants for floating rate note and index linked coupons, reference rates and inflation bond factors. 
+		Note that this includes reference rates such as the Federal Funds rate that are referred to in many bonds. The Fed Finds rate and others have subsequently been added to the Indices and Indicators domain, so references to the terms here should be deprecated in favor of those where they exist.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;BondCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ContractuallyDefinedNumericalParameter"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;DebtSecurityInterestAmount"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond coupon</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mechanism whereby an investor receives income from interest payments, which are usually made periodically.</skos:definition>
+bubu<fibo-fnd-utl-av:synonym rdf:datatype="&rdf;langString" xml:lang="en">bond interest</fibo-fnd-utl-av:synonym>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;BondFixedCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondCoupon"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond fixed coupon</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mechanism whereby an investor receives income from interest payments, which are usually made periodically. These are for a fixed amount.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;BondVariableCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondCoupon"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;projectedValue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;ProjectedCouponPaymentValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond variable coupon</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;DebtInstrumentReferenceRate">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt instrument reference rate</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The interest rate of some debt instrument which is referred to in calculations of some sort.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example a US Treasury Bill interest Rate, used in quoting prices by way of spreads against this instrument. Also potentially an instrument the interest rate of which is used as the Base in a Floating Rate Note or other variable debt coupon formula.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;DebtSecurityInterestAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt security interest amount</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of interest paid out on a debt security at a given point in time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;FRNCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">f r n coupon</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;IndexLinkedCoupon"/>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;InflationBondVariableCoupon"/>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;WACBondCoupon"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mechanism whereby an investor receives income from interest payments, which are usually made periodically. These are for a variable amount based on a specified Interest rate.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;IndexLinkedCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index linked coupon</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;InflationBondVariableCoupon"/>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;WACBondCoupon"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;InflationBondFactor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ReferenceFactor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation bond factor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The factor which is used in determining the principal on an inflation bond. This is used either in calculating the interest payments, in calculating the principal payback or more typically both. Further notes: This is a dated parameter, that is it varies over time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;InflationBondVariableCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation bond variable coupon</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-int;WACBondCoupon"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;ProjectedCouponPaymentValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ProjectedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">projected coupon payment value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Projected Coupon amount, along with parameters defining when and how this is projected.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;TreasuryBillInterestRateValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">treasury bill interest rate value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of a government short term debt security, or treasury bill, at a given point in time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;TreasuryBillReferenceRate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;DebtInstrumentReferenceRate"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;hasInterestRateValue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;TreasuryBillInterestRateValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">treasury bill reference rate</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The parameter which is the interest rate payable by the T Bill at any point in time. This therefore takes a value at any given time and has historical values in the past.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-int;WACBondCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">w a c bond coupon</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;bondHasCoupon">
+bubu<rdfs:label>bond has coupon</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;couponAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The current pr past amount of the bond coupon.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;hasFactor">
+bubu<rdfs:label>has factor</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;hasInterestRateValue">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has interest rate value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-int;TreasuryBillReferenceRate"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-int;TreasuryBillInterestRateValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;interestRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-int;TreasuryBillInterestRateValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rate of interest payable by the Treasury Bill at a stated time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;projectedCoupon">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">projected coupon</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-int;ProjectedCouponPaymentValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Anticipated amount of a future (variable) coupon amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;projectedValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">projected value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-int;ProjectedCouponPaymentValue"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/md/DebtTemporal/DebtPricingYields.rdf
+++ b/md/DebtTemporal/DebtPricingYields.rdf
@@ -1,1472 +1,1476 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-prc-fcp "https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
-	<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
-	<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
-	<!ENTITY fibo-md-dbtx-red "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/">
-	<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-	<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-prc-fcp "https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
+bu<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
+bu<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
+bu<!ENTITY fibo-md-dbtx-red "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/">
+bu<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bu<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
-	xmlns:fibo-bp-prc-fcp="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
-	xmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
-	xmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
-	xmlns:fibo-md-dbtx-red="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/"
-	xmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
-		<rdfs:label xml:lang="en">DebtPricingYields</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-loan-loan-loan;LoanDrawdown">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasLoanMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;AbsolatePrepaymentRateFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:label xml:lang="en">absolate prepayment rate formula</rdfs:label>
-		<skos:definition xml:lang="en">ABS is defined by the following formula where SMM refers to Single Monthly Mortality, which measures the percentage of dollars prepaid in a given month expressed as a percentage of the scheduled loan balance. ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;AbsolutePrepaymentRate">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;AbsolatePrepaymentRateFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">absolute prepayment rate</rdfs:label>
-		<skos:definition xml:lang="en">The absolute prepayment rate (for ABS) is the standard measure of prepayment rates in the auto-loan sector. ABS measures the monthly rate of loan prepayments as a percentage of the original pool balance. ABS is defined by the following formula where SMM refers to Single Monthly Mortality, which measures the percentage of dollars prepaid in a given month expressed as a percentage of the scheduled loan balance. ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The ABS measurement differs from conditional prepayment rate (CPR) used in the mortgage industry, which measures prepayment as an annualized percentage of the current pool balance.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;AccruedInterestAmount">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Interest"/>
-		<rdfs:label xml:lang="en">accrued interest amount</rdfs:label>
-		<skos:definition xml:lang="en">The interest accrued on the bond or debt instrument at the time that the price is quoted. If this is a dirty price, this is the amount of accrued interest that is included in the price. This is therefore passed on to the purchaser of the bond or debt instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;AlgoDebtCreditSpread">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;refersToCreditRating"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;IssuerCreditRating"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;refersToMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Maturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;isBetween"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">algo debt credit spread</rdfs:label>
-		<skos:definition xml:lang="en">The Spread between the Debt Instrument Maturity and the Credit Rating of the Issuer.</skos:definition>
-		<skos:editorialNote xml:lang="en">This does not match the Wikipedia definition for Credit Spread, as defined for Bonds. Is this another, different term or a misunderstanding? Note that the units for this defined item would be nonsencical (the difference between a credit rating and a maturity).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BondEquivalentYield">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;RelativelyDefinedDebtInstrumentYield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedUsing"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;EquivalentYieldCalculationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond equivalent yield</rdfs:label>
-		<skos:definition xml:lang="en">Yield determined on an equivalent basis to the yield of another bond. This is used to be able to realistically compare prices between debt instruments across different markets.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example when comparing Treasury with Corp it&apos;s called a Corp Bond Equivalent Yield; when comparing other kinds of yields this would be labelled differently. Treasury bills typically in discount rates - that&apos;s one of the ways you would compare TB or MM or RePo to BEQ - by changing the day count. Detailed implementation of this: This term refers to the type of bond that it is equivalent to, that is the type of bond whose yield is normally determined according to the yield calculation method that is used in determining this Bond Equivalent Yield figure. The type of bond in this instance is defined in relation to the market on which that bond trades, for example the US Corporate Bond Market.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeClosingPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod"/>
-				<owl:onClass rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond exchange closing price</rdfs:label>
-		<skos:definition xml:lang="en">The price at close of trading on a given trading day on an exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The type of price which is quoted will be determined by the exchange. Last Price is recognised as the last trade on that exchange, not a last quote price. (fact about closing Price) MDDL definition:The final price as of market close.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeHighPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasApplicablePeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceDeterminationMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceIsTraded"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;takesAccountOfQuoteSize"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond exchange high price</rdfs:label>
-		<skos:definition xml:lang="en">The highest valuation over the period specified.</skos:definition>
-		<skos:editorialNote xml:lang="en">This can be regarded as a derived price. See also note in LowPrice Difference: different rules used. May be mased on trade OR quote price Analytic or Price?? this is a derived type but with a much simpler rule.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeLastPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceIsTraded"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond exchange last price</rdfs:label>
-		<skos:definition xml:lang="en">The last (or most recent) valuation.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an actual trade price not a derived price</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeLowPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasApplicablePeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceDeterminationMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceIsTraded"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;takesAccountOfQuoteSize"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond exchange low price</rdfs:label>
-		<skos:definition xml:lang="en">The lowest valuation over the period specified. Possibly but not necessarily based on a trade. Determined by the trading venue as to whether it&apos;s based on a trade or an offer. this can be regarded as a derived price. Price is based on a riule whil will cause one to pick a certain price type.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeOpeningPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:label xml:lang="en">bond exchange opening price</rdfs:label>
-		<skos:definition xml:lang="en">The value at the beginning of trading or opening of the market.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Exchange published price. Sometimes opening price is implied, sometimes it&apos;s published.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BondMarket">
-		<rdfs:label xml:lang="en">bond market</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BondMidPrice">
-		<rdfs:label xml:lang="en">bond mid price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BondTradingContext">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecondaryMarketTradingContext"/>
-		<rdfs:label xml:lang="en">bond trading context</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;BulletRedemptionPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-red;BondRedemptionPayment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-red;hasTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bullet redemption payment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;CashStructuredFinanceInstrumentPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:label xml:lang="en">cash structured finance instrument price</rdfs:label>
-		<skos:definition xml:lang="en">When the price is above a certain level (70), you get a quote in reference to an index e.g. LIBOR+50bp i.e. the yield. When you get below a certain price you get a quote such as 65c to a dollar. Percentage? not seen. Would be a whole number, interpreted as c/$</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This might be a Price, a Spread or a Yield, i.e. &quot;here&apos;s the price., the current Yield is this, and here&apos;s the Spread&quot;.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;CleanPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:label xml:lang="en">clean price</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
-		<skos:definition xml:lang="en">A bond or debt instrument price that does not include accrued interest.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;CurrentYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasParameter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;CleanPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">current yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">The ratio of the interest payment amount to the clean price.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a kind of yield that applies to debt instruments only as it relates to the clean price. It differs from the simple yield in that simple yield relates to the actual price paid for the bond, which on will differ from the clean price by the amount of accrued interest.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtIndependentlyEvaluatedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DerivedPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;evaluatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtPriceIndependentEvaluator"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt independently evaluated price</rdfs:label>
-		<skos:definition xml:lang="en">&quot;Evaluated Price&quot; is the price you get from the vendors.</skos:definition>
-		<skos:editorialNote xml:lang="en">This may not always be the same. Mostly in the US, now also moving into Europe and Asia. See e.g. MiFID. Vendor gives you Spread and Price: Early Price (right at the close of the market) plus a Final Price an hour or so later. Matrix pricing: pure calculation. throws the spread in and calculates the price, rather than surveying the market. Based on some formula, not on research of traders. notes from SMER 18 Nov Pricing Recipe - the prices that are input to that derived price. Notes from SMER 25 Nov If the instrument has not been trading, then there would normally need to be prices for valuing these, so you would go to an independent provider. You would also identify who you sourced it from. You would not put your own numbers in as this would not be impartial. Also since only the very liquid securities are those that trade, a lot of bonds in a Pf are not regularly traded and so there is not a market price, so you use a yield curve and interpolate on this to come up with an estimate of fair value. This also involves modeling what you anticipate the Cr spreads on those bonds would be.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtInstrumentYield">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Yield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;calculationFollowing"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-md-dbtx-aly;LifeAnalytic">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-md-temx-ins;Maturity">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-dbt-cft;PrescriptiveEvent">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-dbt-cft;RedemptionEvent">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;derivedFromOutlay"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt instrument yield</rdfs:label>
-		<skos:definition xml:lang="en">The return on the debt instrument at the stated price.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Yield has a relationship to the price.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtPriceIndependentEvaluator">
-		<rdfs:label xml:lang="en">debt price independent evaluator</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtPriceSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;PriceSpread"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usedToDetermine"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt price spread</rdfs:label>
-		<skos:definition xml:lang="en">The difference between the [what?] of a security and the fair price value of a different security which is used as a point of reference. The spread is used to determine the price of the instrument. (draft definition)</skos:definition>
-		<skos:editorialNote xml:lang="en">This was &quot;Spread&quot; in the Debt pricing reviews, however that word has at least 2 other uses (spread between equity bid and offer prices; spread for derivatives). Detailed notes from Debt Pricing Review session 5 Aug: Identify what the spread is in relation to e.g. LIBOR. ALSO If fixed of floating. So if it&apos;s a FRN, For a fixed rate bond, it&apos;s priced off the on-the-run, e.g. a 30 year bond is priced as a spread wrt a 30 year treasury bond. So e..g spread would be something like 10bp+the value of the 30 year on the run Treasury. On the Run: definition needed. Also class of Thing and where this should go.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usedToDetermine"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LocallyDerivedPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt published point in time price</rdfs:label>
-		<skos:definition xml:lang="en">A debt price, usually in the form of a spread, published by a data provider at some point in time such as the end of the trading day.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The vendor will survey the banks and calculate the spread and publish as a spread. Price as a percentage is determined internally by the investment organization, based on that published spread. In terms of what sort of spread this is, this is information about the market and can be in any of those formats whereby price is specified (see Price Specification terms). Could have spread to price or spread to yield. Valuations are done at the end of the day but equivalent figures can be provided for other times.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecuritiesMarketMaker">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinesMarketPriceForDebt"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt securities market maker</rdfs:label>
-		<skos:definition xml:lang="en">An actor which has the role of Market Maker in a given market.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecurityBidPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityQuotePrice"/>
-		<rdfs:label xml:lang="en">debt security bid price</rdfs:label>
-		<skos:definition xml:lang="en">A price quoted for purchase of a quantity of a debt security in the marketplace. This may be either the OTC market or a securities exchange or a composite market consisting of several exchanges or trading facilities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecurityOfferPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityQuotePrice"/>
-		<rdfs:label xml:lang="en">debt security offer price</rdfs:label>
-		<skos:definition xml:lang="en">A price quoted for sale of a quantity of a debt security in the marketplace. This may be either the OTC market or a securities exchange or a composite market consisting of several exchanges or trading facilities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecurityPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
-		<rdfs:label xml:lang="en">debt security price</rdfs:label>
-		<skos:definition xml:lang="en">The price of a Debt Instrument at some point in time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecurityQuotePrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
-		<rdfs:label xml:lang="en">debt security quote price</rdfs:label>
-		<skos:definition xml:lang="en">A price quoted for purchase or sale of a quantity of a debt security in the marketplace. This may be either the OTC market or a securities exchange or a composite market consisting of several exchanges or trading facilities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToAverageLife">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt yield to average life</rdfs:label>
-		<skos:definition xml:lang="en">The yield achieved by substituting a bond&apos;s average life for the issue&apos;s final maturity date.</skos:definition>
-		<skos:editorialNote xml:lang="en">Assume from this that there is also a Yield to Equivalent Life. Some sources have these as the same term, whereas we have separated them.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToEquivalentLife">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt yield to equivalent life</rdfs:label>
-		<skos:definition xml:lang="en">The yield achieved by substituting a bond&apos;s equivalent life for the issue&apos;s final maturity date.</skos:definition>
-		<skos:editorialNote xml:lang="en">Some sources have Average Life and Equivalent Life as the same term, whereas we have separated them.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToMaturity">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Maturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt yield to maturity</rdfs:label>
-		<skos:definition xml:lang="en">The internal rate of return an investor would achieve if he or she purchased that bond at its current dirty price, and held it to maturity, assuming all coupon and principal payments are received as scheduled.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToNextCall">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;NextCall"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt yield to next call</rdfs:label>
-		<skos:definition xml:lang="en">The yield of a bond to the next possible call date.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToWorst">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;WorstCall"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt yield to worst</rdfs:label>
-		<skos:definition xml:lang="en">Yield to the worst case of when the instrument might be called.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DefaultRate">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
-		<rdfs:label xml:lang="en">default rate</rdfs:label>
-		<skos:definition xml:lang="en">The rate at which holders of loans in the pool default on those loans.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DerivedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:label xml:lang="en">derived price</rdfs:label>
-		<skos:definition xml:lang="en">Any price which is derived from some other source or calculation rather than being the price at which something actually traded or was quoted.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are evaluated prices in which an independent source evaluates a price they have derived, and there are prices which are derived within a firm, from supplied, published end of day price spreads or other market data.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DirtyPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;dirtyPriceIncludes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;AccruedInterestAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dirty price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;DiscountedInstrumentYield">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:label xml:lang="en">discounted instrument yield</rdfs:label>
-		<skos:definition xml:lang="en">Yield quoted for a discount instrument. This is the ratio of the discount to the face value, divided by the period to maturity as a fraction of a year.</skos:definition>
-		<fibo-fnd-utl-av:usageNote xml:lang="en">Applies to Debt only.</fibo-fnd-utl-av:usageNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;EffectiveYield">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:label xml:lang="en">effective yield</rdfs:label>
-		<skos:editorialNote xml:lang="en">The difference between this and Native yield is as per note: Native yield relates to price quotation context; Effective Yild is in relation to portfolio analytics. Recall: every analytic formula relates to the set of cash flows, so there are assumptions underlying each of these, For example the assumption that Y is constant, which it isn&apos;t (because there is a curve, which may be convex not linear (is that right?). So you can compare rate or return between what I see and what the market has out there. In the US market: a Y which is calculated using Monto Carlo method simulation. relationship facts to add: Relation to method / formula (e.g. Monte Carlo), and the method used to determine the actual figure for the MC method. eff Y for single instrument: E Y for bonds without calls and stuff. Variation in this: whether we look at a whole set of bonds YTM quoted by Bmb would be the YTM quoted according to whatever the market is - = the NAtive Yield. SO: Publicly quoted more: choose another adjective.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;ExchangeTradedBondPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ExchangeTradedSecurityPrice"/>
-		<rdfs:label xml:lang="en">exchange traded bond price</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;InterpolatedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DerivedPrice"/>
-		<rdfs:label xml:lang="en">interpolated price</rdfs:label>
-		<skos:definition xml:lang="en">A price determined by interpolation between available price figures, using some algorithm or curve.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Uses an algorithm to interpolate a price from two observed prices. Examples include price derived by interpolation between prices e.g. between Bid and Offer (among others). also includes Yield Curves and implied forward curves. That is, interpolation may either be linear (straight line interpolation between two values) or may be expressed as a non linear curve such as a yield curve or an implied forward curve.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;IssuerCreditRating">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-		<rdfs:label xml:lang="en">issuer credit rating</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;JapaneseCompoundYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasRoundingDirection"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Down"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">japanese compound yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">No definition in selection list.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;JapaneseSimpleYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasRoundingDirection"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Down"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">japanese simple yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">No definition.Term put here from memory. 02 Dec changed from Japanese Yield to Japanese Simple Yield. note hat Japanese Compound yield also here (from FIBIM or anothe rlist, added 25 nov with the rest).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;LoanAge">
-		<rdfs:label xml:lang="en">loan age</rdfs:label>
-		<skos:definition xml:lang="en">The age of the loan.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;LoanMaturity">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;inRelationTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;ThePresent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan maturity</rdfs:label>
-		<skos:definition xml:lang="en">THe length of time from the present until the loan or mortgage matures, that is the date when the last of the principal is paid off along with all interest.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;LoanPoolAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
-		<rdfs:label xml:lang="en">loan pool analytic</rdfs:label>
-		<skos:definition xml:lang="en">A measure of some aspect of a pool of loans.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;LoanPoolPrepaymentModel">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticsCalculationModel"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;includes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanPrepaymentFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan pool prepayment model</rdfs:label>
-		<skos:definition xml:lang="en">Model of the prepayments of loans in a pool of individual loans, such as a mortgage pool or loan pool.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This model captures the parameters that may influence the prepayment of loans or mortgages and relates these mathematically.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;LoanPrepaymentFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:label xml:lang="en">loan prepayment formula</rdfs:label>
-		<skos:definition xml:lang="en">The formula which embodies the model for loan pool prepayment speed.</skos:definition>
-		<skos:editorialNote xml:lang="en">From SMER sessions: This is a model. Includes other factors such as homogeniety. To model this more completely we need to identify the parameters that go in to this formula. Among these is the above homogeneity measure - need to know how that is measured and in what terms it is expressed, e.g. as a percentage, with reference to some mean or standard deviation and so on. Also some of the parameters used in this model would presumably make reference to standard mathematical model constructs such as normal distribution, variaous deviation measures, Chi squared and so on. These are not presently in the semantics model, but can be modeled semantically if required. This would not however be a mathematical model - we only need to identify these and show meaningful relationships (not mathematical relationships) between them.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;LocallyDerivedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DerivedPrice"/>
-		<rdfs:label xml:lang="en">locally derived price</rdfs:label>
-		<skos:definition xml:lang="en">A price derived locally from information supplied by a market data vendor such as an end of day spread.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;MBSFactor">
-		<rdfs:label xml:lang="en">m b s factor</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;InstrumentInternalRateOfReturn"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">MacCaulays Duration Analytic</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;NativeYield">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;RelativelyDefinedDebtInstrumentYield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedUsing"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;NativeYieldCalculationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">native yield</rdfs:label>
-		<skos:definition xml:lang="en">The yield of the security as determined using the Yield Calculation Method that is the default for the market that the security is traded in.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">conventional yield for that security type and geo location, ie. would be in relation too</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;NativeYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;RelativeYieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;isDefaultMethodFor"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">native yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">The convention used in the marketplace for that security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;NextCall">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;NextCallDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">next call</rdfs:label>
-		<skos:definition xml:lang="en">The next call of the issue, as at the current time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;NextCallDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalEntity"/>
-		<rdfs:label xml:lang="en">next call date</rdfs:label>
-		<skos:definition xml:lang="en">The next date on which the issue can be called, from the present date.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;NextPut">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;PutOfIssue"/>
-		<rdfs:label xml:lang="en">next put</rdfs:label>
-		<skos:definition xml:lang="en">The next available put date for the issue, as at the current time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;OTCBondMarketPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;SecurityMarketPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;oTCBondMarketPriceHasPricingSource"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecuritiesMarketMaker"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c bond market price</rdfs:label>
-		<skos:definition xml:lang="en">The price determined for the marketplace for a bond which is traded over the counter.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review comment: Must include Attribution. This is in the model in the form of tha Market Maker (an actor in the activity of secondary market trading for OTC-traded debt).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;OptonAdjustedYield">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:label xml:lang="en">opton adjusted yield</rdfs:label>
-		<skos:definition xml:lang="en">NB specified as a spread. synonym: OAS Based on different Int Rate paths. There are different OAS models just like there are different Yield methods. Also would make reference to the Yield Curve - but these are parameters that go into that model. Limit this model at the point where it distinguishes the difference between things - we are not in a position to mathematically model the things themselves, just capture the basic facts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;Outlay">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Expenditure"/>
-		<rdfs:label xml:lang="en">outlay</rdfs:label>
-		<skos:definition xml:lang="en">Cash spent on something.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;PublishedEndOfDayPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice"/>
-		<rdfs:label xml:lang="en">published end of day price</rdfs:label>
-		<skos:definition xml:lang="en">A price published by a market data vendor at the end of the trading day.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be specified in terms of a spread (end of day spread) or in some other form. EoD spread could be nominal or end of day adjusted.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;PublishedPriceAsRateSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice"/>
-		<rdfs:label xml:lang="en">published price as rate spread</rdfs:label>
-		<skos:definition xml:lang="en">A debt instrument price quoted or defined in terms of a spread of that instrument&apos;s price with reference to some reference rate. The reference rate may be either a market interest rate such as an IBOR or the rate of interest on some reference instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;PublishedPriceAsTreasuryRateSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;PublishedPriceAsRateSpread"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;relativeTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;TreasuryBillReferenceRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">published price as treasury rate spread</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;ReferenceDebtInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasReferenceRate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;DebtInstrumentReferenceRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">reference debt instrument</rdfs:label>
-		<skos:definition xml:lang="en">A debt instrument in the role of a reference instrument. Some property of the instrument is used in calculations, for example the interest or the yield of the instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;ReferenceSovereignBill">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ReferenceDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasReferenceRate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;TreasuryBillReferenceRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">reference sovereign bill</rdfs:label>
-		<skos:definition xml:lang="en">A Treasury Note or other sovereign debt the interest of which is used as a reference rate.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;RelativeYieldCalculationMethod">
-		<rdfs:label xml:lang="en">relative yield calculation method</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;RelativelyDefinedDebtInstrumentYield">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:label xml:lang="en">relatively defined debt instrument yield</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;RussianYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;RussianYieldFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">russian yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">The method used in determining Yield in the Russian markets. This is based on an effective yield with fundamentally different math. To give an example of the use of a different &quot;yield type&quot;, we have Russia, which trades based on an effective yield. The price-yield math is fundamentally different. Notes Origin:Fidessa Uses a trade space and effective yield formula. MAy have same day types but different math.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;RussianYieldFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationFormula"/>
-		<rdfs:label xml:lang="en">russian yield formula</rdfs:label>
-		<skos:definition xml:lang="en">This is based on a different Effective Yield than on another market.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;SecondaryMarketBondDealing">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;SecuritiesTrading"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-prc-fcp;context"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-prc-fcp;SecondaryMarketTradingContext"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">secondary market bond dealing</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;SecuritiesTrading">
-		<rdfs:label xml:lang="en">securities trading</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;SecurityMarketPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
-		<rdfs:label xml:lang="en">security market price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;SimpleYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesPrice"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">simple yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">The annual rate of return expressed as a percentage. This is the return divided by the outlay and multiplied by 100 to express the figure as a percentage.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is yield in its simplest sense, expressed as a percentage of return to outlay. As such, this is the same way that yield is determined for any investments, not just financial instruments or debt investments.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;SpanishYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:label xml:lang="en">spanish yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">The method used in determining annual yield in Spanish corporate bonds.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;ThePresent">
-		<rdfs:label xml:lang="en">the present</rdfs:label>
-		<skos:definition xml:lang="en">Now.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;USCorporateBondYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;ICMAYieldFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">u s corporate bond yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">This has 30/360 and semi-annual compounding.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;USTreasuryYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;ICMAYieldFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">u s treasury yield calculation method</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;WallStreetYieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;ICMAYieldFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">wall street yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">No definition.Term put here from memory.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;WeightedAverageCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic"/>
-		<rdfs:label xml:lang="en">weighted average coupon</rdfs:label>
-		<skos:definition xml:lang="en">The weighted-average gross interest rates of the pool of mortgages that underlie a mortgage-backed security (MBS) at the time the securities were issued. A mortgage-backed security&apos;s current WAC can differ from its original WAC as the underlying mortgages pay down at different speeds. In the weighted-average calculation, the principal balance of each underlying mortgage is used as the weighting factor</skos:definition>
-		<skos:editorialNote xml:lang="en">Provided by the Issuer (loan servicer?) along with the WALA etc. If you know the underlying loans you can calculate this yourself. For ABS you don&apos;t know this so you have to get this information from the loan servicer. Investopedia explains Weighted Average Coupon - WAC For example, suppose a MBS is composed of two different pools of mortgages: $6 million worth of mortgages that yield 7.5% and a pool of $4 million mortgages that yield 5%. The WAC would be 6.5%. The WAC on a mortgage-backed security is an important piece of information used by analysts to estimate the pre-pay characteristics of that security. It is an important relative value tool in MBS portfolio management and analysis.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;WeightedAverageTimeToReceiptOfCashflows">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
-		<rdfs:label xml:lang="en">weighted average time to receipt of cashflows</rdfs:label>
-		<skos:definition xml:lang="en">The weighted average time to the receipt of cashflows for an instrument.</skos:definition>
-		<skos:editorialNote xml:lang="en">A formal definition is needed for this. The name is almost self defining, but only to those who already know what this means. In particular we should define how the weighted average is weighted, and what this means, along with a formula for calculating this at the most generic level (cashflow, time, without assumptions about particular types of instrument).</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;WorstCall">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedToOccurOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;WorstCallDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">worst call</rdfs:label>
-		<skos:definition xml:lang="en">The worst case of when the instrument might be called.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;WorstCallDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalEntity"/>
-		<rdfs:label xml:lang="en">worst call date</rdfs:label>
-		<skos:definition xml:lang="en">The worst date on which the instrument might be called.</skos:definition>
-		<skos:editorialNote xml:lang="en">We should refine what we mean by Worst here - soonest, or most distant?</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;WorstCallDateDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDetermination"/>
-		<rdfs:label xml:lang="en">worst call date determination</rdfs:label>
-		<skos:definition xml:lang="en">The determination of when the call identified as the Worst Call would take place. This consist of some means by which that date is determined and a date on which that date is deemed to be the Worst Call date.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;YieldCalculationFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasSubject"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">yield calculation formula</rdfs:label>
-		<skos:definition xml:lang="en">The formula used in determining the Yield.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The subject of this Formula is the Yield. The formula has an expression which can be defined either in tectual terms or by further local extension of the term &quot;Formula Expression&quot; to define the parameters used.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;YieldCalculationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasParameter"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;YieldCalculationFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">yield calculation method</rdfs:label>
-		<skos:definition xml:lang="en">The method by which the yield is calculated. This includes a formula for calculation and a specific day count convention and compounding. You would apply this calculation method on top of the underlying terms and conditions, do for example the holiday calenders and so on, are used in these formulae. For final cash flow: Japanese yield will round down accrued interest. Add: The actual underlying math. Wall Street uses the same ICMA formula.</skos:definition>
-		<skos:editorialNote xml:lang="en">Initial reviewer notes 18 Nov: this uses the combination of the day count and the compounding gives you the name of the yield calculation method. Names are associated with algorithms. What yield you use to determining the present value. These are typically defined in a prospectus (for exchange traded) or Info Memorandum if it&apos;s traded in an OTC market. where it also defines the method itself. Action: look at some prospecti or get this from a vendor. Additional features 25 nov: Question - maybe Holiday calendar? Also date roll rules and roll back rules. These all apply. YC feeds in to Yield itself.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-py;YieldToNextPut">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;NextPut"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">yield to next put</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;absolutePrepaymentRateHasValue">
-		<rdfs:label xml:lang="en">absolute prepayment rate has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AbsolutePrepaymentRate"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The value of the rate itself, at a given point in time, expressed as a percentage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;accruedInterestAmountHasValue">
-		<rdfs:label xml:lang="en">accrued interest amount has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AccruedInterestAmount"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The amount of accrued interest, at a point in time, expressed as a percentage/</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;amount">
-		<rdfs:label xml:lang="en">amount</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;applicablePeriod.1">
-		<rdfs:label xml:lang="en">applicable period</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;basedUpon">
-		<rdfs:label>based upon</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;calculationFollowing">
-		<rdfs:label xml:lang="en">calculation following</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;closingPriceValue">
-		<rdfs:label xml:lang="en">closing price value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeClosingPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The value of the price at closing, as a monetary amount (amount and currency).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;compounded">
-		<rdfs:label xml:lang="en">compounded</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;compoundingFrequency">
-		<rdfs:label xml:lang="en">compounding frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;dayCountBasis">
-		<rdfs:label xml:lang="en">day count basis</rdfs:label>
-		<terms:description xml:lang="en">The convention used to calculate the number of days in an interest payment period.</terms:description>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;daysAccrued">
-		<rdfs:label xml:lang="en">days accrued</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of days that interest has accrued, as reflected in the price.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;defaultRateValue">
-		<rdfs:label xml:lang="en">default rate value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DefaultRate"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;derivedFrom">
-		<rdfs:label>derived from</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;derivedFrom.1">
-		<rdfs:label>derived from</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;derivedFrom.2">
-		<rdfs:label>derived from</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinationDate">
-		<rdfs:label xml:lang="en">determination date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;WorstCallDateDetermination"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The date at which the identified call date is identified as being the &quot;Worst&quot; possible call date. Market conditions on that date make the call date in question the &quot;Worst Call&quot; at that time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;derivedFrom"/>
-		<rdfs:label xml:lang="en">determined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AbsolutePrepaymentRate"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;AbsolatePrepaymentRateFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinedRelativeTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-temx-tem;isBetween"/>
-		<rdfs:label xml:lang="en">determined relative to</rdfs:label>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinedToOccurOn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;occursOn"/>
-		<rdfs:label xml:lang="en">determined to occur on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;WorstCall"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;WorstCallDate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinedUsing">
-		<rdfs:label xml:lang="en">determined using</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;RelativelyDefinedDebtInstrumentYield"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;RelativeYieldCalculationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinesMarketPriceForDebt">
-		<rdfs:label xml:lang="en">determines market price for debt</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtSecuritiesMarketMaker"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
-		<owl:inverseOf rdf:resource="&fibo-md-dbtx-py;oTCBondMarketPriceHasPricingSource"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;dirtyPriceIncludes">
-		<rdfs:label xml:lang="en">dirty price includes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;AccruedInterestAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;evaluatedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-		<rdfs:label xml:lang="en">evaluated by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtIndependentlyEvaluatedPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtPriceIndependentEvaluator"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;exCoupon.1">
-		<rdfs:label xml:lang="en">ex coupon</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;exchangeTradedBondPriceHasValue">
-		<rdfs:label xml:lang="en">exchange traded bond price has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The percentage value of the price at a given point in time</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;expressedAs">
-		<rdfs:label xml:lang="en">expressed as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AbsolatePrepaymentRateFormula"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;expressedInRelationTo">
-		<rdfs:label>expressed in relation to</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;expression">
-		<rdfs:label xml:lang="en">expression</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;has.2">
-		<rdfs:label>has</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasApplicablePeriod">
-		<rdfs:label xml:lang="en">has applicable period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasDefaultRate">
-		<rdfs:label xml:lang="en">has default rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DefaultRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasDurationValue">
-		<rdfs:label xml:lang="en">has duration value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;WeightedAverageTimeToReceiptOfCashflows"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedDurationSpecification"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasInterestRate">
-		<rdfs:label xml:lang="en">has interest rate</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-int;DebtSecurityInterestAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasLoanMaturity">
-		<rdfs:label xml:lang="en">has loan maturity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasMaturity">
-		<rdfs:label xml:lang="en">has maturity</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;Maturity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasOutlookPeriod">
-		<rdfs:label xml:lang="en">has outlook period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-md-dbtx-aly;LifeAnalytic">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-md-temx-ins;Maturity">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-dbt-cft;PrescriptiveEvent">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-dbt-cft;RedemptionEvent">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasParameter">
-		<rdfs:label xml:lang="en">has parameter</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasReferenceRate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesReferenceParameter"/>
-		<rdfs:label xml:lang="en">has reference rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ReferenceDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-int;DebtInstrumentReferenceRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasRoundingDirection">
-		<rdfs:label xml:lang="en">has rounding direction</rdfs:label>
-		<terms:description xml:lang="en">Whether the accrued interest is rounded up or down in this method.</terms:description>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;Direction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasWac">
-		<rdfs:label xml:lang="en">has wac</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;WeightedAverageCoupon"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasYield">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
-		<rdfs:label xml:lang="en">has yield</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;inRelationTo">
-		<rdfs:label xml:lang="en">in relation to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;ThePresent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;interpolatedBetween">
-		<rdfs:label>interpolated between</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;isCompounded">
-		<rdfs:label xml:lang="en">is compounded</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Definition needed Moved from Yield - assume this can only be about debt instrument or loan / debt yields i..e where the income relates to interest payments. .</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;isDefaultMethodFor">
-		<rdfs:label xml:lang="en">is default method for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;NativeYieldCalculationMethod"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;isSpreadBetween">
-		<rdfs:label xml:lang="en">is spread between</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtPriceSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;loanMaturityValue">
-		<rdfs:label xml:lang="en">loan maturity value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;macCaulaysDurationHasValue">
-		<rdfs:label xml:lang="en">mac caulays duration has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-		<skos:definition xml:lang="en">The MacCaulays Duration in Years.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;macCaulaysDuratonValue">
-		<rdfs:label xml:lang="en">mac caulays duraton value</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;oTCBondMarketPriceHasPricingSource">
-		<rdfs:label xml:lang="en">o t c bond market price has pricing source</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecuritiesMarketMaker"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;openingPriceMethod">
-		<rdfs:label xml:lang="en">opening price method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeOpeningPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The method by which the Opening Price is determined for that exchange.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;otcBondMarketPriceHasValue">
-		<rdfs:label xml:lang="en">otc bond market price has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;pointInTimePriceHasValue">
-		<rdfs:label xml:lang="en">point in time price has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;BasisPointsValue"/>
-		<skos:definition xml:lang="en">Is normally be expressed in basis points, although the meaning of BP implies a percentage value. Change this to BP.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceDeterminationConventionNotes">
-		<rdfs:label xml:lang="en">price determination convention notes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeClosingPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Further free text notes on the way in which the closing price is determined.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceDeterminationMethod">
-		<rdfs:label xml:lang="en">price determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The method by which the High Price is determined on that exchange.</skos:definition>
-		<skos:definition xml:lang="en">The method by which the High or Low Price is determined on that exchange.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;priceDeterminationMethod.1">
-		<rdfs:label xml:lang="en">price determination method</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceIsTraded">
-		<rdfs:label xml:lang="en">price is traded</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The highest valuation over the period specified. Notes from Equity review, may apply to Debt also: this can be regarded as a derived price. See also note in LowPrice Difference: different rules used. May be based on trade OR quote price Analytic or Price?? this is a derived type but with a much simpler rule.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceQuotedExDividend">
-		<rdfs:label xml:lang="en">price quoted ex dividend</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the yield is based on a price which is quoted ex-dividend. When a bond is said to trade ex-dividend it means that there is a period of time prior to each coupon payment during which a bond purchaser does not receive custody of the next coupon. That payment is made to the previous bond holder and accrued interest is therefore negative during the ex-dividend period.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceValue">
-		<rdfs:label xml:lang="en">price value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The price of the debt instrument expressed as a percentage of the par value of the instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;quoteSize">
-		<rdfs:label xml:lang="en">quote size</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;quotedExDividend">
-		<rdfs:label xml:lang="en">quoted ex dividend</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the price is quoted ex-dividend. When a bond is said to trade ex-dividend it means that there is a period of time prior to each coupon payment during which a bond purchaser does not receive custody of the next coupon. That payment is made to the previous bond holder and accrued interest is therefore negative during the ex-dividend period.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;refersToCreditRating">
-		<rdfs:label xml:lang="en">refers to credit rating</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AlgoDebtCreditSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;IssuerCreditRating"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;refersToMaturity">
-		<rdfs:label xml:lang="en">refers to maturity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AlgoDebtCreditSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;Maturity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;relativeTo">
-		<rdfs:label xml:lang="en">relative to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;CreditSpread"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-md-dbtx-int;DebtInstrumentReferenceRate">
-					</rdf:Description>
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;roundingConvention">
-		<rdfs:label xml:lang="en">rounding convention</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The rounding convention used in the calculation method.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;roundingDirection.1">
-		<rdfs:label xml:lang="en">rounding direction</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;takesAccountOfQuoteSize">
-		<rdfs:label xml:lang="en">takes account of quote size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">High or Low Price takes into account size of quote.</skos:definition>
-		<skos:definition xml:lang="en">Low Price takes into account size of quote.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;traded.2">
-		<rdfs:label xml:lang="en">traded</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;tradingDate">
-		<rdfs:label xml:lang="en">trading date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeClosingPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The trading date for which this information is applicable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;usedToDetermine">
-		<rdfs:label xml:lang="en">used to determine</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtPriceSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;usesFormula">
-		<rdfs:label xml:lang="en">uses formula</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;YieldCalculationFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;usesPrice">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-py;hasParameter"/>
-		<rdfs:label xml:lang="en">uses price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;SimpleYieldCalculationMethod"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;valuationDateAndTime">
-		<rdfs:label xml:lang="en">valuation date and time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeLastPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">The date and time at which the Last Price was determined i.e. the time time and date of the offer or trade that the price relates to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;value.1">
-		<rdfs:label xml:lang="en">value</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;wACHasValue">
-		<rdfs:label xml:lang="en">w a c has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-py;WeightedAverageCoupon"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The value of the Weighted Average Coupon at some point in the past or at the present time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;wACValue">
-		<rdfs:label xml:lang="en">w a c value</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasDefaultRate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DefaultRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasWac"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;WeightedAverageCoupon"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasInterestRate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;DebtSecurityInterestAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Maturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasYield"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-prc-fcp="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
+buxmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
+buxmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
+buxmlns:fibo-md-dbtx-red="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/"
+buxmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
+buxmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
+buxmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtPricingYields</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">Debt pricing and yields are intimately related, and this ontology sets out the basic concepts of debt price, including different ways in which debt and bod prices are described and calculated, as well as a range of different kinds of yield (simple yield, Wall Street Yield, Japanese Yield and so on). The pricing terms are supported by a range of trading and exchange related concepts that are used to differentiate different kinds of debt price, for example last, high and low exchange prices.
+		Note that there seems to be some cross-over between terms in this ontology and in the Debt Analytics ontology, for example Macaulay’s Duration is here while modified duration is in the other ontology, and similarly some yield terms are in that other ontology. This was originally one single ontology, and these two ontologies should be used together.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Process/FinancialContextAndProcess/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-loan-loan-loan;LoanDrawdown">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasLoanMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;AbsolatePrepaymentRateFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">absolate prepayment rate formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">ABS is defined by the following formula where SMM refers to Single Monthly Mortality, which measures the percentage of dollars prepaid in a given month expressed as a percentage of the scheduled loan balance. ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;AbsolutePrepaymentRate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;AbsolatePrepaymentRateFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">absolute prepayment rate</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The absolute prepayment rate (for ABS) is the standard measure of prepayment rates in the auto-loan sector. ABS measures the monthly rate of loan prepayments as a percentage of the original pool balance. ABS is defined by the following formula where SMM refers to Single Monthly Mortality, which measures the percentage of dollars prepaid in a given month expressed as a percentage of the scheduled loan balance. ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The ABS measurement differs from conditional prepayment rate (CPR) used in the mortgage industry, which measures prepayment as an annualized percentage of the current pool balance.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;AccruedInterestAmount">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Interest"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accrued interest amount</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The interest accrued on the bond or debt instrument at the time that the price is quoted. If this is a dirty price, this is the amount of accrued interest that is included in the price. This is therefore passed on to the purchaser of the bond or debt instrument.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;AlgoDebtCreditSpread">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;refersToCreditRating"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;IssuerCreditRating"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;refersToMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Maturity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;isBetween"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">algo debt credit spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Spread between the Debt Instrument Maturity and the Credit Rating of the Issuer.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This does not match the Wikipedia definition for Credit Spread, as defined for Bonds. Is this another, different term or a misunderstanding? Note that the units for this defined item would be nonsencical (the difference between a credit rating and a maturity).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BondEquivalentYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;RelativelyDefinedDebtInstrumentYield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedUsing"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;EquivalentYieldCalculationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond equivalent yield</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Yield determined on an equivalent basis to the yield of another bond. This is used to be able to realistically compare prices between debt instruments across different markets.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example when comparing Treasury with Corp it&apos;s called a Corp Bond Equivalent Yield; when comparing other kinds of yields this would be labelled differently. Treasury bills typically in discount rates - that&apos;s one of the ways you would compare TB or MM or RePo to BEQ - by changing the day count. Detailed implementation of this: This term refers to the type of bond that it is equivalent to, that is the type of bond whose yield is normally determined according to the yield calculation method that is used in determining this Bond Equivalent Yield figure. The type of bond in this instance is defined in relation to the market on which that bond trades, for example the US Corporate Bond Market.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeClosingPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod"/>
+bubububu<owl:onClass rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond exchange closing price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price at close of trading on a given trading day on an exchange.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The type of price which is quoted will be determined by the exchange. Last Price is recognised as the last trade on that exchange, not a last quote price. (fact about closing Price) MDDL definition:The final price as of market close.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeHighPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasApplicablePeriod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceDeterminationMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceIsTraded"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;takesAccountOfQuoteSize"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond exchange high price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The highest valuation over the period specified.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This can be regarded as a derived price. See also note in LowPrice Difference: different rules used. May be mased on trade OR quote price Analytic or Price?? this is a derived type but with a much simpler rule.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeLastPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceIsTraded"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond exchange last price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The last (or most recent) valuation.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is an actual trade price not a derived price</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeLowPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasApplicablePeriod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceDeterminationMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;priceIsTraded"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;takesAccountOfQuoteSize"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond exchange low price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The lowest valuation over the period specified. Possibly but not necessarily based on a trade. Determined by the trading venue as to whether it&apos;s based on a trade or an offer. this can be regarded as a derived price. Price is based on a riule whil will cause one to pick a certain price type.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BondExchangeOpeningPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond exchange opening price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value at the beginning of trading or opening of the market.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Exchange published price. Sometimes opening price is implied, sometimes it&apos;s published.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BondMarket">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond market</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BondMidPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond mid price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BondTradingContext">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-prc-fcp;SecondaryMarketTradingContext"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond trading context</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;BulletRedemptionPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-red;BondRedemptionPayment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-red;hasTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bullet redemption payment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;CashStructuredFinanceInstrumentPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash structured finance instrument price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">When the price is above a certain level (70), you get a quote in reference to an index e.g. LIBOR+50bp i.e. the yield. When you get below a certain price you get a quote such as 65c to a dollar. Percentage? not seen. Would be a whole number, interpreted as c/$</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This might be a Price, a Spread or a Yield, i.e. &quot;here&apos;s the price., the current Yield is this, and here&apos;s the Spread&quot;.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;CleanPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">clean price</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond or debt instrument price that does not include accrued interest.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;CurrentYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasParameter"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;CleanPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The ratio of the interest payment amount to the clean price.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a kind of yield that applies to debt instruments only as it relates to the clean price. It differs from the simple yield in that simple yield relates to the actual price paid for the bond, which on will differ from the clean price by the amount of accrued interest.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtIndependentlyEvaluatedPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DerivedPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;evaluatedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtPriceIndependentEvaluator"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt independently evaluated price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&quot;Evaluated Price&quot; is the price you get from the vendors.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This may not always be the same. Mostly in the US, now also moving into Europe and Asia. See e.g. MiFID. Vendor gives you Spread and Price: Early Price (right at the close of the market) plus a Final Price an hour or so later. Matrix pricing: pure calculation. throws the spread in and calculates the price, rather than surveying the market. Based on some formula, not on research of traders. notes from SMER 18 Nov Pricing Recipe - the prices that are input to that derived price. Notes from SMER 25 Nov If the instrument has not been trading, then there would normally need to be prices for valuing these, so you would go to an independent provider. You would also identify who you sourced it from. You would not put your own numbers in as this would not be impartial. Also since only the very liquid securities are those that trade, a lot of bonds in a Pf are not regularly traded and so there is not a market price, so you use a yield curve and interpolate on this to come up with an estimate of fair value. This also involves modeling what you anticipate the Cr spreads on those bonds would be.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtInstrumentYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Yield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;calculationFollowing"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-md-dbtx-aly;LifeAnalytic">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-md-temx-ins;Maturity">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-dbt-cft;PrescriptiveEvent">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-dbt-cft;RedemptionEvent">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;derivedFromOutlay"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt instrument yield</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The return on the debt instrument at the stated price.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Yield has a relationship to the price.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtPriceIndependentEvaluator">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt price independent evaluator</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtPriceSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;PriceSpread"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usedToDetermine"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt price spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The difference between the [what?] of a security and the fair price value of a different security which is used as a point of reference. The spread is used to determine the price of the instrument. (draft definition)</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This was &quot;Spread&quot; in the Debt pricing reviews, however that word has at least 2 other uses (spread between equity bid and offer prices; spread for derivatives). Detailed notes from Debt Pricing Review session 5 Aug: Identify what the spread is in relation to e.g. LIBOR. ALSO If fixed of floating. So if it&apos;s a FRN, For a fixed rate bond, it&apos;s priced off the on-the-run, e.g. a 30 year bond is priced as a spread wrt a 30 year treasury bond. So e..g spread would be something like 10bp+the value of the 30 year on the run Treasury. On the Run: definition needed. Also class of Thing and where this should go.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usedToDetermine"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LocallyDerivedPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt published point in time price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A debt price, usually in the form of a spread, published by a data provider at some point in time such as the end of the trading day.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The vendor will survey the banks and calculate the spread and publish as a spread. Price as a percentage is determined internally by the investment organization, based on that published spread. In terms of what sort of spread this is, this is information about the market and can be in any of those formats whereby price is specified (see Price Specification terms). Could have spread to price or spread to yield. Valuations are done at the end of the day but equivalent figures can be provided for other times.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecuritiesMarketMaker">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinesMarketPriceForDebt"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt securities market maker</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An actor which has the role of Market Maker in a given market.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecurityBidPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityQuotePrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt security bid price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price quoted for purchase of a quantity of a debt security in the marketplace. This may be either the OTC market or a securities exchange or a composite market consisting of several exchanges or trading facilities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecurityOfferPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityQuotePrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt security offer price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price quoted for sale of a quantity of a debt security in the marketplace. This may be either the OTC market or a securities exchange or a composite market consisting of several exchanges or trading facilities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecurityPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt security price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price of a Debt Instrument at some point in time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtSecurityQuotePrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt security quote price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price quoted for purchase or sale of a quantity of a debt security in the marketplace. This may be either the OTC market or a securities exchange or a composite market consisting of several exchanges or trading facilities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToAverageLife">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;AverageLife"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt yield to average life</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The yield achieved by substituting a bond&apos;s average life for the issue&apos;s final maturity date.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Assume from this that there is also a Yield to Equivalent Life. Some sources have these as the same term, whereas we have separated them.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToEquivalentLife">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;EquivalentLifeAnalytic"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt yield to equivalent life</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The yield achieved by substituting a bond&apos;s equivalent life for the issue&apos;s final maturity date.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Some sources have Average Life and Equivalent Life as the same term, whereas we have separated them.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToMaturity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Maturity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt yield to maturity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The internal rate of return an investor would achieve if he or she purchased that bond at its current dirty price, and held it to maturity, assuming all coupon and principal payments are received as scheduled.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToNextCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;NextCall"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt yield to next call</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The yield of a bond to the next possible call date.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DebtYieldToWorst">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;WorstCall"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt yield to worst</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Yield to the worst case of when the instrument might be called.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DefaultRate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default rate</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rate at which holders of loans in the pool default on those loans.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DerivedPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derived price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any price which is derived from some other source or calculation rather than being the price at which something actually traded or was quoted.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There are evaluated prices in which an independent source evaluates a price they have derived, and there are prices which are derived within a firm, from supplied, published end of day price spreads or other market data.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DirtyPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;dirtyPriceIncludes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;AccruedInterestAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dirty price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;DiscountedInstrumentYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">discounted instrument yield</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Yield quoted for a discount instrument. This is the ratio of the discount to the face value, divided by the period to maturity as a fraction of a year.</skos:definition>
+bubu<fibo-fnd-utl-av:usageNote rdf:datatype="&rdf;langString" xml:lang="en">Applies to Debt only.</fibo-fnd-utl-av:usageNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;EffectiveYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">effective yield</rdfs:label>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The difference between this and Native yield is as per note: Native yield relates to price quotation context; Effective Yild is in relation to portfolio analytics. Recall: every analytic formula relates to the set of cash flows, so there are assumptions underlying each of these, For example the assumption that Y is constant, which it isn&apos;t (because there is a curve, which may be convex not linear (is that right?). So you can compare rate or return between what I see and what the market has out there. In the US market: a Y which is calculated using Monto Carlo method simulation. relationship facts to add: Relation to method / formula (e.g. Monte Carlo), and the method used to determine the actual figure for the MC method. eff Y for single instrument: E Y for bonds without calls and stuff. Variation in this: whether we look at a whole set of bonds YTM quoted by Bmb would be the YTM quoted according to whatever the market is - = the NAtive Yield. SO: Publicly quoted more: choose another adjective.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;ExchangeTradedBondPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ExchangeTradedSecurityPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange traded bond price</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;InterpolatedPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DerivedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interpolated price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price determined by interpolation between available price figures, using some algorithm or curve.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Uses an algorithm to interpolate a price from two observed prices. Examples include price derived by interpolation between prices e.g. between Bid and Offer (among others). also includes Yield Curves and implied forward curves. That is, interpolation may either be linear (straight line interpolation between two values) or may be expressed as a non linear curve such as a yield curve or an implied forward curve.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;IssuerCreditRating">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer credit rating</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;JapaneseCompoundYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasRoundingDirection"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Down"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">japanese compound yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">No definition in selection list.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;JapaneseSimpleYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasRoundingDirection"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;Down"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">japanese simple yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">No definition.Term put here from memory. 02 Dec changed from Japanese Yield to Japanese Simple Yield. note hat Japanese Compound yield also here (from FIBIM or anothe rlist, added 25 nov with the rest).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;LoanAge">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan age</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The age of the loan.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;LoanMaturity">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;inRelationTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;ThePresent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan maturity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">THe length of time from the present until the loan or mortgage matures, that is the date when the last of the principal is paid off along with all interest.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;LoanPoolAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DebtPoolAnalyticalParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan pool analytic</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure of some aspect of a pool of loans.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;LoanPoolPrepaymentModel">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticsCalculationModel"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;includes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanPrepaymentFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan pool prepayment model</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Model of the prepayments of loans in a pool of individual loans, such as a mortgage pool or loan pool.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This model captures the parameters that may influence the prepayment of loans or mortgages and relates these mathematically.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;LoanPrepaymentFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan prepayment formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formula which embodies the model for loan pool prepayment speed.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From SMER sessions: This is a model. Includes other factors such as homogeniety. To model this more completely we need to identify the parameters that go in to this formula. Among these is the above homogeneity measure - need to know how that is measured and in what terms it is expressed, e.g. as a percentage, with reference to some mean or standard deviation and so on. Also some of the parameters used in this model would presumably make reference to standard mathematical model constructs such as normal distribution, variaous deviation measures, Chi squared and so on. These are not presently in the semantics model, but can be modeled semantically if required. This would not however be a mathematical model - we only need to identify these and show meaningful relationships (not mathematical relationships) between them.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;LocallyDerivedPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DerivedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">locally derived price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price derived locally from information supplied by a market data vendor such as an end of day spread.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;MBSFactor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m b s factor</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;DurationAnalytic"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;makesReferenceTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;InstrumentInternalRateOfReturn"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">MacCaulays Duration Analytic</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;NativeYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;RelativelyDefinedDebtInstrumentYield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedUsing"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;NativeYieldCalculationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">native yield</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The yield of the security as determined using the Yield Calculation Method that is the default for the market that the security is traded in.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">conventional yield for that security type and geo location, ie. would be in relation too</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;NativeYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;RelativeYieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;isDefaultMethodFor"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">native yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The convention used in the marketplace for that security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;NextCall">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;NextCallDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">next call</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The next call of the issue, as at the current time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;NextCallDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownTemporalEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">next call date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The next date on which the issue can be called, from the present date.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;NextPut">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;PutOfIssue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">next put</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The next available put date for the issue, as at the current time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;OTCBondMarketPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;SecurityMarketPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;oTCBondMarketPriceHasPricingSource"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecuritiesMarketMaker"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c bond market price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price determined for the marketplace for a bond which is traded over the counter.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review comment: Must include Attribution. This is in the model in the form of tha Market Maker (an actor in the activity of secondary market trading for OTC-traded debt).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;OptonAdjustedYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">opton adjusted yield</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">NB specified as a spread. synonym: OAS Based on different Int Rate paths. There are different OAS models just like there are different Yield methods. Also would make reference to the Yield Curve - but these are parameters that go into that model. Limit this model at the point where it distinguishes the difference between things - we are not in a position to mathematically model the things themselves, just capture the basic facts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;Outlay">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Expenditure"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">outlay</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Cash spent on something.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;PublishedEndOfDayPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">published end of day price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price published by a market data vendor at the end of the trading day.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be specified in terms of a spread (end of day spread) or in some other form. EoD spread could be nominal or end of day adjusted.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;PublishedPriceAsRateSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">published price as rate spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A debt instrument price quoted or defined in terms of a spread of that instrument&apos;s price with reference to some reference rate. The reference rate may be either a market interest rate such as an IBOR or the rate of interest on some reference instrument.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;PublishedPriceAsTreasuryRateSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;PublishedPriceAsRateSpread"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;relativeTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;TreasuryBillReferenceRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">published price as treasury rate spread</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;ReferenceDebtInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ParametricReferenceEntity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasReferenceRate"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;DebtInstrumentReferenceRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference debt instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A debt instrument in the role of a reference instrument. Some property of the instrument is used in calculations, for example the interest or the yield of the instrument.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;ReferenceSovereignBill">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;ReferenceDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasReferenceRate"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;TreasuryBillReferenceRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference sovereign bill</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Treasury Note or other sovereign debt the interest of which is used as a reference rate.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;RelativeYieldCalculationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relative yield calculation method</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;RelativelyDefinedDebtInstrumentYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relatively defined debt instrument yield</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;RussianYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;RussianYieldFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">russian yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method used in determining Yield in the Russian markets. This is based on an effective yield with fundamentally different math. To give an example of the use of a different &quot;yield type&quot;, we have Russia, which trades based on an effective yield. The price-yield math is fundamentally different. Notes Origin:Fidessa Uses a trade space and effective yield formula. MAy have same day types but different math.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;RussianYieldFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationFormula"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">russian yield formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">This is based on a different Effective Yield than on another market.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;SecondaryMarketBondDealing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;SecuritiesTrading"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-prc-fcp;context"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-prc-fcp;SecondaryMarketTradingContext"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">secondary market bond dealing</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;SecuritiesTrading">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities trading</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;SecurityMarketPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security market price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;SimpleYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesPrice"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">simple yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The annual rate of return expressed as a percentage. This is the return divided by the outlay and multiplied by 100 to express the figure as a percentage.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is yield in its simplest sense, expressed as a percentage of return to outlay. As such, this is the same way that yield is determined for any investments, not just financial instruments or debt investments.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;SpanishYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spanish yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method used in determining annual yield in Spanish corporate bonds.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;ThePresent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">the present</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Now.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;USCorporateBondYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;ICMAYieldFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">u s corporate bond yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">This has 30/360 and semi-annual compounding.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;USTreasuryYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;ICMAYieldFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">u s treasury yield calculation method</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;WallStreetYieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;ICMAYieldFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">wall street yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">No definition.Term put here from memory.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;WeightedAverageCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;InstrumentAggregateLoanAnalytic"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">weighted average coupon</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The weighted-average gross interest rates of the pool of mortgages that underlie a mortgage-backed security (MBS) at the time the securities were issued. A mortgage-backed security&apos;s current WAC can differ from its original WAC as the underlying mortgages pay down at different speeds. In the weighted-average calculation, the principal balance of each underlying mortgage is used as the weighting factor</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Provided by the Issuer (loan servicer?) along with the WALA etc. If you know the underlying loans you can calculate this yourself. For ABS you don&apos;t know this so you have to get this information from the loan servicer. Investopedia explains Weighted Average Coupon - WAC For example, suppose a MBS is composed of two different pools of mortgages: $6 million worth of mortgages that yield 7.5% and a pool of $4 million mortgages that yield 5%. The WAC would be 6.5%. The WAC on a mortgage-backed security is an important piece of information used by analysts to estimate the pre-pay characteristics of that security. It is an important relative value tool in MBS portfolio management and analysis.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;WeightedAverageTimeToReceiptOfCashflows">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">weighted average time to receipt of cashflows</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The weighted average time to the receipt of cashflows for an instrument.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">A formal definition is needed for this. The name is almost self defining, but only to those who already know what this means. In particular we should define how the weighted average is weighted, and what this means, along with a formula for calculating this at the most generic level (cashflow, time, without assumptions about particular types of instrument).</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;WorstCall">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedToOccurOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;WorstCallDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">worst call</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The worst case of when the instrument might be called.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;WorstCallDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DeterminedTemporalEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">worst call date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The worst date on which the instrument might be called.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">We should refine what we mean by Worst here - soonest, or most distant?</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;WorstCallDateDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;TemporalEntityDetermination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">worst call date determination</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The determination of when the call identified as the Worst Call would take place. This consist of some means by which that date is determined and a date on which that date is deemed to be the Worst Call date.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;YieldCalculationFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasSubject"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">yield calculation formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formula used in determining the Yield.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The subject of this Formula is the Yield. The formula has an expression which can be defined either in tectual terms or by further local extension of the term &quot;Formula Expression&quot; to define the parameters used.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;YieldCalculationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasParameter"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;usesFormula"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;YieldCalculationFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">yield calculation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which the yield is calculated. This includes a formula for calculation and a specific day count convention and compounding. You would apply this calculation method on top of the underlying terms and conditions, do for example the holiday calenders and so on, are used in these formulae. For final cash flow: Japanese yield will round down accrued interest. Add: The actual underlying math. Wall Street uses the same ICMA formula.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Initial reviewer notes 18 Nov: this uses the combination of the day count and the compounding gives you the name of the yield calculation method. Names are associated with algorithms. What yield you use to determining the present value. These are typically defined in a prospectus (for exchange traded) or Info Memorandum if it&apos;s traded in an OTC market. where it also defines the method itself. Action: look at some prospecti or get this from a vendor. Additional features 25 nov: Question - maybe Holiday calendar? Also date roll rules and roll back rules. These all apply. YC feeds in to Yield itself.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-py;YieldToNextPut">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasOutlookPeriod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;NextPut"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">yield to next put</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;absolutePrepaymentRateHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">absolute prepayment rate has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AbsolutePrepaymentRate"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the rate itself, at a given point in time, expressed as a percentage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;accruedInterestAmountHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accrued interest amount has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AccruedInterestAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of accrued interest, at a point in time, expressed as a percentage/</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;amount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">amount</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;applicablePeriod.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable period</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;basedUpon">
+bubu<rdfs:label>based upon</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;calculationFollowing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">calculation following</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;closingPriceValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">closing price value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeClosingPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the price at closing, as a monetary amount (amount and currency).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;compounded">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">compounded</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;compoundingFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">compounding frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;dayCountBasis">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">day count basis</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">The convention used to calculate the number of days in an interest payment period.</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;daysAccrued">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">days accrued</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of days that interest has accrued, as reflected in the price.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;defaultRateValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default rate value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DefaultRate"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;derivedFrom">
+bubu<rdfs:label>derived from</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;derivedFrom.1">
+bubu<rdfs:label>derived from</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;derivedFrom.2">
+bubu<rdfs:label>derived from</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinationDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determination date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;WorstCallDateDetermination"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date at which the identified call date is identified as being the &quot;Worst&quot; possible call date. Market conditions on that date make the call date in question the &quot;Worst Call&quot; at that time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;derivedFrom"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AbsolutePrepaymentRate"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;AbsolatePrepaymentRateFormula"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinedRelativeTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-temx-tem;isBetween"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determined relative to</rdfs:label>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinedToOccurOn">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;occursOn"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determined to occur on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;WorstCall"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;WorstCallDate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinedUsing">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determined using</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;RelativelyDefinedDebtInstrumentYield"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;RelativeYieldCalculationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;determinesMarketPriceForDebt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">determines market price for debt</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtSecuritiesMarketMaker"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
+bubu<owl:inverseOf rdf:resource="&fibo-md-dbtx-py;oTCBondMarketPriceHasPricingSource"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;dirtyPriceIncludes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dirty price includes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;AccruedInterestAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;evaluatedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">evaluated by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtIndependentlyEvaluatedPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtPriceIndependentEvaluator"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;exCoupon.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ex coupon</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;exchangeTradedBondPriceHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange traded bond price has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage value of the price at a given point in time</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;expressedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expressed as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AbsolatePrepaymentRateFormula"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">ABS = (100 * SMM)/100 + (SMM X (Age- 1)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;expressedInRelationTo">
+bubu<rdfs:label>expressed in relation to</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;expression">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expression</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;has.2">
+bubu<rdfs:label>has</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasApplicablePeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has applicable period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasDefaultRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has default rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DefaultRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasDurationValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has duration value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;WeightedAverageTimeToReceiptOfCashflows"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedDurationSpecification"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasInterestRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has interest rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-int;DebtSecurityInterestAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasLoanMaturity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has loan maturity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-loan-loan-loan;LoanDrawdown"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasMaturity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has maturity</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;Maturity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasOutlookPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has outlook period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-md-dbtx-aly;LifeAnalytic">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-md-temx-ins;Maturity">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-dbt-cft;PrescriptiveEvent">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-dbt-cft;RedemptionEvent">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasParameter">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has parameter</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasReferenceRate">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;takesReferenceParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has reference rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ReferenceDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-int;DebtInstrumentReferenceRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasRoundingDirection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has rounding direction</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">Whether the accrued interest is rounded up or down in this method.</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;Direction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasWac">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has wac</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;WeightedAverageCoupon"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;hasYield">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;details"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has yield</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;inRelationTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in relation to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;ThePresent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;interpolatedBetween">
+bubu<rdfs:label>interpolated between</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;isCompounded">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is compounded</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed Moved from Yield - assume this can only be about debt instrument or loan / debt yields i..e where the income relates to interest payments. .</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;isDefaultMethodFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is default method for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;NativeYieldCalculationMethod"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;isSpreadBetween">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is spread between</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtPriceSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;loanMaturityValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan maturity value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;LoanMaturity"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;macCaulaysDurationHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mac caulays duration has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;MacCaulaysDurationAnalytic"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The MacCaulays Duration in Years.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;macCaulaysDuratonValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mac caulays duraton value</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;oTCBondMarketPriceHasPricingSource">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o t c bond market price has pricing source</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecuritiesMarketMaker"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;openingPriceMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">opening price method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeOpeningPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which the Opening Price is determined for that exchange.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;otcBondMarketPriceHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">otc bond market price has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;OTCBondMarketPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;pointInTimePriceHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">point in time price has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtPublishedPointInTimePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;BasisPointsValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Is normally be expressed in basis points, although the meaning of BP implies a percentage value. Change this to BP.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceDeterminationConventionNotes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price determination convention notes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeClosingPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Further free text notes on the way in which the closing price is determined.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceDeterminationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price determination method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which the High Price is determined on that exchange.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which the High or Low Price is determined on that exchange.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;priceDeterminationMethod.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price determination method</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceIsTraded">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price is traded</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The highest valuation over the period specified. Notes from Equity review, may apply to Debt also: this can be regarded as a derived price. See also note in LowPrice Difference: different rules used. May be based on trade OR quote price Analytic or Price?? this is a derived type but with a much simpler rule.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceQuotedExDividend">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price quoted ex dividend</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the yield is based on a price which is quoted ex-dividend. When a bond is said to trade ex-dividend it means that there is a period of time prior to each coupon payment during which a bond purchaser does not receive custody of the next coupon. That payment is made to the previous bond holder and accrued interest is therefore negative during the ex-dividend period.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;priceValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price of the debt instrument expressed as a percentage of the par value of the instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;quoteSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quote size</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;quotedExDividend">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quoted ex dividend</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the price is quoted ex-dividend. When a bond is said to trade ex-dividend it means that there is a period of time prior to each coupon payment during which a bond purchaser does not receive custody of the next coupon. That payment is made to the previous bond holder and accrued interest is therefore negative during the ex-dividend period.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;refersToCreditRating">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to credit rating</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AlgoDebtCreditSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;IssuerCreditRating"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;refersToMaturity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to maturity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;AlgoDebtCreditSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;Maturity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;relativeTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">relative to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;CreditSpread"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-md-dbtx-int;DebtInstrumentReferenceRate">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;roundingConvention">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rounding convention</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rounding convention used in the calculation method.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;roundingDirection.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rounding direction</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;takesAccountOfQuoteSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes account of quote size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;ExchangeTradedBondPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">High or Low Price takes into account size of quote.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Low Price takes into account size of quote.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;traded.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;tradingDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeClosingPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The trading date for which this information is applicable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;usedToDetermine">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">used to determine</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;DebtPriceSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecurityPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;usesFormula">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">uses formula</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;YieldCalculationFormula"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;usesPrice">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-py;hasParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">uses price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;SimpleYieldCalculationMethod"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DirtyPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;valuationDateAndTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation date and time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;BondExchangeLastPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date and time at which the Last Price was determined i.e. the time time and date of the offer or trade that the price relates to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;value.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-py;wACHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">w a c has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-py;WeightedAverageCoupon"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the Weighted Average Coupon at some point in the past or at the present time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-dbtx-py;wACValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">w a c value</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasDefaultRate"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DefaultRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasWac"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;WeightedAverageCoupon"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasInterestRate"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;DebtSecurityInterestAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Maturity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasYield"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtInstrumentYield"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/md/DebtTemporal/DebtRedemptionAmounts.rdf
+++ b/md/DebtTemporal/DebtRedemptionAmounts.rdf
@@ -1,63 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-dbtx-red "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/">
-	<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-md-dbtx-red "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/">
+bu<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-dbtx-red="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/"
-	xmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/">
-		<rdfs:label xml:lang="en">DebtRedemptionAmounts</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-red;AmortizingRedemptionPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-red;BondRedemptionPayment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-red;hasTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">amortizing redemption payment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-dbtx-red;BondRedemptionPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ContractuallyDefinedNumericalParameter"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-red;hasTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond redemption payment</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-red;hasTerms">
-		<rdfs:label xml:lang="en">has terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-dbtx-red;BondRedemptionPayment"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-md-dbtx-red="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/"
+buxmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtRedemptionAmounts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines kinds of payment towards the redemption of a bond or amortizing security, as actual payment events in time.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtRedemptionAmounts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-red;AmortizingRedemptionPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-red;BondRedemptionPayment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-red;hasTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">amortizing redemption payment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-dbtx-red;BondRedemptionPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;ContractuallyDefinedNumericalParameter"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-red;hasTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond redemption payment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-red;hasTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-dbtx-red;BondRedemptionPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/md/DerivativesTemporal/ETOptionsTemporal.rdf
+++ b/md/DerivativesTemporal/ETOptionsTemporal.rdf
@@ -1,236 +1,239 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-etd-ostd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
-	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-derx-eto "https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-etd-ostd "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/">
+bu<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-md-derx-eto "https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/"
-	xmlns:fibo-der-etd-ostd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"
-	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-derx-eto="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/">
-		<rdfs:label xml:lang="en">ETOptionsTemporal</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;Delta">
-		<rdfs:subClassOf rdf:resource="&fibo-md-derx-eto;OptionsGreek"/>
-		<rdfs:label xml:lang="en">delta</rdfs:label>
-		<skos:definition xml:lang="en">First derivative of option value with respect to theoretical price is a delta (or on a position). Theoretical price</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Delta tells you what options to buy to get the equivalent price sensitivity to the underlying. How many at that price to get that hedge. So for example an at the money option has a delta of 50. Units</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;ETOptionPremium">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-derx-eto;reflects"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-md-derx-eto;OptionIntrinsicValue">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-md-derx-eto;OptionTimeValue">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">e t option premium</rdfs:label>
-		<skos:definition xml:lang="en">The amount that is paid for an option. That&apos;s for the whole contract. Units: The premium is a monetary amount; the rate is a percentage.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The term premium originates because these are in the nature of insurance contract (hedges). this is analogous to Price in other securities or indeed anything; that is, the price is what a party would be willing to pay for something. Just like the price of anything at all, the Option Premium has two value components, one which can be determined (known as Value In Use when applied to products or services) and an element which is more subjective and reflects investor sentiment (for products and services this is the Value In Exchange). For Options, these are Intrinsic Value and Time Value respectively; that is, the intrinsic value can be calculated directly while the Time Value reflects the difference between this and the Premium. Additionally, statistical measures can be used to reduce the level of unknown in the Time Value. Time Value reduces to zero as exercise date approaches. Notes Origin:MB Draft</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;ExchangeOptionsPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-derx-eto;expressedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-derx-eto;ETOptionPremium"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exchange options price</rdfs:label>
-		<skos:definition xml:lang="en">options prices types: Bid Ask There is also a bid/ask spread exchange will quote option price as a premium rate. e.g. I ill pay you 2% of face value of underlying trade. That turns into a price (Premium = face x that 2%). OTC uses volatility to get to premium value.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionClosingPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-derx-eto;ExchangeOptionsPrice"/>
-		<rdfs:label xml:lang="en">option closing price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionDailySettlementPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-derx-eto;setBy"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option daily settlement price</rdfs:label>
-		<skos:definition xml:lang="en">The official price at the end of a trading session. This price is established by The Options Clearing Corporation and is used to determine changes in account equity, margin requirements, and for other purposes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionIntrinsicValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;ValueInUse"/>
-		<rdfs:label xml:lang="en">option intrinsic value</rdfs:label>
-		<skos:definition xml:lang="en">Intrinsic Value (Calls): When the underlying security&apos;s price is higher than the strike price a call option is said to be &quot;in-the-money.&quot; Intrinsic Value (Puts): If the underlying security&apos;s price is less than the strike price, a put option is &quot;in-the-money.&quot; Only in-the-money options have intrinsic value, representing the difference between the current price of the underlying security and the option&apos;s exercise price, or strike price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionTheoreticalValue">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-derx-eto;definedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-tem;PriceVolatilitySpecification"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">option theoretical value</rdfs:label>
-		<skos:definition xml:lang="en">Theoretical value looks at variability of the price. The longer until exercise the more this will vary. the more likely it is to finish in the money, the more I am likely to pay for it. But meanwhile, I also have to look at the current value - the amount I would pay for the thing. Any change would be a cost to me.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Fair Value is the amount I would spend in maintaining a neutral hedge.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionTheoreticalValueSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceVolatilitySpecification"/>
-		<rdfs:label xml:lang="en">option theoretical value specification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionTimeValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;ValueInExchange"/>
-		<rdfs:label xml:lang="en">option time value</rdfs:label>
-		<skos:definition xml:lang="en">Prior to expiration, any premium in excess of intrinsic value is called time value. Time value is also known as the amount an investor is willing to pay for an option above its intrinsic value, in the hope that at some time prior to expiration its value will increase because of a favorable change in the price of the underlying security. The longer the amount of time for market conditions to work to an investor&apos;s benefit, the greater the time value.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionVolatility">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/Volatility"/>
-		<rdfs:label xml:lang="en">option volatility</rdfs:label>
-		<skos:definition xml:lang="en">A measure of the fluctuation in the market price of the underlying security. Mathematically, volatility is the annualized standard deviation of returns. More generally: A measure of stock price fluctuation. Mathematically the volatility is the annualized standard deviation of a stock&apos;s daily price changes</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionsGreek">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
-		<rdfs:label xml:lang="en">options greek</rdfs:label>
-		<skos:definition xml:lang="en">One of a set of measures about an option which is used to analyze the value or performance of that instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionsTheta">
-		<rdfs:subClassOf rdf:resource="&fibo-md-derx-eto;OptionsGreek"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-derx-eto;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">options theta</rdfs:label>
-		<skos:definition xml:lang="en">A measure of the rate of change in an option&apos;s theoretical value for a one-unit change in time to the option&apos;s expiration date. Action: add terms that define or influence this.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-derx-eto;OptionsVega">
-		<rdfs:subClassOf rdf:resource="&fibo-md-derx-eto;OptionsGreek"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-derx-eto;refersTo.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">options vega</rdfs:label>
-		<skos:definition xml:lang="en">A measure of the rate of change in an option&apos;s theoretical value for a one-unit change in the volatility assumption. Action: add terms that define or influence this.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;definedBy">
-		<rdfs:label xml:lang="en">defined by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;PriceVolatilitySpecification"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;expressedAs">
-		<rdfs:label xml:lang="en">expressed as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-derx-eto;ExchangeOptionsPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-derx-eto;ETOptionPremium"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;refersTo">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-derx-eto;OptionsTheta"/>
-		<rdfs:range rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;refersTo.1">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-derx-eto;OptionsVega"/>
-		<rdfs:range rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;reflects">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-accx-acc;purportsToReflect"/>
-		<rdfs:label xml:lang="en">reflects</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-derx-eto;ETOptionPremium"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-md-derx-eto;OptionIntrinsicValue">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-md-derx-eto;OptionTimeValue">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;setBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-		<rdfs:label xml:lang="en">set by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-derx-eto;OptionDailySettlementPrice"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-etd-ostd="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"
+buxmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-md-derx-eto="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ETOptionsTemporal</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Exchange traded options date and time dependent terms such as pricing, time values, margining, as well as volatility and other analytics. Also covers greeks (deltas, thetas etc.)</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/ETOptionsTemporal/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;Delta">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-derx-eto;OptionsGreek"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delta</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">First derivative of option value with respect to theoretical price is a delta (or on a position). Theoretical price</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Delta tells you what options to buy to get the equivalent price sensitivity to the underlying. How many at that price to get that hedge. So for example an at the money option has a delta of 50. Units</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;ETOptionPremium">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-derx-eto;reflects"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-md-derx-eto;OptionIntrinsicValue">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-md-derx-eto;OptionTimeValue">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">e t option premium</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount that is paid for an option. That&apos;s for the whole contract. Units: The premium is a monetary amount; the rate is a percentage.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The term premium originates because these are in the nature of insurance contract (hedges). this is analogous to Price in other securities or indeed anything; that is, the price is what a party would be willing to pay for something. Just like the price of anything at all, the Option Premium has two value components, one which can be determined (known as Value In Use when applied to products or services) and an element which is more subjective and reflects investor sentiment (for products and services this is the Value In Exchange). For Options, these are Intrinsic Value and Time Value respectively; that is, the intrinsic value can be calculated directly while the Time Value reflects the difference between this and the Premium. Additionally, statistical measures can be used to reduce the level of unknown in the Time Value. Time Value reduces to zero as exercise date approaches. Notes Origin:MB Draft</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;ExchangeOptionsPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-derx-eto;expressedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-derx-eto;ETOptionPremium"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange options price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">options prices types: Bid Ask There is also a bid/ask spread exchange will quote option price as a premium rate. e.g. I ill pay you 2% of face value of underlying trade. That turns into a price (Premium = face x that 2%). OTC uses volatility to get to premium value.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionClosingPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-derx-eto;ExchangeOptionsPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option closing price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionDailySettlementPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-derx-eto;setBy"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option daily settlement price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The official price at the end of a trading session. This price is established by The Options Clearing Corporation and is used to determine changes in account equity, margin requirements, and for other purposes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionIntrinsicValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;ValueInUse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option intrinsic value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Intrinsic Value (Calls): When the underlying security&apos;s price is higher than the strike price a call option is said to be &quot;in-the-money.&quot; Intrinsic Value (Puts): If the underlying security&apos;s price is less than the strike price, a put option is &quot;in-the-money.&quot; Only in-the-money options have intrinsic value, representing the difference between the current price of the underlying security and the option&apos;s exercise price, or strike price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionTheoreticalValue">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-derx-eto;definedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-tem;PriceVolatilitySpecification"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option theoretical value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Theoretical value looks at variability of the price. The longer until exercise the more this will vary. the more likely it is to finish in the money, the more I am likely to pay for it. But meanwhile, I also have to look at the current value - the amount I would pay for the thing. Any change would be a cost to me.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Fair Value is the amount I would spend in maintaining a neutral hedge.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionTheoreticalValueSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceVolatilitySpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option theoretical value specification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionTimeValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;ValueInExchange"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option time value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Prior to expiration, any premium in excess of intrinsic value is called time value. Time value is also known as the amount an investor is willing to pay for an option above its intrinsic value, in the hope that at some time prior to expiration its value will increase because of a favorable change in the price of the underlying security. The longer the amount of time for market conditions to work to an investor&apos;s benefit, the greater the time value.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionVolatility">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/Volatility"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">option volatility</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure of the fluctuation in the market price of the underlying security. Mathematically, volatility is the annualized standard deviation of returns. More generally: A measure of stock price fluctuation. Mathematically the volatility is the annualized standard deviation of a stock&apos;s daily price changes</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionsGreek">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">options greek</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One of a set of measures about an option which is used to analyze the value or performance of that instrument.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionsTheta">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-derx-eto;OptionsGreek"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-derx-eto;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">options theta</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure of the rate of change in an option&apos;s theoretical value for a one-unit change in time to the option&apos;s expiration date. Action: add terms that define or influence this.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-derx-eto;OptionsVega">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-derx-eto;OptionsGreek"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-derx-eto;refersTo.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">options vega</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure of the rate of change in an option&apos;s theoretical value for a one-unit change in the volatility assumption. Action: add terms that define or influence this.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;definedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;PriceVolatilitySpecification"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;expressedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">expressed as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-derx-eto;ExchangeOptionsPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-derx-eto;ETOptionPremium"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;refersTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-derx-eto;OptionsTheta"/>
+bubu<rdfs:range rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;refersTo.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-derx-eto;OptionsVega"/>
+bubu<rdfs:range rdf:resource="&fibo-md-derx-eto;OptionTheoreticalValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;reflects">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-accx-acc;purportsToReflect"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reflects</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-derx-eto;ETOptionPremium"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-md-derx-eto;OptionIntrinsicValue">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-md-derx-eto;OptionTimeValue">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-derx-eto;setBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">set by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-derx-eto;OptionDailySettlementPrice"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-der-etd-ostd;OptionsClearingEntity">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/md/DerivativesTemporal/FuturesTemporal.rdf
+++ b/md/DerivativesTemporal/FuturesTemporal.rdf
@@ -1,121 +1,124 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-der-fut "https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-md-der-fut "https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/"
-	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-der-fut="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/">
-		<rdfs:label xml:lang="en">FuturesTemporal</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-der-etd-std;DerivativesExchange">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;ExchangeFuturesPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
-		<rdfs:label xml:lang="en">exchange futures price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;FuturesClosingPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;ExchangeFuturesPrice"/>
-		<rdfs:label xml:lang="en">futures closing price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;FuturesDailySettlementPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
-		<rdfs:label xml:lang="en">futures daily settlement price</rdfs:label>
-		<skos:definition xml:lang="en">Review whether this exists</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;FuturesGreek">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
-		<rdfs:label xml:lang="en">futures greek</rdfs:label>
-		<skos:definition xml:lang="en">One of a set of measures about an option which is used to analyze the value or performance of that instrument.</skos:definition>
-		<skos:editorialNote xml:lang="en">ACTION: Do these exist? They have been harvested from the Options world.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;FuturesInitialTradingMargin">
-		<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;FuturesTradingMargin"/>
-		<rdfs:label xml:lang="en">futures initial trading margin</rdfs:label>
-		<skos:definition xml:lang="en">When you open a futures contract, the futures exchange will state a minimum amount of money that you must deposit into your account. This original deposit of money is called the initial margin.</skos:definition>
-		<skos:editorialNote xml:lang="en">See also notes under &quot;Futures Trading Margin&quot;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;FuturesTheta">
-		<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;FuturesGreek"/>
-		<rdfs:label xml:lang="en">futures theta</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;FuturesTradingAccountHolder">
-		<rdfs:label xml:lang="en">futures trading account holder</rdfs:label>
-		<skos:definition xml:lang="en">A party who has an account for futures trading at a derivatives exchange. Further notes: The trader opens an account with a given amount known as a margin.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;FuturesTradingMargin">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-der-fut;heldBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-der-fut;FuturesTradingAccountHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures trading margin</rdfs:label>
-		<skos:definition xml:lang="en">In the futures market, margin refers to the initial deposit of &quot;good faith&quot; made into an account in order to enter into a futures contract. This margin is referred to as good faith because it is this money that is used to debit any day-to-day losses.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">When you open a futures contract, the futures exchange will state a minimum amount of money that you must deposit into your account. This original deposit of money is called the initial margin. When your contract is liquidated, you will be refunded the initial margin plus or minus any gains or losses that occur over the span of the futures contract. In other words, the amount in your margin account changes daily as the market fluctuates in relation to your futures contract. The minimum-level margin is determined by the futures exchange and is usually 5% to 10% of the futures contract. These predetermined initial margin amounts are continuously under review: at times of high market volatility, initial margin requirements can be raised. Notes from Investopedia</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;FuturesVega">
-		<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;FuturesGreek"/>
-		<rdfs:label xml:lang="en">futures vega</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-der-fut;MinimumMargin">
-		<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;FuturesTradingMargin"/>
-		<rdfs:label xml:lang="en">minimum margin</rdfs:label>
-		<skos:definition xml:lang="en">The lowest amount an account can reach before needing to be replenished.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-der-fut;hasAccountHolder">
-		<rdfs:label>has account holder</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-der-fut;heldBy">
-		<rdfs:label xml:lang="en">held by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-der-fut;FuturesTradingMargin"/>
-		<rdfs:range rdf:resource="&fibo-md-der-fut;FuturesTradingAccountHolder"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-der-fut;holds">
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-		<rdfs:range rdf:resource="&fibo-md-der-fut;FuturesTradingMargin"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-md-der-fut="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FuturesTemporal</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Exchange traded futures date and time dependent terms such as prices and margining. Also covers greeks (thetas etc.)</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/ExchangeTradedDerivatives/Futures/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/DerivativesTemporal/FuturesTemporal/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-der-etd-std;DerivativesExchange">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;ExchangeFuturesPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange futures price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;FuturesClosingPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;ExchangeFuturesPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures closing price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;FuturesDailySettlementPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures daily settlement price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Review whether this exists</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;FuturesGreek">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures greek</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">One of a set of measures about an option which is used to analyze the value or performance of that instrument.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">ACTION: Do these exist? They have been harvested from the Options world.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;FuturesInitialTradingMargin">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;FuturesTradingMargin"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures initial trading margin</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">When you open a futures contract, the futures exchange will state a minimum amount of money that you must deposit into your account. This original deposit of money is called the initial margin.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">See also notes under &quot;Futures Trading Margin&quot;</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;FuturesTheta">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;FuturesGreek"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures theta</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;FuturesTradingAccountHolder">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures trading account holder</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party who has an account for futures trading at a derivatives exchange. Further notes: The trader opens an account with a given amount known as a margin.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;FuturesTradingMargin">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-der-fut;heldBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-der-fut;FuturesTradingAccountHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures trading margin</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">In the futures market, margin refers to the initial deposit of &quot;good faith&quot; made into an account in order to enter into a futures contract. This margin is referred to as good faith because it is this money that is used to debit any day-to-day losses.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">When you open a futures contract, the futures exchange will state a minimum amount of money that you must deposit into your account. This original deposit of money is called the initial margin. When your contract is liquidated, you will be refunded the initial margin plus or minus any gains or losses that occur over the span of the futures contract. In other words, the amount in your margin account changes daily as the market fluctuates in relation to your futures contract. The minimum-level margin is determined by the futures exchange and is usually 5% to 10% of the futures contract. These predetermined initial margin amounts are continuously under review: at times of high market volatility, initial margin requirements can be raised. Notes from Investopedia</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;FuturesVega">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;FuturesGreek"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">futures vega</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-der-fut;MinimumMargin">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-der-fut;FuturesTradingMargin"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">minimum margin</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The lowest amount an account can reach before needing to be replenished.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-der-fut;hasAccountHolder">
+bubu<rdfs:label>has account holder</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-der-fut;heldBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">held by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-der-fut;FuturesTradingMargin"/>
+bubu<rdfs:range rdf:resource="&fibo-md-der-fut;FuturesTradingAccountHolder"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-der-fut;holds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
+bubu<rdfs:range rdf:resource="&fibo-md-der-fut;FuturesTradingMargin"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/md/EquityTemporal/EquityPricing.rdf
+++ b/md/EquityTemporal/EquityPricing.rdf
@@ -1,822 +1,825 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
-	<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
-	<!ENTITY fibo-md-eqx-pri "https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
+bu<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
+bu<!ENTITY fibo-md-eqx-pri "https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
-	xmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
-	xmlns:fibo-md-eqx-pri="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/">
-		<rdfs:label xml:lang="en">EquityPricing</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;BestBid">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasOrigin"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;ListedSecuritiesCompositeMarket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">best bid</rdfs:label>
-		<skos:definition xml:lang="en">The highest bid price for the stock up to the present time. Based on rules defined at the market, that determine how best bid and best offer are determined.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Always based on a quote (not a trade) and is measured across markets, not just on the one market. Takes into account time and quote size. Real time price based on latest quotes and their sizes.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;BestOffer">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasOrigin"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;ListedSecuritiesCompositeMarket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">best offer</rdfs:label>
-		<skos:definition xml:lang="en">The lowest bid price for the stock up to the present time. Based on rules defined at the market, that determine how best bid and best offer are determined.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Takes into account time and quote size. And time (it&apos;s the latest). If these take place on more than one exchange at the same time, the best Bid or Offer are the ones with the highest size.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;BidAskSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePriceSpread"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo.3"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bid ask spread</rdfs:label>
-		<skos:definition xml:lang="en">Spread: Range between Bid and Ask</skos:definition>
-		<skos:editorialNote xml:lang="en">SMER 18 Nov: this also applies to debt or indeed any purblicy traded insturment. Appliues whether exchange traded or OTC traded.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;BidPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
-		<rdfs:label xml:lang="en">bid price</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
-		<skos:definition xml:lang="en">The price at which a market participant would put out in an order book indicating that they are willing to pay for a given stock.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If there is not a bid in the market then there would not be a bid price. Bid is a value that requires a size</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;CompositeMarket">
-		<rdfs:label xml:lang="en">composite market</rdfs:label>
-		<skos:definition xml:lang="en">The market as a whole, i.e. one or more exchanges, a market (geographical) etc., about which prices and other derived facts may be quoted by market data vendors.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;CurrentEquityStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">current equity status</rdfs:label>
-		<skos:definition xml:lang="en">Information about the status of the equity at a given point in time.</skos:definition>
-		<skos:editorialNote xml:lang="en">Note that the individual status indications take &quot;dated&quot; values which include date or current value, therefore there is no &quot;Status Date&quot; for these terms. Note also that these values remain steady most of the time and any changes to these values would be the result of corporate actions or events.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;CurrentOrdinaryShareDividend">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
-		<rdfs:label xml:lang="en">current ordinary share dividend</rdfs:label>
-		<skos:definition xml:lang="en">Dividend at the present time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;CurrentShareStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
-		<rdfs:label xml:lang="en">current share status</rdfs:label>
-		<skos:definition xml:lang="en">Information about the status of the security at a given point in time.</skos:definition>
-		<skos:editorialNote xml:lang="en">Note that the individual status indications take &quot;dated&quot; or &quot;Timed&quot; values which include date/time or current value, therefore there is no &quot;Status Date&quot; for these Current Share Status terms. Note also that these values remain steady most of the time and any changes to these values would be the result of corporate actions or events.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;DecimalPriceQuotation">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityPriceQuotationMethod"/>
-		<rdfs:label xml:lang="en">decimal price quotation</rdfs:label>
-		<terms:description xml:lang="en">The price is quoted in decimal</terms:description>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;EquitiesStatisticalPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PriceAnalytic"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo.4"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equities statistical price</rdfs:label>
-		<skos:definition xml:lang="en">Analytics about prices, as determined by markets, exchanges or data providers.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;EquityDividendPayment">
-		<rdfs:label xml:lang="en">equity dividend payment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;EquityExchangePublishedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:label xml:lang="en">equity exchange published price</rdfs:label>
-		<skos:definition xml:lang="en">A price determined by and published by an exchange, based on some parameters applied to actual prices of trades or offers on that exchange during the present day or to the present time. Question: do the ECNs have all these as well? Note that some of these kinds of price (e.g. High Low), may also exist for the Market as a whole - these are a separate meaning.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;EquityPriceQuotationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">equity price quotation method</rdfs:label>
-		<skos:definition xml:lang="en">How a price is quoted.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;ExchangeOpeningPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-		<rdfs:label xml:lang="en">exchange opening price</rdfs:label>
-		<skos:definition xml:lang="en">The value at the beginning of trading or opening of the market.</skos:definition>
-		<skos:editorialNote xml:lang="en">MDDL Exchange published price. Sometimes opening price is implied, sometimes it&apos;s published. you don&apos;t always see an opening price given. Review notes: One possibility: Opening price is an average of pre-market prices. This marks out the difference between closing price and opening price. Caution: Most exchanges may do it that way but some will not. Each exchange will have its on variane in how they determine an oprnhing price., Usually quoted as athe closing price of the previous session but see above. Opening price may be: Previous Closing Price First trade on that venue Difference between last closing and the out of market hours trading. If there is no OOO trading then the Previous Close in the Opening Price. This is only 2 possibillities: It never happens that out of hours trading is ignored. some regulations require some exchange to use the first trade. Composite Open: (also apples to Last, High, Low) BMB: Price at which the security first traded on the current session. Treat this as the only possible Opening Price. THe very 1st trade of the day is taken by the vendors as a trading price. It&apos;s a trading price semantically, and it becomes known as the Opening Price.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;ExchangeTradingSession">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedTemporalThing"/>
-		<rdfs:label xml:lang="en">exchange trading session</rdfs:label>
-		<skos:editorialNote xml:lang="en">See list in original model - e.g. morning, afternoon kerb trading etc.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;FractionalPriceQuotation">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityPriceQuotationMethod"/>
-		<rdfs:label xml:lang="en">fractional price quotation</rdfs:label>
-		<terms:description xml:lang="en">Price is quoted as a fraction.</terms:description>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;HighPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-		<rdfs:label xml:lang="en">high price</rdfs:label>
-		<skos:definition xml:lang="en">The highest valuation over the period specified. this can be regarded as a derived price. See also note in LowPrice Difference: different rules used. May be mased on trade OR quote price Analytic or Price?? this is a derived type but with a much simpler rule.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;LastPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-		<rdfs:label xml:lang="en">last price</rdfs:label>
-		<skos:definition xml:lang="en">The last (or most recent) valuation. This is an actual trade price not a derived price MDDL</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;ListedSecuritiesCompositeMarket">
-		<rdfs:label xml:lang="en">listed securities composite market</rdfs:label>
-		<skos:definition xml:lang="en">A Market defined as being a number of exchanges or trading venues in a particular marketplace or area.</skos:definition>
-		<skos:editorialNote xml:lang="en">From SMER: Definition for &quot;Composite&quot; - across exchanges. Must be exchange or MTF not a vague &quot;Market&quot;. Would always a specofic group of exchanges and MTFs, for example &quot;US Exchanges&quot;. Origin: SEC regulation. Use this and make it less jurisdiction specific if applicable.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;LowPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-		<rdfs:label xml:lang="en">low price</rdfs:label>
-		<skos:definition xml:lang="en">The lowest valuation over the period specified. Possibly but not necessarily based on a trade. Determined by the trading venue as to whether it&apos;s based on a trade or an offer. this can be regarded as a derived price. Price is based on a riule whil will cause one to pick a certain price type.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;MarketOpeningPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
-		<rdfs:label xml:lang="en">market opening price</rdfs:label>
-		<skos:definition xml:lang="en">The market opening price is the price a broker or someone would refer to at the start of trading.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Difference between last closing and the out of market hours trading. If there is no OOD trading then the Opening Price is the Previous Closing Price.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;MarketOpeningPriceType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">market opening price type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;MarketPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersToMarket"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">market price</rdfs:label>
-		<skos:definition xml:lang="en">A price determined about a trading market as a whole.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;MidPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PriceAnalytic"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mid price</rdfs:label>
-		<skos:definition xml:lang="en">Mid (arithmetic mean) between Bid and Offer (Ask) price. Referred to in Europe not in US. e.g. LSE published a Mid price. Always an exchange that publishes. Question from editor: Can a Mid Price ever be an allotted price? Suspect not. Same question for Dealt Price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;OfferPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
-		<rdfs:label xml:lang="en">offer price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;OfficialClosingPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">official closing price</rdfs:label>
-		<skos:definition xml:lang="en">The price at close of trading on a given trading day on an exchange.</skos:definition>
-		<skos:editorialNote xml:lang="en">The type of price which is quoted will be determined by the exchange. Last Price is recognised as the last trade on that exchange, not a last quote price. (fact about closing Price) Possibles: Last trade at the close of the market Last offer. Variants: what if there is no trade for example. Also may use prior to last trade. Official exchange calculated closing price. Questions at review: What about closing bid, mid offer. MDDL definition:The final price as of market close.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;OrdinaryShareDividend">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;embodiesNonBindingTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;OrdinaryDividendTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">ordinary share dividend</rdfs:label>
-		<skos:definition xml:lang="en">A dividend payable to holders of an ordinary share. This is a payment made at the discretion of the company in which the shares are held, and is based on the profit of that company for the period to which the dividend applies.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The amount that the company decides to pay is decided by the company and they decide to pay a lower dividend or suspend it. values: Current Last quarter or whatever theperiod is. 
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
+buxmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
+buxmlns:fibo-md-eqx-pri="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">EquityPricing</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">Pricing and analytics for equity products. Includes types of price which may be quoted by stock exchanges (end of day, intra-day, first and last prices and so on). All prices are a feature of a given market or exchange.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;BestBid">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasOrigin"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;ListedSecuritiesCompositeMarket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">best bid</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The highest bid price for the stock up to the present time. Based on rules defined at the market, that determine how best bid and best offer are determined.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Always based on a quote (not a trade) and is measured across markets, not just on the one market. Takes into account time and quote size. Real time price based on latest quotes and their sizes.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;BestOffer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasOrigin"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;ListedSecuritiesCompositeMarket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">best offer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The lowest bid price for the stock up to the present time. Based on rules defined at the market, that determine how best bid and best offer are determined.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Takes into account time and quote size. And time (it&apos;s the latest). If these take place on more than one exchange at the same time, the best Bid or Offer are the ones with the highest size.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;BidAskSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePriceSpread"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo.3"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bid ask spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Spread: Range between Bid and Ask</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">SMER 18 Nov: this also applies to debt or indeed any purblicy traded insturment. Appliues whether exchange traded or OTC traded.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;BidPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bid price</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price at which a market participant would put out in an order book indicating that they are willing to pay for a given stock.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">If there is not a bid in the market then there would not be a bid price. Bid is a value that requires a size</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;CompositeMarket">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">composite market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The market as a whole, i.e. one or more exchanges, a market (geographical) etc., about which prices and other derived facts may be quoted by market data vendors.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;CurrentEquityStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current equity status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the status of the equity at a given point in time.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Note that the individual status indications take &quot;dated&quot; values which include date or current value, therefore there is no &quot;Status Date&quot; for these terms. Note also that these values remain steady most of the time and any changes to these values would be the result of corporate actions or events.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;CurrentOrdinaryShareDividend">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current ordinary share dividend</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Dividend at the present time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;CurrentShareStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;Information"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current share status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the status of the security at a given point in time.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Note that the individual status indications take &quot;dated&quot; or &quot;Timed&quot; values which include date/time or current value, therefore there is no &quot;Status Date&quot; for these Current Share Status terms. Note also that these values remain steady most of the time and any changes to these values would be the result of corporate actions or events.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;DecimalPriceQuotation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityPriceQuotationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">decimal price quotation</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">The price is quoted in decimal</terms:description>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;EquitiesStatisticalPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PriceAnalytic"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo.4"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equities statistical price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Analytics about prices, as determined by markets, exchanges or data providers.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;EquityDividendPayment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity dividend payment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;EquityExchangePublishedPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity exchange published price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price determined by and published by an exchange, based on some parameters applied to actual prices of trades or offers on that exchange during the present day or to the present time. Question: do the ECNs have all these as well? Note that some of these kinds of price (e.g. High Low), may also exist for the Market as a whole - these are a separate meaning.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;EquityPriceQuotationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity price quotation method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How a price is quoted.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;ExchangeOpeningPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange opening price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value at the beginning of trading or opening of the market.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">MDDL Exchange published price. Sometimes opening price is implied, sometimes it&apos;s published. you don&apos;t always see an opening price given. Review notes: One possibility: Opening price is an average of pre-market prices. This marks out the difference between closing price and opening price. Caution: Most exchanges may do it that way but some will not. Each exchange will have its on variane in how they determine an oprnhing price., Usually quoted as athe closing price of the previous session but see above. Opening price may be: Previous Closing Price First trade on that venue Difference between last closing and the out of market hours trading. If there is no OOO trading then the Previous Close in the Opening Price. This is only 2 possibillities: It never happens that out of hours trading is ignored. some regulations require some exchange to use the first trade. Composite Open: (also apples to Last, High, Low) BMB: Price at which the security first traded on the current session. Treat this as the only possible Opening Price. THe very 1st trade of the day is taken by the vendors as a trading price. It&apos;s a trading price semantically, and it becomes known as the Opening Price.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;ExchangeTradingSession">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;SpecifiedTemporalThing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange trading session</rdfs:label>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">See list in original model - e.g. morning, afternoon kerb trading etc.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;FractionalPriceQuotation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityPriceQuotationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fractional price quotation</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">Price is quoted as a fraction.</terms:description>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;HighPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">high price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The highest valuation over the period specified. this can be regarded as a derived price. See also note in LowPrice Difference: different rules used. May be mased on trade OR quote price Analytic or Price?? this is a derived type but with a much simpler rule.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;LastPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">last price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The last (or most recent) valuation. This is an actual trade price not a derived price MDDL</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;ListedSecuritiesCompositeMarket">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listed securities composite market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Market defined as being a number of exchanges or trading venues in a particular marketplace or area.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From SMER: Definition for &quot;Composite&quot; - across exchanges. Must be exchange or MTF not a vague &quot;Market&quot;. Would always a specofic group of exchanges and MTFs, for example &quot;US Exchanges&quot;. Origin: SEC regulation. Use this and make it less jurisdiction specific if applicable.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;LowPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">low price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The lowest valuation over the period specified. Possibly but not necessarily based on a trade. Determined by the trading venue as to whether it&apos;s based on a trade or an offer. this can be regarded as a derived price. Price is based on a riule whil will cause one to pick a certain price type.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;MarketOpeningPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market opening price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The market opening price is the price a broker or someone would refer to at the start of trading.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Difference between last closing and the out of market hours trading. If there is no OOD trading then the Opening Price is the Previous Closing Price.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;MarketOpeningPriceType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market opening price type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;MarketPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersToMarket"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price determined about a trading market as a whole.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;MidPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PriceAnalytic"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;refersTo.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mid price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mid (arithmetic mean) between Bid and Offer (Ask) price. Referred to in Europe not in US. e.g. LSE published a Mid price. Always an exchange that publishes. Question from editor: Can a Mid Price ever be an allotted price? Suspect not. Same question for Dealt Price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;OfferPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">offer price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;OfficialClosingPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">official closing price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price at close of trading on a given trading day on an exchange.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The type of price which is quoted will be determined by the exchange. Last Price is recognised as the last trade on that exchange, not a last quote price. (fact about closing Price) Possibles: Last trade at the close of the market Last offer. Variants: what if there is no trade for example. Also may use prior to last trade. Official exchange calculated closing price. Questions at review: What about closing bid, mid offer. MDDL definition:The final price as of market close.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;OrdinaryShareDividend">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;embodiesNonBindingTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;OrdinaryDividendTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ordinary share dividend</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A dividend payable to holders of an ordinary share. This is a payment made at the discretion of the company in which the shares are held, and is based on the profit of that company for the period to which the dividend applies.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The amount that the company decides to pay is decided by the company and they decide to pay a lower dividend or suspend it. values: Current Last quarter or whatever theperiod is. 
 Further Notes:Working definition not from any formal source.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;OrdinaryShareYield">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Yield"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;derivedFromOutlay"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-md-eqx-pri;OrdinaryShareDividend">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-md-eqx-pri;SharePrice">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">ordinary share yield</rdfs:label>
-		<skos:definition xml:lang="en">The return on an equity instrument investment.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;PreferenceShareCoupon">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;embodiesTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">preference share coupon</rdfs:label>
-		<skos:definition xml:lang="en">Agreed Dividend or Coupon payments to the holder of a Preferred Share.</skos:definition>
-		<skos:editorialNote xml:lang="en">There is a question about whether the Coupon here is the same kind of commitment as coupon interest on a debt instrument. With a debt instrument if a coupon payment is missed, this is seen as a default, that is, the Coupon is an obligation whic if missed constitus a credit event. Equity Coupon is similar btu not the same: If a coupon (Dividend) payment on a Preference Share is missed, it can be carried over to a future days, typically over 3 or 5 years. This means that legally it is still an obligation, but on different and more lenient terms than debt interest. Note that &quot;Coupon&quot; is a label of convenience but it is not the same meaning as interest payment on a debt, even though to the holder it behaves in a siilar way.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;QuotePrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasOrigin"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">quote price</rdfs:label>
-		<skos:definition xml:lang="en">A price quoted for the purchase or sale of a security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;SharePrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ExchangeTradedSecurityPrice"/>
-		<rdfs:label xml:lang="en">share price</rdfs:label>
-		<skos:definition xml:lang="en">The amount of money that is paid or could be paid for a share.</skos:definition>
-		<skos:editorialNote xml:lang="en">From SME Review sessions: There are these sorts of prices: Price based on trades; Price Bid or Offer (i.e. quote) that was placed; analytics of prices. These are generally prices on a regulated market.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;SharePriceSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PriceAnalytic"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;PriceSpread"/>
-		<rdfs:label xml:lang="en">share price spread</rdfs:label>
-		<skos:definition xml:lang="en">Bid offer spread applies to any traded instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;UncrossingPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;origin"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">uncrossing price</rdfs:label>
-		<skos:definition xml:lang="en">The indicative uncrossing price and corresponding uncrossing volume broadcast during auction calls and immediately following uncrossing.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;VWAP">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquitiesStatisticalPrice"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:label xml:lang="en">v w a p</rdfs:label>
-		<skos:definition xml:lang="en">Volume Weighted Average Price determined by multiplying each trade by its volume then dividing by the volume for the day. MDDL</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-eqx-pri;VWOP">
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquitiesStatisticalPrice"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:label xml:lang="en">v w o p</rdfs:label>
-		<skos:definition xml:lang="en">Volume Weighted Open Price determined by multiplying each trade by its volume then dividing by the volume over a certain period during the open. MDDL</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;allotted">
-		<rdfs:label xml:lang="en">allotted</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the Quote Price was allotted.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;applicablePeriod">
-		<rdfs:label xml:lang="en">applicable period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquitiesStatisticalPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;applicablePeriod.1">
-		<rdfs:label xml:lang="en">applicable period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;HighPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The period to which the price applies.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;applicablePeriod.2">
-		<rdfs:label xml:lang="en">applicable period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LowPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The period to which the price applies.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;applicableTradingPeriod">
-		<rdfs:label xml:lang="en">applicable trading period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;ExchangeTradingSession"/>
-		<skos:definition xml:lang="en">Session that the exchange traded price refers to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;attribution">
-		<rdfs:label xml:lang="en">attribution</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;bestBidDateTime">
-		<rdfs:label xml:lang="en">best bid date time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BestBid"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">The date and time on which the best bid was made.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;bestOfferDateTime">
-		<rdfs:label xml:lang="en">best offer date time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BestOffer"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">The date and time that the Best Offer was made</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;closingPriceValue">
-		<rdfs:label xml:lang="en">closing price value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfficialClosingPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The value of the price at closing, as a monetary amount (amount and currency).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;compositeTradingMarketConsistsOf">
-		<rdfs:label xml:lang="en">composite trading market consists of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;ListedSecuritiesCompositeMarket"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;couponAmount">
-		<rdfs:label xml:lang="en">coupon amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;PreferenceShareCoupon"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
-		<skos:definition xml:lang="en">Coupon amount as a percentage. Not FIBIM has only &quot;Planned first amount&quot; both for dividend amount and percentage. Further research: may be quoted as an amount not a percentage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;dealt">
-		<rdfs:label xml:lang="en">dealt</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the Quote Price was subsequently the price of a trade, i.e. the Trade Price.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;depthOfOrderBook">
-		<rdfs:label xml:lang="en">depth of order book</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The depth of the order book to which the price refers.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;dividendAmount">
-		<rdfs:label xml:lang="en">dividend amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentOrdinaryShareDividend"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;CurrentMonetaryAmount"/>
-		<skos:definition xml:lang="en">The dividend amount at the current time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;dividendAmount.1">
-		<rdfs:label xml:lang="en">dividend amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
-		<skos:definition xml:lang="en">Dividend amount as a monetary amount. Not FIBIM has only &quot;Planned first amount&quot; both for dividend amount and percentage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;embodiesNonBindingTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasNonBindingTerms"/>
-		<rdfs:label xml:lang="en">embodies non binding terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-sha;OrdinaryDividendTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;embodiesTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasTerms"/>
-		<rdfs:label xml:lang="en">embodies terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;PreferenceShareCoupon"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;hasCurrentStatus">
-		<rdfs:label xml:lang="en">has current status</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;CurrentEquityStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;hasOrigin">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-eqx-pri;refersToMarket"/>
-		<rdfs:label xml:lang="en">has origin</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;hasStatus">
-		<rdfs:label xml:lang="en">has status</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;CurrentShareStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;howQuoted">
-		<rdfs:label xml:lang="en">how quoted</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;EquityPriceQuotationMethod"/>
-		<skos:definition xml:lang="en">How the price is quoted e.g. decimal or fraction.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;isBetween">
-		<rdfs:label xml:lang="en">is between</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePriceSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;nextExDivDate">
-		<rdfs:label xml:lang="en">next ex div date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentOrdinaryShareDividend"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;nextExpectedDividendDate">
-		<rdfs:label xml:lang="en">next expected dividend date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentOrdinaryShareDividend"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;nonPaidAmount">
-		<rdfs:label xml:lang="en">non paid amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentShareStatus"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
-		<skos:definition xml:lang="en">Nominal amount which is not paid at a given time</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;numberOfSharesOutstanding">
-		<rdfs:label xml:lang="en">number of shares outstanding</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentShareStatus"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
-		<skos:definition xml:lang="en">Number of shares outstanding at any given time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;openingPriceMethod">
-		<rdfs:label xml:lang="en">opening price method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;ExchangeOpeningPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The method by which the Opening Price is determined for that exchange.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;openingPriceType">
-		<rdfs:label xml:lang="en">opening price type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MarketOpeningPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;MarketOpeningPriceType"/>
-		<skos:definition xml:lang="en">The type of price which is used and disseminated as the Opening Price on that particular market, for example the first trade price in that session or the closing price of the previous session.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;origin">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-eqx-pri;refersToMarket"/>
-		<rdfs:label xml:lang="en">origin</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;UncrossingPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;outstandingEquityAmount">
-		<rdfs:label xml:lang="en">outstanding equity amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentEquityStatus"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;precision">
-		<rdfs:label xml:lang="en">precision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of decimal places in the price.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDateVolume">
-		<rdfs:label xml:lang="en">price date volume</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
-		<skos:definition xml:lang="en">Number of units traded on the price date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDeterminationConventionNotes">
-		<rdfs:label xml:lang="en">price determination convention notes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfficialClosingPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Further free text notes on the way in which the closing price is determined.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDeterminationMethod">
-		<rdfs:label xml:lang="en">price determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;HighPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The method by which the High Price is determined on that exchange.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDeterminationMethod.1">
-		<rdfs:label xml:lang="en">price determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LowPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The method by which the Low Price is determined on that exchange.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDeterminationMethod.2">
-		<rdfs:label xml:lang="en">price determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfficialClosingPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-		<skos:definition xml:lang="en">The method by which the closing price is defined.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;publishedBy">
-		<rdfs:label xml:lang="en">published by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;quoteLotSize">
-		<rdfs:label xml:lang="en">quote lot size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
-		<skos:definition xml:lang="en">The number of securities against which the price is quoted. This is usually the default lot size for a given exchange, but may be different.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;quoteSize">
-		<rdfs:label xml:lang="en">quote size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;HighPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">High Price takes into account size of quote.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;quoteSize.1">
-		<rdfs:label xml:lang="en">quote size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LowPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Low Price takes into account size of quote.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;redeemedEquityAmount">
-		<rdfs:label xml:lang="en">redeemed equity amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentEquityStatus"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MidPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo.1">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MidPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo.2">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-eqx-pri;isBetween"/>
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BidAskSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo.3">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-eqx-pri;isBetween"/>
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BidAskSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo.4">
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquitiesStatisticalPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersToMarket">
-		<rdfs:label xml:lang="en">refers to market</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;scheduledDividendPayment">
-		<rdfs:label>scheduled dividend payment</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;sharePriceValue">
-		<rdfs:label xml:lang="en">share price value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
-		<skos:definition xml:lang="en">Value of the price, as a monetary amount with a currency.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;size">
-		<rdfs:label xml:lang="en">size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
-		<skos:definition xml:lang="en">The size of the trade to which the Bid Price refers.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;size.1">
-		<rdfs:label xml:lang="en">size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
-		<skos:definition xml:lang="en">The size of the trade that the Offer Price refers to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;traded">
-		<rdfs:label xml:lang="en">traded</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;HighPrice"/>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LowPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Always based on a trade not a quote.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;traded.1">
-		<rdfs:label xml:lang="en">traded</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LastPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the Last Price was the subject of a trade or not. Yes means that the Last Price is the last price at which a trade was carried out.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;traded.3">
-		<rdfs:label xml:lang="en">traded</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the price is that of a trade. No = this is a quote price.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;traded.4">
-		<rdfs:label xml:lang="en">traded</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the price is that of a trade. If No, this is a quote price.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;tradingDate">
-		<rdfs:label xml:lang="en">trading date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The trading date for which the price is published.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;tradingDate.1">
-		<rdfs:label xml:lang="en">trading date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfficialClosingPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">The trading date for which this information is applicable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;tradingSession">
-		<rdfs:label xml:lang="en">trading session</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MarketOpeningPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;ExchangeTradingSession"/>
-		<skos:definition xml:lang="en">Whether the price reflects the Open in post market session, pre market session or some trading period within the trading day.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;uncrossingVolume">
-		<rdfs:label xml:lang="en">uncrossing volume</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;UncrossingPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The uncrossing volume broadcast during auction calls and immediately following uncrossing.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;vWAPValue">
-		<rdfs:label xml:lang="en">v w a p value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;VWAP"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
-		<skos:definition xml:lang="en">The value of the VWAP.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;vWOPValue">
-		<rdfs:label xml:lang="en">v w o p value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;VWOP"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
-		<skos:definition xml:lang="en">The value of the VWOP.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;valuationDateAndTime">
-		<rdfs:label xml:lang="en">valuation date and time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LastPrice"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
-		<skos:definition xml:lang="en">The date and time at which the Last Price was determined i.e. the time time and date of the offer or trade that the price relates to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;yieldType">
-		<rdfs:label xml:lang="en">yield type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OrdinaryShareYield"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;yieldValue">
-		<rdfs:label xml:lang="en">yield value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OrdinaryShareYield"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;PubliclyIssuedEquity">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;PubliclyTradedShare">
-	</owl:Class>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;OrdinaryShareYield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Yield"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;derivedFromOutlay"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-md-eqx-pri;OrdinaryShareDividend">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-md-eqx-pri;SharePrice">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ordinary share yield</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The return on an equity instrument investment.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;PreferenceShareCoupon">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;embodiesTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">preference share coupon</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Agreed Dividend or Coupon payments to the holder of a Preferred Share.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">There is a question about whether the Coupon here is the same kind of commitment as coupon interest on a debt instrument. With a debt instrument if a coupon payment is missed, this is seen as a default, that is, the Coupon is an obligation whic if missed constitus a credit event. Equity Coupon is similar btu not the same: If a coupon (Dividend) payment on a Preference Share is missed, it can be carried over to a future days, typically over 3 or 5 years. This means that legally it is still an obligation, but on different and more lenient terms than debt interest. Note that &quot;Coupon&quot; is a label of convenience but it is not the same meaning as interest payment on a debt, even though to the holder it behaves in a siilar way.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;QuotePrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasOrigin"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quote price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price quoted for the purchase or sale of a security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;SharePrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ExchangeTradedSecurityPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of money that is paid or could be paid for a share.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From SME Review sessions: There are these sorts of prices: Price based on trades; Price Bid or Offer (i.e. quote) that was placed; analytics of prices. These are generally prices on a regulated market.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;SharePriceSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-aly;PriceAnalytic"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;PriceSpread"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share price spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Bid offer spread applies to any traded instrument.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;UncrossingPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;origin"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">uncrossing price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The indicative uncrossing price and corresponding uncrossing volume broadcast during auction calls and immediately following uncrossing.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;VWAP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquitiesStatisticalPrice"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">v w a p</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Volume Weighted Average Price determined by multiplying each trade by its volume then dividing by the volume for the day. MDDL</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-eqx-pri;VWOP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;EquitiesStatisticalPrice"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">v w o p</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Volume Weighted Open Price determined by multiplying each trade by its volume then dividing by the volume over a certain period during the open. MDDL</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;allotted">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allotted</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Quote Price was allotted.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;applicablePeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquitiesStatisticalPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;applicablePeriod.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;HighPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period to which the price applies.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;applicablePeriod.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LowPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period to which the price applies.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;applicableTradingPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable trading period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;ExchangeTradingSession"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Session that the exchange traded price refers to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;attribution">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">attribution</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;bestBidDateTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">best bid date time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BestBid"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date and time on which the best bid was made.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;bestOfferDateTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">best offer date time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BestOffer"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date and time that the Best Offer was made</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;closingPriceValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">closing price value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfficialClosingPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the price at closing, as a monetary amount (amount and currency).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;compositeTradingMarketConsistsOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">composite trading market consists of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;ListedSecuritiesCompositeMarket"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;couponAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;PreferenceShareCoupon"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Coupon amount as a percentage. Not FIBIM has only &quot;Planned first amount&quot; both for dividend amount and percentage. Further research: may be quoted as an amount not a percentage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;dealt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dealt</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Quote Price was subsequently the price of a trade, i.e. the Trade Price.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;depthOfOrderBook">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">depth of order book</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The depth of the order book to which the price refers.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;dividendAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentOrdinaryShareDividend"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;CurrentMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The dividend amount at the current time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;dividendAmount.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Dividend amount as a monetary amount. Not FIBIM has only &quot;Planned first amount&quot; both for dividend amount and percentage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;embodiesNonBindingTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasNonBindingTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies non binding terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-sha;OrdinaryDividendTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;embodiesTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">embodies terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;PreferenceShareCoupon"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;hasCurrentStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has current status</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;CurrentEquityStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;hasOrigin">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-eqx-pri;refersToMarket"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has origin</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;hasStatus">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has status</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;CurrentShareStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;howQuoted">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">how quoted</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;EquityPriceQuotationMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How the price is quoted e.g. decimal or fraction.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;isBetween">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is between</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePriceSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;nextExDivDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">next ex div date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentOrdinaryShareDividend"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;nextExpectedDividendDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">next expected dividend date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentOrdinaryShareDividend"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;nonPaidAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non paid amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentShareStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Nominal amount which is not paid at a given time</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;numberOfSharesOutstanding">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of shares outstanding</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentShareStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of shares outstanding at any given time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;openingPriceMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">opening price method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;ExchangeOpeningPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which the Opening Price is determined for that exchange.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;openingPriceType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">opening price type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MarketOpeningPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;MarketOpeningPriceType"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of price which is used and disseminated as the Opening Price on that particular market, for example the first trade price in that session or the closing price of the previous session.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;origin">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-eqx-pri;refersToMarket"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">origin</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;UncrossingPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;outstandingEquityAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">outstanding equity amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentEquityStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;precision">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">precision</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of decimal places in the price.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDateVolume">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price date volume</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of units traded on the price date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDeterminationConventionNotes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price determination convention notes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfficialClosingPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Further free text notes on the way in which the closing price is determined.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDeterminationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price determination method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;HighPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which the High Price is determined on that exchange.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDeterminationMethod.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price determination method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LowPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which the Low Price is determined on that exchange.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;priceDeterminationMethod.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price determination method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfficialClosingPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which the closing price is defined.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;publishedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">published by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;quoteLotSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quote lot size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of securities against which the price is quoted. This is usually the default lot size for a given exchange, but may be different.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;quoteSize">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quote size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;HighPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">High Price takes into account size of quote.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;quoteSize.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quote size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LowPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Low Price takes into account size of quote.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;redeemedEquityAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redeemed equity amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;CurrentEquityStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MidPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MidPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo.2">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-eqx-pri;isBetween"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BidAskSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo.3">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-eqx-pri;isBetween"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BidAskSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersTo.4">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquitiesStatisticalPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;refersToMarket">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to market</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MarketPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;CompositeMarket"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;scheduledDividendPayment">
+bubu<rdfs:label>scheduled dividend payment</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;sharePriceValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share price value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Value of the price, as a monetary amount with a currency.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;size">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;BidPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The size of the trade to which the Bid Price refers.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;size.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">size</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfferPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The size of the trade that the Offer Price refers to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;traded">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;HighPrice"/>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LowPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Always based on a trade not a quote.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;traded.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LastPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Last Price was the subject of a trade or not. Yes means that the Last Price is the last price at which a trade was carried out.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;traded.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;QuotePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the price is that of a trade. No = this is a quote price.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;traded.4">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;SharePrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the price is that of a trade. If No, this is a quote price.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;tradingDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;EquityExchangePublishedPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The trading date for which the price is published.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;tradingDate.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OfficialClosingPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The trading date for which this information is applicable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;tradingSession">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading session</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;MarketOpeningPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;ExchangeTradingSession"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the price reflects the Open in post market session, pre market session or some trading period within the trading day.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;uncrossingVolume">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">uncrossing volume</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;UncrossingPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The uncrossing volume broadcast during auction calls and immediately following uncrossing.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;vWAPValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">v w a p value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;VWAP"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the VWAP.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;vWOPValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">v w o p value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;VWOP"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the VWOP.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;valuationDateAndTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">valuation date and time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;LastPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DateTimeValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date and time at which the Last Price was determined i.e. the time time and date of the offer or trade that the price relates to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;yieldType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">yield type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OrdinaryShareYield"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;YieldCalculationMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-eqx-pri;yieldValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">yield value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-eqx-pri;OrdinaryShareYield"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;PubliclyIssuedEquity">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;PubliclyTradedShare">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/md/TemporalCore/AnalysisCurves.rdf
+++ b/md/TemporalCore/AnalysisCurves.rdf
@@ -1,55 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-temx-cur "https://spec.edmcouncil.org/fibo/MD/TemporalCore/AnalysisCurves/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-md-temx-cur "https://spec.edmcouncil.org/fibo/MD/TemporalCore/AnalysisCurves/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/TemporalCore/AnalysisCurves/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-temx-cur="https://spec.edmcouncil.org/fibo/MD/TemporalCore/AnalysisCurves/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/AnalysisCurves/">
-		<rdfs:label xml:lang="en">AnalysisCurves</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/AnalysisCurves/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cur;CreditCurveToUse">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cur;CurveToUse"/>
-		<rdfs:label xml:lang="en">credit curve to use</rdfs:label>
-		<skos:definition xml:lang="en">This is a working note from ongoing reviews.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cur;CurveToUse">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cur;SpreadCurve"/>
-		<rdfs:label xml:lang="en">curve to use</rdfs:label>
-		<skos:definition xml:lang="en">This is a working note from ongoing reviews.</skos:definition>
-		<skos:editorialNote xml:lang="en">There is a big list of these. Bloomberg will have publicly available lists of these curves. Thyere are people that clean these up, e.g. Bmb, MarkIT, TR, and so on. No-one uses the raw feed so thtese curves, they are always cleaned up by someone first. At least for Risk Mgt purposes.For trading purposes they may well use a raw fee of risk Curves from e.g. Bmb. It takes the form of a selectable lists of names of curves. trhese have various ways of identifying what they are, so there are many ID schemes, e.g. CUSIPs, and other non security tyes of ID e.g. Red numbers. Different types o finstruments may have different ways in which these curves are generated. Some are proivided directly, some have highly complex stuff gong in to them, and so on. But for our purposes they are just a named list of pre-identified things which are a Curve. you might then specify a technique that you apply to the use of this curve.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cur;DiscountCurveToUse">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cur;CurveToUse"/>
-		<rdfs:label xml:lang="en">discount curve to use</rdfs:label>
-		<skos:definition xml:lang="en">This is a working note from ongoing reviews.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cur;SpreadCurve">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalCurve"/>
-		<rdfs:label xml:lang="en">spread curve</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-md-temx-cur="https://spec.edmcouncil.org/fibo/MD/TemporalCore/AnalysisCurves/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/AnalysisCurves/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AnalysisCurves</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the basic concept of a curve, as well as specific applications of this in credit and spread curves. 
+		Note that there is one concept for which no label could be agreed, being rendered simply as a kind of ‘curve to use’. Further research on the usage context and application of this and the related credit curve to use, is required.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/AnalysisCurves/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cur;CreditCurveToUse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cur;CurveToUse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit curve to use</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">This is a working note from ongoing reviews.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cur;CurveToUse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cur;SpreadCurve"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">curve to use</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">This is a working note from ongoing reviews.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">There is a big list of these. Bloomberg will have publicly available lists of these curves. Thyere are people that clean these up, e.g. Bmb, MarkIT, TR, and so on. No-one uses the raw feed so thtese curves, they are always cleaned up by someone first. At least for Risk Mgt purposes.For trading purposes they may well use a raw fee of risk Curves from e.g. Bmb. It takes the form of a selectable lists of names of curves. trhese have various ways of identifying what they are, so there are many ID schemes, e.g. CUSIPs, and other non security tyes of ID e.g. Red numbers. Different types o finstruments may have different ways in which these curves are generated. Some are proivided directly, some have highly complex stuff gong in to them, and so on. But for our purposes they are just a named list of pre-identified things which are a Curve. you might then specify a technique that you apply to the use of this curve.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cur;DiscountCurveToUse">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cur;CurveToUse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">discount curve to use</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">This is a working note from ongoing reviews.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cur;SpreadCurve">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalCurve"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spread curve</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/md/TemporalCore/CreditEvents.rdf
+++ b/md/TemporalCore/CreditEvents.rdf
@@ -1,173 +1,177 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
-		<rdfs:label xml:lang="en">CreditEvents</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;Bankruptcy">
-		<rdfs:label xml:lang="en">bankruptcy</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Bankruptcy would not be a Credit Event since the defined creti events are set up as earlier identification of the risk.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;CreditEvent">
-		<rdfs:label xml:lang="en">credit event</rdfs:label>
-		<skos:definition xml:lang="en">An event which has some bearing on the credit worthiness of the Reference Entity.</skos:definition>
-		<skos:editorialNote xml:lang="en">ISDA has combinations of credit event types. These are: Bankruptcy Failure to pay principal Failure to pay interest Obligation Default Obligation Acceleration Repudiation / Moratorium Distressed Ratings Downgrade Maturity Extension Writedown Not yes/no: Restructuring (Restructuring structure) Failure to Pay (Failure to Pay structure) Default Requirement (Monetary Amount) - applies to: Obligation Acceleration, Obligation Default, Repudiation/Moratorium, Restructuring Credit Event notice (Notice) Review note: term not in FpML, called Failure to Repair event (May equate to ISDA &quot;Failure To Pay&quot;) Conclusion: It is the same thing. Added as synonym Modeling note: Note that some of these are simple &quot;Yes/no&quot; conditions i.e. the event has happened or it has not. Others comprise more detailed information. However, 4 of those that are given as &quot;yes/no&quot; in FpML do in fact have the additional fact of Default Requirement. So almost none are simple yes/no or list entry terms. Modeled accordingly. Note also that the term Credit Event is defined more widely than just in CDS, for example in credit indices or just as business events generally. Therefore some of the CDS-specific terms here won&apos;t apply in those other contexts. Review comment: 22 styles of ISDA agreements for CDS as well, with different combinations of terms. FpML Full Definition: &apos;This element contains all the ISDA terms relating to credit events.&apos;</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;DistressedRatingsDowngrade">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
-		<rdfs:label xml:lang="en">distressed ratings downgrade</rdfs:label>
-		<skos:definition xml:lang="en">The fact that the rating of the reference obligation is downgraded to a distressed rating level. Further notes: From a usage standpoint, this credit event is typically not applicable in case of RMBS trades. A credit event. FpML full definition: &apos;A credit event. Results from the fact that the rating of the reference obligation is downgraded to a distressed rating level. From a usage standpoint, this credit event is typically not applicable in case of RMBS trades.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;EntityCreditEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-cre;pertainsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">entity credit event</rdfs:label>
-		<skos:definition xml:lang="en">Some Credit Event which is defined with reference to the Reference Entity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The Reference Entity is some business entity, i.e. the company or other entity to which the Credit Event relates. Some CDS terms define some terms in relation to the entity, and some with reference to a specific debt obligation, called the Reference Obligation. Scope Note: There are open questions about events which relate to some debt obligation which is not the Reference Obligation of a specific CDS contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;FailureToPay">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-cre;gracePeriod"/>
-				<owl:onClass rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">failure to pay</rdfs:label>
-		<skos:definition xml:lang="en">&apos;A credit event. This credit event triggers, after the expiration of any applicable grace period, if the reference entity fails to make due payments in an aggregrate amount of not less than the payment requirement on one or more obligations (e.g. a missed coupon payment). ISDA 2003 Term: Failure to Pay.&apos;</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This credit event corresponds to a failure to pay principal or interest after the applicable grace period, and is therefore not the common super-type of Failure to pay Interest and Failure to pay Principal - those are simple missed payments. By implication therefore, this event comes under the more serious heading (Hard Credit Event).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;FailureToPayInterest">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
-		<rdfs:label xml:lang="en">failure to pay interest</rdfs:label>
-		<skos:definition xml:lang="en">The failure by the Reference Entity to pay an expected interest amount or the payment of an actual interest amount that is less than the expected interest amount. Further notes: A credit event. ISDA 2003 Term: Failure to Pay Interest. FpML full definition: &apos;A credit event. Corresponds to the failure by the Reference Entity to pay an expected interest amount or the payment of an actual interest amount that is less than the expected interest amount. ISDA 2003 Term: Failure to Pay Interest.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;FailureToPayPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
-		<rdfs:label xml:lang="en">failure to pay principal</rdfs:label>
-		<skos:definition xml:lang="en">The failure by the Reference Entity to pay an expected principal amount or the payment of an actual principal amount that is less than the expected principal amount. Further notes: A credit event. ISDA 2003 Term: Failure to Pay Principal.&apos; FpML full definition: &apos;A credit event. Corresponds to the failure by the Reference Entity to pay an expected principal amount or the payment of an actual principal amount that is less than the expected principal amount. ISDA 2003 Term: Failure to Pay Principal.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;FilingForBankruptcy">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;EntityCreditEvent"/>
-		<rdfs:label xml:lang="en">filing for bankruptcy</rdfs:label>
-		<skos:definition xml:lang="en">An event in which an organization files for bankruptcy.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be defined as the Credit Event in a CDS.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;HardCreditEvent">
-		<rdfs:label xml:lang="en">hard credit event</rdfs:label>
-		<skos:definition xml:lang="en">Hard default. This is defined by the event not being repairable.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Soft and Hard defaults are defined by whether or not the event is repairable. Typically defined by the crossing of some threshold in some measurement. If you don&apos;t repair, this becomes a &quot;failure to repair&quot; credit event. The &quot;failure to repair&quot; triggers either a hard default or there is a whole lot of possible terms about the extension of the grace period.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;MaturityExtension">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
-		<rdfs:label xml:lang="en">maturity extension</rdfs:label>
-		<skos:definition xml:lang="en">The fact that the underlier fails to make principal payments as expected. Further notes: A credit event. REVIEW: The definition from FpML appears to be a variant on that for Failure To Pay Principal. The definition given here is the definition of a failure to pay principal but the FpML definition for Failure to pay Principal is more detailed. This definition alone does not justify an extension of the maturity. FpML full definition: &apos;A credit event. Results from the fact that the underlier fails to make principal payments as expected.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;ObligationCreditEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-cre;pertainsTo"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-loan-loan-loan;LoanContract">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">obligation credit event</rdfs:label>
-		<skos:definition xml:lang="en">An event which relates specifically to an individual security issued by the Reference Entity (the Reference Obligation).</skos:definition>
-		<skos:editorialNote xml:lang="en">From inspection of the ISDA definitions it is clear that some Credit Events relate to a business entity (legal entity since it is incurring debts) while others relate specifically to an individual instrument. The distinction may be of minor interest in practice since most entities would presumably only have one debt instrument in issue. This term added to pick up the explicit relationship to the Reference Obligation for these Credit Event types. The others are deemed to relate to the Reference Entity directly and to the Reference Obligation by extension.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;RepudiationOrMoratorium">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;EntityCreditEvent"/>
-		<rdfs:label xml:lang="en">repudiation or moratorium</rdfs:label>
-		<skos:definition xml:lang="en">The reference entity, or a governmental authority, either refuses to recognise or challenges the validity of one or more obligations of the reference entity, or imposes a moratorium thereby postponing payments on one or more of the obligations of the reference entity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Subject to the default requirement amount. This is a Credit Event. ISDA 2003 Term: Repudiation/Moratorium FpML full definition: &apos;A credit event. The reference entity, or a governmental authority, either refuses to recognise or challenges the validity of one or more obligations of the reference entity, or imposes a moratorium thereby postponing payments on one or more of the obligations of the reference entity. Subject to the default requirement amount. ISDA 2003 Term: Repudiation/Moratorium.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;Restructuring">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;EntityCreditEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-cre;hasRestructuringTypeCode"/>
-				<owl:allValuesFrom rdf:resource="&fibo-md-temx-cre;RestructuringTypeCode"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">restructuring</rdfs:label>
-		<skos:definition xml:lang="en">A restructuring is an event that materially impacts the reference entity&apos;s obligations, such as an interest rate reduction, principal reduction, deferral of interest or principal, change in priority ranking, or change in currency or composition of payment.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a Credit Event. ISDA 2003 Term: Restructuring. FpML full definition: &apos;A credit event. A restructuring is an event that materially impacts the reference entity\&apos;s obligations, such as an interest rate reduction, principal reduction, deferral of interest or principal, change in priority ranking, or change in currency or composition of payment. ISDA 2003 Term: Restructuring.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;RestructuringTypeCode">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/hasDefinition"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;RestructuringTypeScheme"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">restructuring type code</rdfs:label>
-		<skos:definition xml:lang="en">A textual code identifying the type of restructuring event in relation to some restructuring type scheme. This is information about the event rather than an aspect of the event itself, and is commonly identified in messages.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is derived from the FpML term, the contents of which are a URI for the applicable Restructuring scheme. 
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CreditEvents</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines a range of credit events, that is events in which some payment or payments are not made. These include credit events relating to a specific debt obligation and events relating to the business entity as a whole. 
+		Note: these were derived from the credit default swaps model, with extensive reference to the FpML standard for those instruments. Additional kinds of credit event may be needed for loan and other contexts.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;Bankruptcy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bankruptcy</rdfs:label>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Bankruptcy would not be a Credit Event since the defined creti events are set up as earlier identification of the risk.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;CreditEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event which has some bearing on the credit worthiness of the Reference Entity.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">ISDA has combinations of credit event types. These are: Bankruptcy Failure to pay principal Failure to pay interest Obligation Default Obligation Acceleration Repudiation / Moratorium Distressed Ratings Downgrade Maturity Extension Writedown Not yes/no: Restructuring (Restructuring structure) Failure to Pay (Failure to Pay structure) Default Requirement (Monetary Amount) - applies to: Obligation Acceleration, Obligation Default, Repudiation/Moratorium, Restructuring Credit Event notice (Notice) Review note: term not in FpML, called Failure to Repair event (May equate to ISDA &quot;Failure To Pay&quot;) Conclusion: It is the same thing. Added as synonym Modeling note: Note that some of these are simple &quot;Yes/no&quot; conditions i.e. the event has happened or it has not. Others comprise more detailed information. However, 4 of those that are given as &quot;yes/no&quot; in FpML do in fact have the additional fact of Default Requirement. So almost none are simple yes/no or list entry terms. Modeled accordingly. Note also that the term Credit Event is defined more widely than just in CDS, for example in credit indices or just as business events generally. Therefore some of the CDS-specific terms here won&apos;t apply in those other contexts. Review comment: 22 styles of ISDA agreements for CDS as well, with different combinations of terms. FpML Full Definition: &apos;This element contains all the ISDA terms relating to credit events.&apos;</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;DistressedRatingsDowngrade">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">distressed ratings downgrade</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The fact that the rating of the reference obligation is downgraded to a distressed rating level. Further notes: From a usage standpoint, this credit event is typically not applicable in case of RMBS trades. A credit event. FpML full definition: &apos;A credit event. Results from the fact that the rating of the reference obligation is downgraded to a distressed rating level. From a usage standpoint, this credit event is typically not applicable in case of RMBS trades.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;EntityCreditEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-cre;pertainsTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">entity credit event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some Credit Event which is defined with reference to the Reference Entity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The Reference Entity is some business entity, i.e. the company or other entity to which the Credit Event relates. Some CDS terms define some terms in relation to the entity, and some with reference to a specific debt obligation, called the Reference Obligation. Scope Note: There are open questions about events which relate to some debt obligation which is not the Reference Obligation of a specific CDS contract.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;FailureToPay">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-cre;gracePeriod"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">failure to pay</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&apos;A credit event. This credit event triggers, after the expiration of any applicable grace period, if the reference entity fails to make due payments in an aggregrate amount of not less than the payment requirement on one or more obligations (e.g. a missed coupon payment). ISDA 2003 Term: Failure to Pay.&apos;</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This credit event corresponds to a failure to pay principal or interest after the applicable grace period, and is therefore not the common super-type of Failure to pay Interest and Failure to pay Principal - those are simple missed payments. By implication therefore, this event comes under the more serious heading (Hard Credit Event).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;FailureToPayInterest">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">failure to pay interest</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The failure by the Reference Entity to pay an expected interest amount or the payment of an actual interest amount that is less than the expected interest amount. Further notes: A credit event. ISDA 2003 Term: Failure to Pay Interest. FpML full definition: &apos;A credit event. Corresponds to the failure by the Reference Entity to pay an expected interest amount or the payment of an actual interest amount that is less than the expected interest amount. ISDA 2003 Term: Failure to Pay Interest.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;FailureToPayPrincipal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">failure to pay principal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The failure by the Reference Entity to pay an expected principal amount or the payment of an actual principal amount that is less than the expected principal amount. Further notes: A credit event. ISDA 2003 Term: Failure to Pay Principal.&apos; FpML full definition: &apos;A credit event. Corresponds to the failure by the Reference Entity to pay an expected principal amount or the payment of an actual principal amount that is less than the expected principal amount. ISDA 2003 Term: Failure to Pay Principal.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;FilingForBankruptcy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;EntityCreditEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">filing for bankruptcy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event in which an organization files for bankruptcy.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be defined as the Credit Event in a CDS.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;HardCreditEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">hard credit event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Hard default. This is defined by the event not being repairable.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Soft and Hard defaults are defined by whether or not the event is repairable. Typically defined by the crossing of some threshold in some measurement. If you don&apos;t repair, this becomes a &quot;failure to repair&quot; credit event. The &quot;failure to repair&quot; triggers either a hard default or there is a whole lot of possible terms about the extension of the grace period.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;MaturityExtension">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity extension</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The fact that the underlier fails to make principal payments as expected. Further notes: A credit event. REVIEW: The definition from FpML appears to be a variant on that for Failure To Pay Principal. The definition given here is the definition of a failure to pay principal but the FpML definition for Failure to pay Principal is more detailed. This definition alone does not justify an extension of the maturity. FpML full definition: &apos;A credit event. Results from the fact that the underlier fails to make principal payments as expected.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;ObligationCreditEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-cre;pertainsTo"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-loan-loan-loan;LoanContract">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">obligation credit event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event which relates specifically to an individual security issued by the Reference Entity (the Reference Obligation).</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From inspection of the ISDA definitions it is clear that some Credit Events relate to a business entity (legal entity since it is incurring debts) while others relate specifically to an individual instrument. The distinction may be of minor interest in practice since most entities would presumably only have one debt instrument in issue. This term added to pick up the explicit relationship to the Reference Obligation for these Credit Event types. The others are deemed to relate to the Reference Entity directly and to the Reference Obligation by extension.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;RepudiationOrMoratorium">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;EntityCreditEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repudiation or moratorium</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The reference entity, or a governmental authority, either refuses to recognise or challenges the validity of one or more obligations of the reference entity, or imposes a moratorium thereby postponing payments on one or more of the obligations of the reference entity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Subject to the default requirement amount. This is a Credit Event. ISDA 2003 Term: Repudiation/Moratorium FpML full definition: &apos;A credit event. The reference entity, or a governmental authority, either refuses to recognise or challenges the validity of one or more obligations of the reference entity, or imposes a moratorium thereby postponing payments on one or more of the obligations of the reference entity. Subject to the default requirement amount. ISDA 2003 Term: Repudiation/Moratorium.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;Restructuring">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;EntityCreditEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-cre;hasRestructuringTypeCode"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-md-temx-cre;RestructuringTypeCode"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">restructuring</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A restructuring is an event that materially impacts the reference entity&apos;s obligations, such as an interest rate reduction, principal reduction, deferral of interest or principal, change in priority ranking, or change in currency or composition of payment.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a Credit Event. ISDA 2003 Term: Restructuring. FpML full definition: &apos;A credit event. A restructuring is an event that materially impacts the reference entity\&apos;s obligations, such as an interest rate reduction, principal reduction, deferral of interest or principal, change in priority ranking, or change in currency or composition of payment. ISDA 2003 Term: Restructuring.&apos;</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;RestructuringTypeCode">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/hasDefinition"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;RestructuringTypeScheme"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">restructuring type code</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A textual code identifying the type of restructuring event in relation to some restructuring type scheme. This is information about the event rather than an aspect of the event itself, and is commonly identified in messages.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is derived from the FpML term, the contents of which are a URI for the applicable Restructuring scheme. 
 
 Modeling notes:
 This is therefore modeled as a reference to a suitable scheme rather than to a given type of restructuring, on the assumption that the CDS Contract will be set up in this way. A more complete semantics would identify the type as a type of restructuring event and treat the scheme as ancillary, but for now we will assume that this is sufficient for the formal definition of these terms in a CDS Contract. To be confirmed at review. 
@@ -179,109 +183,109 @@ Term Origin:FpML = restructuringType
 Definition Origin:SR Draft
 
 Consensus:Review</skos:editorialNote>
-		<skos:editorialNote xml:lang="en">is of type defined in: The scheme which defines the type of restructuring that is applicable. (former property)</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;RestructuringTypeScheme">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeSet"/>
-		<rdfs:label xml:lang="en">restructuring type scheme</rdfs:label>
-		<skos:definition xml:lang="en">The scheme which defines the restructuring type in a Restructuring credit event.</skos:definition>
-		<skos:editorialNote xml:lang="en">No definition given in the FpML schema. This is given as a URI with which to identify the scheme.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;SoftCreditEvent">
-		<rdfs:label xml:lang="en">soft credit event</rdfs:label>
-		<skos:definition xml:lang="en">Soft default. This is defined by the event being repairable.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Soft and Hard defaults are defined by whether or not the event is repairable. Typically defined by the crossing of some threshold in some measurement. If you don&apos;t repair, this becomes a &quot;failure to repair&quot; credit event. The &quot;failure to repair&quot; (Failure To Pay) triggers either a hard default or there is a whole lot of possible terms about the extension of the grace period. Grace period extension applicability would in principle apply to the soft credit event. The hard credit event (e.g. Failure to Repair) is after such a period, if it exists, has passed.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-cre;Writedown">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
-		<rdfs:label xml:lang="en">writedown</rdfs:label>
-		<skos:definition xml:lang="en">The fact that the underlier writes down its outstanding principal amount. Further notes: A credit event. FpML full definition: &apos;A credit event. Results from the fact that the underlier writes down its outstanding principal amount.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;applicable">
-		<rdfs:label xml:lang="en">applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the failure to pay provision is applicable Further notes: FpML full definition: &apos;Indicates whether the failure to pay provision is applicable.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;applicable.1">
-		<rdfs:label xml:lang="en">applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the restructuring provision is applicable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;defaultRequirement">
-		<rdfs:label xml:lang="en">default requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;RepudiationOrMoratorium"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The threshold for Repudiation/Moratorium.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;defaultRequirement.1">
-		<rdfs:label xml:lang="en">default requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The threshold for Restructuring.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;gracePeriod">
-		<rdfs:label xml:lang="en">grace period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The period of days after any due date that the reference entity has to fulfil its obligations before a failure to pay credit event is deemed to have occurred. Further notes: ISDA 2003 Term: Grace Period. Note this may be a period denominated in business days or calendar days - this is a qualifying fact about the referenced term &quot;Date Period&quot;. FpML full definition: &apos;The number of calendar or business days after any due date that the reference entity has to fulfil its obligations before a failure to pay credit event is deemed to have occurred. ISDA 2003 Term: Grace Period.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;gracePeriodExtensionApplicable">
-		<rdfs:label xml:lang="en">grace period extension applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the grace period extension provision is applicable. Further notes: Whether this is applicable or not would vary by jurisdiction. Would in fact be a clause in the Loan Contract. There may also be statutory clauses that would override those in a contract, for a given jurisidction. FpML full definition: &apos;Indicates whether the grace period extension provision is applicable.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;hasRestructuringTypeCode">
-		<rdfs:label xml:lang="en">has restructuring type code</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-cre;RestructuringTypeCode"/>
-		<skos:definition xml:lang="en">has a code representing the kind of restructuring event in relation to some defined scheme of such</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;multipleCreditEvent">
-		<rdfs:label xml:lang="en">multiple credit event</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Section 3.9 of the ISDA 2003 Credit Derivatives Definitions shall apply.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;multipleHolderObligation">
-		<rdfs:label xml:lang="en">multiple holder obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">A multiple holder obligation means an obligation that is held by more than three holders that are not affiliates of each other and where at least two thirds of the holders must agree to the event that constitutes the restructuring credit event.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;paymentRequirement">
-		<rdfs:label xml:lang="en">payment requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A threshold for the failure to pay credit event. Further notes: Market standard is USD 1,000,000 (JPY 100,000,000 for Japanese Yen trades) or its equivalent in the relevant obligation currency. This is applied on an aggregate basis across all Obligations of the Reference Entity. Intended to prevent technical/operational errors from triggering credit events. ISDA 2003 Term: Payment Requirement. FpML full definition: &apos;Specifies a threshold for the failure to pay credit event. Market standard is USD 1,000,000 (JPY 100,000,000 for Japanese Yen trades) or its equivalent in the relevant obligation currency. This is applied on an aggregate basis across all Obligations of the Reference Entity. Intended to prevent technical/operational errors from triggering credit events. ISDA 2003 Term: Payment Requirement.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;pertainsTo">
-		<rdfs:label xml:lang="en">pertains to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;schemeReference">
-		<rdfs:label xml:lang="en">scheme reference</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;RestructuringTypeScheme"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;URIValue"/>
-		<skos:definition xml:lang="en">The reference by which the scheme is identified, as a URI.</skos:definition>
-	</owl:ObjectProperty>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">is of type defined in: The scheme which defines the type of restructuring that is applicable. (former property)</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;RestructuringTypeScheme">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">restructuring type scheme</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The scheme which defines the restructuring type in a Restructuring credit event.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">No definition given in the FpML schema. This is given as a URI with which to identify the scheme.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;SoftCreditEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">soft credit event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Soft default. This is defined by the event being repairable.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Soft and Hard defaults are defined by whether or not the event is repairable. Typically defined by the crossing of some threshold in some measurement. If you don&apos;t repair, this becomes a &quot;failure to repair&quot; credit event. The &quot;failure to repair&quot; (Failure To Pay) triggers either a hard default or there is a whole lot of possible terms about the extension of the grace period. Grace period extension applicability would in principle apply to the soft credit event. The hard credit event (e.g. Failure to Repair) is after such a period, if it exists, has passed.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-cre;Writedown">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">writedown</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The fact that the underlier writes down its outstanding principal amount. Further notes: A credit event. FpML full definition: &apos;A credit event. Results from the fact that the underlier writes down its outstanding principal amount.&apos;</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;applicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the failure to pay provision is applicable Further notes: FpML full definition: &apos;Indicates whether the failure to pay provision is applicable.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;applicable.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the restructuring provision is applicable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;defaultRequirement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default requirement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;RepudiationOrMoratorium"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The threshold for Repudiation/Moratorium.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;defaultRequirement.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">default requirement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The threshold for Restructuring.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;gracePeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">grace period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period of days after any due date that the reference entity has to fulfil its obligations before a failure to pay credit event is deemed to have occurred. Further notes: ISDA 2003 Term: Grace Period. Note this may be a period denominated in business days or calendar days - this is a qualifying fact about the referenced term &quot;Date Period&quot;. FpML full definition: &apos;The number of calendar or business days after any due date that the reference entity has to fulfil its obligations before a failure to pay credit event is deemed to have occurred. ISDA 2003 Term: Grace Period.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;gracePeriodExtensionApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">grace period extension applicable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the grace period extension provision is applicable. Further notes: Whether this is applicable or not would vary by jurisdiction. Would in fact be a clause in the Loan Contract. There may also be statutory clauses that would override those in a contract, for a given jurisidction. FpML full definition: &apos;Indicates whether the grace period extension provision is applicable.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;hasRestructuringTypeCode">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has restructuring type code</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-cre;RestructuringTypeCode"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">has a code representing the kind of restructuring event in relation to some defined scheme of such</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;multipleCreditEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiple credit event</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Section 3.9 of the ISDA 2003 Credit Derivatives Definitions shall apply.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;multipleHolderObligation">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiple holder obligation</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A multiple holder obligation means an obligation that is held by more than three holders that are not affiliates of each other and where at least two thirds of the holders must agree to the event that constitutes the restructuring credit event.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;paymentRequirement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment requirement</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A threshold for the failure to pay credit event. Further notes: Market standard is USD 1,000,000 (JPY 100,000,000 for Japanese Yen trades) or its equivalent in the relevant obligation currency. This is applied on an aggregate basis across all Obligations of the Reference Entity. Intended to prevent technical/operational errors from triggering credit events. ISDA 2003 Term: Payment Requirement. FpML full definition: &apos;Specifies a threshold for the failure to pay credit event. Market standard is USD 1,000,000 (JPY 100,000,000 for Japanese Yen trades) or its equivalent in the relevant obligation currency. This is applied on an aggregate basis across all Obligations of the Reference Entity. Intended to prevent technical/operational errors from triggering credit events. ISDA 2003 Term: Payment Requirement.&apos;</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;pertainsTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pertains to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;schemeReference">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheme reference</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-cre;RestructuringTypeScheme"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;URIValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The reference by which the scheme is identified, as a URI.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/md/TemporalCore/CreditRatings.rdf
+++ b/md/TemporalCore/CreditRatings.rdf
@@ -1,229 +1,233 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
-		<rdfs:label xml:lang="en">CreditRatings</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crr;rated"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;InstrumentCreditRating"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<owl:equivalentClass rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;CreditRating">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Rating"/>
-		<rdfs:label xml:lang="en">credit rating</rdfs:label>
-		<skos:definition xml:lang="en">Some rating which formally describes the credit worthiness of something or someone.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Includes credit ratings of people, corporations, investments and so on.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;CreditRatingAgency">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishingHouse"/>
-		<rdfs:label xml:lang="en">credit rating agency</rdfs:label>
-		<skos:definition xml:lang="en">An entity which publishes Credit Ratings.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;CreditRatingIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crr;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;CreditRatingAgency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit rating issuer</rdfs:label>
-		<skos:definition xml:lang="en">An entity which publishes credit ratings for business entities and / or securities Further notes: This entity also defines the meanings (judgements) represented by each Ratings code as documented in the Credit Rating Scheme. .</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;CreditRatingScheme">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeSet"/>
-		<rdfs:label xml:lang="en">credit rating scheme</rdfs:label>
-		<skos:definition xml:lang="en">The scheme which defines what rating codes exist and what judgements each one represents, as defined by the Rating agency.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;CreditWatchDirection">
-		<rdfs:label xml:lang="en">credit watch direction</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;CreditWatchDowngrade">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditWatchDirection"/>
-		<rdfs:label xml:lang="en">credit watch downgrade</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;CreditWatchOutlook">
-		<rdfs:label xml:lang="en">credit watch outlook</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;CreditWatchUpgrade">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditWatchDirection"/>
-		<rdfs:label xml:lang="en">credit watch upgrade</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;IndividualCreditRating">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditRating"/>
-		<rdfs:label xml:lang="en">individual credit rating</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;InstrumentCreditRating">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crr;rates"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">instrument credit rating</rdfs:label>
-		<skos:definition xml:lang="en">An Instrument Credit Rating, that is the creditworthiness of the investment as determined by a Ratings Agency.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For tranched securities: the instrument /is/ the Tranche for tranched securities so this is really just the Instrument Credit Rating under a different name? However the term Tranche Rating at Issue is meaningful.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;InvestmentCreditRating">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditRating"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasDefinition"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;CreditRatingScheme"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crr;issuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;CreditRatingIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crr;rates"/>
-				<owl:someValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">investment credit rating</rdfs:label>
-		<skos:definition xml:lang="en">The creditworthiness of an investment as determined by a Ratings Agency. Further notes: Anything can be bought and sold can have a rating. Credit rating can be assigned to an instrument, an organization, even a person. The rating is assigned to any kind of instrument that the organization etc. issues. Use Wikipedia credit rating definition Long term, short term and generic ratings The rating differentiates between short and long term (not sure about generic). In all systems these are differentiated. This relates to how long the holder might hold the thing. Or does it? The agencies offer two different servies and you pay 2 different fees for short and long. ACTION: to find The codes themselves are different. So it&apos;s not AAA etc. for short term it&apos;s something else. so the thing we&apos;ve been thinking about is actually long term ratings.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;IssueCreditRating">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crr;rates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issue credit rating</rdfs:label>
-		<skos:definition xml:lang="en">The creditworthiness of the overall issue as determined by a Ratings Agency.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For a tranched secrutity issue, there is a credit rating for the overall issue as well as a different ratings for each tranche. The rating for the individual tranche is covered as the term &quot;Instrument Credit Rating&quot; since each tranche is an individual instrument (contract).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;OnWatchOutlook">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditWatchOutlook"/>
-		<rdfs:label xml:lang="en">on watch outlook</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;OrganizationCreditRating">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;IndividualCreditRating"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crr;rates"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">organization credit rating</rdfs:label>
-		<skos:definition xml:lang="en">The credit rating of the organization. That is the creditworthiness of the organization as determined by a ratings agency. If the organization is the issuer of a security then this becomes the issuer rating for that security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;ShortTermCreditRating">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-		<rdfs:label xml:lang="en">short term credit rating</rdfs:label>
-		<skos:definition xml:lang="en">A short term rating is a probability factor of an individual going into default within a year. This is in contrast to long-term rating which is evaluated over a long timeframe.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crr;StableOutlook">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditWatchOutlook"/>
-		<rdfs:label xml:lang="en">stable outlook</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;hasIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publisherIdentity"/>
-		<rdfs:label xml:lang="en">has identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crr;CreditRatingIssuer"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-crr;CreditRatingAgency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;issuedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-		<rdfs:label xml:lang="en">issued by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-crr;CreditRatingIssuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;rated">
-		<rdfs:label xml:lang="en">rated</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-crr;InstrumentCreditRating"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;rates">
-		<rdfs:label xml:lang="en">rates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-		<skos:definition xml:lang="en">The Credit rating rates something, for example a legal entity, an instrument or some such.</skos:definition>
-		<skos:editorialNote xml:lang="en">The thing that can be rated is any type of Continuant Thing or, since a securities issue or deal may also be rated, any occurrent thing.</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;watchDirection">
-		<rdfs:label xml:lang="en">watch direction</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-crr;CreditWatchDirection"/>
-		<skos:definition xml:lang="en">The direction in which the credit rating is expected to move, for something which has a credit rating on watch.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;watchOutlook">
-		<rdfs:label xml:lang="en">watch outlook</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-crr;CreditWatchOutlook"/>
-		<skos:definition xml:lang="en">The expected outlook for the rated entity.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CreditRatings</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the concept of a credit rating, along with credit watch and outlook qualifying terms. There are credit ratings for individuals, for organizations and for instruments. 
+		These are referenced extensively in the securities models but are also applicable to business entities generally and in the context of lending and account maintenance.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crr;rated"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;InstrumentCreditRating"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<owl:equivalentClass rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;CreditRating">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Rating"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit rating</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some rating which formally describes the credit worthiness of something or someone.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Includes credit ratings of people, corporations, investments and so on.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;CreditRatingAgency">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishingHouse"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit rating agency</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An entity which publishes Credit Ratings.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;CreditRatingIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;Publisher"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crr;hasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;CreditRatingAgency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit rating issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An entity which publishes credit ratings for business entities and / or securities Further notes: This entity also defines the meanings (judgements) represented by each Ratings code as documented in the Credit Rating Scheme. .</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;CreditRatingScheme">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/CodeSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit rating scheme</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The scheme which defines what rating codes exist and what judgements each one represents, as defined by the Rating agency.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;CreditWatchDirection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit watch direction</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;CreditWatchDowngrade">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditWatchDirection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit watch downgrade</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;CreditWatchOutlook">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit watch outlook</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;CreditWatchUpgrade">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditWatchDirection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit watch upgrade</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;IndividualCreditRating">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditRating"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">individual credit rating</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;InstrumentCreditRating">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crr;rates"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instrument credit rating</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Instrument Credit Rating, that is the creditworthiness of the investment as determined by a Ratings Agency.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For tranched securities: the instrument /is/ the Tranche for tranched securities so this is really just the Instrument Credit Rating under a different name? However the term Tranche Rating at Issue is meaningful.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;InvestmentCreditRating">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditRating"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasDefinition"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;CreditRatingScheme"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crr;issuedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;CreditRatingIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crr;rates"/>
+bubububu<owl:someValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment credit rating</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The creditworthiness of an investment as determined by a Ratings Agency. Further notes: Anything can be bought and sold can have a rating. Credit rating can be assigned to an instrument, an organization, even a person. The rating is assigned to any kind of instrument that the organization etc. issues. Use Wikipedia credit rating definition Long term, short term and generic ratings The rating differentiates between short and long term (not sure about generic). In all systems these are differentiated. This relates to how long the holder might hold the thing. Or does it? The agencies offer two different servies and you pay 2 different fees for short and long. ACTION: to find The codes themselves are different. So it&apos;s not AAA etc. for short term it&apos;s something else. so the thing we&apos;ve been thinking about is actually long term ratings.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;IssueCreditRating">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crr;rates"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;OfferIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue credit rating</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The creditworthiness of the overall issue as determined by a Ratings Agency.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For a tranched secrutity issue, there is a credit rating for the overall issue as well as a different ratings for each tranche. The rating for the individual tranche is covered as the term &quot;Instrument Credit Rating&quot; since each tranche is an individual instrument (contract).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;OnWatchOutlook">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditWatchOutlook"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">on watch outlook</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;OrganizationCreditRating">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;IndividualCreditRating"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crr;rates"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">organization credit rating</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The credit rating of the organization. That is the creditworthiness of the organization as determined by a ratings agency. If the organization is the issuer of a security then this becomes the issuer rating for that security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;ShortTermCreditRating">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">short term credit rating</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A short term rating is a probability factor of an individual going into default within a year. This is in contrast to long-term rating which is evaluated over a long timeframe.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crr;StableOutlook">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crr;CreditWatchOutlook"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stable outlook</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;hasIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publisherIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crr;CreditRatingIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-crr;CreditRatingAgency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;issuedBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-crr;CreditRatingIssuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;rated">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rated</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-crr;InstrumentCreditRating"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;rates">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rates</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Credit rating rates something, for example a legal entity, an instrument or some such.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The thing that can be rated is any type of Continuant Thing or, since a securities issue or deal may also be rated, any occurrent thing.</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;watchDirection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">watch direction</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-crr;CreditWatchDirection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The direction in which the credit rating is expected to move, for something which has a credit rating on watch.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crr;watchOutlook">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">watch outlook</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crr;InvestmentCreditRating"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-crr;CreditWatchOutlook"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The expected outlook for the rated entity.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/md/TemporalCore/InstrumentTemporalTerms.rdf
+++ b/md/TemporalCore/InstrumentTemporalTerms.rdf
@@ -1,420 +1,424 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/">
-	<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/">
-	<!ENTITY fibo-ind-ir-pub "https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRatePublishers/">
-	<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
-	<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-pub-pub "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/">
+bu<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/">
+bu<!ENTITY fibo-ind-ir-pub "https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRatePublishers/">
+bu<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
+bu<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"
-	xmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"
-	xmlns:fibo-ind-ir-pub="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRatePublishers/"
-	xmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
-	xmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-		<rdfs:label xml:lang="en">InstrumentTemporalTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRatePublishers/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;ClosingPriceDeterminationMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;PriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">closing price determination method</rdfs:label>
-		<skos:definition xml:lang="en">The way in which a price is determined, usually by an exchange or trading venue, for example when publishing a closing price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;CreditSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;YieldSpread"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-md-dbtx-int;DebtInstrumentReferenceRate">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-ind-ir-ir;ReferenceInterestRate">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-tem;referencesYieldOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;ReferenceDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit spread</rdfs:label>
-		<skos:definition xml:lang="en">In finance, a credit spread is the yield spread, or difference in yield between different securities, due to different credit quality. The credit spread reflects the additional net yield an investor can earn from a security with more credit risk relative to one with less credit risk. The credit spread of a particular security is often quoted in relation to the yield on a credit risk-free benchmark security or reference rate. Further Notes There are several measures of credit spread, including Z-spread and option-adjusted spread. Old definition (Algo) The spread between the credit rating of something and its maturity. THis is now defined as a different term pending further review with Algorithmics. Update from SMER. difference between risk free price (price of govt bond) and the price of this security. (matches Wikipedia definition above) i.e. price of this credit versus the price of a (near) risk free credit. The latter is a reference security with low risk such as a Treasury Bond. Is this between prices or between yields? can be expressed as either wrt price or yield, and this is detemined by context for different markets. Try and get a list. This is more generic - the meaning is not that it is speciufically wrt yield as such. Debt Price Spread is in context of price, whereas this is more generic.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;DerivativeSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Spread"/>
-		<rdfs:label xml:lang="en">derivative spread</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;ExchangeTradedSecurityPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;quotedOn"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/Markets/MultilateralTradingFacility">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecuritiesExchange">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">exchange traded security price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;providesAnalysisAbout"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial instrument analytical parameter</rdfs:label>
-		<skos:definition xml:lang="en">Some measure of a financial instrument, that may be referred to in analysing or understanding that instrument for investment or risk management purposes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;FinancialMarketInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
-		<rdfs:label xml:lang="en">financial market information</rdfs:label>
-		<skos:definition xml:lang="en">Information about the financial markets, that is published by some publisher or data vendor.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;InstrumentInternalRateOfReturn">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;InternalRateOfReturn"/>
-		<rdfs:label xml:lang="en">instrument internal rate of return</rdfs:label>
-		<skos:definition xml:lang="en">The discount rate that results in a Net Present Value of zero for a series of future cash flows for the holder of the financial instrument.</skos:definition>
-		<skos:editorialNote xml:lang="en">notes @SMER on 18 November ISS is the interest rate used to calculate the NPV from a given Face Value. Yield &amp;amp; Face =&amp;gt; NPV NPV &amp;amp; Yield =&amp;gt; IRR is the rate used to calculate that NPV. This makes specific reinvestment assumptions.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;InternalRateOfReturn">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
-		<rdfs:label xml:lang="en">internal rate of return</rdfs:label>
-		<skos:definition xml:lang="en">The discount rate that results in a Net Present Value of zero for a series of future cash flows.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is not a figure given out as market data but is at the center of many definitions of financial debt instrument analytics. This is the inverse of Net Present Value (NPV). NPV is expressed in monetary units while IRR is expressed in percentage.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;Kassa">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">kassa</rdfs:label>
-		<skos:definition xml:lang="en">Official declared price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;Listino">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">listino</rdfs:label>
-		<skos:definition xml:lang="en">only associated with a closing price</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;MarketData">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialMarketInformation"/>
-		<rdfs:label xml:lang="en">market data</rdfs:label>
-		<skos:definition xml:lang="en">Data about financial instruments, that is published and may be used to support decision making or processing of financial instruments. Definition source: own definition.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;Maturity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:label xml:lang="en">maturity</rdfs:label>
-		<skos:definition xml:lang="en">The period remaining until an instrument reaches the end of its life.</skos:definition>
-		<skos:editorialNote xml:lang="en">This applies to all instruments that have a specific time to run. This replaces the model whereby a debt instrument has maturity defined in terms of a known and measured period of time. That concept will still exist as maturity &quot;at issue&quot;, one of many &quot;at issue&quot; specializations of terms that vary over time. Conesnsus:Review</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;MeanPriceDetermination">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">mean price determination</rdfs:label>
-		<skos:definition xml:lang="en">Exchange closing price may take an average (mean) price.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;PriceSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Spread"/>
-		<rdfs:label xml:lang="en">price spread</rdfs:label>
-		<skos:definition xml:lang="en">The difference between two prices.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;PublishedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;MarketData"/>
-		<rdfs:label xml:lang="en">published price</rdfs:label>
-		<skos:definition xml:lang="en">The price of some financial instrument on some market, published by some agent, in some suitable format.</skos:definition>
-		<skos:editorialNote xml:lang="en">The property of &quot;Value&quot; as identified in FIBIM is now a feature of whichever type of specification is used.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;ReferenceFactor">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:label xml:lang="en">reference factor</rdfs:label>
-		<skos:definition xml:lang="en">Some factor which is referred to in calculations and which is itself calculated in order to perform those calculations.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">An example of this would be the factor for an Inflation Bond, which may be used to determine interest payments, principal repayments or both, using formulae which refer to that factor.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;Riferimento">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">riferimento</rdfs:label>
-		<skos:definition xml:lang="en">Meaning not known</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;SecurityPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
-		<rdfs:label xml:lang="en">security price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;Spread">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Difference"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">spread</rdfs:label>
-		<skos:definition xml:lang="en">The difference between two parameters that may vary over time, such as prices or rates.</skos:definition>
-		<skos:editorialNote xml:lang="en">The parameters do not need to identify the same kind of parameter; for example there may be a spread between a price and a rate. However, the types of spread which are defined are expected to be meaningful and useful. Clearly they also need to takes values that are of the same simple type, for example two percentages or two monetary amounts. In practice spreads are generally denominated in percentage units. Note also that, in addition to being identified as a numerical value at some point in time, a spread may be represented as a curve, this being the plot of the two values, one on each axis of a 2 dimensional graph.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;StockVolatillity">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-ind-ind;Volatility"/>
-		<rdfs:label xml:lang="en">stock volatillity</rdfs:label>
-		<skos:definition xml:lang="en">A measure of stock price fluctuation. Mathematically the volatility is the annualized standard deviation of a stock&apos;s daily price changes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;TradedSecurityPublishedPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;PublishedPrice"/>
-		<rdfs:label xml:lang="en">traded security published price</rdfs:label>
-		<skos:definition xml:lang="en">The price of a tradable security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;Ufficiale">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-		<rdfs:label xml:lang="en">ufficiale</rdfs:label>
-		<skos:definition xml:lang="en">Meaning not known - Official price</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;Yield">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;basedUpon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Income"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;expressedInRelationTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;derivedFromOutlay"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;Outlay"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">yield</rdfs:label>
-		<skos:definition xml:lang="en">The yield of a financial instrument based on its current price is the return to the investor expressed as an annual percentage.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Yields come in various types with various qiualifying terms. A Yield must be based on a price, and must be in reference to some event or duration of time. It has a calculation method, and may have other qualifying terms such as for compounded yield. Most data models have these in a single selectable list, covering the different semantics above. Yield calculation methods remain as a selection list.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-ins;YieldSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Spread"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
-				<owl:onClass rdf:resource="&fibo-md-temx-ins;Yield"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>yield spread</rdfs:label>
-		<skos:definition xml:lang="en">the spread between the yields of two items</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;derivedFrom">
-		<rdfs:label>derived from</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;derivedFromOutlay">
-		<rdfs:label xml:lang="en">derived from outlay</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;Yield"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;Outlay"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasAnalyticsDetails">
-		<rdfs:label xml:lang="en">has analytics details</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod">
-		<rdfs:label xml:lang="en">has closing price determination method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;ExchangeTradedSecurityPrice"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-		<skos:definition xml:lang="en">The method by which the closing price is defined.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This method itself changes quite frequently i.e. the exchange may change the way it computes closing prices.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasPrice">
-		<rdfs:label xml:lang="en">has price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;PublishedPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasRateOfReturn">
-		<rdfs:label xml:lang="en">has rate of return</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;InstrumentInternalRateOfReturn"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasSpread">
-		<rdfs:label xml:lang="en">has spread</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;CreditSpread"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;identifiedAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publisherIdentity"/>
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-ind-ir-pub;MarketDataProvider"/>
-		<skos:definition xml:lang="en">The business entity which is the supplier of the market data.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;irrHasValue">
-		<rdfs:label xml:lang="en">irr has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;InternalRateOfReturn"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The value of the IRR at a given point in time, expressed as a percentage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;isBetween">
-		<rdfs:label xml:lang="en">is between</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;PriceSpread"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;maturityHasValue">
-		<rdfs:label xml:lang="en">maturity has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;Maturity"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedDurationSpecification"/>
-		<skos:definition xml:lang="en">The value of the Maturity at some point in time, expressed in terms of the length of time to maturity (a duration) at the time specified for that maturity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;providesAnalysisAbout">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
-		<rdfs:label xml:lang="en">provides analysis about</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
-		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
-		<owl:inverseOf rdf:resource="&fibo-md-temx-ins;hasAnalyticsDetails"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;quotedOn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
-		<rdfs:label xml:lang="en">quoted on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;ExchangeTradedSecurityPrice"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/Markets/MultilateralTradingFacility">
-					</rdf:Description>
-					<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecuritiesExchange">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;referenceFactorHasValue">
-		<rdfs:label xml:lang="en">reference factor has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;ReferenceFactor"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;yieldHasValue">
-		<rdfs:label xml:lang="en">yield has value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;Yield"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The value of the yield expressed as a percentage.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-pub-pub="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"
+buxmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"
+buxmlns:fibo-ind-ir-pub="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRatePublishers/"
+buxmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
+buxmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">InstrumentTemporalTerms</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines common concepts for instrument temporal terms, such as prices, yields, spreads, volatility and the like. These are the concepts as they apply to all classes of instrument.
+		The detailed terms in equity and debt pricing and analytics among others, are defined with reference to these basic concepts.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Publications/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRatePublishers/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;ClosingPriceDeterminationMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;PriceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">closing price determination method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The way in which a price is determined, usually by an exchange or trading venue, for example when publishing a closing price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;CreditSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;YieldSpread"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-md-dbtx-int;DebtInstrumentReferenceRate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-ind-ir-ir;ReferenceInterestRate">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-tem;referencesYieldOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;ReferenceDebtInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">In finance, a credit spread is the yield spread, or difference in yield between different securities, due to different credit quality. The credit spread reflects the additional net yield an investor can earn from a security with more credit risk relative to one with less credit risk. The credit spread of a particular security is often quoted in relation to the yield on a credit risk-free benchmark security or reference rate. Further Notes There are several measures of credit spread, including Z-spread and option-adjusted spread. Old definition (Algo) The spread between the credit rating of something and its maturity. THis is now defined as a different term pending further review with Algorithmics. Update from SMER. difference between risk free price (price of govt bond) and the price of this security. (matches Wikipedia definition above) i.e. price of this credit versus the price of a (near) risk free credit. The latter is a reference security with low risk such as a Treasury Bond. Is this between prices or between yields? can be expressed as either wrt price or yield, and this is detemined by context for different markets. Try and get a list. This is more generic - the meaning is not that it is speciufically wrt yield as such. Debt Price Spread is in context of price, whereas this is more generic.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;DerivativeSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Spread"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derivative spread</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;ExchangeTradedSecurityPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;quotedOn"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/Markets/MultilateralTradingFacility">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecuritiesExchange">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange traded security price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;providesAnalysisAbout"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial instrument analytical parameter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some measure of a financial instrument, that may be referred to in analysing or understanding that instrument for investment or risk management purposes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;FinancialMarketInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-pub;PublishedInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial market information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the financial markets, that is published by some publisher or data vendor.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;InstrumentInternalRateOfReturn">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;InternalRateOfReturn"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instrument internal rate of return</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The discount rate that results in a Net Present Value of zero for a series of future cash flows for the holder of the financial instrument.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">notes @SMER on 18 November ISS is the interest rate used to calculate the NPV from a given Face Value. Yield &amp;amp; Face =&amp;gt; NPV NPV &amp;amp; Yield =&amp;gt; IRR is the rate used to calculate that NPV. This makes specific reinvestment assumptions.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;InternalRateOfReturn">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;AnalyticalInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">internal rate of return</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The discount rate that results in a Net Present Value of zero for a series of future cash flows.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is not a figure given out as market data but is at the center of many definitions of financial debt instrument analytics. This is the inverse of Net Present Value (NPV). NPV is expressed in monetary units while IRR is expressed in percentage.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;Kassa">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">kassa</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Official declared price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;Listino">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listino</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">only associated with a closing price</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;MarketData">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;FinancialMarketInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market data</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Data about financial instruments, that is published and may be used to support decision making or processing of financial instruments. Definition source: own definition.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;Maturity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The period remaining until an instrument reaches the end of its life.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This applies to all instruments that have a specific time to run. This replaces the model whereby a debt instrument has maturity defined in terms of a known and measured period of time. That concept will still exist as maturity &quot;at issue&quot;, one of many &quot;at issue&quot; specializations of terms that vary over time. Conesnsus:Review</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;MeanPriceDetermination">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mean price determination</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Exchange closing price may take an average (mean) price.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;PriceSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Spread"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The difference between two prices.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;PublishedPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;MarketData"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">published price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price of some financial instrument on some market, published by some agent, in some suitable format.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The property of &quot;Value&quot; as identified in FIBIM is now a feature of whichever type of specification is used.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;ReferenceFactor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference factor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some factor which is referred to in calculations and which is itself calculated in order to perform those calculations.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">An example of this would be the factor for an Inflation Bond, which may be used to determine interest payments, principal repayments or both, using formulae which refer to that factor.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;Riferimento">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">riferimento</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Meaning not known</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;SecurityPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;Spread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Difference"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;takesValuesOverTime"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The difference between two parameters that may vary over time, such as prices or rates.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The parameters do not need to identify the same kind of parameter; for example there may be a spread between a price and a rate. However, the types of spread which are defined are expected to be meaningful and useful. Clearly they also need to takes values that are of the same simple type, for example two percentages or two monetary amounts. In practice spreads are generally denominated in percentage units. Note also that, in addition to being identified as a numerical value at some point in time, a spread may be represented as a curve, this being the plot of the two values, one on each axis of a 2 dimensional graph.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;StockVolatillity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-ind-ind-ind;Volatility"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stock volatillity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A measure of stock price fluctuation. Mathematically the volatility is the annualized standard deviation of a stock&apos;s daily price changes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;TradedSecurityPublishedPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;PublishedPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">traded security published price</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The price of a tradable security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;Ufficiale">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ufficiale</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Meaning not known - Official price</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;Yield">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;basedUpon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-acc;Income"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;expressedInRelationTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;derivedFromOutlay"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;Outlay"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">yield</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The yield of a financial instrument based on its current price is the return to the investor expressed as an annual percentage.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Yields come in various types with various qiualifying terms. A Yield must be based on a price, and must be in reference to some event or duration of time. It has a calculation method, and may have other qualifying terms such as for compounded yield. Most data models have these in a single selectable list, covering the different semantics above. Yield calculation methods remain as a selection list.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-ins;YieldSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;Spread"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasArgument"/>
+bubububu<owl:onClass rdf:resource="&fibo-md-temx-ins;Yield"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>yield spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">the spread between the yields of two items</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;derivedFrom">
+bubu<rdfs:label>derived from</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;derivedFromOutlay">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">derived from outlay</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;Yield"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;Outlay"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasAnalyticsDetails">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has analytics details</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasClosingPriceDeterminationMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has closing price determination method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;ExchangeTradedSecurityPrice"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which the closing price is defined.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This method itself changes quite frequently i.e. the exchange may change the way it computes closing prices.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;PublishedPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasRateOfReturn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has rate of return</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;InstrumentInternalRateOfReturn"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;hasSpread">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has spread</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;CreditSpread"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;identifiedAs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publisherIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified as</rdfs:label>
+bubu<rdfs:range rdf:resource="&fibo-ind-ir-pub;MarketDataProvider"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The business entity which is the supplier of the market data.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;irrHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">irr has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;InternalRateOfReturn"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the IRR at a given point in time, expressed as a percentage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;isBetween">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is between</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;PriceSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;maturityHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;Maturity"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedDurationSpecification"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the Maturity at some point in time, expressed in terms of the length of time to maturity (a duration) at the time specified for that maturity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;providesAnalysisAbout">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;isAbout"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">provides analysis about</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;FinancialInstrumentAnalyticalParameter"/>
+bubu<rdfs:range rdf:resource="&fibo-fbc-fi-fi;FinancialInstrument"/>
+bubu<owl:inverseOf rdf:resource="&fibo-md-temx-ins;hasAnalyticsDetails"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;quotedOn">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pub-pub;publishedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">quoted on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;ExchangeTradedSecurityPrice"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/Markets/MultilateralTradingFacility">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecuritiesExchange">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;referenceFactorHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reference factor has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;ReferenceFactor"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-ins;yieldHasValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">yield has value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;Yield"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the yield expressed as a percentage.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/md/TemporalCore/SecurityCreditStatuses.rdf
+++ b/md/TemporalCore/SecurityCreditStatuses.rdf
@@ -1,109 +1,113 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-accx-dbpx "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-temx-crs "https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityCreditStatuses/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-accx-dbpx "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-temx-crs "https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityCreditStatuses/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityCreditStatuses/"
-	xmlns:fibo-fnd-accx-dbpx="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-temx-crs="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityCreditStatuses/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityCreditStatuses/">
-		<rdfs:label xml:lang="en">SecurityCreditStatuses</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityCreditStatuses/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crs;CreditOK">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
-		<rdfs:label xml:lang="en">credit o k</rdfs:label>
-		<skos:definition xml:lang="en">Not defaulted.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crs;InDefault">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
-		<rdfs:label xml:lang="en">in default</rdfs:label>
-		<skos:definition xml:lang="en">The issuer has failed to pay somthing that they are contractually obliged to pay.</skos:definition>
-		<skos:editorialNote xml:lang="en">(review 7 Oct 09) Does this exist as a term? This is a characteristic of the instrument not the rating. Because it&apos;s in default you can expect the rating to drop. Applies to instrument not to debtor. So a company may have 3 bond issues and may be defualt on only one. 14 Oct: Degrees of defaults e.g. tranche not paying interest due to losses on the underlying portrfolio; tranches being used to pay down more senior tranches.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crs;SecurityCashflowStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">security cashflow status</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
-		<skos:definition xml:lang="en">The status of the cashflow due to the holder from the security.</skos:definition>
-		<skos:editorialNote xml:lang="en">Specialize this for preferred stocks, debt tranches and so on.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-crs;SecurityCreditStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crs;inRespectOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-crs;isStatusOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security credit status</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;acceleratedPrincipalPaymentsExpected">
-		<rdfs:label xml:lang="en">accelerated principal payments expected</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCashflowStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;inRespectOf">
-		<rdfs:label xml:lang="en">in respect of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
-		<skos:definition xml:lang="en">Basis of the Credit Rating, i.e. the Credit of the Creditor assuming this is taken into account in determining the Credit Rating. This model may be adjusted to put more detail into the basis, including payments history, credit history and the like.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;interestPaymentsExpected">
-		<rdfs:label xml:lang="en">interest payments expected</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCashflowStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;isStatusOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;isOf"/>
-		<rdfs:label xml:lang="en">is status of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;principalPaymentsExpected">
-		<rdfs:label xml:lang="en">principal payments expected</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCashflowStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-accx-dbpx="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-temx-crs="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityCreditStatuses/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityCreditStatuses/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SecurityCreditStatuses</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology extends the credit status ontology to define credit status concepts that are specific to issued securities. These include cashflow status and the basic credit statuses of being OK or in default. 
+		Note that in application data models these concepts would be represented as one or more selectable code lists or enumerations.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquityExt/DebtPerspectives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityCreditStatuses/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crs;CreditOK">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit o k</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Not defaulted.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crs;InDefault">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in default</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer has failed to pay somthing that they are contractually obliged to pay.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">(review 7 Oct 09) Does this exist as a term? This is a characteristic of the instrument not the rating. Because it&apos;s in default you can expect the rating to drop. Applies to instrument not to debtor. So a company may have 3 bond issues and may be defualt on only one. 14 Oct: Degrees of defaults e.g. tranche not paying interest due to losses on the underlying portrfolio; tranches being used to pay down more senior tranches.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crs;SecurityCashflowStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security cashflow status</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of the cashflow due to the holder from the security.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Specialize this for preferred stocks, debt tranches and so on.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-crs;SecurityCreditStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crs;inRespectOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-crs;isStatusOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security credit status</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;acceleratedPrincipalPaymentsExpected">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">accelerated principal payments expected</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCashflowStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;inRespectOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">in respect of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-accx-dbpx;CreditSide"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Basis of the Credit Rating, i.e. the Credit of the Creditor assuming this is taken into account in determining the Credit Rating. This model may be adjusted to put more detail into the basis, including payments history, credit history and the like.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;interestPaymentsExpected">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest payments expected</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCashflowStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;isStatusOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;isOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is status of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCreditStatus"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-crs;principalPaymentsExpected">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">principal payments expected</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-crs;SecurityCashflowStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/md/TemporalCore/SecurityTradingStatuses.rdf
+++ b/md/TemporalCore/SecurityTradingStatuses.rdf
@@ -1,205 +1,208 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY fibo-md-temx-trs "https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY fibo-md-temx-trs "https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:fibo-md-temx-trs="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/">
-		<rdfs:label xml:lang="en">SecurityTradingStatuses</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-		<owl:equivalentClass rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;Active">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
-		<rdfs:label xml:lang="en">active</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-temx-trs;Inactive"/>
-		<skos:definition xml:lang="en">Security is actively traded</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;ActivelyTrading">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;ExchangeSecurityTradingStatus"/>
-		<rdfs:label xml:lang="en">actively trading</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-temx-trs;TradingHalted"/>
-		<skos:definition xml:lang="en">Security is actively traded on the exchange or trading facility</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;CurrentStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;StatusCodeValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;statusHasTense"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Present"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">current status</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-md-temx-trs;PastStatus"/>
-		<skos:definition xml:lang="en">The status at the present time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;ExchangeSecurityTradingStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">exchange security trading status</rdfs:label>
-		<skos:definition xml:lang="en">The trading status of a security on a given trading exchange.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;Inactive">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
-		<rdfs:label xml:lang="en">inactive</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;Issued">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
-		<rdfs:label xml:lang="en">issued</rdfs:label>
-		<skos:definition xml:lang="en">The security has been issued into the secondary market.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;PastStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;StatusCodeValue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;statusHasTense"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Past"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">past status</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;SecurityLifecycleStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">security lifecycle status</rdfs:label>
-		<skos:definition xml:lang="en">The status of a security within its lifecycle.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;SecurityTradingStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">security trading status</rdfs:label>
-		<skos:definition xml:lang="en">The status of the security in terms of whether it is trading or not, and any special considerations relating to trading.</skos:definition>
-		<skos:editorialNote xml:lang="en">Exchange Traded Security trading status is now a separate term, covering trading suspension on an exchange, so that does not form part of this term.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;TradingHalted">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;ExchangeSecurityTradingStatus"/>
-		<rdfs:label xml:lang="en">trading halted</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;WhenDistributed">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
-		<rdfs:label xml:lang="en">when distributed</rdfs:label>
-		<skos:definition xml:lang="en">Used to refer to a security that trades after the date of issue but before the time at which the certificates are delivered</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;WhenIssued">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
-		<rdfs:label xml:lang="en">when issued</rdfs:label>
-		<skos:definition xml:lang="en">When Issued or Gray Market trading is when a security is traded ahead of the date at which it is to be issued.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-trs;Worthless">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-trs;describes"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">worthless</rdfs:label>
-		<skos:definition xml:lang="en">Announcement by the regulator that the security has become worthless.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">e.g. bankruptcy hearings - might result in this being said.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;delisted">
-		<rdfs:label xml:lang="en">delisted</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-trs;ExchangeSecurityTradingStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the security is currently delisted on that exchange or trading facility.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;describes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;isOf"/>
-		<rdfs:label xml:lang="en">describes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-trs;Worthless"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;hasStatus">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;hasStatus"/>
-		<rdfs:label xml:lang="en">has listing status</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-trs;ExchangeSecurityTradingStatus"/>
-		<skos:definition xml:lang="en">The trading status of this listing i.e. this security on this exchange.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;hasTradingStatus">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;hasStatus"/>
-		<rdfs:label xml:lang="en">has trading status</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;status">
-		<rdfs:label xml:lang="en">status</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;statusDate">
-		<rdfs:label xml:lang="en">status date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-trs;PastStatus"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">Date at which the status of the security is taken.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-temx-trs;tense.1">
-		<rdfs:label xml:lang="en">tense</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;worthless">
-		<rdfs:label xml:lang="en">worthless</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-trs;Worthless"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing">
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:fibo-md-temx-trs="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SecurityTradingStatuses</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the various kinds of trading status that a security may be in at any given point in time. These includes such terms as active and halted, inactive and so on, along with their qualifying terms.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bubu<owl:equivalentClass rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;Active">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">active</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-temx-trs;Inactive"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Security is actively traded</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;ActivelyTrading">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;ExchangeSecurityTradingStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">actively trading</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-temx-trs;TradingHalted"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Security is actively traded on the exchange or trading facility</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;CurrentStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;StatusCodeValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;statusHasTense"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Present"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current status</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-md-temx-trs;PastStatus"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status at the present time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;ExchangeSecurityTradingStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exchange security trading status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The trading status of a security on a given trading exchange.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;Inactive">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inactive</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;Issued">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The security has been issued into the secondary market.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;PastStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;StatusCodeValue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;statusHasTense"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;Past"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">past status</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;SecurityLifecycleStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security lifecycle status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of a security within its lifecycle.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;SecurityTradingStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security trading status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The status of the security in terms of whether it is trading or not, and any special considerations relating to trading.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Exchange Traded Security trading status is now a separate term, covering trading suspension on an exchange, so that does not form part of this term.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;TradingHalted">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;ExchangeSecurityTradingStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading halted</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;WhenDistributed">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">when distributed</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Used to refer to a security that trades after the date of issue but before the time at which the certificates are delivered</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;WhenIssued">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">when issued</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">When Issued or Gray Market trading is when a security is traded ahead of the date at which it is to be issued.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-trs;Worthless">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-trs;describes"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">worthless</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Announcement by the regulator that the security has become worthless.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">e.g. bankruptcy hearings - might result in this being said.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;delisted">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">delisted</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-trs;ExchangeSecurityTradingStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the security is currently delisted on that exchange or trading facility.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;describes">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;isOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">describes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-trs;Worthless"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;hasStatus">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;hasStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has listing status</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-trs;ExchangeSecurityTradingStatus"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The trading status of this listing i.e. this security on this exchange.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;hasTradingStatus">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;hasStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has trading status</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-trs;SecurityTradingStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;status">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">status</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;statusDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">status date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-trs;PastStatus"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date at which the status of the security is taken.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-temx-trs;tense.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tense</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-trs;worthless">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">worthless</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-trs;Worthless"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing">
+bu</owl:Class>
 
 </rdf:RDF>

--- a/md/TemporalCore/TemporalConcepts.rdf
+++ b/md/TemporalCore/TemporalConcepts.rdf
@@ -1,447 +1,451 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-math-amt "https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-txn-ecr "https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-		<rdfs:label xml:lang="en">TemporalConcepts</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;CurrentMonetaryAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;CurrentValue"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
-		<rdfs:label xml:lang="en">current monetary amount</rdfs:label>
-		<skos:definition xml:lang="en">Monetary amount at the present time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;CurveConvexity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-tem;isOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Spread"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">curve convexity</rdfs:label>
-		<skos:definition xml:lang="en">The convexity of the curve between any two time-variant parameters.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;DatedDurationSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
-		<rdfs:label xml:lang="en">dated duration specification</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;DatedMonetaryAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
-		<rdfs:label xml:lang="en">dated monetary amount</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;DatedPastValue">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;PastValue"/>
-		<rdfs:label xml:lang="en">dated past value</rdfs:label>
-		<skos:definition xml:lang="en">A value at a given time and date. The value of a dated parameter, at a stated point in the past, present or future.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;DatedPercentage">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<rdfs:label xml:lang="en">dated percentage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;DebtMarginSpread">
-		<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPriceSpread"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-tem;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecurityBidPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-tem;refersTo.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecurityOfferPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt margin spread</rdfs:label>
-		<skos:definition xml:lang="en">The spread between a Bid Price and an Offer Price.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the spread between the two prices, in whichever way those are specified. So for example a margin spread may be the margin between two prices each specified as a yield spread or in percentage terms.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;EndOfDayPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
-		<rdfs:label xml:lang="en">end of day price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;IntraDayPrice">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
-		<rdfs:label xml:lang="en">intra day price</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceBarterSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
-		<rdfs:label xml:lang="en">price barter specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of the price of some item in terms of the number of some other (non currency) items of value that may exchanged for some quantity of the item so prices.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that in this case it is not necessarily the case that the item so priced is priced against one unit of that item; rather, the barter specification would most generally be a specification of the exchange of a number of the priced items for a number of the other item.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceExchangeSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;PriceSpecification"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-tem;denominatorRefersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-tem;numeratorRefersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">price exchange specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a price in terms of the exchange of some quantity of some item of value in return for some quantity of the item so priced. That is, a simple price or exchange ratio which specifies the amount of an asset that will be exchanged for another asset;</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Prices that fall into this category include: 1. Exchange Rates the amount of one currency that can be exchanged for a unit of another currency 2. Commodity Price the amount of a specific Commodity that can be exchanged for a unit of a currency 3. Security price per Hundred where - albeit not explicit - the numerator asset is today’s Currency and the denominator Asset is future Currency (face Value). Notes Origin: NAB</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceInterpolationSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;interpolatedBetween"/>
-				<owl:onClass rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">price interpolation specification</rdfs:label>
-		<skos:definition xml:lang="en">A price which is an interpolation between two publicly available prices fo rths instrument.</skos:definition>
-		<skos:editorialNote xml:lang="en">Establish at review whether these are always interpolations between two prices of the instrument itself, or for example an interpolation between a price of the instrument and the price of something comparable. If the latter exists, then there are two kinds of interpolation specifications for price. The term currently modeled is the interpolation between two prices of the instrument so priced.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceModelSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-tem;uses"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-tem;PricingModel"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">price model specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a price using a model.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceParameterSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;PriceSpecification"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-tem;specifiesUseOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">price parameter specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a price as a quote of the primary parameter passed into an algorithm used to calculate the Present Value of the relevant Asset.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Two significant examples of this pricing method are 1. Yields a yield is expressed as the annualized interest Rate that an investor requires for an investment. In the case of a loan the terms are set up so that the interest rate (coupon) equals that required yield and therefore the present value is equal to the loan principal. For a security, however the coupon rate is already determined so the required yield is applied to the projected cash flows in order to calculate a present value ( the price an investor is prepared to pay for the specified cash flows) Typically the required yield for a debt security is the yield to maturity 2. Volatilities in reality a volatility (used to calculate the fair value of an option) is a measure of the variability of the price of the transaction over which the beneficiary of the option has control. This is the primary parameter passed into an option valuation (eg Black-Scholes, Binomial) Notes Origin: NAB</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceRateSpreadSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceSpreadSpecification"/>
-		<rdfs:label xml:lang="en">price rate spread specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a price in terms of the difference between that price as a percentage, and some publicly available rate at that same point in time, such as the interest rate on a Treasury Note or an inter-bank rate (IBOR).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the different between two rates.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceRatioSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
-		<rdfs:label xml:lang="en">price ratio specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a price in terms of some ratio to the face value of the item, expressed as a percentage. Security price per Hundred.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the default in debt pricing: debt instruments are commonly priced in percentage terms, the price being the percentage of the face value of the security. Debt prices that are specified and distributed in other ways, can be calculated back to this specification. Effectively the numerator asset is today’s Currency and the denominator Asset is future Currency (face Value).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceSpreadSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-tem;specifiesUseOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Spread"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">price spread specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a price in terms of the difference between that price and some other paramater at that same point in time.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a class of price specifications which are specifications by way of spread, including spread between two yields, spread between two prices. The latter is relevant in Fx and Commodities for example.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceValue">
-		<rdfs:label xml:lang="en">price value</rdfs:label>
-		<skos:definition xml:lang="en">Value given to a price. FIBIM</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceVolatilitySpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
-		<rdfs:label xml:lang="en">price volatility specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of an option price in terms of its volatility, that being a measure of the variability of the price of the transaction over which the beneficiary of the option has control.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In reality a volatility (used to calculate the fair value of an option) is a measure of the variability of the price of the transaction over which the beneficiary of the option has control. This is the primary parameter passed into an option valuation (eg Black-Scholes, Binomial) Notes origin:NAB</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PriceYieldSpreadSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceSpreadSpecification"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedRelativeTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">price yield spread specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a price in terms of the difference between the yield that an investor requires for an investment and the published yield on some reference instrument at that same point in time, such as a Treasury Note.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In Debt pricing, Spreads are used because it&apos;s easier to quote things in a stable way, and it reflects the relative value of the thing. This is a spread of yields between the instrument so priced and the reference instrument. This spread is the mechanism by which the price is determined in yield terms, as the annualised interest rate that a investor requires for an investment. A yield is expressed as the annualised interest Rate that a investor requires for an investment. In the case of a loan the terms are set up so that the interest rate (coupon) equals that required yield and therefore the present value is equal to the loan principal. For a security, however the coupon rate is already determined so the required yield is applied to the projected cash flows in order to calculate a present value ( the price an investor is prepared to pay for the specified cash flows) Typically the required yield for a debt security is the yield to maturity. Note that this may be a discount or premium. Using the Spread lets you calculat e a yield from another observed yield as follows: Yield 1 = risk free yield Spread is to Yield 2 which is the instrument you are pricing. Earlier notes from Strucured finance review of prices quoted in relative terms: The price quoted in reference to an index e.g. LIBOR+50bp i.e. the yield. (the rate which is currently LIBOR)+50 is the price, and 50bp is the spread. e.g. Price:101% Yield = Benchmark + spread Price of 101% can be expressed as LIBOR+50 or Treasury+20 so these are separate ways of expressing the same thing. The one thing which is the price is expressed in these different ways. note also that unlike equities there&apos;s not a range of different price results from this. Spread = analytic. Bond has Price + yield. then compared to today&apos;s 90 day treasury value it&apos;s Spread is X, compared with (1 month) LIBOR its spread is Y and so on. Notes origin:NAB and SMER</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;PricingModel">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalModel"/>
-		<rdfs:label xml:lang="en">pricing model</rdfs:label>
-		<skos:definition xml:lang="en">The model used in the Price Model Specification.</skos:definition>
-		<skos:scopeNote xml:lang="en">It is beyond the capacity of the Semantic Model to model the method itself in detail. Key facts about this method may be modeled.</skos:scopeNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;StatusCodeValue">
-		<rdfs:label xml:lang="en">status code value</rdfs:label>
-		<skos:definition xml:lang="en">The value of the status of something that is set in terms of a list of selectable values taken from a list, which may take different values from that list at different times.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;TimedDurationSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
-		<rdfs:label xml:lang="en">timed duration specification</rdfs:label>
-		<skos:definition xml:lang="en">A period of time, determined at some point in time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;TimedMonetaryAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-		<rdfs:label xml:lang="en">timed monetary amount</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;TimedNumericAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-amt;hasValue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">timed numeric amount</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;TimedPercentage">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
-		<rdfs:label xml:lang="en">timed percentage</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-md-temx-tem;UnitPriceMonetarySpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
-		<rdfs:label xml:lang="en">unit price monetary specification</rdfs:label>
-		<skos:definition xml:lang="en">The specification of a price in terms of some monetary amount, that is a number and a currency unit, in exchange for one unit if the item so priced.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is the most common kind of price specification, and specifies that a given thing costs a given number of Dollars or other currency units for one of the item or for some other well defined denimination of the unit (e.g. price per hundred). This is also the Fx rate for one unit of a given currency, being effectively the &quot;price&quot; of that currency in the specified currency.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-md-temx-tem;amount">
-		<rdfs:label xml:lang="en">amount</rdfs:label>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;currency">
-		<rdfs:label xml:lang="en">currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;denominator">
-		<rdfs:label xml:lang="en">denominator</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceRatioSpecification"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;denominator.1">
-		<rdfs:label xml:lang="en">denominator</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;UnitPriceMonetarySpecification"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;denominatorQuantity">
-		<rdfs:label xml:lang="en">denominator quantity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceBarterSpecification"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;denominatorRefersTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;isParameterOfReferenceEntity"/>
-		<rdfs:label xml:lang="en">denominator refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;isBetween">
-		<rdfs:label xml:lang="en">is between</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-ins;YieldSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;Yield"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;isOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;analyzes"/>
-		<rdfs:label xml:lang="en">is of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;CurveConvexity"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;Spread"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;isOfCurveBetween">
-		<rdfs:label xml:lang="en">is of curve between</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;CurveConvexity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;modelDescription">
-		<rdfs:label xml:lang="en">model description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PricingModel"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">A textual description and narrative of the model.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;numerator">
-		<rdfs:label xml:lang="en">numerator</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceRatioSpecification"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The value of the Price, stated as a percentage, at a given point in time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;numeratorQuantity">
-		<rdfs:label xml:lang="en">numerator quantity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceBarterSpecification"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;numeratorQuantity.1">
-		<rdfs:label xml:lang="en">numerator quantity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;UnitPriceMonetarySpecification"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
-		<skos:definition xml:lang="en">The value of the price, stated as a monetary amount at a given point in time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;numeratorRefersTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;isParameterOfReferenceEntity"/>
-		<rdfs:label xml:lang="en">numerator refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
-		<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;referencesYieldOf">
-		<rdfs:label>references yield of</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;refersTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-py;isSpreadBetween"/>
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;DebtMarginSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecurityBidPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;refersTo.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-py;isSpreadBetween"/>
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;DebtMarginSpread"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecurityOfferPrice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;specifiesUseOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasOperand"/>
-		<rdfs:label xml:lang="en">specifies use of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
-		<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;uses">
-		<rdfs:label xml:lang="en">uses</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceModelSpecification"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;PricingModel"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;value">
-		<rdfs:label xml:lang="en">value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceSpreadSpecification"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The value of the Spread, expressed in percentage terms, at a given point in time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;value.1">
-		<rdfs:label xml:lang="en">value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceVolatilitySpecification"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<skos:definition xml:lang="en">The value of the volatillity, expressed as a percentage, at a given point in time.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;value.2">
-		<rdfs:label xml:lang="en">value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;value.3">
-		<rdfs:label xml:lang="en">value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;valueTime">
-		<rdfs:label xml:lang="en">value time</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-tem;DatedPastValue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-math-amt="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-txn-ecr="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">TemporalConcepts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This is the core ontology for temporally sensitive terms and provides the basic definitions that are extended in other ontologies specific to securities, types of security and so on. These concepts include basic prices, yields, volatilities, spreads and so on, as well as times percentages and amounts.
+		Note that this is a highly conceptual foundational ontology of these concepts, as it distinguishes between for example the notions of price and the ways these are specified. These concepts should be reviewed to make reference to the newer Values ontology and may be further simplified for application ontologies.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;CurrentMonetaryAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;CurrentValue"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">current monetary amount</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Monetary amount at the present time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;CurveConvexity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-tem;isOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Spread"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">curve convexity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The convexity of the curve between any two time-variant parameters.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;DatedDurationSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedDurationSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dated duration specification</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;DatedMonetaryAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dated monetary amount</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;DatedPastValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;PastValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dated past value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A value at a given time and date. The value of a dated parameter, at a stated point in the past, present or future.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;DatedPercentage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dated percentage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;DebtMarginSpread">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-dbtx-py;DebtPriceSpread"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-tem;refersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecurityBidPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-tem;refersTo.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DebtSecurityOfferPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt margin spread</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The spread between a Bid Price and an Offer Price.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the spread between the two prices, in whichever way those are specified. So for example a margin spread may be the margin between two prices each specified as a yield spread or in percentage terms.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;EndOfDayPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">end of day price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;IntraDayPrice">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-ins;SecurityPrice"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">intra day price</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceBarterSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price barter specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of the price of some item in terms of the number of some other (non currency) items of value that may exchanged for some quantity of the item so prices.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note that in this case it is not necessarily the case that the item so priced is priced against one unit of that item; rather, the barter specification would most generally be a specification of the exchange of a number of the priced items for a number of the other item.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceExchangeSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;PriceSpecification"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-tem;denominatorRefersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-tem;numeratorRefersTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price exchange specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a price in terms of the exchange of some quantity of some item of value in return for some quantity of the item so priced. That is, a simple price or exchange ratio which specifies the amount of an asset that will be exchanged for another asset;</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Prices that fall into this category include: 1. Exchange Rates the amount of one currency that can be exchanged for a unit of another currency 2. Commodity Price the amount of a specific Commodity that can be exchanged for a unit of a currency 3. Security price per Hundred where - albeit not explicit - the numerator asset is today’s Currency and the denominator Asset is future Currency (face Value). Notes Origin: NAB</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceInterpolationSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;interpolatedBetween"/>
+bubububu<owl:onClass rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price interpolation specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A price which is an interpolation between two publicly available prices fo rths instrument.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Establish at review whether these are always interpolations between two prices of the instrument itself, or for example an interpolation between a price of the instrument and the price of something comparable. If the latter exists, then there are two kinds of interpolation specifications for price. The term currently modeled is the interpolation between two prices of the instrument so priced.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceModelSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-tem;uses"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-tem;PricingModel"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price model specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a price using a model.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceParameterSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;PriceSpecification"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-tem;specifiesUseOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price parameter specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a price as a quote of the primary parameter passed into an algorithm used to calculate the Present Value of the relevant Asset.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Two significant examples of this pricing method are 1. Yields a yield is expressed as the annualized interest Rate that an investor requires for an investment. In the case of a loan the terms are set up so that the interest rate (coupon) equals that required yield and therefore the present value is equal to the loan principal. For a security, however the coupon rate is already determined so the required yield is applied to the projected cash flows in order to calculate a present value ( the price an investor is prepared to pay for the specified cash flows) Typically the required yield for a debt security is the yield to maturity 2. Volatilities in reality a volatility (used to calculate the fair value of an option) is a measure of the variability of the price of the transaction over which the beneficiary of the option has control. This is the primary parameter passed into an option valuation (eg Black-Scholes, Binomial) Notes Origin: NAB</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceRateSpreadSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceSpreadSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price rate spread specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a price in terms of the difference between that price as a percentage, and some publicly available rate at that same point in time, such as the interest rate on a Treasury Note or an inter-bank rate (IBOR).</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the different between two rates.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceRatioSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price ratio specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a price in terms of some ratio to the face value of the item, expressed as a percentage. Security price per Hundred.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the default in debt pricing: debt instruments are commonly priced in percentage terms, the price being the percentage of the face value of the security. Debt prices that are specified and distributed in other ways, can be calculated back to this specification. Effectively the numerator asset is today’s Currency and the denominator Asset is future Currency (face Value).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceSpreadSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-tem;specifiesUseOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;Spread"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price spread specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a price in terms of the difference between that price and some other paramater at that same point in time.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a class of price specifications which are specifications by way of spread, including spread between two yields, spread between two prices. The latter is relevant in Fx and Commodities for example.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Value given to a price. FIBIM</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceVolatilitySpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price volatility specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of an option price in terms of its volatility, that being a measure of the variability of the price of the transaction over which the beneficiary of the option has control.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In reality a volatility (used to calculate the fair value of an option) is a measure of the variability of the price of the transaction over which the beneficiary of the option has control. This is the primary parameter passed into an option valuation (eg Black-Scholes, Binomial) Notes origin:NAB</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PriceYieldSpreadSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceSpreadSpecification"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;determinedRelativeTo"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">price yield spread specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a price in terms of the difference between the yield that an investor requires for an investment and the published yield on some reference instrument at that same point in time, such as a Treasury Note.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In Debt pricing, Spreads are used because it&apos;s easier to quote things in a stable way, and it reflects the relative value of the thing. This is a spread of yields between the instrument so priced and the reference instrument. This spread is the mechanism by which the price is determined in yield terms, as the annualised interest rate that a investor requires for an investment. A yield is expressed as the annualised interest Rate that a investor requires for an investment. In the case of a loan the terms are set up so that the interest rate (coupon) equals that required yield and therefore the present value is equal to the loan principal. For a security, however the coupon rate is already determined so the required yield is applied to the projected cash flows in order to calculate a present value ( the price an investor is prepared to pay for the specified cash flows) Typically the required yield for a debt security is the yield to maturity. Note that this may be a discount or premium. Using the Spread lets you calculat e a yield from another observed yield as follows: Yield 1 = risk free yield Spread is to Yield 2 which is the instrument you are pricing. Earlier notes from Strucured finance review of prices quoted in relative terms: The price quoted in reference to an index e.g. LIBOR+50bp i.e. the yield. (the rate which is currently LIBOR)+50 is the price, and 50bp is the spread. e.g. Price:101% Yield = Benchmark + spread Price of 101% can be expressed as LIBOR+50 or Treasury+20 so these are separate ways of expressing the same thing. The one thing which is the price is expressed in these different ways. note also that unlike equities there&apos;s not a range of different price results from this. Spread = analytic. Bond has Price + yield. then compared to today&apos;s 90 day treasury value it&apos;s Spread is X, compared with (1 month) LIBOR its spread is Y and so on. Notes origin:NAB and SMER</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;PricingModel">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;MathematicalModel"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pricing model</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The model used in the Price Model Specification.</skos:definition>
+bubu<skos:scopeNote rdf:datatype="&rdf;langString" xml:lang="en">It is beyond the capacity of the Semantic Model to model the method itself in detail. Key facts about this method may be modeled.</skos:scopeNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;StatusCodeValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">status code value</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the status of something that is set in terms of a list of selectable values taken from a list, which may take different values from that list at different times.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;TimedDurationSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescription"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">timed duration specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A period of time, determined at some point in time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;TimedMonetaryAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">timed monetary amount</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;TimedNumericAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-amt;NumericAmount"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-amt;hasValue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">timed numeric amount</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;TimedPercentage">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;TimedValue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">timed percentage</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-md-temx-tem;UnitPriceMonetarySpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unit price monetary specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The specification of a price in terms of some monetary amount, that is a number and a currency unit, in exchange for one unit if the item so priced.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is the most common kind of price specification, and specifies that a given thing costs a given number of Dollars or other currency units for one of the item or for some other well defined denimination of the unit (e.g. price per hundred). This is also the Fx rate for one unit of a given currency, being effectively the &quot;price&quot; of that currency in the specified currency.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-md-temx-tem;amount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">amount</rdfs:label>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;currency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;denominator">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denominator</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceRatioSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;denominator.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denominator</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;UnitPriceMonetarySpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;denominatorQuantity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denominator quantity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceBarterSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;denominatorRefersTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;isParameterOfReferenceEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denominator refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;isBetween">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is between</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-ins;YieldSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;Yield"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;isOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-tem;analyzes"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;CurveConvexity"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;Spread"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;isOfCurveBetween">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is of curve between</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;CurveConvexity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;modelDescription">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">model description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PricingModel"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A textual description and narrative of the model.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;numerator">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numerator</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceRatioSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the Price, stated as a percentage, at a given point in time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;numeratorQuantity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numerator quantity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceBarterSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedNumericAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;numeratorQuantity.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numerator quantity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;UnitPriceMonetarySpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the price, stated as a monetary amount at a given point in time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;numeratorRefersTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;isParameterOfReferenceEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">numerator refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceExchangeSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-txn-ecr;EconomicResource"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;referencesYieldOf">
+bubu<rdfs:label>references yield of</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;refersTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-py;isSpreadBetween"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;DebtMarginSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecurityBidPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;refersTo.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-md-dbtx-py;isSpreadBetween"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;DebtMarginSpread"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-py;DebtSecurityOfferPrice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;specifiesUseOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasOperand"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies use of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceParameterSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-math-math;TimedParameter"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;uses">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">uses</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceModelSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;PricingModel"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;value">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceSpreadSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the Spread, expressed in percentage terms, at a given point in time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;value.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;PriceVolatilitySpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The value of the volatillity, expressed as a percentage, at a given point in time.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;value.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;TimedMonetaryAmount"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;value.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;TimedPercentage"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-temx-tem;valueTime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">value time</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-md-temx-tem;DatedPastValue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/AssetBacked/AssetBackedSPVs.rdf
+++ b/sec/Debt/AssetBacked/AssetBackedSPVs.rdf
@@ -1,76 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fctx-spv "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-ab-spv "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
-	<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fctx-spv "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-ab-spv "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
+bu<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"
-	xmlns:fibo-be-fctx-spv="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-ab-spv="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"
-	xmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
-		<rdfs:label xml:lang="en">AssetBackedSPVs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-spv;DebtSPV">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-spv;isSetUpFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-spv;DebtSecuritiesIssuance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-spv;holds"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/SecuritizedDebtPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt s p v</rdfs:label>
-		<skos:definition xml:lang="en">A Special Purpose Vehicle (SPV) set up specifically to issue a debt security or securities. It is set up by a company or a group of companies to create instruments that are off the company&apos;s balance sheet.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The SPV exists for a specific period of time and is then disbanded. It may take the form of an LLC or other legal entity. Special Purpose Vehicles are also referred to as bankruptcy remote entities, as they isolate financial risk.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-spv;DebtSecuritiesIssuance">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuance"/>
-		<rdfs:label xml:lang="en">debt securities issuance</rdfs:label>
-		<skos:definition xml:lang="en">SPV set up to issue debt instruments such as for structured finance.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-spv;holds">
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
-		<skos:definition xml:lang="en">The Debt Special Purpose Vehicle holds assets in the form of a debt pool.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-spv;isREMIC">
-		<rdfs:label xml:lang="en">is r e m i c</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the SPV is set up and registered as a Real Estate Mortgage Investment Conduit (REMIC). REMICs are a type of special purpose vehicle used for the pooling of mortgage loans and issuance of mortgage-backed securities. They are defined under the United States Internal Revenue Code (Tax Reform Act of 1986), and are the typical vehicle of choice for the securitization of residential mortgages in the US.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fctx-spv="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-ab-spv="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"
+buxmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AssetBackedSPVs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Special purpose vehicles used in the issuance of asset backed securities.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-spv;DebtSPV">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-spv;isSetUpFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-spv;DebtSecuritiesIssuance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-spv;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/SecuritizedDebtPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt s p v</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Special Purpose Vehicle (SPV) set up specifically to issue a debt security or securities. It is set up by a company or a group of companies to create instruments that are off the company&apos;s balance sheet.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The SPV exists for a specific period of time and is then disbanded. It may take the form of an LLC or other legal entity. Special Purpose Vehicles are also referred to as bankruptcy remote entities, as they isolate financial risk.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-spv;DebtSecuritiesIssuance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuance"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt securities issuance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">SPV set up to issue debt instruments such as for structured finance.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-spv;holds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Debt Special Purpose Vehicle holds assets in the form of a debt pool.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-spv;isREMIC">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is r e m i c</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the SPV is set up and registered as a Real Estate Mortgage Investment Conduit (REMIC). REMICs are a type of special purpose vehicle used for the pooling of mortgage loans and issuance of mortgage-backed securities. They are defined under the United States Internal Revenue Code (Tax Reform Act of 1986), and are the typical vehicle of choice for the securitization of residential mortgages in the US.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/AssetBacked/AssetBackedSecurities.rdf
+++ b/sec/Debt/AssetBacked/AssetBackedSecurities.rdf
@@ -1,356 +1,359 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
-	<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-cdo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
-	<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-spv "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-loan-loan "https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/">
+bu<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-cdo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
+bu<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-spv "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
-	xmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-cdo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"
-	xmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-spv="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
-		<rdfs:label xml:lang="en">AssetBackedSecurities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;ABSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
-		<rdfs:label xml:lang="en">a b s deal</rdfs:label>
-		<skos:definition xml:lang="en">The issue of a series of Cash Asset Backed Security certificates.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;ABSDealProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedDealProspectus"/>
-		<rdfs:label xml:lang="en">a b s deal prospectus</rdfs:label>
-		<skos:definition xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the asset backed security issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;ABSIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;describedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">a b s issuer</rdfs:label>
-		<skos:definition xml:lang="en">The issuer of the (Cash) Asset Backed Security. This is generally a Special Purpose Vehicle set up by a corporation. Further details from riskglossary.com: To create an ABS, a corporation creates a special purpose vehicle to which it sells the assets. While is is common to speak of the corporation as the issuer of the ABS, legally, it is the trust or special purpose vehicle that is the issuer. It sells securities to investors. To protect investors from possible bankruptcy of the corporation, there are three legal safeguards: - Transfer of assets from the corporation is a non-recourse, true sale. - Investors receive a perfected interest in the assets&apos; cash flows. - A non-consolidation legal opinion is obtained certifying that assets of the trust or special purpose vehicle cannot be consolidated with the corporation&apos;s assets in the event of bankruptcy. These same safeguards allow the corporation to remove the assets from its balance sheet. The corporation generally continues to service the assets - collecting interest and principal payments, pursuing delinquencies, etc. It is paid out of asset cash flows for providing these ongoing services.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AutoLoanABS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">auto loan a b s</rdfs:label>
-		<skos:definition xml:lang="en">ABS issued by auto finance companies and are backed by underlying pools of auto-related loans or leases.</skos:definition>
-		<skos:editorialNote xml:lang="en">Leases not shown at present. Added during later review.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AutoLoanPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPoolConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;poolHasLoanType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;AutoLoanPurpose"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">auto loan pool</rdfs:label>
-		<skos:definition xml:lang="en">A loan pool covering automobile-related loans.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AutoLoanPoolConstituent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-		<rdfs:label xml:lang="en">auto loan pool constituent</rdfs:label>
-		<skos:definition xml:lang="en">An auto loan defined as a constituent of an Auto Loan Pool.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;subordinatedTo"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;CreditCardPool">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasTrancheType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;issuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;ABSIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash asset backed security instrument</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
-		<skos:definition xml:lang="en">An asset-backed security is a type of bond or note that is based on pools of assets, or collateralized by the cash flows from a specified pool of underlying assets. Assets are pooled to make otherwise minor and uneconomical investments worthwhile, while also reducing risk by diversifying the underlying assets.</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition of ABS is one with any kind of asset underlying which is not a mortgage, e.g. a loan, credit card etc. Asset Backed Securities, for example home equity loans (HEL), credit cards, etc. These are securities backed by receivables [payments] that are either secured (HEL) or unsecured (credit card), tranched on the basis of prepayment and default risks. Action: Determine where mobile home and second mortgage based securities fit in, and add to the relevant definition. Outcome: these would be specialised kinds of pools of loans and are therefore reflected by specific typs of Cash ABS, in the same way as Auto Loan ABS are defined. Note also that an issue of ABS certificates (contracts) may have different tranches which relate to these different kinds of loan, and other as yet undefined types of loan. These are capable of extension into indefinite numbers of loan types / pool types, so it would not be practical to include all the possibilities in the standard terms other than as selectable types of loan in the loan type selection data range.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CreditCardABS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;CreditCardPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">credit card a b s</rdfs:label>
-		<skos:definition xml:lang="en">These are generally issued by a bank and backed by largely unsecured obligations owed by individuals to the issuer of the card. Definition origin:CESR</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CreditCardPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-		<rdfs:label xml:lang="en">credit card pool</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;EsotericABS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingCashflow"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">esoteric a b s</rdfs:label>
-		<skos:definition xml:lang="en">An asset backed security based on some underlying promised future cashflow.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">New example from Goldman Sachs hearing April 2010: Exotic ABS bsaed on box office takings for movies.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasConstituent.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPoolConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">home equity line of credit pool</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPoolConstituent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-		<rdfs:label xml:lang="en">home equity line of credit pool constituent</rdfs:label>
-		<skos:definition xml:lang="en">A line of credit defined as a constituent of a Home Equity Line Of Credit Pool.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasConsituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan pool</rdfs:label>
-		<skos:definition xml:lang="en">A number of loans, combined into a single pool and used as an asset.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;LoanPoolConstituent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;isConstituentOf"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan pool constituent</rdfs:label>
-		<skos:definition xml:lang="en">A loan constituent of a Loan Pool.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
-		<rdfs:label xml:lang="en">promised cash flow asset</rdfs:label>
-		<skos:definition xml:lang="en">An asset which takes the form of some promised future cashflow. This may be securitized.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, exotic Cash ABS instruments may be created where the underlying asset is not a pool of securities or debt but a promised cash flow. People have securitized the cash flows of businesses, artists, mobile phone tower income, airplane leases, lotto receivables, etc.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;balanceAtInclusionDate">
-		<rdfs:label xml:lang="en">balance at inclusion date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;category">
-		<rdfs:label xml:lang="en">category</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanABS"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CreditworthinessSelection"/>
-		<skos:definition xml:lang="en">Auto-loans ABS are classified into three categories: prime, non-prime, and sub-prime.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;definesTermsFor">
-		<rdfs:label>defines terms for</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;describedAs">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/securityIssuerDescribedAs"/>
-		<rdfs:label xml:lang="en">described as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;ABSIssuer"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;description">
-		<rdfs:label xml:lang="en">description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">a textual description of the cash flow used as an asset.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasConsituent">
-		<rdfs:label xml:lang="en">has consituent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-		<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-abs;isConstituentOf"/>
-		<skos:definition xml:lang="en">The loans which make up the pool of Loans grouped as an Asset for example to be used as Collateral for a Security. Note: Implied from the definition of Loan Participation Note.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasConstituent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-abs;hasConsituent"/>
-		<rdfs:label xml:lang="en">has constituent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPool"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPoolConstituent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasConstituent.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-abs;hasConsituent"/>
-		<rdfs:label xml:lang="en">has constituent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPoolConstituent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets">
-		<rdfs:label xml:lang="en">has underlying assets</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;CreditCardPool">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-		<skos:definition xml:lang="en">The ABS has an underlying pool asset which is either a loan pool or a credit card pool. This is actually defined as being any kind of pool asset that is not a mortgage pool, so any other types of pool should be added. This is more satisfactory that modeling it with a &quot;not&quot; relationship to Mortgage Pool, though that may be more correct.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasUnderlyingCashflow">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
-		<rdfs:label xml:lang="en">has underlying cashflow</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;EsotericABS"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;isConstituentOf">
-		<rdfs:label xml:lang="en">is constituent of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;poolHasLoanType">
-		<rdfs:label xml:lang="en">pool has loan type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-		<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
-		<skos:definition xml:lang="en">The type of loans that make up the pool.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;revolving">
-		<rdfs:label xml:lang="en">revolving</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CreditCardPool"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Feature whereby the principal can go up or down. This means that the loan could pay down principal or add principal to it.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;subordinatedTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo"/>
-		<rdfs:label xml:lang="en">subordinated to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;tranche">
-		<rdfs:label xml:lang="en">tranche</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Security Tranche that this ABS security forms part of.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-loan-loan="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"
+buxmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-cdo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"
+buxmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-spv="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">AssetBackedSecurities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Debt securities backed by a pool of assets, including loans of various kinds, credit card pools and home equity lines of credit, as well as esoteric assets.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;ABSDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">a b s deal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issue of a series of Cash Asset Backed Security certificates.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;ABSDealProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedDealProspectus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">a b s deal prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the asset backed security issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;ABSIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;describedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">a b s issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer of the (Cash) Asset Backed Security. This is generally a Special Purpose Vehicle set up by a corporation. Further details from riskglossary.com: To create an ABS, a corporation creates a special purpose vehicle to which it sells the assets. While is is common to speak of the corporation as the issuer of the ABS, legally, it is the trust or special purpose vehicle that is the issuer. It sells securities to investors. To protect investors from possible bankruptcy of the corporation, there are three legal safeguards: - Transfer of assets from the corporation is a non-recourse, true sale. - Investors receive a perfected interest in the assets&apos; cash flows. - A non-consolidation legal opinion is obtained certifying that assets of the trust or special purpose vehicle cannot be consolidated with the corporation&apos;s assets in the event of bankruptcy. These same safeguards allow the corporation to remove the assets from its balance sheet. The corporation generally continues to service the assets - collecting interest and principal payments, pursuing delinquencies, etc. It is paid out of asset cash flows for providing these ongoing services.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AutoLoanABS">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">auto loan a b s</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">ABS issued by auto finance companies and are backed by underlying pools of auto-related loans or leases.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Leases not shown at present. Added during later review.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AutoLoanPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasConstituent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPoolConstituent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;poolHasLoanType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-loan-loan;AutoLoanPurpose"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">auto loan pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan pool covering automobile-related loans.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;AutoLoanPoolConstituent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">auto loan pool constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An auto loan defined as a constituent of an Auto Loan Pool.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;subordinatedTo"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;CreditCardPool">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasTrancheType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;issuedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;ABSIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash asset backed security instrument</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An asset-backed security is a type of bond or note that is based on pools of assets, or collateralized by the cash flows from a specified pool of underlying assets. Assets are pooled to make otherwise minor and uneconomical investments worthwhile, while also reducing risk by diversifying the underlying assets.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Definition of ABS is one with any kind of asset underlying which is not a mortgage, e.g. a loan, credit card etc. Asset Backed Securities, for example home equity loans (HEL), credit cards, etc. These are securities backed by receivables [payments] that are either secured (HEL) or unsecured (credit card), tranched on the basis of prepayment and default risks. Action: Determine where mobile home and second mortgage based securities fit in, and add to the relevant definition. Outcome: these would be specialised kinds of pools of loans and are therefore reflected by specific typs of Cash ABS, in the same way as Auto Loan ABS are defined. Note also that an issue of ABS certificates (contracts) may have different tranches which relate to these different kinds of loan, and other as yet undefined types of loan. These are capable of extension into indefinite numbers of loan types / pool types, so it would not be practical to include all the possibilities in the standard terms other than as selectable types of loan in the loan type selection data range.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CreditCardABS">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;CreditCardPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit card a b s</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">These are generally issued by a bank and backed by largely unsecured obligations owed by individuals to the issuer of the card. Definition origin:CESR</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;CreditCardPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">credit card pool</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;EsotericABS">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingCashflow"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">esoteric a b s</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An asset backed security based on some underlying promised future cashflow.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">New example from Goldman Sachs hearing April 2010: Exotic ABS bsaed on box office takings for movies.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasConstituent.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPoolConstituent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">home equity line of credit pool</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPoolConstituent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">home equity line of credit pool constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A line of credit defined as a constituent of a Home Equity Line Of Credit Pool.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;hasConsituent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A number of loans, combined into a single pool and used as an asset.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;LoanPoolConstituent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;isConstituentOf"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan pool constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A loan constituent of a Loan Pool.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">promised cash flow asset</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An asset which takes the form of some promised future cashflow. This may be securitized.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example, exotic Cash ABS instruments may be created where the underlying asset is not a pool of securities or debt but a promised cash flow. People have securitized the cash flows of businesses, artists, mobile phone tower income, airplane leases, lotto receivables, etc.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;balanceAtInclusionDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance at inclusion date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;category">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">category</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanABS"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CreditworthinessSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Auto-loans ABS are classified into three categories: prime, non-prime, and sub-prime.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;definesTermsFor">
+bubu<rdfs:label>defines terms for</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;describedAs">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/securityIssuerDescribedAs"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">described as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;ABSIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;description">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">a textual description of the cash flow used as an asset.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasConsituent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has consituent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
+bubu<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-abs;isConstituentOf"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The loans which make up the pool of Loans grouped as an Asset for example to be used as Collateral for a Security. Note: Implied from the definition of Loan Participation Note.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasConstituent">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-abs;hasConsituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has constituent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPool"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;AutoLoanPoolConstituent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasConstituent.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-abs;hasConsituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has constituent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPoolConstituent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying assets</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;CreditCardPool">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-abs;LoanPool">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The ABS has an underlying pool asset which is either a loan pool or a credit card pool. This is actually defined as being any kind of pool asset that is not a mortgage pool, so any other types of pool should be added. This is more satisfactory that modeling it with a &quot;not&quot; relationship to Mortgage Pool, though that may be more correct.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;hasUnderlyingCashflow">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-abs;hasUnderlyingAssets"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying cashflow</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;EsotericABS"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;PromisedCashFlowAsset"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;isConstituentOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is constituent of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;poolHasLoanType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool has loan type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-loan-loan;LoanPurposeSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of loans that make up the pool.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;revolving">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">revolving</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CreditCardPool"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;HomeEquityLineOfCreditPool"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Feature whereby the principal can go up or down. This means that the loan could pay down principal or add principal to it.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;subordinatedTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subordinated to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-abs;tranche">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-abs;CashAssetBackedSecurityInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Security Tranche that this ABS security forms part of.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/AssetBacked/CBOs.rdf
+++ b/sec/Debt/AssetBacked/CBOs.rdf
@@ -1,60 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-dbt-ab-cbo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/">
-	<!ENTITY fibo-sec-dbt-ab-cdo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
-	<!ENTITY fibo-sec-dbt-ab-clo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/">
-	<!ENTITY fibo-sec-dbt-ab-cmo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-dbt-ab-cbo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/">
+bu<!ENTITY fibo-sec-dbt-ab-cdo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
+bu<!ENTITY fibo-sec-dbt-ab-clo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/">
+bu<!ENTITY fibo-sec-dbt-ab-cmo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-dbt-ab-cbo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"
-	xmlns:fibo-sec-dbt-ab-cdo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"
-	xmlns:fibo-sec-dbt-ab-clo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/"
-	xmlns:fibo-sec-dbt-ab-cmo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/">
-		<rdfs:label xml:lang="en">CBOs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cbo;BondPool">
-		<rdfs:label xml:lang="en">bond pool</rdfs:label>
-		<skos:definition xml:lang="en">A pool investment consisting of a collection of Bonds.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cbo;CBODeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
-		<rdfs:label xml:lang="en">c b o deal</rdfs:label>
-		<skos:definition xml:lang="en">An issue of Collateralized Bond Obligation notes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cbo;CBOInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
-		<rdfs:label xml:lang="en">c b o instrument</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-clo;CLO"/>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-		<skos:definition xml:lang="en">A multitranche debt structure similar in some respects to a collateralized mortgage obligation (CMO) structure. Typically low-rated bonds rather than mortgages serve as the collateral. The organization creating and promoting the structure usually holds the underlying equity and may also collect a fee.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Junk bonds are typically not investment grade, but because they pool several types of credit quality bonds together, they offer enough diversification to be &quot;investment grade.&quot; For example high yield [emerging market] CBO which consists of a portfolio of different high yield [emerging market] bonds. Investopedia: Similar in structure to a collateralized mortgage obligation (CMO), but different in that CBOs represent different levels of credit risk, not different maturities. Defoinition Origin:Investopedia</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-dbt-ab-cbo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"
+buxmlns:fibo-sec-dbt-ab-cdo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"
+buxmlns:fibo-sec-dbt-ab-clo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/"
+buxmlns:fibo-sec-dbt-ab-cmo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CBOs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Collateralized bond obligations, based on a pool of bonds.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cbo;BondPool">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool investment consisting of a collection of Bonds.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cbo;CBODeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c b o deal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An issue of Collateralized Bond Obligation notes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cbo;CBOInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c b o instrument</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-clo;CLO"/>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A multitranche debt structure similar in some respects to a collateralized mortgage obligation (CMO) structure. Typically low-rated bonds rather than mortgages serve as the collateral. The organization creating and promoting the structure usually holds the underlying equity and may also collect a fee.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Junk bonds are typically not investment grade, but because they pool several types of credit quality bonds together, they offer enough diversification to be &quot;investment grade.&quot; For example high yield [emerging market] CBO which consists of a portfolio of different high yield [emerging market] bonds. Investopedia: Similar in structure to a collateralized mortgage obligation (CMO), but different in that CBOs represent different levels of credit risk, not different maturities. Defoinition Origin:Investopedia</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/sec/Debt/AssetBacked/CDOs.rdf
+++ b/sec/Debt/AssetBacked/CDOs.rdf
@@ -1,775 +1,778 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Objectives/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-ab-cbo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/">
-	<!ENTITY fibo-sec-dbt-ab-cdo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
-	<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-spv "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
-	<!ENTITY fibo-sec-dbt-ab-syn "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Objectives/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-ab-cbo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/">
+bu<!ENTITY fibo-sec-dbt-ab-cdo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
+bu<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-spv "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
+bu<!ENTITY fibo-sec-dbt-ab-syn "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Objectives/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-ab-cbo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"
-	xmlns:fibo-sec-dbt-ab-cdo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"
-	xmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-spv="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"
-	xmlns:fibo-sec-dbt-ab-syn="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
-		<rdfs:label xml:lang="en">CDOs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Objectives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ABSCDODeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasUnderlyingPool"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-cdo;CDOPool">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-cdo;CashABSPool">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">a b s c d o deal</rdfs:label>
-		<skos:definition xml:lang="en">An issue of Asset Backed Security CDO notes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ABSCDOInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
-		<rdfs:label xml:lang="en">a b s c d o instrument</rdfs:label>
-		<skos:definition xml:lang="en">CDO where the underlying asset pool is ABS.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ArbitrageCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasCDOOriginationObjective"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;ArbitrageCdoObjective"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">arbitrage c d o</rdfs:label>
-		<skos:definition xml:lang="en">Arbitrage CDO/CLO/CBO - the reference assets are bought by a firm or conduit or SPV (Special Purpose Vehicle) with a view to repackage them and sell them on as the structured product.</skos:definition>
-		<skos:editorialNote xml:lang="en">Arbitrage deals are motivated by the opportunity to add value by repackaging collateral into tranches. This is the same motivation for most CMOs. In finance, the law of one price suggests that the securities of a CDO should have the same market value as its underlying collateral. In practice, this is often not the case. Accordingly, a CDO can represent a theoretical arbitrage. april 28 note: Does this have meaning for Cash CDO? Are these always? Arbitrage is there to exploit market inefficiencies. Would there not be some arbitrage exploited in the CDO. The definition here implies cash CDO only. not cler to reviewers what the ditinctio nis and whether these are mutually excluive. On eview is that the arb CDO has cash inflorws different to cash outflows, e.g. 9.5% v 9% with the 50bp taken as fees. So that might be Arb CDO. There is another type we hav emissed: like an arb CDO where there is instead a spread between in/out as above, you have instead a MArket Value CDO, where its base don the market value of the deal. Not clear how you are supposed to realized that value. you are supposed to realize the xxxx of securities .Seen both referred to. So is arb a risk management tool.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ArbitrageCdoObjective">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
-		<rdfs:label xml:lang="en">arbitrage cdo objective</rdfs:label>
-		<skos:definition xml:lang="en">The objective is arbitrage, whereby the motivation is to add value by repackaging assets into tranches.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;BalanceSheetCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasCDOOriginationObjective"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;BalanceSheetCDOObjective"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">balance sheet c d o</rdfs:label>
-		<skos:definition xml:lang="en">Balance Sheet CDO/CLO/CBO - the reference assets for the SDO portfolio are taken from a company/firm&apos;s balance sheet.</skos:definition>
-		<skos:editorialNote xml:lang="en">With a balance sheet deal, the sponsoring organization is a bank or other institution that holds - or anticipates acquiring - loans or debt that it wants to remove from its balance sheet. Similar to a traditional ABS, the CDO is a vehicle for it to do so. Balance Sheet CDO = Funded CDO. This is about whether or not ther is actual borrowing or lending underpinning the CDO. Does this have meaning in the context of synthetic CDO? It has meaning in the context of a sythetic CDO because you can constructt hat from a unifirm funding and use the CDSs to break up and creat the manyt risks. Derive the funds from a uniform source using CDSs. So that would be on Balance Sheet CDO. April 28 notes does Balance sheet CDPO have any meaning fo rCash =CDO? No. cash CDOs would have to have a balance sheet impact, so this distinction between Balance sheet and Arbittrrage only has meaning for Synthetics.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;BalanceSheetCDOObjective">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
-		<rdfs:label xml:lang="en">balance sheet c d o objective</rdfs:label>
-		<skos:definition xml:lang="en">The objective is that the CDO is created to move assets off the originator balance sheet.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">c d o cashflow treatment structure</rdfs:label>
-		<skos:definition xml:lang="en">The way in which cash flows are handled in a CDO.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDODeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasTranche"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasTranche.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasTranche.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasTranche.3"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;SuperSeniorCDOTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;managedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d o deal</rdfs:label>
-		<skos:definition xml:lang="en">An Issue of a set of CDO tranches as part of an offering to the market.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Multiple tranches of securities are issued by the CDO issue (usually referred to simply as the CDO), offering investors various maturity and credit risk characteristics. Note that it is in the sense of CDO as an issue that one might say that a CDO &quot;has tranches&quot;. The CDO as an individual instrument (labelled CDO in this model) does not have tranches but is itself a member of one or another tranche.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOIssuingParty">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;describedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d o issuing party</rdfs:label>
-		<skos:definition xml:lang="en">The party which issues the CDO on behalf of the sponsor. This is identified as being a Special Purpose Vehicle (SPV) set up specifically to issue the CDO. A CDO has a sponsoring organization, which establishes a special purpose vehicle to hold collateral and issue securities. Sponsors can include banks, other financial institutions or investment managers, as described below. Expenses associated with running the special purpose vehicle are subtracted from cash flows to investors. Often, the sponsoring organization retains the most subordinate equity tranch of a CDO.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOManagementStyle">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">c d o management style</rdfs:label>
-		<skos:definition xml:lang="en">The manner in which reference assets are managed during the life of a CDO.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDONote">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;subordinatedTo"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOIssuingParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d o note</rdfs:label>
-		<skos:definition xml:lang="en">Collateralized Debt Obligation. This is a type of asset-backed security and is constructed from a portfolio of fixed income assets including corporate loans and mortgage backed securities. A special purpose vehicle (SPV) issues notes to investors in order to raise funds that are invested in a portfolio of those fixed income assets, held by the SPV as collateral for the notes. Further notes: Collateralized Debt Obligation, for example, ABS CDO which consists of a portfolio of different ABS bonds, and the payments to the holders of these trust certificates are derived from the cash flows of the ABS bonds. This CDO instrument is part of a CDO issue, consisting of individual CDO instruments of a given seniority. Often referred to as tranches and slices (Investopedia). Investopedia: Similar in structure to a collateralized mortgage obligation (CMO) or collateralized bond obligation (CBO), CDOs are unique in that they represent different types of debt and credit risk. In the case of CDOs, these different types of debt are often referred to as &apos;tranches&apos; or &apos;slices&apos;. Each slice has a different maturity and risk associated with it. The higher the risk, the more the CDO pays. Further details: Collateralized Debt obligations are securitized interests in pools of - generally non-mortgage - assets. Assets - called collateral - usually comprise loans or debt instruments. A CDO may be called a collateralized loan obligation (CLO) or collateralized bond obligation (CBO) if it holds only loans or bonds, respectively. Investors bear the credit risk of the collateral. Multiple tranches of securities are issued by the CDO, offering investors various maturity and credit risk characteristics.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Objective"/>
-		<rdfs:label xml:lang="en">c d o origination objective</rdfs:label>
-		<skos:definition xml:lang="en">The origin or motivation behind a CDO issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrumentPool"/>
-		<rdfs:label xml:lang="en">c d o pool</rdfs:label>
-		<skos:definition xml:lang="en">A pool of CDO securities. The underlying of the CDO Squared is a pool of CDO instruments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOPortfolio">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;InvestmentPortfolio"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;MBSInstrumentSlice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;managedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;overseenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioTrustee"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d o portfolio</rdfs:label>
-		<skos:definition xml:lang="en">A portfolio in which the reference assets of the CDO are held.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;manages"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d o portfolio manager</rdfs:label>
-		<skos:definition xml:lang="en">The portfolio manager for a managed CDO or arbitrage CDO (also called an asset manager). This assumes that the role is the same in both cases.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOPortfolioTrustee">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;Trustee"/>
-		<rdfs:label xml:lang="en">c d o portfolio trustee</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOReferenceObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;becomesConstituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d o reference obligation</rdfs:label>
-		<skos:definition xml:lang="en">A CDS Reference Obligation specifically defined for and referenced in a Synthectic CDO.</skos:definition>
-		<skos:editorialNote xml:lang="en">Facts that distinguish this from Reference Obligation in general: This is basically the same concept but the reference obligation is subsequently used to define the constituents of a synthetic CDO portfolio. That is, the instrument which is the Reference Obligation becomes a member of that portfolio (REVIEW this - isn&apos;t it that sometimes different instruments are used instead? Need to clarify on this. What then is the relationship between the CDS Reference Obligation and the Synthetic CDO Pool constituent</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOSquaredDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasUnderlyingPool"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c d o squared deal</rdfs:label>
-		<skos:definition xml:lang="en">An issue of CDO Squared notes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOSquaredInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:label xml:lang="en">c d o squared instrument</rdfs:label>
-		<skos:definition xml:lang="en">CDOs where the underlying asset pool is CDOs.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOTrancheSenioritySelection">
-		<rdfs:label xml:lang="en">CDOTrancheSenioritySelection</rdfs:label>
-		<skos:definition xml:lang="en">The seniority of a tranche of a CDO issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashABSPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrumentPool"/>
-		<rdfs:label xml:lang="en">cash a b s pool</rdfs:label>
-		<skos:definition xml:lang="en">A pool investment consisting of a collection of cash ABS instruments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;issues"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash c d o</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDO"/>
-		<skos:definition xml:lang="en">A CDO which has an uderlying portfolio of assets which are held by the issuer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashCDOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-cbo;BondPool">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrumentPool">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash c d o tranche</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashflowCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;structure.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CashflowStructure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cashflow c d o</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cdo;MarketValueCDO"/>
-		<skos:definition xml:lang="en">A cash-flow CDO is analogous to a CMO. Cash flows from collateral are used to pay principal and interest to investors. If such cash flows prove inadequate, principal and interest is paid to tranches according to seniority. At any point in time, all immediate obligations to a given tranch are met before any payments are made to less senior tranches.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">There are some cases where &quot;triggers&quot; can come into effect to cause the payments to be distributed in other ways. For example, if the CDO fails its senior overcollateralization (OC) trigger, it may cause extra cash to be diverted to the senior tranches&apos; principal in order to bring the deal back into compliance with the OC test.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashflowStructure">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure"/>
-		<rdfs:label xml:lang="en">cashflow structure</rdfs:label>
-		<skos:definition xml:lang="en">The source of funds for the CDO is cashflow. this means that cash flows from collateral are used to pay principal and interest to investors.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;Creditworthiness">
-		<rdfs:label xml:lang="en">Creditworthiness</rdfs:label>
-		<skos:definition xml:lang="en">A selection of types of creditworthiness, such as sub prime. Created for ABS but may be referred to in any instrument or tranche where this is a feature.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CreditworthinessSelection">
-		<rdfs:label>creditworthiness selection</rdfs:label>
-		<owl:equivalentClass>
-			<rdfs:Datatype>
-				<owl:oneOf>
-					<rdf:List>
-						<rdf:first>Alt A</rdf:first>
-						<rdf:rest>
-							<rdf:List>
-								<rdf:first>NonPrime</rdf:first>
-								<rdf:rest>
-									<rdf:List>
-										<rdf:first>Prime</rdf:first>
-										<rdf:rest>
-											<rdf:List>
-												<rdf:first>SubPrime</rdf:first>
-												<rdf:rest rdf:resource="&rdf;nil"/>
-											</rdf:List>
-										</rdf:rest>
-									</rdf:List>
-								</rdf:rest>
-							</rdf:List>
-						</rdf:rest>
-					</rdf:List>
-				</owl:oneOf>
-			</rdfs:Datatype>
-		</owl:equivalentClass>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;HybridCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
-				<owl:allValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-cdo;CashCDOTranche">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:allValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">hybrid c d o</rdfs:label>
-		<skos:definition xml:lang="en">A CDO which combines features both of the cash and synthetic CDO. This is a CDO with tranches of cash and tranches of synthetic underlying assets. Further notes: So for example an issiue of $550 million may have $500 million in an asset pool and an additional $50 million created via a synthetic asset.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;MBSInstrumentSlice">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolding"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;takesFormOf.1"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-mbs;MBSTrancheNote">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrumentNote">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">m b s instrument slice</rdfs:label>
-		<skos:definition xml:lang="en">A holding of an individual slice or slices of a tranche.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These may be held in different notes, with different denominations. Tranche slice in this sense is only relevant in the context of something like a CDO or analogous things such as CBO.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ManagedCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;ManagedCDOPortfolio"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;holds.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;MBSInstrumentSlice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;managementStyle.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;ManagedManagementStyle"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">managed c d o</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cdo;StaticCDO"/>
-		<skos:definition xml:lang="en">A CDO where the reference assets are bought (the portfolio is ramped up) and then the CDO manager may alter the portfolio as they see fit.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ManagedCDOPortfolio">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
-		<rdfs:label xml:lang="en">managed c d o portfolio</rdfs:label>
-		<skos:definition xml:lang="en">A portfolio where the reference assets of the CDO are bought (the portfolio is ramped up) and then the CDO manager may alter the portfolio as they see fit.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ManagedManagementStyle">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOManagementStyle"/>
-		<rdfs:label xml:lang="en">managed management style</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;MarketValueCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;structure.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;MarketValueStructure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">market value c d o</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;MarketValueStructure">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure"/>
-		<rdfs:label xml:lang="en">market value structure</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;ratedAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mezzanine c d o tranche</rdfs:label>
-		<skos:definition xml:lang="en">The tranche between senior and subordinated. Mezzanine tranches of a CDO issue are typically rated B to BBB.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to mezzanine tranches take precedence over those to subordinated/equity tranches.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;ratedAtIssue.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">senior c d o tranche</rdfs:label>
-		<skos:definition xml:lang="en">The most senior tranche of the CDO issue. Typically rated A to AAA. If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to senior tranches take precedence over those of mezzanine tranches.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;StaticCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;managementStyle.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;StaticManagementStyle"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">static c d o</rdfs:label>
-		<skos:definition xml:lang="en">A CDO where collateral is fixed through the life of the CDO. The reference assets are bought and then are kept untouched for the term of the product.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Investors can assess the various tranches of the CDO with full knowledge of what the collateral will be. The primary risk they face is credit risk. A deal that starts off managed can become static if the performance is too poor. Also, some deals are static but allow managers to sell out poorly performing assets subject to certain conditions, but do not allow purchase of new assets, so are semi-static.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;StaticCDOPortfolio">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
-		<rdfs:label xml:lang="en">static c d o portfolio</rdfs:label>
-		<skos:definition xml:lang="en">A portfolio where collateral of the CDO is fixed through the life of the CDO. The reference assets are bought and then are kept untouched for the term of the product.</skos:definition>
-		<skos:editorialNote xml:lang="en">There are cases where badly performing assets may be sold off. These are not modeled at present and it&apos;s possible that a third type of CDO may be indicated where the portfolio manager has certain capabilities.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;StaticManagementStyle">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOManagementStyle"/>
-		<rdfs:label xml:lang="en">static management style</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:label xml:lang="en">subordinated c d o equity</rdfs:label>
-		<skos:definition xml:lang="en">The subordinated (also known as equity) CDO tranche is the most junior tranche in the CDO issue. If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to senior and mezzanine tranches take precedence over those to subordinated/equity tranches.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is not a tranche of the debt in the CDO but an equity interest in the pool of underlying. There is a very bottom piece, not a tranche, but rather called the preferred shares (or just pref shares, or equity) that is the very bottom most layer in a CDO and is also referred to as the &quot;first loss piece&quot; since, like equity in a corporation, losses are incurred here before any of the actual bond holders take losses. This isn&apos;t a tranche</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;SuperSeniorCDOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:label xml:lang="en">super senior c d o tranche</rdfs:label>
-		<skos:definition xml:lang="en">A tranche at the very top of a CDO Issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;TruePSObjective">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
-		<rdfs:label xml:lang="en">true p s objective</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;becomesConstituent">
-		<rdfs:label xml:lang="en">becomes constituent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDOReferenceObligation"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;confersOwnershipOf">
-		<rdfs:label xml:lang="en">confers ownership of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;describedAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
-		<rdfs:label xml:lang="en">described as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDOIssuingParty"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasCDOOriginationObjective">
-		<rdfs:label xml:lang="en">has c d o origination objective</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasTranche">
-		<rdfs:label xml:lang="en">has tranche</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasTranche.1">
-		<rdfs:label xml:lang="en">has tranche</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasTranche.2">
-		<rdfs:label xml:lang="en">has tranche</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasTranche.3">
-		<rdfs:label xml:lang="en">has tranche</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;SuperSeniorCDOTranche"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasUnderlyingPool">
-		<rdfs:label xml:lang="en">has underlying pool</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;holds">
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;holds.1">
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;ManagedCDO"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;MBSInstrumentSlice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;isCash">
-		<rdfs:label xml:lang="en">is cash</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the CDO has an underlying pool of real assets. If yes, the CDO has an underlying pool of real assets. If no, the CDO has a synthetic pool of underlying assets.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;isCash.1">
-		<rdfs:label xml:lang="en">is cash</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the CDO has an underlying pool of real assets. This is yes: the CDO has an underlying pool of real assets,</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;issues">
-		<rdfs:label xml:lang="en">issues</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDO"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;managedBy">
-		<rdfs:label xml:lang="en">managed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;managementStyle">
-		<rdfs:label xml:lang="en">has deal management style</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOManagementStyle"/>
-		<skos:definition xml:lang="en">Whether the CDO is static or managed. This refers to whether or not the CDO manager may make changes to the reference portfolio during the life of the security. Further notes: If it is static, collateral is fixed through the life of the CDO. The reference assets are bought and then are kept untouched for the term of the product.If it is managed, the reference assets are bought (the portfolio is ramped up) and then the CDO manager may alter the portfolio as they see fit.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;managementStyle.1">
-		<rdfs:label xml:lang="en">management style</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOManagementStyle"/>
-		<skos:definition xml:lang="en">A CDO where the reference assets are bought (the portfolio is ramped up) and then the CDO manager may alter the portfolio as they see fit.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;manages">
-		<rdfs:label xml:lang="en">manages</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;origination.2">
-		<rdfs:label xml:lang="en">has origination objective</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;overseenBy">
-		<rdfs:label xml:lang="en">overseen by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioTrustee"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;ratedAtIssue">
-		<rdfs:label xml:lang="en">rated at issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;ratedAtIssue.1">
-		<rdfs:label xml:lang="en">rated at issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority">
-		<rdfs:label xml:lang="en">seniority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOTrancheSenioritySelection"/>
-		<skos:definition xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. Further notes: Tranches are categorized as senior, mezzanine, and subordinated/equity, according to their degree of credit risk. If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to senior tranches take precedence over those of mezzanine tranches, and scheduled payments to mezzanine tranches take precedence over those to subordinated/equity tranches. Senior and mezzanine tranches are typically rated, with the former receiving ratings of A to AAA and the latter receiving ratings of B to BBB. The ratings reflect both the credit quality of underlying collateral as well as how much protection a given tranch is afforded by tranches that are subordinate to it.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority.1">
-		<rdfs:label xml:lang="en">seniority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche"/>
-		<skos:definition xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. This is Mezzanine, meaning the tranche between senior and subordinated.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority.2">
-		<rdfs:label xml:lang="en">seniority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche"/>
-		<skos:definition xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. This is defined as Senior, i.e. this is the most senior tranche of the CDO issue.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority.3">
-		<rdfs:label xml:lang="en">seniority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity"/>
-		<skos:definition xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. This is subordinated (also known as equity) and is the most junior tranche in the CDO issue.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority.4">
-		<rdfs:label xml:lang="en">seniority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SuperSeniorCDOTranche"/>
-		<skos:definition xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. This is defined as Senior, i.e. this is the most senior tranche of the CDO issue.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;structure">
-		<rdfs:label xml:lang="en">has structure type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure"/>
-		<skos:definition xml:lang="en">The source of funds for the CDO. This is either cashflow or market value.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;structure.2">
-		<rdfs:label xml:lang="en">structure</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure"/>
-		<skos:definition xml:lang="en">The source of funds for the CDO is market value. This means that principal and interest payments to investors come from both collateral cash flows as well as sales of collateral.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;subordinatedTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo"/>
-		<rdfs:label xml:lang="en">subordinated to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;tranche">
-		<rdfs:label xml:lang="en">tranche</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Security Tranche that this CDO note forms part of within the overall CDO Issue.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Objectives/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-ab-cbo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"
+buxmlns:fibo-sec-dbt-ab-cdo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"
+buxmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-spv="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"
+buxmlns:fibo-sec-dbt-ab-syn="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CDOs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Collateralized debt obligations. These are tranched debt instruments based on pools of debt instruments, and those pools may have different management styles and objectives. Generally includes an equity tranche. This ontology also includes CDO squared.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Objectives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ABSCDODeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasUnderlyingPool"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-cdo;CDOPool">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-cdo;CashABSPool">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">a b s c d o deal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An issue of Asset Backed Security CDO notes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ABSCDOInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">a b s c d o instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">CDO where the underlying asset pool is ABS.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ArbitrageCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasCDOOriginationObjective"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;ArbitrageCdoObjective"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">arbitrage c d o</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Arbitrage CDO/CLO/CBO - the reference assets are bought by a firm or conduit or SPV (Special Purpose Vehicle) with a view to repackage them and sell them on as the structured product.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Arbitrage deals are motivated by the opportunity to add value by repackaging collateral into tranches. This is the same motivation for most CMOs. In finance, the law of one price suggests that the securities of a CDO should have the same market value as its underlying collateral. In practice, this is often not the case. Accordingly, a CDO can represent a theoretical arbitrage. april 28 note: Does this have meaning for Cash CDO? Are these always? Arbitrage is there to exploit market inefficiencies. Would there not be some arbitrage exploited in the CDO. The definition here implies cash CDO only. not cler to reviewers what the ditinctio nis and whether these are mutually excluive. On eview is that the arb CDO has cash inflorws different to cash outflows, e.g. 9.5% v 9% with the 50bp taken as fees. So that might be Arb CDO. There is another type we hav emissed: like an arb CDO where there is instead a spread between in/out as above, you have instead a MArket Value CDO, where its base don the market value of the deal. Not clear how you are supposed to realized that value. you are supposed to realize the xxxx of securities .Seen both referred to. So is arb a risk management tool.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ArbitrageCdoObjective">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">arbitrage cdo objective</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The objective is arbitrage, whereby the motivation is to add value by repackaging assets into tranches.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;BalanceSheetCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasCDOOriginationObjective"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;BalanceSheetCDOObjective"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance sheet c d o</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Balance Sheet CDO/CLO/CBO - the reference assets for the SDO portfolio are taken from a company/firm&apos;s balance sheet.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">With a balance sheet deal, the sponsoring organization is a bank or other institution that holds - or anticipates acquiring - loans or debt that it wants to remove from its balance sheet. Similar to a traditional ABS, the CDO is a vehicle for it to do so. Balance Sheet CDO = Funded CDO. This is about whether or not ther is actual borrowing or lending underpinning the CDO. Does this have meaning in the context of synthetic CDO? It has meaning in the context of a sythetic CDO because you can constructt hat from a unifirm funding and use the CDSs to break up and creat the manyt risks. Derive the funds from a uniform source using CDSs. So that would be on Balance Sheet CDO. April 28 notes does Balance sheet CDPO have any meaning fo rCash =CDO? No. cash CDOs would have to have a balance sheet impact, so this distinction between Balance sheet and Arbittrrage only has meaning for Synthetics.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;BalanceSheetCDOObjective">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">balance sheet c d o objective</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The objective is that the CDO is created to move assets off the originator balance sheet.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o cashflow treatment structure</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The way in which cash flows are handled in a CDO.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDODeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasTranche"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasTranche.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasTranche.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasTranche.3"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;SuperSeniorCDOTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;managedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o deal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Issue of a set of CDO tranches as part of an offering to the market.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Multiple tranches of securities are issued by the CDO issue (usually referred to simply as the CDO), offering investors various maturity and credit risk characteristics. Note that it is in the sense of CDO as an issue that one might say that a CDO &quot;has tranches&quot;. The CDO as an individual instrument (labelled CDO in this model) does not have tranches but is itself a member of one or another tranche.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOIssuingParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;describedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o issuing party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which issues the CDO on behalf of the sponsor. This is identified as being a Special Purpose Vehicle (SPV) set up specifically to issue the CDO. A CDO has a sponsoring organization, which establishes a special purpose vehicle to hold collateral and issue securities. Sponsors can include banks, other financial institutions or investment managers, as described below. Expenses associated with running the special purpose vehicle are subtracted from cash flows to investors. Often, the sponsoring organization retains the most subordinate equity tranch of a CDO.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOManagementStyle">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o management style</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The manner in which reference assets are managed during the life of a CDO.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDONote">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;subordinatedTo"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOIssuingParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o note</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Collateralized Debt Obligation. This is a type of asset-backed security and is constructed from a portfolio of fixed income assets including corporate loans and mortgage backed securities. A special purpose vehicle (SPV) issues notes to investors in order to raise funds that are invested in a portfolio of those fixed income assets, held by the SPV as collateral for the notes. Further notes: Collateralized Debt Obligation, for example, ABS CDO which consists of a portfolio of different ABS bonds, and the payments to the holders of these trust certificates are derived from the cash flows of the ABS bonds. This CDO instrument is part of a CDO issue, consisting of individual CDO instruments of a given seniority. Often referred to as tranches and slices (Investopedia). Investopedia: Similar in structure to a collateralized mortgage obligation (CMO) or collateralized bond obligation (CBO), CDOs are unique in that they represent different types of debt and credit risk. In the case of CDOs, these different types of debt are often referred to as &apos;tranches&apos; or &apos;slices&apos;. Each slice has a different maturity and risk associated with it. The higher the risk, the more the CDO pays. Further details: Collateralized Debt obligations are securitized interests in pools of - generally non-mortgage - assets. Assets - called collateral - usually comprise loans or debt instruments. A CDO may be called a collateralized loan obligation (CLO) or collateralized bond obligation (CBO) if it holds only loans or bonds, respectively. Investors bear the credit risk of the collateral. Multiple tranches of securities are issued by the CDO, offering investors various maturity and credit risk characteristics.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-gao-obj;Objective"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o origination objective</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The origin or motivation behind a CDO issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrumentPool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool of CDO securities. The underlying of the CDO Squared is a pool of CDO instruments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOPortfolio">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;InvestmentPortfolio"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;MBSInstrumentSlice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;managedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;overseenBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioTrustee"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o portfolio</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A portfolio in which the reference assets of the CDO are held.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;manages"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o portfolio manager</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The portfolio manager for a managed CDO or arbitrage CDO (also called an asset manager). This assumes that the role is the same in both cases.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOPortfolioTrustee">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;Trustee"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o portfolio trustee</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOReferenceObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-cr-cds;ReferenceObligation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;becomesConstituent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o reference obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A CDS Reference Obligation specifically defined for and referenced in a Synthectic CDO.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Facts that distinguish this from Reference Obligation in general: This is basically the same concept but the reference obligation is subsequently used to define the constituents of a synthetic CDO portfolio. That is, the instrument which is the Reference Obligation becomes a member of that portfolio (REVIEW this - isn&apos;t it that sometimes different instruments are used instead? Need to clarify on this. What then is the relationship between the CDS Reference Obligation and the Synthetic CDO Pool constituent</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOSquaredDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;hasUnderlyingPool"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o squared deal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An issue of CDO Squared notes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOSquaredInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c d o squared instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">CDOs where the underlying asset pool is CDOs.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CDOTrancheSenioritySelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CDOTrancheSenioritySelection</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority of a tranche of a CDO issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashABSPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrumentPool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash a b s pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool investment consisting of a collection of cash ABS instruments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;issues"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash c d o</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDO"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A CDO which has an uderlying portfolio of assets which are held by the issuer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashCDOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-cbo;BondPool">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrumentPool">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash c d o tranche</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashflowCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;structure.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CashflowStructure"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cashflow c d o</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cdo;MarketValueCDO"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A cash-flow CDO is analogous to a CMO. Cash flows from collateral are used to pay principal and interest to investors. If such cash flows prove inadequate, principal and interest is paid to tranches according to seniority. At any point in time, all immediate obligations to a given tranch are met before any payments are made to less senior tranches.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">There are some cases where &quot;triggers&quot; can come into effect to cause the payments to be distributed in other ways. For example, if the CDO fails its senior overcollateralization (OC) trigger, it may cause extra cash to be diverted to the senior tranches&apos; principal in order to bring the deal back into compliance with the OC test.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashflowStructure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cashflow structure</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The source of funds for the CDO is cashflow. this means that cash flows from collateral are used to pay principal and interest to investors.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;Creditworthiness">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Creditworthiness</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A selection of types of creditworthiness, such as sub prime. Created for ABS but may be referred to in any instrument or tranche where this is a feature.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CreditworthinessSelection">
+bubu<rdfs:label>creditworthiness selection</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<rdfs:Datatype>
+bubububu<owl:oneOf>
+bububububu<rdf:List>
+bubububububu<rdf:first rdf:datatype="&xsd;string">Alt A</rdf:first>
+bubububububu<rdf:rest>
+bububububububu<rdf:List>
+bubububububububu<rdf:first rdf:datatype="&xsd;string">NonPrime</rdf:first>
+bubububububububu<rdf:rest>
+bububububububububu<rdf:List>
+bubububububububububu<rdf:first rdf:datatype="&xsd;string">Prime</rdf:first>
+bubububububububububu<rdf:rest>
+bububububububububububu<rdf:List>
+bubububububububububububu<rdf:first rdf:datatype="&xsd;string">SubPrime</rdf:first>
+bubububububububububububu<rdf:rest rdf:resource="&rdf;nil"/>
+bububububububububububu</rdf:List>
+bubububububububububu</rdf:rest>
+bububububububububu</rdf:List>
+bubububububububu</rdf:rest>
+bububububububu</rdf:List>
+bubububububu</rdf:rest>
+bububububu</rdf:List>
+bubububu</owl:oneOf>
+bububu</rdfs:Datatype>
+bubu</owl:equivalentClass>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;HybridCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
+bubububu<owl:allValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-cdo;CashCDOTranche">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:allValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">hybrid c d o</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A CDO which combines features both of the cash and synthetic CDO. This is a CDO with tranches of cash and tranches of synthetic underlying assets. Further notes: So for example an issiue of $550 million may have $500 million in an asset pool and an additional $50 million created via a synthetic asset.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;MBSInstrumentSlice">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolding"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;takesFormOf.1"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-mbs;MBSTrancheNote">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrumentNote">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m b s instrument slice</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A holding of an individual slice or slices of a tranche.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These may be held in different notes, with different denominations. Tranche slice in this sense is only relevant in the context of something like a CDO or analogous things such as CBO.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ManagedCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;ManagedCDOPortfolio"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;holds.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;MBSInstrumentSlice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;managementStyle.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;ManagedManagementStyle"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">managed c d o</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cdo;StaticCDO"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A CDO where the reference assets are bought (the portfolio is ramped up) and then the CDO manager may alter the portfolio as they see fit.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ManagedCDOPortfolio">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">managed c d o portfolio</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A portfolio where the reference assets of the CDO are bought (the portfolio is ramped up) and then the CDO manager may alter the portfolio as they see fit.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;ManagedManagementStyle">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOManagementStyle"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">managed management style</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;MarketValueCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;structure.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;MarketValueStructure"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market value c d o</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;MarketValueStructure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">market value structure</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;ratedAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mezzanine c d o tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The tranche between senior and subordinated. Mezzanine tranches of a CDO issue are typically rated B to BBB.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to mezzanine tranches take precedence over those to subordinated/equity tranches.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;ratedAtIssue.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">senior c d o tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The most senior tranche of the CDO issue. Typically rated A to AAA. If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to senior tranches take precedence over those of mezzanine tranches.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;StaticCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cdo;managementStyle.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;StaticManagementStyle"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">static c d o</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A CDO where collateral is fixed through the life of the CDO. The reference assets are bought and then are kept untouched for the term of the product.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Investors can assess the various tranches of the CDO with full knowledge of what the collateral will be. The primary risk they face is credit risk. A deal that starts off managed can become static if the performance is too poor. Also, some deals are static but allow managers to sell out poorly performing assets subject to certain conditions, but do not allow purchase of new assets, so are semi-static.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;StaticCDOPortfolio">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">static c d o portfolio</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A portfolio where collateral of the CDO is fixed through the life of the CDO. The reference assets are bought and then are kept untouched for the term of the product.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">There are cases where badly performing assets may be sold off. These are not modeled at present and it&apos;s possible that a third type of CDO may be indicated where the portfolio manager has certain capabilities.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;StaticManagementStyle">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOManagementStyle"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">static management style</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subordinated c d o equity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The subordinated (also known as equity) CDO tranche is the most junior tranche in the CDO issue. If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to senior and mezzanine tranches take precedence over those to subordinated/equity tranches.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is not a tranche of the debt in the CDO but an equity interest in the pool of underlying. There is a very bottom piece, not a tranche, but rather called the preferred shares (or just pref shares, or equity) that is the very bottom most layer in a CDO and is also referred to as the &quot;first loss piece&quot; since, like equity in a corporation, losses are incurred here before any of the actual bond holders take losses. This isn&apos;t a tranche</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;SuperSeniorCDOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">super senior c d o tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A tranche at the very top of a CDO Issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;TruePSObjective">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">true p s objective</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;becomesConstituent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes constituent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDOReferenceObligation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;confersOwnershipOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers ownership of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;describedAs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">described as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDOIssuingParty"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasCDOOriginationObjective">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has c d o origination objective</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasTranche">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tranche</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasTranche.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tranche</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasTranche.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tranche</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasTranche.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tranche</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;SuperSeniorCDOTranche"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;hasUnderlyingPool">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying pool</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;holds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;holds.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;ManagedCDO"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;MBSInstrumentSlice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;isCash">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is cash</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the CDO has an underlying pool of real assets. If yes, the CDO has an underlying pool of real assets. If no, the CDO has a synthetic pool of underlying assets.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;isCash.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is cash</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the CDO has an underlying pool of real assets. This is yes: the CDO has an underlying pool of real assets,</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;issues">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issues</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDO"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CashCDOTranche"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;managedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">managed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;managementStyle">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has deal management style</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOManagementStyle"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the CDO is static or managed. This refers to whether or not the CDO manager may make changes to the reference portfolio during the life of the security. Further notes: If it is static, collateral is fixed through the life of the CDO. The reference assets are bought and then are kept untouched for the term of the product.If it is managed, the reference assets are bought (the portfolio is ramped up) and then the CDO manager may alter the portfolio as they see fit.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;managementStyle.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">management style</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOManagementStyle"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A CDO where the reference assets are bought (the portfolio is ramped up) and then the CDO manager may alter the portfolio as they see fit.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;manages">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">manages</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;origination.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has origination objective</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOOriginationObjective"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;overseenBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">overseen by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioTrustee"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;ratedAtIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rated at issue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;ratedAtIssue.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rated at issue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">seniority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOTrancheSenioritySelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. Further notes: Tranches are categorized as senior, mezzanine, and subordinated/equity, according to their degree of credit risk. If there are defaults or the CDO&apos;s collateral otherwise underperforms, scheduled payments to senior tranches take precedence over those of mezzanine tranches, and scheduled payments to mezzanine tranches take precedence over those to subordinated/equity tranches. Senior and mezzanine tranches are typically rated, with the former receiving ratings of A to AAA and the latter receiving ratings of B to BBB. The ratings reflect both the credit quality of underlying collateral as well as how much protection a given tranch is afforded by tranches that are subordinate to it.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">seniority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;MezzanineCDOTranche"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. This is Mezzanine, meaning the tranche between senior and subordinated.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">seniority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SeniorCDOTranche"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. This is defined as Senior, i.e. this is the most senior tranche of the CDO issue.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">seniority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SubordinatedCDOEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. This is subordinated (also known as equity) and is the most junior tranche in the CDO issue.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-ab-cdo;seniority.4">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">seniority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;SuperSeniorCDOTranche"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority which defines this tranche. This is the precedence order for scheduled payments. This is defined as Senior, i.e. this is the most senior tranche of the CDO issue.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;structure">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has structure type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The source of funds for the CDO. This is either cashflow or market value.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;structure.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">structure</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOCashflowTreatmentStructure"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The source of funds for the CDO is market value. This means that principal and interest payments to investors come from both collateral cash flows as well as sales of collateral.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;subordinatedTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subordinated to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cdo;tranche">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Security Tranche that this CDO note forms part of within the overall CDO Issue.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/AssetBacked/CLOs.rdf
+++ b/sec/Debt/AssetBacked/CLOs.rdf
@@ -1,61 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-clo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/">
-	<!ENTITY fibo-sec-dbt-ab-cmo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-clo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/">
+bu<!ENTITY fibo-sec-dbt-ab-cmo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-clo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/"
-	xmlns:fibo-sec-dbt-ab-cmo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/">
-		<rdfs:label xml:lang="en">CLOs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-clo;CLO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-clo;isPoolOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c l o</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-clo;CLODeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
-		<rdfs:label xml:lang="en">c l o deal</rdfs:label>
-		<skos:definition xml:lang="en">An issue of Collateralized Loan Obligations.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-clo;isPoolOf">
-		<rdfs:label xml:lang="en">is pool of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-clo;CLO"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-clo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/"
+buxmlns:fibo-sec-dbt-ab-cmo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CLOs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Collateralized Loan Obligations are similar to asset backed securities and have a pool of loans as their underlying asset type. 
+		Note that some work is still required on the precise categorization of this class of instrument.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CLOs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-clo;CLO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-clo;isPoolOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c l o</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-clo;CLODeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c l o deal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An issue of Collateralized Loan Obligations.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-clo;isPoolOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is pool of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-clo;CLO"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/AssetBacked/CMOs.rdf
+++ b/sec/Debt/AssetBacked/CMOs.rdf
@@ -1,357 +1,361 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-dbt-ab-cmo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
-	<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-dbt-ab-cmo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
+bu<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-dbt-ab-cmo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"
-	xmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
-		<rdfs:label xml:lang="en">CMOs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyCMO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;hasUnderlyingPool"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMBSPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupport"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasTrancheType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">agency c m o</rdfs:label>
-		<skos:editorialNote xml:lang="en">Definition for the property &apos;has tranche type&apos; which is now a restriction: The type of tranche for the CMO. Many different structures are used in practice, including stable PAC bonds or risky IOs and POs. There are floaters and inverse floaters. There are also Z-bonds, which are analogous to zero-coupon bonds.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyIOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-		<rdfs:label xml:lang="en">agency i o tranche</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyPOTranche"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyJumpTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;specifiesTrigger"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">agency jump tranche</rdfs:label>
-		<skos:definition xml:lang="en">A tranche where if there is some sort of trigger event reached then the holders of the tranche will begin to receive payments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyJumpZTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyJumpTranche"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyZTranche"/>
-		<rdfs:label xml:lang="en">agency jump z tranche</rdfs:label>
-		<skos:definition xml:lang="en">A Jump Z tranche is like a Z tranche but if there is some sort of trigger event reached then the holders of the Jump Z tranche will begin to receive payments. Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyPOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-		<rdfs:label xml:lang="en">agency p o tranche</rdfs:label>
-		<skos:definition xml:lang="en">Principal Only tranche. This tranche will only pay principal.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyRegularJumpZ">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyJumpZTranche"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;revertsOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">agency regular jump z</rdfs:label>
-		<skos:definition xml:lang="en">Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyStickyJumpZ">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyJumpZTranche"/>
-		<rdfs:label xml:lang="en">agency sticky jump z</rdfs:label>
-		<skos:definition xml:lang="en">&quot;Sticky&quot; Jump Z tranches maintain the payment priority of a Jump Z tranche until they are retired.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyZTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-		<rdfs:label xml:lang="en">agency z tranche</rdfs:label>
-		<skos:definition xml:lang="en">A tranche that does not receive payments while other tranches remain.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;CMODeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
-		<rdfs:label xml:lang="en">c m o deal</rdfs:label>
-		<skos:definition xml:lang="en">An issue of Collateralized mortgaged Obligations.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;IOette">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyIOTranche"/>
-		<rdfs:label xml:lang="en">i oette</rdfs:label>
-		<skos:definition xml:lang="en">REVIEW: Is this a kind of IO Tranche.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;TriggerEvent"/>
-		<rdfs:label xml:lang="en">jump z trigger event</rdfs:label>
-		<skos:definition xml:lang="en">The event which triggers the Jump Z</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">If this trigger event is reached then the holders of the Jump Z tranche will begin to receive payments. Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed. The event may be a market event or an event relating to the deal.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;TriggerEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;specifiesReverseTrigger"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">jump z trigger event reversal</rdfs:label>
-		<skos:definition xml:lang="en">The reversal of the event which triggers the Jump Z</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PAC-1Class">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;takesPrepaymentAfter"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">p a c-1 class</rdfs:label>
-		<skos:definition xml:lang="en">Planned Amortization Class tranche. PAC-1 is the most senior Planned Amortization Class tranche.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PAC-2Class">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;takesPrepaymentAfter.1"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-3Class"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">p a c-2 class</rdfs:label>
-		<skos:definition xml:lang="en">Planned Amortization Class tranche. PAC-2 refers to a support tranche that is given a scheduled payment structure like a PAC bond.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. For example, let&apos;s say you have a deal with a PAC tranche and a support tranche (i.e., a tranche that is a support tranche and is therefore subordinate to the PAC tranche) that has a scheduled payment structure like you did with the PAC bond. That support bond then is called the PAC-2 bond. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PAC-3Class">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<rdfs:label xml:lang="en">p a c-3 class</rdfs:label>
-		<skos:definition xml:lang="en">Planned Amortization Class tranche. Additional support tranche with scheduled payments.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. See PAC-2 for explanation. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PAC-ZTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyZTranche"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<rdfs:label xml:lang="en">p a c- z tranche</rdfs:label>
-		<skos:definition xml:lang="en">Planned Amortization Class tranche which is also a Z tranche, that is Definition needed.</skos:definition>
-		<skos:editorialNote xml:lang="en">Assume this is a PAC tranche that is a Z Tranche.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PACPOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyPOTranche"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<rdfs:label xml:lang="en">p a c p o tranche</rdfs:label>
-		<skos:definition xml:lang="en">Planned Amortization Class principal only tranche.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PACTrancheAmortizationSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
-		<rdfs:label xml:lang="en">p a c tranche amortization schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupportFor"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;supportedBy"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;specifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PACTrancheAmortizationSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">planned amortization class bond</rdfs:label>
-		<skos:definition xml:lang="en">Planned Amortization Class tranche.This is a tranche where the principal payment must follow a certain schedule.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. There are usually several PAC tranches created. PAC-1, PAC-2, PAC-3 -- this requires some more explanation. PAC-2 refers to a support tranche that is given a scheduled payment structure like a PAC bond. For example, let&apos;s say you have a deal with a PAC tranche and a support tranche (i.e., a tranche that is a support tranche and is therefore subordinate to the PAC tranche) that has a scheduled payment structure like you did with the PAC bond. That support bond then is called the PAC-2 bond. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond. Prospectus will cover each class. Prospectus is at the level of an issue.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;SuperPOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyPOTranche"/>
-		<rdfs:label xml:lang="en">super p o tranche</rdfs:label>
-		<skos:definition xml:lang="en">Principal Only tranche. This tranche will only pay principal. Not clear how this is distinct from generic PO.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;SupportTranche">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">support tranche</rdfs:label>
-		<skos:definition xml:lang="en">A tranche which provides payment support to a PAC Tranche.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">PAC tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;TACTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;specifies.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;TACTrancheAmortizationSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">t a c tranche</rdfs:label>
-		<skos:definition xml:lang="en">Targeted Amortization Class. This is related to a PAC tranche and has a payment schedule geared towards a specified prepayment speed (called the pricing speed). Agency CMO</skos:definition>
-		<skos:editorialNote xml:lang="en">The main difference between TAC and PAC is that the PAC schedule remains under a certain prepayment range (such as 50-150 PSA) while the TAC tranche is geared from the outset at a specified prepayment speed (such as 150 PSA). Math note: Originally specified in PSAin the examples. What is PSA? Review how we have modeled &quot;Payment Speed&quot; as a concept.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;TACTrancheAmortizationSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
-		<rdfs:label xml:lang="en">t a c tranche amortization schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;TriggerEvent">
-		<rdfs:label xml:lang="en">trigger event</rdfs:label>
-		<skos:definition xml:lang="en">Any event where some value passes some threashold. Or some other type of business event. This is not restricted to &quot;trigger&quot; in the sense of a value passing a threshold. Can also be an seen such as a CDO manager going into bankruptcy.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;hasUnderlyingPool">
-		<rdfs:label xml:lang="en">has underlying pool</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMBSPool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;identity">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;SupportTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;maximumPrepaymentSpeed">
-		<rdfs:label xml:lang="en">maximum prepayment speed</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;PaymentSpeed"/>
-		<skos:definition xml:lang="en">The prepayment range under which the PAC schedule must remain, in PSA.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;pricingSpeed">
-		<rdfs:label xml:lang="en">pricing speed</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;TACTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;PaymentSpeed"/>
-		<skos:definition xml:lang="en">The prepayment speed specified fo the TAC Tranche at the outset of the deal, in PSA.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupport">
-		<rdfs:label xml:lang="en">provides prepayment support</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupportFor">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupport"/>
-		<rdfs:label xml:lang="en">provides prepayment support for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-cmo;supportedBy"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;revertsOn">
-		<rdfs:label xml:lang="en">reverts on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyRegularJumpZ"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;specifies">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PACTrancheAmortizationSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;specifies.1">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;TACTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;TACTrancheAmortizationSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;specifiesReverseTrigger">
-		<rdfs:label xml:lang="en">specifies reverse trigger</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;specifiesTrigger">
-		<rdfs:label xml:lang="en">specifies trigger</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyJumpTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;supportedBy">
-		<rdfs:label xml:lang="en">supported by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;takesPrepaymentAfter">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-cmo;supportedBy"/>
-		<rdfs:label xml:lang="en">takes prepayment after</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-1Class"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;takesPrepaymentAfter.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-cmo;supportedBy"/>
-		<rdfs:label xml:lang="en">takes prepayment after</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-3Class"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-dbt-ab-cmo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"
+buxmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CMOs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Collateralized Mortgage Obligations are similar to other kinds of collateralized debt or asset backed security, with the underlying asset being a pool of mortgage loans. These may be issued by a government agency (in the US) or by a commercial entity (when they are known as private label CMOs). This ontology includes an extensive range of tranche types. 
+		Note that some work is still required on the precise categorization of this class of instrument. Note also that the range of tranche types given here may be applicable to other types of collateralized debt instrument.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyCMO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;hasUnderlyingPool"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMBSPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupport"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasTrancheType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency c m o</rdfs:label>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Definition for the property &apos;has tranche type&apos; which is now a restriction: The type of tranche for the CMO. Many different structures are used in practice, including stable PAC bonds or risky IOs and POs. There are floaters and inverse floaters. There are also Z-bonds, which are analogous to zero-coupon bonds.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyIOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency i o tranche</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyPOTranche"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyJumpTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;specifiesTrigger"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency jump tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A tranche where if there is some sort of trigger event reached then the holders of the tranche will begin to receive payments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyJumpZTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyJumpTranche"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyZTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency jump z tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Jump Z tranche is like a Z tranche but if there is some sort of trigger event reached then the holders of the Jump Z tranche will begin to receive payments. Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyPOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency p o tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Principal Only tranche. This tranche will only pay principal.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyRegularJumpZ">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyJumpZTranche"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;revertsOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency regular jump z</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyStickyJumpZ">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyJumpZTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency sticky jump z</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&quot;Sticky&quot; Jump Z tranches maintain the payment priority of a Jump Z tranche until they are retired.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;AgencyZTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency z tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A tranche that does not receive payments while other tranches remain.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;CMODeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c m o deal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An issue of Collateralized mortgaged Obligations.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;IOette">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyIOTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">i oette</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">REVIEW: Is this a kind of IO Tranche.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;TriggerEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">jump z trigger event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The event which triggers the Jump Z</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">If this trigger event is reached then the holders of the Jump Z tranche will begin to receive payments. Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed. The event may be a market event or an event relating to the deal.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;TriggerEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;specifiesReverseTrigger"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">jump z trigger event reversal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The reversal of the event which triggers the Jump Z</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PAC-1Class">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;takesPrepaymentAfter"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">p a c-1 class</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Planned Amortization Class tranche. PAC-1 is the most senior Planned Amortization Class tranche.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PAC-2Class">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;takesPrepaymentAfter.1"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-3Class"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">p a c-2 class</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Planned Amortization Class tranche. PAC-2 refers to a support tranche that is given a scheduled payment structure like a PAC bond.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. For example, let&apos;s say you have a deal with a PAC tranche and a support tranche (i.e., a tranche that is a support tranche and is therefore subordinate to the PAC tranche) that has a scheduled payment structure like you did with the PAC bond. That support bond then is called the PAC-2 bond. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PAC-3Class">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">p a c-3 class</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Planned Amortization Class tranche. Additional support tranche with scheduled payments.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Principal payment must follow a certain schedule. These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. See PAC-2 for explanation. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PAC-ZTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyZTranche"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">p a c- z tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Planned Amortization Class tranche which is also a Z tranche, that is Definition needed.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Assume this is a PAC tranche that is a Z Tranche.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PACPOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyPOTranche"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">p a c p o tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Planned Amortization Class principal only tranche.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PACTrancheAmortizationSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">p a c tranche amortization schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupportFor"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;supportedBy"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;specifies"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PACTrancheAmortizationSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">planned amortization class bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Planned Amortization Class tranche.This is a tranche where the principal payment must follow a certain schedule.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches. There are usually several PAC tranches created. PAC-1, PAC-2, PAC-3 -- this requires some more explanation. PAC-2 refers to a support tranche that is given a scheduled payment structure like a PAC bond. For example, let&apos;s say you have a deal with a PAC tranche and a support tranche (i.e., a tranche that is a support tranche and is therefore subordinate to the PAC tranche) that has a scheduled payment structure like you did with the PAC bond. That support bond then is called the PAC-2 bond. If you continue, and create another support tranche that also has scheduled payments, that would become the PAC-3 bond. Prospectus will cover each class. Prospectus is at the level of an issue.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;SuperPOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyPOTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">super p o tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Principal Only tranche. This tranche will only pay principal. Not clear how this is distinct from generic PO.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;SupportTranche">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">support tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A tranche which provides payment support to a PAC Tranche.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">PAC tranches have priority over the other tranches in the deal, which are then referred to as the support or companion tranches.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;TACTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-cmo;specifies.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;TACTrancheAmortizationSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">t a c tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Targeted Amortization Class. This is related to a PAC tranche and has a payment schedule geared towards a specified prepayment speed (called the pricing speed). Agency CMO</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The main difference between TAC and PAC is that the PAC schedule remains under a certain prepayment range (such as 50-150 PSA) while the TAC tranche is geared from the outset at a specified prepayment speed (such as 150 PSA). Math note: Originally specified in PSAin the examples. What is PSA? Review how we have modeled &quot;Payment Speed&quot; as a concept.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;TACTrancheAmortizationSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">t a c tranche amortization schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cmo;TriggerEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trigger event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any event where some value passes some threashold. Or some other type of business event. This is not restricted to &quot;trigger&quot; in the sense of a value passing a threshold. Can also be an seen such as a CDO manager going into bankruptcy.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;hasUnderlyingPool">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying pool</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMBSPool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;identity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;SupportTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;maximumPrepaymentSpeed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maximum prepayment speed</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;PaymentSpeed"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The prepayment range under which the PAC schedule must remain, in PSA.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;pricingSpeed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pricing speed</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;TACTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;PaymentSpeed"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The prepayment speed specified fo the TAC Tranche at the outset of the deal, in PSA.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupport">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">provides prepayment support</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyCMO"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupportFor">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-cmo;providesPrepaymentSupport"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">provides prepayment support for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-cmo;supportedBy"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;revertsOn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reverts on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyRegularJumpZ"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;specifies">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PACTrancheAmortizationSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;specifies.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;TACTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;TACTrancheAmortizationSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;specifiesReverseTrigger">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies reverse trigger</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;specifiesTrigger">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies trigger</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;AgencyJumpTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;supportedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">supported by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PlannedAmortizationClassBond"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;takesPrepaymentAfter">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-cmo;supportedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes prepayment after</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-1Class"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-cmo;takesPrepaymentAfter.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-cmo;supportedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes prepayment after</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-2Class"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;PAC-3Class"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/AssetBacked/MortgageBackedSecurities.rdf
+++ b/sec/Debt/AssetBacked/MortgageBackedSecurities.rdf
@@ -1,335 +1,338 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
-	<!ENTITY fibo-be-fctx-sta "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/">
-	<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-loan-tem-ev "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
-	<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
-	<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-cmo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
-	<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
+bu<!ENTITY fibo-be-fctx-sta "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/">
+bu<!ENTITY fibo-bp-iss-dbti "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-loan-tem-ev "https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/">
+bu<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
+bu<!ENTITY fibo-sec-dbt-ab-abs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-cmo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/">
+bu<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
-	xmlns:fibo-be-fctx-sta="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/"
-	xmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-loan-tem-ev="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"
-	xmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
-	xmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-cmo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"
-	xmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-		<rdfs:label xml:lang="en">MortgageBackedSecurities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/Bank">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;AgencyMBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
-		<rdfs:label xml:lang="en">agency m b s deal</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal"/>
-		<skos:definition xml:lang="en">An issue of securities backed by pools of mortgages held by government agencies.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are Ginnie Mae, Freddie Mac and Fannie Mae (for the US). Of these agencies, GNMA (Ginnie Mae) issues mortgages in its own right (Investorwords differs on this). Fannie Mae and Freddie Mac purchase mortgages. Those mortgages are issued by banks. Before one of these agencies purchases a mortgage, there are certain criteria that have to be met. These are specified in terms of, for example, the balance of the mortgage, limits to credit ratings.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;AgencyMBSIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fctx-sta;GovernmentMortgageAgency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">agency m b s issuer</rdfs:label>
-		<skos:definition xml:lang="en">The issuer of the pass through MBS is an Agency issuer. This is identified as being some kind of agency that is set up specifically to issue these instruments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;AgencyMBSPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSPool"/>
-		<rdfs:label xml:lang="en">agency m b s pool</rdfs:label>
-		<skos:definition xml:lang="en">A pool investment consisting of a collection of Agency MBS instruments.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This pool may be used as the underlying for an agency CMO. Non agency CMOs do not exist.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
-		<rdfs:label xml:lang="en">agency mortgage pool</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
-		<skos:definition xml:lang="en">A pool of agency mortgages.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;CommercialMBS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
-		<rdfs:label xml:lang="en">commercial m b s</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;ResidentialMBS"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;FHLMC-GoldPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:label xml:lang="en">FHLMC Gold pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;FHLMC-Pool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:label xml:lang="en">FHLMC pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;FNMA-Pool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:label xml:lang="en">FNMA pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;FloaterTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;resetDayAndMonth"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">12</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;resetDayAndMonth"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">floater tranche</rdfs:label>
-		<skos:definition xml:lang="en">A floater tranche is a tranche that is keyed to an index and a spread.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, 3 month LIBOR +50 -- meaning that the coupon would be whatever the 3 month LIBOR is plus 50 basis points. This is not a continuously updated number, rather it resets at specified intervals.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;GNMA-IIPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:label xml:lang="en">GNMA-II pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;GNMA-PlatinumPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:label xml:lang="en">GNMA Platinum pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;GNMA-iPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:label xml:lang="en">GNMA-i pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;InverseFloaterTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;FloaterTranche"/>
-		<rdfs:label xml:lang="en">inverse floater tranche</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;RegularFloaterTranche"/>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;SuperFloaterTranche"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedAgencyMortagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;Issued"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issued and securitized agency mortage pool</rdfs:label>
-		<skos:definition xml:lang="en">An agency mortgage pool which has been securitized as part of an agency Mortgage Backed Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedNonAgencyMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;Issued"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issued and securitized non agency mortgage pool</rdfs:label>
-		<skos:definition xml:lang="en">A non agency mortgage pool which has been securitized as part of a tranched Mortgage Backed Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedPoolOfIndividualDebts">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;Issued"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">issued and securitized pool of individual debts</rdfs:label>
-		<skos:definition xml:lang="en">A pool of individual debts (such as loans or mortgages) which is securitized as part of the issue of some security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;SecuritizedMortgagePool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">m b s deal</rdfs:label>
-		<skos:definition xml:lang="en">The issue of a series of Mortgage Backed Security certificates.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSDealProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedDealProspectus"/>
-		<rdfs:label xml:lang="en">m b s deal prospectus</rdfs:label>
-		<skos:definition xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the mortgage backed security issue. Term origin:SMER</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-fctx-sta;GovernmentMortgageAgency">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/Bank">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-mbs;SpecialistMortgageIssuer">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">m b s issuer</rdfs:label>
-		<skos:definition xml:lang="en">The issuer of a Mortgage Backed Security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This can be an agency that exists for this purpose or it may be the issuer of the original mortgages in the pool.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrumentPool"/>
-		<rdfs:label xml:lang="en">m b s pool</rdfs:label>
-		<skos:definition xml:lang="en">A pool investment consisting of a collection of MBS instruments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSTrancheNote">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecurityNote"/>
-		<rdfs:label xml:lang="en">m b s tranche note</rdfs:label>
-		<skos:definition xml:lang="en">An individual note of a tranche.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A Tranche is made up of e.g. $500m in notes and so on. These may be in different notes, with different denominations. Analytics that would apply to the Tranche would by implication apply to each slice of the tranche.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MezzanineMBSTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;seniorTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;SubordinatedMBSTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mezzanine m b s tranche</rdfs:label>
-		<skos:definition xml:lang="en">Specific kinds of tranche are modeled for example and investigation only and have been removed from the diagrams. These will be removed from the final model.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;has.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageDebt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;issuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MBSIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage backed security instrument</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageCollateral">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;DebtCollateral"/>
-		<rdfs:label xml:lang="en">mortgage collateral</rdfs:label>
-		<skos:definition xml:lang="en">Mortgage Debt Assets pledged to a lender until a loan is repaid. Further notes: This provides one means by which some extension of finance (such as a loan, debt or equity issue) is under-written.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageDebt">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedDebt"/>
-		<rdfs:label xml:lang="en">mortgage debt</rdfs:label>
-		<skos:definition xml:lang="en">Mortgage debt issued under a Mortgage Backed Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;constituent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePoolConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mortgage pool</rdfs:label>
-		<skos:definition xml:lang="en">A number of mortgages combined into a single pool and used as an asset.</skos:definition>
-		<skos:editorialNote xml:lang="en">Analytics review session notes: Dated facts (for non agency mortgage pools): Aggregate of : Scheduled payments (% and $) Payments Prepayments (% and $ notional) Default amounts (statistics: Prepayments: (start at 0 and ramp up and then level off (why?)) SMM basic measure monthly Basis CPR C? Prepayment Rate based on SMM annualised PSA based on CPR takes the COR and applies a curve to the rate of prepayments on the model. (%) e.g. 100% PSA is applied to model. 200% PSA implies x%CPR per month Tries to reflect how prepayments in a pool will accelerate and then burn out. This reflects the nature of a mortgage pool, elgl why people will prepay, refinance, address selection and so on i.e. local economy facts. so those will drop out of the pool and you are left with those who will not. that&apos;s why it levels off. So who originates these figures? Is it measured ongoing?: No . Used to determine a pricing speed when marketing the security to investors. So this is part of the primary market / issuance where there is marketing. These are the estimated figures as they will be at issue. PSA may also be used as triggers. 100 - 400% PSA band - if you go outside that band, may change payment behaviour of those classes. Defaults: measures or rate of default CDR conditional default rate (annual) MDR Monhtly default rate - like CPR = Rate over time. - both defined as Rates. (%) Figures are originated by the servicer of the debt pool. Each serviceer will have their own formats but will do info on prepayments, llosses, detauls on specific loans and so on.</skos:editorialNote>
-		<skos:editorialNote xml:lang="en">The class Mortgage Pool originally had a property &apos;pool type&apos; referring to a selection list of textual stylings of pool types. Those are now replaced with actual sub types of mortgage pool. Here are the original notes and definition that went with the enumerated list of pool types: 
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
+buxmlns:fibo-be-fctx-sta="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/"
+buxmlns:fibo-bp-iss-dbti="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-loan-tem-ev="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"
+buxmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
+buxmlns:fibo-sec-dbt-ab-abs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-cmo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"
+buxmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">MortgageBackedSecurities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Mortgage backed securities are like asset backed securities except that the underlying loan pool is a pool of mortgage loans.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/StateEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoansTemporal/LoansEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CMOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/Bank">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;AgencyMBSDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency m b s deal</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An issue of securities backed by pools of mortgages held by government agencies.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are Ginnie Mae, Freddie Mac and Fannie Mae (for the US). Of these agencies, GNMA (Ginnie Mae) issues mortgages in its own right (Investorwords differs on this). Fannie Mae and Freddie Mac purchase mortgages. Those mortgages are issued by banks. Before one of these agencies purchases a mortgage, there are certain criteria that have to be met. These are specified in terms of, for example, the balance of the mortgage, limits to credit ratings.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;AgencyMBSIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-fctx-sta;GovernmentMortgageAgency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency m b s issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer of the pass through MBS is an Agency issuer. This is identified as being some kind of agency that is set up specifically to issue these instruments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;AgencyMBSPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSPool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency m b s pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool investment consisting of a collection of Agency MBS instruments.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This pool may be used as the underlying for an agency CMO. Non agency CMOs do not exist.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">agency mortgage pool</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool of agency mortgages.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;CommercialMBS">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commercial m b s</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;ResidentialMBS"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;FHLMC-GoldPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FHLMC Gold pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;FHLMC-Pool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FHLMC pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;FNMA-Pool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">FNMA pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;FloaterTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;resetDayAndMonth"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">12</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;resetDayAndMonth"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floater tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A floater tranche is a tranche that is keyed to an index and a spread.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example, 3 month LIBOR +50 -- meaning that the coupon would be whatever the 3 month LIBOR is plus 50 basis points. This is not a continuously updated number, rather it resets at specified intervals.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;GNMA-IIPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">GNMA-II pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;GNMA-PlatinumPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">GNMA Platinum pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;GNMA-iPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">GNMA-i pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;InverseFloaterTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;FloaterTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inverse floater tranche</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;RegularFloaterTranche"/>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;SuperFloaterTranche"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedAgencyMortagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMortgagePool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;Issued"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued and securitized agency mortage pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An agency mortgage pool which has been securitized as part of an agency Mortgage Backed Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedNonAgencyMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;Issued"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued and securitized non agency mortgage pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A non agency mortgage pool which has been securitized as part of a tranched Mortgage Backed Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedPoolOfIndividualDebts">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;lifecycleState"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-dbti;Issued"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued and securitized pool of individual debts</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool of individual debts (such as loans or mortgages) which is securitized as part of the issue of some security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;SecuritizedMortgagePool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m b s deal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issue of a series of Mortgage Backed Security certificates.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSDealProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedDealProspectus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m b s deal prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the mortgage backed security issue. Term origin:SMER</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-be-fctx-sta;GovernmentMortgageAgency">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/Bank">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-mbs;SpecialistMortgageIssuer">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m b s issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer of a Mortgage Backed Security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This can be an agency that exists for this purpose or it may be the issuer of the original mortgages in the pool.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrumentPool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m b s pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool investment consisting of a collection of MBS instruments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MBSTrancheNote">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecurityNote"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m b s tranche note</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An individual note of a tranche.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A Tranche is made up of e.g. $500m in notes and so on. These may be in different notes, with different denominations. Analytics that would apply to the Tranche would by implication apply to each slice of the tranche.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MezzanineMBSTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;seniorTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;SubordinatedMBSTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mezzanine m b s tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Specific kinds of tranche are modeled for example and investigation only and have been removed from the diagrams. These will be removed from the final model.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;has.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;MortgageInstrumentWeightedAverageRemainingMaturity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-abs;definesTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageDebt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;issuedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MBSIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage backed security instrument</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageCollateral">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;DebtCollateral"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage collateral</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mortgage Debt Assets pledged to a lender until a loan is repaid. Further notes: This provides one means by which some extension of finance (such as a loan, debt or equity issue) is under-written.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgageDebt">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedDebt"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage debt</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Mortgage debt issued under a Mortgage Backed Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPool"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;constituent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePoolConstituent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A number of mortgages combined into a single pool and used as an asset.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Analytics review session notes: Dated facts (for non agency mortgage pools): Aggregate of : Scheduled payments (% and $) Payments Prepayments (% and $ notional) Default amounts (statistics: Prepayments: (start at 0 and ramp up and then level off (why?)) SMM basic measure monthly Basis CPR C? Prepayment Rate based on SMM annualised PSA based on CPR takes the COR and applies a curve to the rate of prepayments on the model. (%) e.g. 100% PSA is applied to model. 200% PSA implies x%CPR per month Tries to reflect how prepayments in a pool will accelerate and then burn out. This reflects the nature of a mortgage pool, elgl why people will prepay, refinance, address selection and so on i.e. local economy facts. so those will drop out of the pool and you are left with those who will not. that&apos;s why it levels off. So who originates these figures? Is it measured ongoing?: No . Used to determine a pricing speed when marketing the security to investors. So this is part of the primary market / issuance where there is marketing. These are the estimated figures as they will be at issue. PSA may also be used as triggers. 100 - 400% PSA band - if you go outside that band, may change payment behaviour of those classes. Defaults: measures or rate of default CDR conditional default rate (annual) MDR Monhtly default rate - like CPR = Rate over time. - both defined as Rates. (%) Figures are originated by the servicer of the debt pool. Each serviceer will have their own formats but will do info on prepayments, llosses, detauls on specific loans and so on.</skos:editorialNote>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The class Mortgage Pool originally had a property &apos;pool type&apos; referring to a selection list of textual stylings of pool types. Those are now replaced with actual sub types of mortgage pool. Here are the original notes and definition that went with the enumerated list of pool types: 
 
 The type of pool for a pool backed security. Each of these pool types represents pools of mortgages that have conformed to certain standards (that change periodically) that make them &quot;conforming&quot; -- such as mortgage balance under a certain threshold, creditworthiness, loan-to-value, etc.
 
@@ -349,466 +352,466 @@ Under Agency mortgages, basically you have various types of pools under the vari
 As far as definitions:The simple definition is that each of these pool types represents pools of mortgages that have conformed to certain standards (that change periodically) that make them &quot;conforming&quot; -- such as mortgage balance under a certain threshold, creditworthiness, loan-to-value, etc. Also, GNMA is explicitly backed by the US government, while FNMA and FHLMC are only implicitly backed by the US government. Perhaps there needs to be some research done on the parameters for what makes a loan conforming or not. 
 
 Consensus:Review.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgagePoolConstituent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
-		<rdfs:label xml:lang="en">mortgage pool constituent</rdfs:label>
-		<skos:definition xml:lang="en">Amortgage defined as a constituent of a Mortgage Pool.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyIOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:label xml:lang="en">non agency i o tranche</rdfs:label>
-		<skos:definition xml:lang="en">Interest Only tranche, meaning that this tranche will only pay interest.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyJumpTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;specifiesTrigger"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">non agency jump tranche</rdfs:label>
-		<skos:definition xml:lang="en">A tranche where if there is some sort of trigger event reached then the holders of the tranche will begin to receive payments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyJumpZTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyJumpTranche"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyZTranche"/>
-		<rdfs:label xml:lang="en">non agency jump z tranche</rdfs:label>
-		<skos:definition xml:lang="en">A Jump Z tranche is like a Z tranche but if there is some sort of trigger event reached then the holders of the Jump Z tranche will begin to receive payments. Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyMBSIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/Bank">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-ab-mbs;SpecialistMortgageIssuer">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">non agency m b s issuer</rdfs:label>
-		<skos:definition xml:lang="en">A party which is a non agency issuer of MBS securities. The identity of this party may be a bank or a specialist (non agency) mortgage company. Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
-		<rdfs:label xml:lang="en">non agency mortgage pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyPOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:label xml:lang="en">non agency p o tranche</rdfs:label>
-		<skos:definition xml:lang="en">Principal Only tranche. This tranche will only pay principal.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyRegularJumpZTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyJumpZTranche"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;reverts"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">non agency regular jump z tranche</rdfs:label>
-		<skos:definition xml:lang="en">Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyStickyJumpZTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyJumpZTranche"/>
-		<rdfs:label xml:lang="en">non agency sticky jump z tranche</rdfs:label>
-		<skos:definition xml:lang="en">&quot;Sticky&quot; Jump Z tranches maintain the payment priority of a Jump Z tranche until they are retired.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyZTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:label xml:lang="en">non agency z tranche</rdfs:label>
-		<skos:definition xml:lang="en">A tranche that does not receive payments while other tranches remain.</skos:definition>
-		<skos:editorialNote xml:lang="en">These tranches are credited for interest that would have been received and that interest is accrued to the Z tranche. Once all other tranches have been paid, the holders of the Z tranche receive payments. Types of Z Tranche: A Jump Z tranche is like a Z tranche but if there is some sort of trigger event reached then the holders of the Jump Z tranche will begin to receive payments. &quot;Sticky&quot; Jump Z tranches maintain this payment priority until they are retired, while regular, non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed. Review note: These are currently separate entries - they should be entries for types of Z Tranche. Add new list and move these to there.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;Pass-throughPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
-		<rdfs:label xml:lang="en">pass-through pool</rdfs:label>
-		<skos:editorialNote xml:lang="en">REVIEW: These are all Pass-through so not clear why this term is here. Term originates with Cutter SME review but seems redundant. If not, this would be non mutually exclusive with agency pool. In general, agency MBS pools are pass through and non agency are tranched, but this reflects a business necessity not a logical necessity.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;isAlso"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMBSDeal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pass through m b s deal</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
-		<skos:definition xml:lang="en">An issue of Mortgage Backed Security instruments in which payments on the pool are passed through to investors</skos:definition>
-		<skos:editorialNote xml:lang="en">The cashflows from interest and principal payments on the mortgages in the underlying pool are passed on to investors, usually with the deduction of fees in for them of a reduction in a mumber of percentage points or a monetary amount. Modeling note: Thinking about this further, and after more PoC reviews, it seems to me that we should simply define two kinds of Deal which are Tranched and Pass Thtrough, just below the level of Pool Backed Securities Deal. Investigaiton of various SMOs and REMICs and the like suggests that the original PoC term duality shown here (Tranched = Non Agency; Pass Through = Agency) is too simplistic.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSDealProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDealProspectus"/>
-		<rdfs:label xml:lang="en">pass through m b s deal prospectus</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
-		<skos:definition xml:lang="en">The written prospectus for an agency, pass through issue of Mortgage Backed Securities</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;hasNote"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrumentNote"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pass through m b s instrument</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<skos:definition xml:lang="en">A security in which the cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrumentNote">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecurityNote"/>
-		<rdfs:label xml:lang="en">pass through m b s instrument note</rdfs:label>
-		<skos:definition xml:lang="en">An individual note of a pass through instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSIssueUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter"/>
-		<rdfs:label xml:lang="en">pass through m b s issue underwriter</rdfs:label>
-		<skos:definition xml:lang="en">The party which agrees to buy any certificates that are not bought by investors Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PayingAgent">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;responsibleFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;Payment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">paying agent</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PaymentSpeed">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Rate"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;isRateOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">payment speed</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
-		<rdfs:label xml:lang="en">private label m b s deal</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;RegularFloaterTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;FloaterTranche"/>
-		<rdfs:label xml:lang="en">regular floater tranche</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;SuperFloaterTranche"/>
-		<skos:definition xml:lang="en">A floater tranche is a tranche that is keyed to an index and a spread. The spread is added to the index.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example, 3 month LIBOR +50 -- meaning that the coupon would be whatever the 3 month LIBOR is plus 50 basis points. This is not a continuously updated number, rather it resets at specified intervals.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;ResidentialMBS">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
-		<rdfs:label xml:lang="en">residential m b s</rdfs:label>
-		<skos:definition xml:lang="en">Residential Mortgage-Backed Securities, which are trust certificates (bonds) backed by a pool of residential mortgage loans.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Notes from CESR: They are issued by banks and backed by an underlying pool of residential mortgages. There can be some distinctions between prime RMBS and sub-prime/non-conforming RMBS although there is no consensus about what constitutes a sub-prime/non-conforming mortgage in Europe.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;ResidualTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:label xml:lang="en">residual tranche</rdfs:label>
-		<skos:definition xml:lang="en">Unknown Further notes: Verify whether Residual Tranche and Support Tranche are meant to be in the same list of types as PAC etc. i.e. can a tranche not be PAC and Residual? this looks suspicioulsy like two semantics.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SBA-Pool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
-		<rdfs:label xml:lang="en">SBA pool</rdfs:label>
-		<skos:editorialNote xml:lang="en">Unknown pool type, from Cutter SME reviews; other pool types listed under Agency are from or validated by AdeptAdvisory SME review.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SecuritizedMortgagePool">
-		<rdfs:label xml:lang="en">securitized mortgage pool</rdfs:label>
-		<skos:definition xml:lang="en">A mortgage pool which is securitized as part of the issue of some mortgage backed security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a logical union of a non agency mortgage pool which is securitized and an agency mortgage pool which has been securitized.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SeniorMBSTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;seniorTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MezzanineMBSTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">senior m b s tranche</rdfs:label>
-		<skos:definition xml:lang="en">Specific kinds of tranche are modeled for example and investigation only and have been removed from the diagrams. These will be removed from the final model.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SpecialistMortgageIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-		<rdfs:label xml:lang="en">specialist mortgage issuer</rdfs:label>
-		<skos:definition xml:lang="en">A business organization that specialises in and exists for the issuance of mortgages to the general public.</skos:definition>
-		<skos:editorialNote xml:lang="en">Possibly add: Building Society. these exist in the UK (though almost extinct) but have not come up in US-based reviews of the model. Also known as Friendly Societies. There may be analogous organisations in other parts of the world, e.g. South America??</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SubordinatedMBSTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:label xml:lang="en">subordinated m b s tranche</rdfs:label>
-		<skos:definition xml:lang="en">Specific kinds of tranche are modeled for example and investigation only and have been removed from the diagrams. These will be removed from the final model.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SuperFloaterTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;FloaterTranche"/>
-		<rdfs:label xml:lang="en">super floater tranche</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TrancheNonPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;NonPayment"/>
-		<rdfs:label xml:lang="en">tranche non payment</rdfs:label>
-		<skos:definition xml:lang="en">Failure of a tranche of a tranched security to pay out. This may or may not be interpreted as a credit event.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue">
-		<rdfs:label xml:lang="en">tranche rating at issue</rdfs:label>
-		<skos:definition xml:lang="en">The rating at issue of a tranche of a security. Note this is under review</skos:definition>
-		<skos:editorialNote xml:lang="en">In the case of CDOs, senior and mezzanine tranches of a CDO issue are typically rated, with the former receiving ratings of A to AAA and the latter receiving ratings of B to BBB. The ratings reflect both the credit quality of underlying collateral as well as how much protection a given tranch is afforded by tranches that are subordinate to it. Review note: Remove this it&apos;s no different from an instrument.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TrancheType">
-		<rdfs:label xml:lang="en">tranche type</rdfs:label>
-		<skos:definition xml:lang="en">the type of tranche in a tranched MBS security</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;isAlso.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tranched m b s deal</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDealProspectus"/>
-		<rdfs:label xml:lang="en">tranched m b s deal prospectus</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;cashflowPrecedence"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;providesCreditSupportTo"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;hasNote"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MBSTrancheNote"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;hasPotentialEvent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheNonPayment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">tranched m b s instrument</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSIssueUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter"/>
-		<rdfs:label xml:lang="en">tranched m b s issue underwriter</rdfs:label>
-		<skos:definition xml:lang="en">The party which agrees to buy any certificates that are not bought by investors Term origin:MBS PoC Reviews</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;Trustee">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">trustee</rdfs:label>
-		<skos:definition xml:lang="en">A party which has some role in relation to some financial investment (portfolio, issue etc.) which is formally defined as being a &quot;Trustee&quot; in that context.</skos:definition>
-		<skos:editorialNote xml:lang="en">Definition is a bit self referential at present. Working definition for this class (added April 2010 as making CDO Portfolio Trusttee a direct child of &quot;Party&quot; seemed too simplistic). Action: Other types of Trustee need to be added to this class.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;cashflowPrecedence">
-		<rdfs:label xml:lang="en">cashflow precedence</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-mbs;providesCreditSupportTo"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;constituent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-abs;hasConsituent"/>
-		<rdfs:label xml:lang="en">constituent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePoolConstituent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;denomination">
-		<rdfs:label xml:lang="en">denomination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MBSTrancheNote"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The currency amount in which the Note is denominated, for example $500 notes.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;denomination.1">
-		<rdfs:label xml:lang="en">denomination</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrumentNote"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The currency amount in which the Note is denominated, for example $500 notes. This term added by symmettry with MBS Tranche Note. needs to be reviewed and validated.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;hasNote">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
-		<rdfs:label xml:lang="en">has note</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityNote"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;hasPotentialEvent">
-		<rdfs:label xml:lang="en">has potential event</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheNonPayment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;isAlso">
-		<rdfs:label xml:lang="en">is also</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSDeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMBSDeal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;isAlso.1">
-		<rdfs:label xml:lang="en">is also</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;isRateOf">
-		<rdfs:label xml:lang="en">is rate of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PaymentSpeed"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;isSliceOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isPartOf"/>
-		<rdfs:label xml:lang="en">is slice of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecurityNote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
-		<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-mbs;hasNote"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough">
-		<rdfs:label xml:lang="en">pass through</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough.1">
-		<rdfs:label xml:lang="en">pass through</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSDeal"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough.2">
-		<rdfs:label xml:lang="en">pass through</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The cash flows from the underlying asset pool are passed through to the holder of this instrument by way of redemption payments.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough.3">
-		<rdfs:label xml:lang="en">pass through</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Cash flows from the underlying asset pool are not passed through to the investor by way of redemption payments. Instead a tranched structure is used.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough.4">
-		<rdfs:label xml:lang="en">pass through</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The cash flows from the underlying asset pool are not passed directly through to the investor by way of redemption payments but are used to fund cashflows that are defined specifically for the tranche.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;prime">
-		<rdfs:label xml:lang="en">prime</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;ResidentialMBS"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the mortage pool is identified as Prime or not.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;providesCreditSupportTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo"/>
-		<rdfs:label xml:lang="en">provides credit support to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;resetDayAndMonth">
-		<rdfs:label xml:lang="en">reset day and month</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;FloaterTranche"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;responsibleFor">
-		<rdfs:label xml:lang="en">responsible for</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PayingAgent"/>
-		<rdfs:range rdf:resource="&fibo-loan-tem-ev;Payment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;reverts">
-		<rdfs:label xml:lang="en">reverts</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyRegularJumpZTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;seniorTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-mbs;cashflowPrecedence"/>
-		<rdfs:label xml:lang="en">senior to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MezzanineMBSTranche"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;SeniorMBSTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MezzanineMBSTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;SubordinatedMBSTranche"/>
-		<skos:definition xml:lang="en">Specific kinds of tranche are modeled for example and investigation only and have been removed from the diagrams. These will be removed from the final model.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;specifiesTrigger">
-		<rdfs:label xml:lang="en">specifies trigger</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyJumpTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
-		<skos:definition xml:lang="en">The event which, when it takes place, causes the Jump Z holders to begin receiving payments.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;takesFormOf.1">
-		<rdfs:label>takes form of</rdfs:label>
-	</owl:ObjectProperty>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;MortgagePoolConstituent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-abs;LoanPoolConstituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mortgage pool constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Amortgage defined as a constituent of a Mortgage Pool.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyIOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency i o tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Interest Only tranche, meaning that this tranche will only pay interest.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyJumpTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;specifiesTrigger"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency jump tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A tranche where if there is some sort of trigger event reached then the holders of the tranche will begin to receive payments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyJumpZTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyJumpTranche"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyZTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency jump z tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Jump Z tranche is like a Z tranche but if there is some sort of trigger event reached then the holders of the Jump Z tranche will begin to receive payments. Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyMBSIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/Bank">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-ab-mbs;SpecialistMortgageIssuer">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency m b s issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which is a non agency issuer of MBS securities. The identity of this party may be a bank or a specialist (non agency) mortgage company. Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyMortgagePool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency mortgage pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyPOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency p o tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Principal Only tranche. This tranche will only pay principal.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyRegularJumpZTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyJumpZTranche"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;reverts"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency regular jump z tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Regular non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyStickyJumpZTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyJumpZTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency sticky jump z tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">&quot;Sticky&quot; Jump Z tranches maintain the payment priority of a Jump Z tranche until they are retired.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;NonAgencyZTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non agency z tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A tranche that does not receive payments while other tranches remain.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">These tranches are credited for interest that would have been received and that interest is accrued to the Z tranche. Once all other tranches have been paid, the holders of the Z tranche receive payments. Types of Z Tranche: A Jump Z tranche is like a Z tranche but if there is some sort of trigger event reached then the holders of the Jump Z tranche will begin to receive payments. &quot;Sticky&quot; Jump Z tranches maintain this payment priority until they are retired, while regular, non-Sticky Jump Z tranches maintain their changed status only while the trigger event is in effect, and revert to their old payment status once the trigger event has passed. Review note: These are currently separate entries - they should be entries for types of Z Tranche. Add new list and move these to there.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;Pass-throughPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass-through pool</rdfs:label>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">REVIEW: These are all Pass-through so not clear why this term is here. Term originates with Cutter SME review but seems redundant. If not, this would be non mutually exclusive with agency pool. In general, agency MBS pools are pass through and non agency are tranched, but this reflects a business necessity not a logical necessity.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;isAlso"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMBSDeal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through m b s deal</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An issue of Mortgage Backed Security instruments in which payments on the pool are passed through to investors</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">The cashflows from interest and principal payments on the mortgages in the underlying pool are passed on to investors, usually with the deduction of fees in for them of a reduction in a mumber of percentage points or a monetary amount. Modeling note: Thinking about this further, and after more PoC reviews, it seems to me that we should simply define two kinds of Deal which are Tranched and Pass Thtrough, just below the level of Pool Backed Securities Deal. Investigaiton of various SMOs and REMICs and the like suggests that the original PoC term duality shown here (Tranched = Non Agency; Pass Through = Agency) is too simplistic.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSDealProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDealProspectus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through m b s deal prospectus</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The written prospectus for an agency, pass through issue of Mortgage Backed Securities</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;hasNote"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrumentNote"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through m b s instrument</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security in which the cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrumentNote">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecurityNote"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through m b s instrument note</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An individual note of a pass through instrument.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PassThroughMBSIssueUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through m b s issue underwriter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which agrees to buy any certificates that are not bought by investors Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PayingAgent">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;responsibleFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-loan-tem-ev;Payment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">paying agent</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PaymentSpeed">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Rate"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;isRateOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">payment speed</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">private label m b s deal</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;RegularFloaterTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;FloaterTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regular floater tranche</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-mbs;SuperFloaterTranche"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A floater tranche is a tranche that is keyed to an index and a spread. The spread is added to the index.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example, 3 month LIBOR +50 -- meaning that the coupon would be whatever the 3 month LIBOR is plus 50 basis points. This is not a continuously updated number, rather it resets at specified intervals.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;ResidentialMBS">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">residential m b s</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Residential Mortgage-Backed Securities, which are trust certificates (bonds) backed by a pool of residential mortgage loans.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Notes from CESR: They are issued by banks and backed by an underlying pool of residential mortgages. There can be some distinctions between prime RMBS and sub-prime/non-conforming RMBS although there is no consensus about what constitutes a sub-prime/non-conforming mortgage in Europe.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;ResidualTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">residual tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Unknown Further notes: Verify whether Residual Tranche and Support Tranche are meant to be in the same list of types as PAC etc. i.e. can a tranche not be PAC and Residual? this looks suspicioulsy like two semantics.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SBA-Pool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SBA pool</rdfs:label>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Unknown pool type, from Cutter SME reviews; other pool types listed under Agency are from or validated by AdeptAdvisory SME review.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SecuritizedMortgagePool">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securitized mortgage pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A mortgage pool which is securitized as part of the issue of some mortgage backed security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a logical union of a non agency mortgage pool which is securitized and an agency mortgage pool which has been securitized.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SeniorMBSTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;seniorTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MezzanineMBSTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">senior m b s tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Specific kinds of tranche are modeled for example and investigation only and have been removed from the diagrams. These will be removed from the final model.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SpecialistMortgageIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specialist mortgage issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A business organization that specialises in and exists for the issuance of mortgages to the general public.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Possibly add: Building Society. these exist in the UK (though almost extinct) but have not come up in US-based reviews of the model. Also known as Friendly Societies. There may be analogous organisations in other parts of the world, e.g. South America??</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SubordinatedMBSTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subordinated m b s tranche</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Specific kinds of tranche are modeled for example and investigation only and have been removed from the diagrams. These will be removed from the final model.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;SuperFloaterTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;FloaterTranche"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">super floater tranche</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TrancheNonPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-loan-tem-ev;NonPayment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche non payment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Failure of a tranche of a tranched security to pay out. This may or may not be interpreted as a credit event.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TrancheRatingAtIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche rating at issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rating at issue of a tranche of a security. Note this is under review</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">In the case of CDOs, senior and mezzanine tranches of a CDO issue are typically rated, with the former receiving ratings of A to AAA and the latter receiving ratings of B to BBB. The ratings reflect both the credit quality of underlying collateral as well as how much protection a given tranch is afforded by tranches that are subordinate to it. Review note: Remove this it&apos;s no different from an instrument.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TrancheType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">the type of tranche in a tranched MBS security</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;isAlso.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s deal</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSDealProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDealProspectus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s deal prospectus</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;cashflowPrecedence"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;providesCreditSupportTo"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;hasNote"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;MBSTrancheNote"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-mbs;hasPotentialEvent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheNonPayment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s instrument</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;TranchedMBSIssueUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranched m b s issue underwriter</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which agrees to buy any certificates that are not bought by investors Term origin:MBS PoC Reviews</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-mbs;Trustee">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trustee</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which has some role in relation to some financial investment (portfolio, issue etc.) which is formally defined as being a &quot;Trustee&quot; in that context.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Definition is a bit self referential at present. Working definition for this class (added April 2010 as making CDO Portfolio Trusttee a direct child of &quot;Party&quot; seemed too simplistic). Action: Other types of Trustee need to be added to this class.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;cashflowPrecedence">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cashflow precedence</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-mbs;providesCreditSupportTo"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;constituent">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-abs;hasConsituent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">constituent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePool"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MortgagePoolConstituent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;denomination">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MBSTrancheNote"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency amount in which the Note is denominated, for example $500 notes.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;denomination.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrumentNote"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency amount in which the Note is denominated, for example $500 notes. This term added by symmettry with MBS Tranche Note. needs to be reviewed and validated.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;hasNote">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasPart"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has note</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityNote"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;hasPotentialEvent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has potential event</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheNonPayment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;isAlso">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is also</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSDeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;AgencyMBSDeal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;isAlso.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is also</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;PrivateLabelMBSDeal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;isRateOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is rate of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PaymentSpeed"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;isSliceOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isPartOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is slice of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecurityNote"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+bubu<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-mbs;hasNote"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MBSDeal"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MortgageBackedSecurityInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSDeal"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PassThroughMBSInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The cash flows from the underlying asset pool are passed through to the holder of this instrument by way of redemption payments.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSDeal"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Cash flows from the underlying asset pool are not passed through to the investor by way of redemption payments. Instead a tranched structure is used.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;passThrough.4">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The cash flows from the underlying asset pool are not passed directly through to the investor by way of redemption payments but are used to fund cashflows that are defined specifically for the tranche.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;prime">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">prime</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;ResidentialMBS"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the mortage pool is identified as Prime or not.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;providesCreditSupportTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">provides credit support to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TranchedMBSInstrument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;resetDayAndMonth">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reset day and month</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;FloaterTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;responsibleFor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">responsible for</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;PayingAgent"/>
+bubu<rdfs:range rdf:resource="&fibo-loan-tem-ev;Payment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;reverts">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reverts</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyRegularJumpZTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEventReversal"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;seniorTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-mbs;cashflowPrecedence"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">senior to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;MezzanineMBSTranche"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;SeniorMBSTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;MezzanineMBSTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;SubordinatedMBSTranche"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Specific kinds of tranche are modeled for example and investigation only and have been removed from the diagrams. These will be removed from the final model.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;specifiesTrigger">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies trigger</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-mbs;NonAgencyJumpTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cmo;JumpZTriggerEvent"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The event which, when it takes place, causes the Jump Z holders to begin receiving payments.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-mbs;takesFormOf.1">
+bubu<rdfs:label>takes form of</rdfs:label>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/AssetBacked/PoolBackedSecurities.rdf
+++ b/sec/Debt/AssetBacked/PoolBackedSecurities.rdf
@@ -1,324 +1,328 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
-	<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
-	<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-syn "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/">
-	<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-	<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
-	<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
+bu<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
+bu<!ENTITY fibo-sec-dbt-ab-mbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-syn "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/">
+bu<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bu<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
+bu<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
-	xmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
-	xmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-syn="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"
-	xmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
-	xmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-		<rdfs:label xml:lang="en">PoolBackedSecurities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">cash structured finance instrument</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticStructuredFinanceInstrument"/>
-		<skos:definition xml:lang="en">A structured finance instrument with a real asset underlying.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrumentPool">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrumentPool"/>
-		<rdfs:label xml:lang="en">cash structured finance instrument pool</rdfs:label>
-		<skos:definition xml:lang="en">A pool investment consisting of a collection of cash structured finance instruments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CollateralizedDebt">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
-		<rdfs:label xml:lang="en">collateralized debt</rdfs:label>
-		<skos:definition xml:lang="en">Debt issued under some Security, with some Collateral.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
-		<rdfs:label xml:lang="en">collateralized obligation deal</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CollateralizedObligationInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
-		<rdfs:label xml:lang="en">collateralized obligation instrument</rdfs:label>
-		<skos:definition xml:lang="en">Pending further investigation. At present: CDO = issued against pool of securities MBS = issued against pool of individual debts (base loans) Action: identify if this is the case. Option 1: Model as it was; Option 2: Add a level of detail in between, whereby there is a pool of pools or some other such thing Option 3: this is a terminological thing only in that CDOs are never referred to as a parent of CMO for purely teerminological reasons as per ABS v MBS in which case we would add in a terminological layer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;DebtCollateral">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Collateral"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;takesFormOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt collateral</rdfs:label>
-		<skos:definition xml:lang="en">Debt Assets pledged to a lender until a loan is repaid. Further notes: This provides one means by which some extension of finance (such as a loan, debt or equity issue) is under-written.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedDealProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus"/>
-		<rdfs:label xml:lang="en">pool backed deal prospectus</rdfs:label>
-		<skos:definition xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the pool backed security issue. Term origin:SMER</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasIssuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedPoolOfIndividualDebts"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool backed securities deal</rdfs:label>
-		<skos:definition xml:lang="en">The issue of a series of Pool Backed Security certificates. These are (at least in this context) securities issued backed by a pool of individual loans, mortgages or other individual loan products.</skos:definition>
-		<skos:editorialNote xml:lang="en">This term makes the distinction, perhaps artificial, between deals backed by pools of individual debt (this term), and deals backed by pools of securities (collateralized deals). This structure of relations between kinds of deals may prove to be a little artificial, but it reflects the structure of relations between kinds of securities, arrived at in earlier SME reviews. That is, Pool Backed Security (which breaks down into ABS and MBS) has a pool of individual loan products (a sub type of which is mortgage loans). The terms reflect the fact that in common parlance the term &quot;ABS&quot; is taken to mean something which is explicitly NOT a MBS but can be any other type of loan or credit based security, hence the creation of the non standard term &quot;Pool Backed Security&quot;. The naming of deals simply attempts to reflect that. Terms to be included in Deal (per PoC conversations): Underwriters Issuer Deal Number Series number Deal Value Different collateral pools that support the deal. Review existing terms and make sure all covered.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedDebt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;issuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool backed security instrument</rdfs:label>
-		<skos:definition xml:lang="en">A type of bond or note which derives its cashflow from some underlying pool of debt in which loans or mortgage advanced to borrowers are pooled together for the purposes of creating this type of security. Further notes: This is distinguished from CDO instruments which have an underlying pool of debt securities, as distinct from an underlying pool of loan products such as mortgages, credit cards or loans.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool backed security issuer</rdfs:label>
-		<skos:definition xml:lang="en">The issuer of a Pool Backed Security. This may be an Asset Backed Security, Mortgage Backed Security or CDO.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">this is not always and necesarily a special Purpose Vehicle, since many mortage backed securities are issued by Agencies set up for the purpose but not really referred to as SPVs (e.g. Fannie Mae), or issued by mortgage-issuing banks (non Agency).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasAnalytic"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;backs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;developsInto"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">pool of individual debts</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool">
-		<rdfs:label xml:lang="en">securitized debt pool</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasUnderlying.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;mayBe"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">structured finance instrument</rdfs:label>
-		<skos:definition xml:lang="en">A security that has periodic principal payments with the amount of principal that is paid being dictated by a published factor.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be either an invented product (synthetic) or based on a real underlying asset pool. Either way, the underlying is defined by the issuing bank or investment company. These are traded. This is based on tranches of underlying asset pools. These are defined by the issuing bank or investment company.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrumentPool">
-		<rdfs:label xml:lang="en">structured finance instrument pool</rdfs:label>
-		<skos:definition xml:lang="en">A pool investment consisting of a collection of structured finance instruments.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;backs">
-		<rdfs:label xml:lang="en">backs</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
-		<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;dealAmount">
-		<rdfs:label xml:lang="en">deal amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amount of the overall deal.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;developsInto">
-		<rdfs:label xml:lang="en">develops into</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;hasIssuer">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-pbs;issuedBy"/>
-		<rdfs:label xml:lang="en">has issuer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;hasTrancheType">
-		<rdfs:label xml:lang="en">has tranche type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheType"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;hasUnderlying">
-		<rdfs:label xml:lang="en">has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedPoolOfIndividualDebts"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;hasUnderlying.1">
-		<rdfs:label xml:lang="en">has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;isTrancheOf">
-		<rdfs:label xml:lang="en">is tranche of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
-		<skos:definition xml:lang="en">The asset pool which is the underlying of a traditional or cash structured finance instrument. This is a real pool of real assets, as distinct from synthetic pools.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;issuedBy">
-		<rdfs:label xml:lang="en">issued by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;lifecycleState">
-		<rdfs:label xml:lang="en">lifecycle state</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/PoolLifecycleStateSelection"/>
-		<skos:definition xml:lang="en">The state of the pool in terms of the lifecycle of that pool from not yet issued, through the issuance process, to securitized pool.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;mayBe">
-		<rdfs:label xml:lang="en">may be</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;passThrough">
-		<rdfs:label xml:lang="en">pass through</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
+buxmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
+buxmlns:fibo-sec-dbt-ab-mbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-syn="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"
+buxmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
+buxmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
+buxmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">PoolBackedSecurities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Concepts common to asset backed and mortgage backed securities, including pools, instruments, prospectuses and deals common concepts. 
+		Note that in common industry parlance, the term ‘asset backed security’ is used to refer to securities which specifically do not have a mortgage loan pool as their underlying asset. For this reason, this ontology provides a common parent to both asset backed and mortgage backed securities, which is effectively an asset backed security in the broader sense. This has been labeled as ‘pool backed security instrument’ as there is no common industry name for this common parent class, other than ‘asset backed security’.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/DebtIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CBOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash structured finance instrument</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticStructuredFinanceInstrument"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A structured finance instrument with a real asset underlying.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrumentPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrumentPool"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash structured finance instrument pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool investment consisting of a collection of cash structured finance instruments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CollateralizedDebt">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateralized debt</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Debt issued under some Security, with some Collateral.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CollateralizedObligationDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateralized obligation deal</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;CollateralizedObligationInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateralized obligation instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Pending further investigation. At present: CDO = issued against pool of securities MBS = issued against pool of individual debts (base loans) Action: identify if this is the case. Option 1: Model as it was; Option 2: Add a level of detail in between, whereby there is a pool of pools or some other such thing Option 3: this is a terminological thing only in that CDOs are never referred to as a parent of CMO for purely teerminological reasons as per ABS v MBS in which case we would add in a terminological layer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;DebtCollateral">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Collateral"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-accx-acc;takesFormOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt collateral</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Debt Assets pledged to a lender until a loan is repaid. Further notes: This provides one means by which some extension of finance (such as a loan, debt or equity issue) is under-written.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedDealProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool backed deal prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Prospectus describing the terms of the issue and each of the instruments included in the pool backed security issue. Term origin:SMER</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasIssuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedPoolOfIndividualDebts"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool backed securities deal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issue of a series of Pool Backed Security certificates. These are (at least in this context) securities issued backed by a pool of individual loans, mortgages or other individual loan products.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This term makes the distinction, perhaps artificial, between deals backed by pools of individual debt (this term), and deals backed by pools of securities (collateralized deals). This structure of relations between kinds of deals may prove to be a little artificial, but it reflects the structure of relations between kinds of securities, arrived at in earlier SME reviews. That is, Pool Backed Security (which breaks down into ABS and MBS) has a pool of individual loan products (a sub type of which is mortgage loans). The terms reflect the fact that in common parlance the term &quot;ABS&quot; is taken to mean something which is explicitly NOT a MBS but can be any other type of loan or credit based security, hence the creation of the non standard term &quot;Pool Backed Security&quot;. The naming of deals simply attempts to reflect that. Terms to be included in Deal (per PoC conversations): Underwriters Issuer Deal Number Series number Deal Value Different collateral pools that support the deal. Review existing terms and make sure all covered.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSecurities/definesTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;CollateralizedDebt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;issuedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool backed security instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A type of bond or note which derives its cashflow from some underlying pool of debt in which loans or mortgage advanced to borrowers are pooled together for the purposes of creating this type of security. Further notes: This is distinguished from CDO instruments which have an underlying pool of debt securities, as distinct from an underlying pool of loan products such as mortgages, credit cards or loans.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;identity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool backed security issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer of a Pool Backed Security. This may be an Asset Backed Security, Mortgage Backed Security or CDO.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">this is not always and necesarily a special Purpose Vehicle, since many mortage backed securities are issued by Agencies set up for the purpose but not really referred to as SPVs (e.g. Fannie Mae), or issued by mortgage-issuing banks (non Agency).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-aly;hasAnalytic"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;LoanPoolAnalytic"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;backs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;developsInto"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pool of individual debts</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securitized debt pool</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasUnderlying.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;mayBe"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">structured finance instrument</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security that has periodic principal payments with the amount of principal that is paid being dictated by a published factor.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This may be either an invented product (synthetic) or based on a real underlying asset pool. Either way, the underlying is defined by the issuing bank or investment company. These are traded. This is based on tranches of underlying asset pools. These are defined by the issuing bank or investment company.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrumentPool">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">structured finance instrument pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A pool investment consisting of a collection of structured finance instruments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;backs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">backs</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
+bubu<owl:inverseOf rdf:resource="&fibo-sec-dbt-ab-pbs;isTrancheOf"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;dealAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deal amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of the overall deal.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;developsInto">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">develops into</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;hasIssuer">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-ab-pbs;issuedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has issuer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;hasTrancheType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tranche type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;TrancheType"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;hasUnderlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecuritiesDeal"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-mbs;IssuedAndSecuritizedPoolOfIndividualDebts"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;hasUnderlying.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-oac-own;Asset"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;isTrancheOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is tranche of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;SecuritizedDebtPool"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The asset pool which is the underlying of a traditional or cash structured finance instrument. This is a real pool of real assets, as distinct from synthetic pools.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;issuedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-pbs;PoolBackedSecurityIssuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;lifecycleState">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lifecycle state</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;PoolOfIndividualDebts"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/PoolLifecycleStateSelection"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The state of the pool in terms of the lifecycle of that pool from not yet issued, through the issuance process, to securitized pool.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;mayBe">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may be</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-pbs;passThrough">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pass through</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-pbs;CashStructuredFinanceInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the cash flows from the underlying asset pool are passed through to the investor by way of redemption payments.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/AssetBacked/SyntheticCDOs.rdf
+++ b/sec/Debt/AssetBacked/SyntheticCDOs.rdf
@@ -1,298 +1,301 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
-	<!ENTITY fibo-sec-dbt-ab-cdo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
-	<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
-	<!ENTITY fibo-sec-dbt-ab-spv "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
-	<!ENTITY fibo-sec-dbt-ab-syn "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-temx-crr "https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/">
+bu<!ENTITY fibo-sec-dbt-ab-cdo "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/">
+bu<!ENTITY fibo-sec-dbt-ab-pbs "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/">
+bu<!ENTITY fibo-sec-dbt-ab-spv "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/">
+bu<!ENTITY fibo-sec-dbt-ab-syn "https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"
-	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
-	xmlns:fibo-sec-dbt-ab-cdo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"
-	xmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
-	xmlns:fibo-sec-dbt-ab-spv="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"
-	xmlns:fibo-sec-dbt-ab-syn="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/">
-		<rdfs:label xml:lang="en">SyntheticCDOs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashCDOTranche">
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;ArbitrageSyntheticCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;ArbitrageCDO"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDO"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;assetsManagedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;issues"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">arbitrage synthetic c d o</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticBalanceSheetCDO"/>
-		<skos:definition xml:lang="en">Arbitrage synthetic CDO deals are motivated by regulatory or practical considerations that might make a bank want to retain ownership of debt while achieving capital relief through CDSs. In this case, the sponsoring bank has a portfolio of obligations, called the reference portfolio. It retains that portfolio, but offloads its credit risk by transacting CDSs with the CDO.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For arbitrage synthetic deals, two advantages are - an abbreviated ramp-up period (for managed deals), and - the possibility that selling protection through CDSs can be less expensive than directly buying the underlying bonds. This is often true at the lower end of the credit spectrum.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticAmortizingSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticStructuredFinanceInstrument"/>
-		<rdfs:label xml:lang="en">synthetic amortizing security</rdfs:label>
-		<skos:definition xml:lang="en">Security constructed to emulate an amortizing security.</skos:definition>
-		<skos:scopeNote xml:lang="en">Synthetic instruments can be created to mimic a wide range of debt instruments. These are not all shown here. This one is shown as an example</skos:scopeNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticBalanceSheetCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;BalanceSheetCDO"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDO"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;issues"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synthetic balance sheet c d o</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDO">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;issues"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synthetic c d o</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolio">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;notionallyHolds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synthetic c d o portfolio</rdfs:label>
-		<skos:editorialNote xml:lang="en">Review notes: What real stuff is this made of? Would be the actual contracts (the Ref Obligation contracts or the CDS contract)? Buyer of protection is buying protection and paying a fee. Similar to shorting on a stock. Seller of the protection is the one creating the instruments. So the Protection Seller is using the synthetic CDO as some kind of synthetic vehicle. Inside the portfolio is the actual contract that generates the cash.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent">
-		<rdfs:label xml:lang="en">synthetic c d o portfolio constituent</rdfs:label>
-		<skos:definition xml:lang="en">An instrument which is defined as a constituent of a synthetic pool of instruments. These are not holdings because they are not held, but in all other respects they are the constituents of the portfolio.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;isTrancheOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synthetic c d o tranche</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;AbstractCashflowConstruct"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;fundedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;hasUnderlyingContract"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;makesReferenceTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolio"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synthetic debt instrument pool</rdfs:label>
-		<skos:definition xml:lang="en">A cash flow structure which synthesizes the behavior of a portfolio of debt securities. For example a synthesized portfolio of CDO / Bonds / ABS using Total Returns Swaps and CDS. This does exist, it is just manufactured from different instruments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;hasInvestmentGrade"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;InstrumentCreditRating"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synthetic debt instrument pool funding asset</rdfs:label>
-		<terms:description xml:lang="en">From April 28 review session: CDS mechanization: Q: Are the CDS taken out on the constituents of the (non owned) pool or on some other instrument? A: There is funding to underpin the pool. The funding may be high grade debt or may be low grade. There is an undedrlying source of funds. then you swap (using CDS) into other risks. so I might lend to a government institution, and then sell protection against a whole series of corporates. So I&apos;ve taken the high quality portfolio and added other risks to it. Or the other way round. conclusions:</terms:description>
-		<skos:definition xml:lang="en">An asset which provides the funding for a synthetic debt instrument pool, as used in a synthetic CDO.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticDebtSPV">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;holds"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synthetic debt s p v</rdfs:label>
-		<skos:definition xml:lang="en">A Special Purpose Vehicle set up for the issuance of synthetics CDOs. This entity (like all SPVs) its itself registered as some kind of legal entity, distinct from the sponsoring organization. It becomes the Issuer of Synthetic CDO issues.</skos:definition>
-		<skos:editorialNote xml:lang="en">REVIEW: Whether this is (or is ever) a separate SPV for Synthetics, as it is for Cash CDO and other Cash structured finance. If not, how to define the facts at the level of SPV without contradictions. Moving stuff off the balance sheet is involved in putting it into the SPV. So talking a bout balance sheet or off balanc sheet, this is about creating the pool which is going to be sold off. This applies whether hte pool is cash (real holdings) or synthetics. Either way ,the instruments are transferred into the CPV to sell them off. conclusion: applies to cash and non cash. In the old days there were all sorts of guarantees added to that SPOV. Now if you provide support to that =SPV it is no longer &quot;Off balance sheet&quot; froma regulatory point of view. Accounting rules refer.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticPoolAsset">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;AbstractCashflowConstruct"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;simulatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synthetic pool asset</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticStructuredFinanceInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasUnderlying.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticPoolAsset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">synthetic structured finance instrument</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;assetsManagedBy">
-		<rdfs:label xml:lang="en">assets managed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;ArbitrageSyntheticCDO"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;fundedBy">
-		<rdfs:label xml:lang="en">funded by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;hasInvestmentGrade">
-		<rdfs:label xml:lang="en">has investment grade</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-crr;InstrumentCreditRating"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;hasUnderlyingContract">
-		<rdfs:label xml:lang="en">has underlying contract</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<skos:definition xml:lang="en">The underlying CDS which is created to mechanise the cash flows in the synthetic portfolio.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;holds">
-		<rdfs:label xml:lang="en">holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtSPV"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;isCash">
-		<rdfs:label xml:lang="en">is cash</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the CDO has an underlying pool of real assets. This is No: the CDO has a synthetic pool of underlying assets.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;isTrancheOf">
-		<rdfs:label xml:lang="en">is tranche of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;issues">
-		<rdfs:label xml:lang="en">issues</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDO"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;makesReferenceTo">
-		<rdfs:label xml:lang="en">makes reference to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolio"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;notionallyHolds">
-		<rdfs:label xml:lang="en">notionally holds</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolio"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;percentageOfDefaultsThisTranche">
-		<rdfs:label xml:lang="en">percentage of defaults this tranche</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The percentage of defaults which holders of this are exposed to, that is the percentage of defaults that this tranche represents. Further Notes Review session notes 21 April: The first, second and so on, to stop paying out when there is a default. In each case you get the first, second etc. x% of defaults. Base underlying may be high or low quality. Create the pool by buying or selling protection depending on hich way you want to go, e..g. have high quality funds, (borrowers), would sell protection. If low quality, would buy protection to improve quality. So risk is no longer bound to the funding. REVIEW: More likely this is a band of percentages (from and to); review and formalize. See also note on attachment and detachment points.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;simulatedBy">
-		<rdfs:label xml:lang="en">simulated by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticPoolAsset"/>
-		<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
-		<skos:definition xml:lang="en">The underlying CDS which is created to mechanise the cash flows in the synthetic portfolio.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;simulates">
-		<rdfs:label xml:lang="en">simulates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticPoolAsset"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;simulates.1">
-		<rdfs:label xml:lang="en">simulates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;trancheType">
-		<rdfs:label xml:lang="en">tranche type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOTrancheSenioritySelection"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-temx-crr="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"
+buxmlns:fibo-sec-dbt-ab-cdo="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"
+buxmlns:fibo-sec-dbt-ab-pbs="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"
+buxmlns:fibo-sec-dbt-ab-spv="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"
+buxmlns:fibo-sec-dbt-ab-syn="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SyntheticCDOs</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">Synthetic collateralized debt obligations are instruments designed to provide the same kind of structure and returns as a CDO, but these are not backed by an actual pool of debt assets.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditRatings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/AssetBackedSPVs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/CDOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/SyntheticCDOs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-cdo;CashCDOTranche">
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;ArbitrageSyntheticCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;ArbitrageCDO"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDO"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;assetsManagedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;issues"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">arbitrage synthetic c d o</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticBalanceSheetCDO"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Arbitrage synthetic CDO deals are motivated by regulatory or practical considerations that might make a bank want to retain ownership of debt while achieving capital relief through CDSs. In this case, the sponsoring bank has a portfolio of obligations, called the reference portfolio. It retains that portfolio, but offloads its credit risk by transacting CDSs with the CDO.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For arbitrage synthetic deals, two advantages are - an abbreviated ramp-up period (for managed deals), and - the possibility that selling protection through CDSs can be less expensive than directly buying the underlying bonds. This is often true at the lower end of the credit spectrum.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticAmortizingSecurity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticStructuredFinanceInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic amortizing security</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Security constructed to emulate an amortizing security.</skos:definition>
+bubu<skos:scopeNote rdf:datatype="&rdf;langString" xml:lang="en">Synthetic instruments can be created to mimic a wide range of debt instruments. These are not all shown here. This one is shown as an example</skos:scopeNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticBalanceSheetCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;BalanceSheetCDO"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDO"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;issues"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic balance sheet c d o</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDO">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDODeal"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;issues"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic c d o</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolio">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;notionallyHolds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic c d o portfolio</rdfs:label>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review notes: What real stuff is this made of? Would be the actual contracts (the Ref Obligation contracts or the CDS contract)? Buyer of protection is buying protection and paying a fee. Similar to shorting on a stock. Seller of the protection is the one creating the instruments. So the Protection Seller is using the synthetic CDO as some kind of synthetic vehicle. Inside the portfolio is the actual contract that generates the cash.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic c d o portfolio constituent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An instrument which is defined as a constituent of a synthetic pool of instruments. These are not holdings because they are not held, but in all other respects they are the constituents of the portfolio.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-cdo;CDONote"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;isTrancheOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic c d o tranche</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;AbstractCashflowConstruct"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;fundedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;hasUnderlyingContract"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;makesReferenceTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolio"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic debt instrument pool</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A cash flow structure which synthesizes the behavior of a portfolio of debt securities. For example a synthesized portfolio of CDO / Bonds / ABS using Total Returns Swaps and CDS. This does exist, it is just manufactured from different instruments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;hasInvestmentGrade"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-crr;InstrumentCreditRating"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic debt instrument pool funding asset</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">From April 28 review session: CDS mechanization: Q: Are the CDS taken out on the constituents of the (non owned) pool or on some other instrument? A: There is funding to underpin the pool. The funding may be high grade debt or may be low grade. There is an undedrlying source of funds. then you swap (using CDS) into other risks. so I might lend to a government institution, and then sell protection against a whole series of corporates. So I&apos;ve taken the high quality portfolio and added other risks to it. Or the other way round. conclusions:</terms:description>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An asset which provides the funding for a synthetic debt instrument pool, as used in a synthetic CDO.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticDebtSPV">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-spv;DebtSPV"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;holds"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic debt s p v</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Special Purpose Vehicle set up for the issuance of synthetics CDOs. This entity (like all SPVs) its itself registered as some kind of legal entity, distinct from the sponsoring organization. It becomes the Issuer of Synthetic CDO issues.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">REVIEW: Whether this is (or is ever) a separate SPV for Synthetics, as it is for Cash CDO and other Cash structured finance. If not, how to define the facts at the level of SPV without contradictions. Moving stuff off the balance sheet is involved in putting it into the SPV. So talking a bout balance sheet or off balanc sheet, this is about creating the pool which is going to be sold off. This applies whether hte pool is cash (real holdings) or synthetics. Either way ,the instruments are transferred into the CPV to sell them off. conclusion: applies to cash and non cash. In the old days there were all sorts of guarantees added to that SPOV. Now if you provide support to that =SPV it is no longer &quot;Off balance sheet&quot; froma regulatory point of view. Accounting rules refer.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticPoolAsset">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;AbstractCashflowConstruct"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-syn;simulatedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic pool asset</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-ab-syn;SyntheticStructuredFinanceInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-ab-pbs;StructuredFinanceInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-ab-pbs;hasUnderlying.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticPoolAsset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">synthetic structured finance instrument</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;assetsManagedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">assets managed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;ArbitrageSyntheticCDO"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOPortfolioManager"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;fundedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">funded by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;hasInvestmentGrade">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has investment grade</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-crr;InstrumentCreditRating"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;hasUnderlyingContract">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying contract</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The underlying CDS which is created to mechanise the cash flows in the synthetic portfolio.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;holds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtSPV"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPoolFundingAsset"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;isCash">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is cash</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the CDO has an underlying pool of real assets. This is No: the CDO has a synthetic pool of underlying assets.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;isTrancheOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is tranche of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;issues">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issues</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDO"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;makesReferenceTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">makes reference to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolio"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;notionallyHolds">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notionally holds</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolio"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOPortfolioConstituent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;percentageOfDefaultsThisTranche">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage of defaults this tranche</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage of defaults which holders of this are exposed to, that is the percentage of defaults that this tranche represents. Further Notes Review session notes 21 April: The first, second and so on, to stop paying out when there is a default. In each case you get the first, second etc. x% of defaults. Base underlying may be high or low quality. Create the pool by buying or selling protection depending on hich way you want to go, e..g. have high quality funds, (borrowers), would sell protection. If low quality, would buy protection to improve quality. So risk is no longer bound to the funding. REVIEW: More likely this is a band of percentages (from and to); review and formalize. See also note on attachment and detachment points.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;simulatedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">simulated by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticPoolAsset"/>
+bubu<rdfs:range rdf:resource="&fibo-der-cr-cds;CreditDefaultSwapContract"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The underlying CDS which is created to mechanise the cash flows in the synthetic portfolio.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;simulates">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">simulates</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticPoolAsset"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;simulates.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">simulates</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticDebtInstrumentPool"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-ab-syn;trancheType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tranche type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-ab-syn;SyntheticCDOTranche"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-ab-cdo;CDOTrancheSenioritySelection"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/Bonds/BondsCashflowTerms.rdf
+++ b/sec/Debt/Bonds/BondsCashflowTerms.rdf
@@ -1,1360 +1,1364 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
-	<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-	<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
-	<!ENTITY fibo-sec-secx-schx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-der-der-ex "https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
+bu<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bu<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
+bu<!ENTITY fibo-sec-secx-schx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
-	xmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
-	xmlns:fibo-sec-secx-schx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-		<rdfs:label xml:lang="en">BondsCashflowTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasPrincipalAmortizationType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond amortization payment terms</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
-		<rdfs:label xml:lang="en">bond bullet principal repayment terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms for payment of Principal as a single amount of payment of the full Principal.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondCallTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;premium"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond call terms set</rdfs:label>
-		<skos:definition xml:lang="en">The terms and conditions in which a bond can be redeemed by the issuer prior to its maturity. Usually a premium is paid to the bond owner when the bond is called.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Also known as a &quot;redeemable bond&quot;. The main cause of a call is a decline in interest rates. If interest rates have declined since a company first issued the bonds, it will likely want to refinance this debt at a lower rate of interest. The company will call its current bonds and reissue them at a lower rate of interest. The maturity date of a callable debt instrument is the latest and final possible date at which the security will be retired and principal will be redeemed at par. Conesnsus:Review</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;couponPaymentCurrency"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond coupon interest terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms for payment of Interest on a Bond. These include terms for determining interest amounts, and terms for dates on which those amounts are to be paid.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For stepped coupons, several set of this information may exist, with these coming into force.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondCouponStructureType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifies.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond coupon structure type</rdfs:label>
-		<skos:definition xml:lang="en">A set of contractual terms defining the interest payments for a coupon of a bond, beginning with terms describing stepped or conditional coupon structures if these exist.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Multiple sets of Interest Payment Terms may exist for one Security. This covers for example Step-up interest features.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondExtraordinaryRedemption">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasExtraordinaryRedemptionMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond extraordinary redemption</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:label xml:lang="en">bond principal repayment terms set</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<skos:definition xml:lang="en">Terms for the repayment of the Principal on a Bond security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallDate">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
-		<rdfs:label xml:lang="en">call date</rdfs:label>
-		<skos:definition xml:lang="en">Date on which the instrument may be called.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallOfIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;RedemptionEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCallCalendarType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;CalendarType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">call of issue</rdfs:label>
-		<skos:definition xml:lang="en">The calling back of an Issue of a Traded Security by the Issuer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">call schedule</rdfs:label>
-		<terms:description xml:lang="en">The list of dates on which a fixed-income security can be redeemed prior to maturity by the issuer; also includes the corresponding call prices.</terms:description>
-		<fibo-fnd-utl-av:definitionOrigin xml:lang="en">https://www.fidelity.com/glossary/overview</fibo-fnd-utl-av:definitionOrigin>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallScheduleListing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;schedulesPossibleEvent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">call schedule listing</rdfs:label>
-		<skos:definition xml:lang="en">Schedule of dates on which a Traded Security can be Called (recalled) by the Issuer.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is not the same as similarly named terms within a derivative security.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">call type</rdfs:label>
-		<skos:definition xml:lang="en">Way in which a call will be executed, which is by Lottery or Pro-Rata.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ClawBackCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
-		<rdfs:label xml:lang="en">claw back call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ConditionalCouponTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasTermForOneCoupon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponConditionalTerm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">conditional coupon type</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;SingleCouponTermsSet"/>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ControlledAmortizationStructure">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
-		<rdfs:label xml:lang="en">controlled amortization structure</rdfs:label>
-		<terms:description xml:lang="en">a method of providing investors with a relatively predictable repayment schedule, even though the underlying assets are nonamortizing</terms:description>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponConditionalTerm">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">coupon conditional term</rdfs:label>
-		<skos:definition xml:lang="en">A term in the conditional coupon terms which matches one set of coupon terms (fixed rate or variable coupon) with one condition.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponPayment">
-		<rdfs:label xml:lang="en">coupon payment</rdfs:label>
-		<skos:definition xml:lang="en">The event whereby a coupon amount is paid or is to be paid.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponPeriodicDateSeries">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;PeriodicDateSeries"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;regularPeriodDuration"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponRegularPeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">coupon periodic date series</rdfs:label>
-		<skos:definition xml:lang="en">Periodic dates on which Interest Payments are made.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponRegularPeriod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponRegularPeriodLength"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">coupon regular period</rdfs:label>
-		<skos:definition xml:lang="en">The regular periodic component of a coupon schedule.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponRegularPeriodLength">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<rdfs:label xml:lang="en">coupon regular period length</rdfs:label>
-		<skos:definition xml:lang="en">Length of a regular periodic component of a coupon schedule.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">coupon schedule</rdfs:label>
-		<skos:definition xml:lang="en">Schedule for regular payment of Coupon Amounts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponScheduleSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CouponSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasStub"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponStubPeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasStub"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cft;CouponStubPeriod"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;scheduledCouponPayment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponPayment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">coupon schedule specification</rdfs:label>
-		<skos:definition xml:lang="en">Formal specification of the Schedule for regular payment of Coupon Amounts.</skos:definition>
-		<skos:editorialNote xml:lang="en">(from Algo review Oct 09) May need to add information about at which stage in the process you have received the information about the date e.g. whether the date you are looking at has been rolled back or needs to be rolled back. CONTEXT: add this detail in the context of trading or other consumption of data.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponStubEndDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDate"/>
-		<rdfs:label xml:lang="en">coupon stub end date</rdfs:label>
-		<skos:definition xml:lang="en">The calendar date when the coupon stub period is scheduled to end.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponStubPeriod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ScheduleStub"/>
-		<rdfs:label xml:lang="en">coupon stub period</rdfs:label>
-		<skos:definition xml:lang="en">Irregular Coupon Period at the start and / or the end of the Coupon Schedule, which does not fall into the Periodic Date Series.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponStubPeriodDuration">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasLength"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;StubLength"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">coupon stub period duration</rdfs:label>
-		<skos:definition xml:lang="en">The Stub Period as a temporal duration.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponStubStartDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDate"/>
-		<rdfs:label xml:lang="en">coupon stub start date</rdfs:label>
-		<skos:definition xml:lang="en">The calendar date when the coupon stub period is scheduled to start.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DanishBorrowerCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-		<rdfs:label xml:lang="en">danish borrower call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtAmericanCallExerciseType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;AmericanExerciseConvention"/>
-		<rdfs:label xml:lang="en">debt american call exercise type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtBermudanCallExerciseType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;BermudaExerciseConvention"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;includesSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt bermudan call exercise type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtEuropeanCallExerciseType">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
-		<rdfs:label xml:lang="en">debt european call exercise type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtFixedCouponTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;fixedCouponAmount"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestCalculationFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond fixed coupon terms set</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
-		<skos:definition xml:lang="en">Terms for payment of Interest on a Bond, where this pays a fixed rate of interest.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesBaseRate"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;VariableInterestCalculationFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond variable coupon terms set</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;EntireCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-		<rdfs:label xml:lang="en">entire call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;EntireOrPartialCallChoice">
-		<rdfs:label xml:lang="en">entire or partial call choice</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ExplicitCouponScheduleListing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CouponSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasPeriodicDateSeries"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponPeriodicDateSeries"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPayment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">explicit coupon schedule listing</rdfs:label>
-		<skos:definition xml:lang="en">Schedule of itemised coupon payment dates.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">extraordinary redemption method</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FRNTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesBaseRate"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-md-dbtx-int;DebtInstrumentReferenceRate">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">f r n terms set</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedCouponTermsSet"/>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet"/>
-		<skos:definition xml:lang="en">Terms setting out the interest payments determination and dates for Flating Rate Note interest.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FirstRegularCouponDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;ContractuallyDeterminedDate"/>
-		<rdfs:label xml:lang="en">first regular coupon date</rdfs:label>
-		<skos:definition xml:lang="en">The scheduled date of the first regular coupon payment, that is the start of payments according to a regular repeating series of coupon periods, after any non standard (long or short) first coupon period in the schedule.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FixedInterestAmount">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;Margin"/>
-		<rdfs:label xml:lang="en">fixed interest amount</rdfs:label>
-		<skos:definition xml:lang="en">The Fixed Interest amount which is the parameter of the Expression. This is the only parameter in this expression.</skos:definition>
-		<skos:editorialNote xml:lang="en">This duplicates the simple fact &quot;Interest Amount&quot; in the Fixed Interest expression and is essentially redundant. It is included only to show how the parameter relationship for Interst Calculation Expression is specialized (and thereby overridden) for the Fixed Interest Expression.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FixedInterestCalculationFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationFormula"/>
-		<rdfs:label xml:lang="en">fixed interest calculation formula</rdfs:label>
-		<skos:definition xml:lang="en">Formula for Fixed Interest.</skos:definition>
-		<fibo-fnd-utl-av:usageNote xml:lang="en">This limits the more general interest calculation formula, for fixed interest rates. Alternatively this formula can be ignored and the interest rate specified directly as a value in the Interest Terms. It is provided here for completeness.</fibo-fnd-utl-av:usageNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FixedInterestExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasParameter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fixed interest expression</rdfs:label>
-		<skos:definition xml:lang="en">Expression of the value of a fixed interest amount.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a numerical amount only. The operand Base does not exist and the Margin operand is over-ridden by the single property Interest Amount here, i.e. this sub-class of Interest Calculation Expression restricts those operands by not having them (this cannot be shown graphically).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;HoldersOptionCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
-		<rdfs:label xml:lang="en">holders option call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;IndexLinkedCouponTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesBaseRate"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">index linked coupon terms set</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasFormulaTerm.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;PrincipalPaymentCalculationFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesIndexParameter"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">index linked principal determination terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms for payment of the principal. These link the principal amounts to some underlying index or interest rate.</skos:definition>
-		<skos:editorialNote xml:lang="en">Terms are linked to the calculation of the factor - see definition for Inflation Bond. This has been renamed from Principal Repayment Terms to Principal Determination Terms, since further review indicates a term whereby the principal amount itself varies, and this is borne out by the notes made at the original review, where this was mislabeled.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasInflationBondFactor"/>
-				<owl:allValuesFrom rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation bond variable coupon terms set</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;IssuersOptionCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
-		<rdfs:label xml:lang="en">issuers option call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;LastRegularCouponDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;ContractuallyDeterminedDate"/>
-		<rdfs:label xml:lang="en">last regular coupon date</rdfs:label>
-		<skos:definition xml:lang="en">The scheduled date of the last regular coupon payment, that is the last of the payments that are made according to a regular repeating series of coupon periods, before any non standard (long or short) last coupon period in the schedule.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;LotteryCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
-		<rdfs:label xml:lang="en">lottery call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;MakeWholeCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
-		<rdfs:label xml:lang="en">make whole call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;MandatorySinkingFundSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">mandatory sinking fund schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;MandatorySinkingFundScheduleListing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;schedulesMandatoryEvent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mandatory sinking fund schedule listing</rdfs:label>
-		<skos:definition xml:lang="en">A full schedule of dates and payments for a Mandatory Sinking Fund style of Call.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;includes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">mandatory sinking fund description</rdfs:label>
-		<skos:definition xml:lang="en">Terms relating to a Mandatory Sinking Fund call of the issue.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ParametricCallSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-schx;schedules"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">parametric call schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PartialCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCallRedemptionType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">partial call</rdfs:label>
-		<terms:description xml:lang="en">a call of part of the issue</terms:description>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PartialCallAllocation">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">partial call allocation</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PartialCallFeature">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
-		<rdfs:label xml:lang="en">partial call feature</rdfs:label>
-		<skos:definition xml:lang="en">These are terms whereby the issuer can recall part of the issue on scheduled dates but there is no specific amount defined for those dates. Consenus:Yes</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PercentageCAV">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RateBasisType"/>
-		<rdfs:label xml:lang="en">percentage c a v</rdfs:label>
-		<skos:definition xml:lang="en">Percentage specified as percent of CAV (Cumulative Average Value)</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PercentagePar">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RateBasisType"/>
-		<rdfs:label xml:lang="en">percentage par</rdfs:label>
-		<skos:definition xml:lang="en">Figure specified as a percentage of Par Value</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PrincipalPaymentCalculationFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasExpression"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;PrincipalPaymentFormulaExpression"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">principal payment calculation formula</rdfs:label>
-		<skos:definition xml:lang="en">A formula for calculation of principal payments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PrincipalPaymentFormulaExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
-		<rdfs:label xml:lang="en">principal payment formula expression</rdfs:label>
-		<skos:definition xml:lang="en">The expression of the formula by which the payment of principal is formally described.</skos:definition>
-		<skos:editorialNote xml:lang="en">Determine what these can be at the next review and model accordingly. For example, presume this is a base parameter plus a margin percentage, similar to interest payment calculation formula expressions.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ProRataCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
-		<rdfs:label xml:lang="en">pro rata call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RateBasisType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
-		<rdfs:label xml:lang="en">rate basis type</rdfs:label>
-		<skos:definition xml:lang="en">The type of basis for a percentage quoted figure, as used in specifying Bond Call percentage amounts. REVIEW: Does this same meaningful term have wider applicability?</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionByBondNumber">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
-		<rdfs:label xml:lang="en">redemption by bond number</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionByLot">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
-		<rdfs:label xml:lang="en">redemption by lot</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionInInverseOrder">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
-		<rdfs:label xml:lang="en">redemption in inverse order</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;RedemptionEvent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPaymentDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">redemption payment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionPaymentDate">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
-		<rdfs:label xml:lang="en">redemption payment date</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">redemption schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionScheduleListing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPayment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">redemption schedule listing</rdfs:label>
-		<skos:definition xml:lang="en">Schedule for payments of defined amounts of the Principal on a Debt Security.</skos:definition>
-		<skos:editorialNote xml:lang="en">Terms for dates and amounts to be added.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RegularCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
-		<rdfs:label xml:lang="en">regular call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RegulatoryCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
-		<rdfs:label xml:lang="en">regulatory call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ScheduledCouponPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPaymentDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">scheduled coupon payment</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ScheduledCouponPaymentDate">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
-		<rdfs:label xml:lang="en">scheduled coupon payment date</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SerialNumberCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
-		<rdfs:label xml:lang="en">serial number call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SingleCouponTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">single coupon type</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet"/>
-		<skos:definition xml:lang="en">A set of coupon terms which remain the same through the life of the Bond. This is the default and is the case when there is not a Step Coupon or Conditional Coupon.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SinkingFundAmortizationTermsSet">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;includes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">published sinking fund amortization terms description</rdfs:label>
-		<skos:definition xml:lang="en">Terms for the paydown of principal in a sinking fund type of amortizing security.</skos:definition>
-		<skos:editorialNote xml:lang="en">At present there is only a schedule, there should be other terms for what happens on the scheduled dates. Sinking fund may be bullet e.g. x% over year for y years. SF may be mandatory or contingent on some other economic event.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SpecialCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
-		<rdfs:label xml:lang="en">special call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StepDate">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
-		<rdfs:label xml:lang="en">step date</rdfs:label>
-		<skos:definition xml:lang="en">The date from which the next set of coupon terms specified in the Step Schedule takes effect.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StepEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn.2"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;StepDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;DebtFixedCouponTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">step event</rdfs:label>
-		<skos:definition xml:lang="en">The event whereby a set of fixed coupon terms comes into force as specified in the Step Schedule.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StepSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label xml:lang="en">step schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StepScheduleListing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;StepSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;StepEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">step schedule listing</rdfs:label>
-		<skos:definition xml:lang="en">A schedule of dates and interest rates which take effect on those dates. At present these are assumed to always be ficxed interest rates, and are modeled as such.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;StepSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">stepped coupon type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StubLength">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<rdfs:label xml:lang="en">stub length</rdfs:label>
-		<skos:definition xml:lang="en">The length of the Stub Period as a temporal duration (a number of days).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;TrusteeCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
-		<rdfs:label xml:lang="en">trustee call</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;VariableInterestCalculationFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationFormula"/>
-		<rdfs:label xml:lang="en">variable interest calculation formula</rdfs:label>
-		<skos:definition xml:lang="en">Formula for the calculation of variable interest.</skos:definition>
-		<skos:editorialNote xml:lang="en">This inherits all the facts about Interest Calculation Formula without alteration.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;VariableInterestExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;cap"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;floor"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">variable interest expression</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ZeroCouponAndOIDBondCallTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;includesBasisForEachDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">zero coupon and o i d bond call terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms defining the Call options for a Zero Coupon or OID Bond.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Fannie Mae also issues zero-coupon callable debt securities. Zero-coupon notes are debt securities on which no coupon interest is paid to the investor. Rather, the security is purchased at a discounted dollar price and matures at par. If the option on a callable zero-coupon security is exercised, it is redeemed at a higher dollar price than the original issue price. The yield for a callable zero-coupon security is based on the difference between the original discounted price and the principal payment at the call date.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCallRateBasis"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;RateBasisType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">zero coupon bond call</rdfs:label>
-		<skos:definition xml:lang="en">Call of a Zero Coupon bond.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ZeroCouponTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;fixedCouponAmount"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;fixedCouponAmount"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">zero coupon terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms for payment of Interest on a Bond, where this pays a zero rate of interest.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;annualCouponRate">
-		<rdfs:label xml:lang="en">annual coupon rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Original annual rate of interest payable to the lender as expressed as a percentage of principal as stated in the bond&apos;s offering documents.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;baseOffsetBusinessDays">
-		<rdfs:label xml:lang="en">base offset business days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;FRNTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of days before the coupon refix date, when the value of the underlying base is to be taken from. Also known as Lookback.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;callAmount">
-		<rdfs:label xml:lang="en">call amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The amount of the Call on the specified Call Date, expressed as a Percentage either of Par or of CAV.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;callConditions">
-		<rdfs:label xml:lang="en">call conditions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The conditions under which a bond can be called back by the issuer.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;callPrice">
-		<rdfs:label xml:lang="en">call price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The amount of the Call on the specified Call Date, expressed as a Percentage.</skos:definition>
-		<skos:definition xml:lang="en">The amount of the Call on the specified Call Date, expressed as a Percentage. This is the price a bond issuer or preferred stock issuer must pay investors if it wants to buy back, or call, all or part of an issue before the maturity date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;callableOnlyForTaxReasons">
-		<rdfs:label xml:lang="en">callable only for tax reasons</rdfs:label>
-		<terms:description xml:lang="en">whether the bond is callable only for tax reasons</terms:description>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;cap">
-		<rdfs:label xml:lang="en">cap</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;VariableInterestExpression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;condition">
-		<rdfs:label xml:lang="en">condition</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponConditionalTerm"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The condition under which the given coupon is payable. This is stated as text.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;couponAmount">
-		<rdfs:label xml:lang="en">coupon amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPayment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;couponFrequencyForAccrualCalculations">
-		<rdfs:label xml:lang="en">coupon frequency for accrual calculations</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">The frequency to be used in the calculation of accruals. Supersedes the Coupon Payment Frequency.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;couponPaymentCurrency">
-		<rdfs:label xml:lang="en">coupon payment currency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which interest payment is to be made.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;couponPaymentFrequency">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbt-cft;interestPaymentFrequency"/>
-		<rdfs:label xml:lang="en">coupon payment frequency</rdfs:label>
-		<terms:description xml:lang="en">the established frequency for the interest payment on a bond</terms:description>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;firstCouponDate">
-		<rdfs:label xml:lang="en">first coupon date</rdfs:label>
-		<terms:description xml:lang="en">the first date on which the issuer or its agent expects or commits to make a coupon payment</terms:description>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The first coupon payment period can be long or short when this date doesn&apos;t coincide with the start of a normal coupon payment period.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;fixedCouponAmount">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;annualCouponRate"/>
-		<rdfs:label xml:lang="en">fixed coupon amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtFixedCouponTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Fixed interest payment amount due on each Interest Payment Date. This is derived from the Annual Coupon Rate.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;floor">
-		<rdfs:label xml:lang="en">floor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;VariableInterestExpression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasCallCalendarType">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
-		<rdfs:label xml:lang="en">has call calendar type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;CalendarType"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasCallRateBasis">
-		<rdfs:label xml:lang="en">has call rate basis</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;RateBasisType"/>
-		<skos:definition xml:lang="en">For each call event on the schedule: whether the rate is expressed as a % of Par or % of CAV. Zero coupon bonds and OID bonds are callable at an accreted value.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasCallRedemptionType">
-		<rdfs:label xml:lang="en">has call redemption type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;PartialCall"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
-		<skos:definition xml:lang="en">Whether the call will be executed by Lottery or Pro-Rata.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasCouponStructureTerms">
-		<rdfs:label>has coupon structure terms</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasEntireOrPartialCallChoice">
-		<rdfs:label xml:lang="en">has entire or partial call choice</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;EntireOrPartialCallChoice"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasExerciseType">
-		<rdfs:label xml:lang="en">has exercise type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasExtraordinaryRedemptionMethod">
-		<rdfs:label xml:lang="en">has extraordinary redemption method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondExtraordinaryRedemption"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasFormulaTerm.1">
-		<rdfs:label xml:lang="en">has formula term</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;VariableInterestCalculationFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasFormulaTerm.2">
-		<rdfs:label xml:lang="en">has formula term</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;PrincipalPaymentCalculationFormula"/>
-		<skos:definition xml:lang="en">The term setting out the formula for calculating the principal paydown amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasInflationBondFactor">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;specifiesBaseRate"/>
-		<rdfs:label xml:lang="en">has inflation bond factor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasLength">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
-		<rdfs:label xml:lang="en">has length</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponStubPeriodDuration"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;StubLength"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasParameter">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbt-cft;hasMarginParameter"/>
-		<rdfs:label xml:lang="en">has parameter</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestExpression"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasPercentage">
-		<rdfs:label xml:lang="en">has percentage</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasPeriodicDateSeries">
-		<rdfs:label xml:lang="en">has periodic date series</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponScheduleSpecification"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponPeriodicDateSeries"/>
-		<skos:definition xml:lang="en">Periodic regular Coupon payments in the Coupon Schedule.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasPrincipalRepaymentTerms">
-		<rdfs:label>has principal repayment terms</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasSchedule">
-		<rdfs:label xml:lang="en">has schedule</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;StepSchedule"/>
-		<skos:definition xml:lang="en">The schedule of dates and interest amounts applicable from those dates, forming part of the terms of the Stepped Coupon.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasTermForOneCoupon">
-		<rdfs:label xml:lang="en">has term for one coupon</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ConditionalCouponTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponConditionalTerm"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;includes">
-		<rdfs:label xml:lang="en">includes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;SinkingFundAmortizationTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
-		<skos:definition xml:lang="en">The schedule for payment of scheduled amounts of principal on pre-defined dates.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;includesBasisForEachDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;schedulesPossibleEvent"/>
-		<rdfs:label xml:lang="en">includes basis for each date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponAndOIDBondCallTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;includesSchedule">
-		<rdfs:label xml:lang="en">includes schedule</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtBermudanCallExerciseType"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;interestAmount">
-		<rdfs:label xml:lang="en">interest amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestExpression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The percentage fixed amount of the Interest.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;isMandatory">
-		<rdfs:label xml:lang="en">is mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondExtraordinaryRedemption"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;isOptional">
-		<rdfs:label xml:lang="en">is optional</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondExtraordinaryRedemption"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;lockoutPeriod">
-		<rdfs:label xml:lang="en">lockout period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">The lockout period refers to the amount of time for which a callable security cannot be called and only interest coupon payments are received by the security holder. For example, with a 10-year noncall 3-year (&quot;10nc3&quot;) debt security, the security cannot be called for the first three years.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;makeWholeCallBasisPointSpread">
-		<rdfs:label xml:lang="en">make whole call basis point spread</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MakeWholeCall"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;makeWholeTreasuryItem">
-		<rdfs:label xml:lang="en">make whole treasury item</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MakeWholeCall"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;mandatory">
-		<rdfs:label xml:lang="en">mandatory</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;SinkingFundAmortizationTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the SF is mandatory or conditional on some event (No means conditional)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;mandatorySinkingFund">
-		<rdfs:label xml:lang="en">mandatory sinking fund</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Yes indicates there is a Mandatory Sinking fund feature.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;occursOn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
-		<rdfs:label xml:lang="en">occurs on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPayment"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPaymentDate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;occursOn.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
-		<rdfs:label xml:lang="en">occurs on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPayment"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPaymentDate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;occursOn.2">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
-		<rdfs:label xml:lang="en">occurs on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;StepEvent"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;StepDate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;periodicAmortizationAmount">
-		<rdfs:label xml:lang="en">periodic amortization amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The monetary amount of each amortization payment in the Amortization Schedule.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;premium">
-		<rdfs:label xml:lang="en">premium</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A premium paid to the bond owner when the bond is called.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;redemptionAmount">
-		<rdfs:label xml:lang="en">redemption amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPayment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The amountof the principal paid with this redemption payment.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;regularCallFrequency">
-		<rdfs:label xml:lang="en">regular call frequency</rdfs:label>
-		<terms:description xml:lang="en">the frequency of the periods in which redemption is scheduled to occur per year</terms:description>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ParametricCallSchedule"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;regularPeriodDays">
-		<rdfs:label xml:lang="en">regular period days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponRegularPeriodLength"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of days in coupon period in the series.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;regularPeriodDuration">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;hasPeriodDuration"/>
-		<rdfs:label xml:lang="en">regular period duration</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponPeriodicDateSeries"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponRegularPeriod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;resetDateOffsetDays">
-		<rdfs:label xml:lang="en">reset date offset days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of days from the Coupon Payment Date that the Coupon Rate is reset. Offset - Relative date e.g. 2 days before Rate rest may be the Fixing date. Payment is separate from this, so this is an Accrual term. Payment dates may also be specified relative to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;scheduledCouponPayment">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;schedules"/>
-		<rdfs:label xml:lang="en">scheduled coupon payment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponScheduleSpecification"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponPayment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;schedulesCallOfIssue">
-		<rdfs:label xml:lang="en">schedules call of issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtEuropeanCallExerciseType"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;schedulesMandatoryEvent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
-		<rdfs:label xml:lang="en">schedules mandatory event</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundScheduleListing"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;schedulesPossibleCallOfIssue">
-		<rdfs:label xml:lang="en">schedules possible call of issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtAmericanCallExerciseType"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;schedulesPossibleEvent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
-		<rdfs:label xml:lang="en">schedules possible event</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CallScheduleListing"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specialRecordDate">
-		<rdfs:label xml:lang="en">special record date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">The record date associated with an odd first interest payment date that occurs before the start of the normal accrual cycle.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specifies.1">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specifiesBaseRate">
-		<rdfs:label xml:lang="en">specifies base rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-		<skos:definition xml:lang="en">The variable parameter specified in the variable terms, for the Base value in calculating variable interest rates. Note: this is also identified as the &quot;Operand&quot; for the Base part of the Formula which is included in these Terms.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specifiesIndexParameter">
-		<rdfs:label xml:lang="en">specifies index parameter</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
-		<skos:definition xml:lang="en">The term specified in the formula for determination of principal paydown amounts.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specifiesTerms">
-		<rdfs:label xml:lang="en">specifies terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;stubDays">
-		<rdfs:label xml:lang="en">stub days</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;StubLength"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Length in days of the irregular Stub period.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;superSinker">
-		<rdfs:label xml:lang="en">super sinker</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">A colloquial term for a term maturity, usually from a single family mortgage revenue issue with several term maturities, that will be the first to be called from a sinking fund into which all proceeds from prepayments of mortgages financed by the issue are deposited.  The maturity&apos;s priority status under the call provisions means that it is likely to be redeemed in its entirety well before the stated maturity date.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-der-der-ex="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
+buxmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
+buxmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
+buxmlns:fibo-sec-secx-schx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BondsCashflowTerms</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">This ontology defines the cashflow terms for bonds, both for interest payment and for principal repayment (including calls and puts). 
+		The terms in this ontology need to be elevated to a point higher up in the model where similar terms for loans may also be derived. At that point the terms in this ontology should also be aligned or mapped to the corresponding terms in the ACTUS de facto standard.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasPrincipalAmortizationType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond amortization payment terms</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond bullet principal repayment terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for payment of Principal as a single amount of payment of the full Principal.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondCallTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;premium"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond call terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The terms and conditions in which a bond can be redeemed by the issuer prior to its maturity. Usually a premium is paid to the bond owner when the bond is called.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Also known as a &quot;redeemable bond&quot;. The main cause of a call is a decline in interest rates. If interest rates have declined since a company first issued the bonds, it will likely want to refinance this debt at a lower rate of interest. The company will call its current bonds and reissue them at a lower rate of interest. The maturity date of a callable debt instrument is the latest and final possible date at which the security will be retired and principal will be redeemed at par. Conesnsus:Review</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;couponPaymentCurrency"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond coupon interest terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for payment of Interest on a Bond. These include terms for determining interest amounts, and terms for dates on which those amounts are to be paid.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For stepped coupons, several set of this information may exist, with these coming into force.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondCouponStructureType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifies.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond coupon structure type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of contractual terms defining the interest payments for a coupon of a bond, beginning with terms describing stepped or conditional coupon structures if these exist.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Multiple sets of Interest Payment Terms may exist for one Security. This covers for example Step-up interest features.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondExtraordinaryRedemption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasExtraordinaryRedemptionMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond extraordinary redemption</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond principal repayment terms set</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for the repayment of the Principal on a Bond security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date on which the instrument may be called.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallOfIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;RedemptionEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCallCalendarType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;CalendarType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call of issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The calling back of an Issue of a Traded Security by the Issuer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call schedule</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">The list of dates on which a fixed-income security can be redeemed prior to maturity by the issuer; also includes the corresponding call prices.</terms:description>
+bubu<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&rdf;langString" xml:lang="en">https://www.fidelity.com/glossary/overview</fibo-fnd-utl-av:definitionOrigin>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallScheduleListing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;schedulesPossibleEvent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call schedule listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Schedule of dates on which a Traded Security can be Called (recalled) by the Issuer.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is not the same as similarly named terms within a derivative security.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CallType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Way in which a call will be executed, which is by Lottery or Pro-Rata.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ClawBackCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">claw back call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ConditionalCouponTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasTermForOneCoupon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponConditionalTerm"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conditional coupon type</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;SingleCouponTermsSet"/>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ControlledAmortizationStructure">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">controlled amortization structure</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">a method of providing investors with a relatively predictable repayment schedule, even though the underlying assets are nonamortizing</terms:description>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponConditionalTerm">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon conditional term</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A term in the conditional coupon terms which matches one set of coupon terms (fixed rate or variable coupon) with one condition.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponPayment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon payment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The event whereby a coupon amount is paid or is to be paid.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponPeriodicDateSeries">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;PeriodicDateSeries"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;regularPeriodDuration"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponRegularPeriod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon periodic date series</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Periodic dates on which Interest Payments are made.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponRegularPeriod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponRegularPeriodLength"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon regular period</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The regular periodic component of a coupon schedule.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponRegularPeriodLength">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon regular period length</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Length of a regular periodic component of a coupon schedule.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon schedule</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Schedule for regular payment of Coupon Amounts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponScheduleSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CouponSchedule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasStub"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponStubPeriod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasStub"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cft;CouponStubPeriod"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;scheduledCouponPayment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponPayment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon schedule specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal specification of the Schedule for regular payment of Coupon Amounts.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">(from Algo review Oct 09) May need to add information about at which stage in the process you have received the information about the date e.g. whether the date you are looking at has been rolled back or needs to be rolled back. CONTEXT: add this detail in the context of trading or other consumption of data.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponStubEndDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon stub end date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The calendar date when the coupon stub period is scheduled to end.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponStubPeriod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ScheduleStub"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon stub period</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Irregular Coupon Period at the start and / or the end of the Coupon Schedule, which does not fall into the Periodic Date Series.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponStubPeriodDuration">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDuration"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasLength"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;StubLength"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon stub period duration</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Stub Period as a temporal duration.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;CouponStubStartDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;KnownDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon stub start date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The calendar date when the coupon stub period is scheduled to start.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DanishBorrowerCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">danish borrower call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtAmericanCallExerciseType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;AmericanExerciseConvention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt american call exercise type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtBermudanCallExerciseType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;BermudaExerciseConvention"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;includesSchedule"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt bermudan call exercise type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtEuropeanCallExerciseType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-der-der-ex;EuropeanExerciseConvention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt european call exercise type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtFixedCouponTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;fixedCouponAmount"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasFormula"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestCalculationFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond fixed coupon terms set</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for payment of Interest on a Bond, where this pays a fixed rate of interest.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesBaseRate"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasFormula"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;VariableInterestCalculationFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond variable coupon terms set</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;EntireCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">entire call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;EntireOrPartialCallChoice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">entire or partial call choice</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ExplicitCouponScheduleListing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CouponSchedule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasPeriodicDateSeries"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CouponPeriodicDateSeries"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPayment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">explicit coupon schedule listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Schedule of itemised coupon payment dates.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">extraordinary redemption method</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FRNTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesBaseRate"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-md-dbtx-int;DebtInstrumentReferenceRate">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/ReferenceInterestRate">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">f r n terms set</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedCouponTermsSet"/>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out the interest payments determination and dates for Flating Rate Note interest.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FirstRegularCouponDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;ContractuallyDeterminedDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first regular coupon date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The scheduled date of the first regular coupon payment, that is the start of payments according to a regular repeating series of coupon periods, after any non standard (long or short) first coupon period in the schedule.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FixedInterestAmount">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;Margin"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed interest amount</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Fixed Interest amount which is the parameter of the Expression. This is the only parameter in this expression.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This duplicates the simple fact &quot;Interest Amount&quot; in the Fixed Interest expression and is essentially redundant. It is included only to show how the parameter relationship for Interst Calculation Expression is specialized (and thereby overridden) for the Fixed Interest Expression.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FixedInterestCalculationFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationFormula"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed interest calculation formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formula for Fixed Interest.</skos:definition>
+bubu<fibo-fnd-utl-av:usageNote rdf:datatype="&rdf;langString" xml:lang="en">This limits the more general interest calculation formula, for fixed interest rates. Alternatively this formula can be ignored and the interest rate specified directly as a value in the Interest Terms. It is provided here for completeness.</fibo-fnd-utl-av:usageNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;FixedInterestExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasParameter"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed interest expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Expression of the value of a fixed interest amount.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is a numerical amount only. The operand Base does not exist and the Margin operand is over-ridden by the single property Interest Amount here, i.e. this sub-class of Interest Calculation Expression restricts those operands by not having them (this cannot be shown graphically).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;HoldersOptionCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holders option call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;IndexLinkedCouponTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesBaseRate"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/EconomicIndicator"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index linked coupon terms set</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasFormulaTerm.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;PrincipalPaymentCalculationFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesIndexParameter"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index linked principal determination terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for payment of the principal. These link the principal amounts to some underlying index or interest rate.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Terms are linked to the calculation of the factor - see definition for Inflation Bond. This has been renamed from Principal Repayment Terms to Principal Determination Terms, since further review indicates a term whereby the principal amount itself varies, and this is borne out by the notes made at the original review, where this was mislabeled.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasInflationBondFactor"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation bond variable coupon terms set</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;IssuersOptionCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuers option call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;LastRegularCouponDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;ContractuallyDeterminedDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">last regular coupon date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The scheduled date of the last regular coupon payment, that is the last of the payments that are made according to a regular repeating series of coupon periods, before any non standard (long or short) last coupon period in the schedule.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;LotteryCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lottery call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;MakeWholeCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">make whole call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;MandatorySinkingFundSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory sinking fund schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;MandatorySinkingFundScheduleListing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundSchedule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;schedulesMandatoryEvent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory sinking fund schedule listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A full schedule of dates and payments for a Mandatory Sinking Fund style of Call.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;includes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory sinking fund description</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms relating to a Mandatory Sinking Fund call of the issue.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ParametricCallSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-schx;schedules"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">parametric call schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PartialCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCallRedemptionType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partial call</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">a call of part of the issue</terms:description>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PartialCallAllocation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partial call allocation</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PartialCallFeature">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partial call feature</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">These are terms whereby the issuer can recall part of the issue on scheduled dates but there is no specific amount defined for those dates. Consenus:Yes</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PercentageCAV">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RateBasisType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage c a v</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Percentage specified as percent of CAV (Cumulative Average Value)</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PercentagePar">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RateBasisType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">percentage par</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Figure specified as a percentage of Par Value</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PrincipalPaymentCalculationFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasExpression"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;PrincipalPaymentFormulaExpression"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">principal payment calculation formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A formula for calculation of principal payments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;PrincipalPaymentFormulaExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">principal payment formula expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The expression of the formula by which the payment of principal is formally described.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Determine what these can be at the next review and model accordingly. For example, presume this is a base parameter plus a margin percentage, similar to interest payment calculation formula expressions.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ProRataCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pro rata call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RateBasisType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Method"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">rate basis type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The type of basis for a percentage quoted figure, as used in specifying Bond Call percentage amounts. REVIEW: Does this same meaningful term have wider applicability?</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionByBondNumber">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption by bond number</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionByLot">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption by lot</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionInInverseOrder">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption in inverse order</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;RedemptionEvent"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPaymentDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption payment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionPaymentDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption payment date</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RedemptionScheduleListing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPayment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption schedule listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Schedule for payments of defined amounts of the Principal on a Debt Security.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Terms for dates and amounts to be added.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RegularCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regular call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;RegulatoryCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regulatory call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ScheduledCouponPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPaymentDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheduled coupon payment</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ScheduledCouponPaymentDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheduled coupon payment date</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SerialNumberCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">serial number call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SingleCouponTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">single coupon type</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A set of coupon terms which remain the same through the life of the Bond. This is the default and is the case when there is not a Step Coupon or Conditional Coupon.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SinkingFundAmortizationTermsSet">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;includes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">published sinking fund amortization terms description</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for the paydown of principal in a sinking fund type of amortizing security.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">At present there is only a schedule, there should be other terms for what happens on the scheduled dates. Sinking fund may be bullet e.g. x% over year for y years. SF may be mandatory or contingent on some other economic event.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SpecialCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">special call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StepDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">step date</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The date from which the next set of coupon terms specified in the Step Schedule takes effect.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StepEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;occursOn.2"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;StepDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;DebtFixedCouponTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">step event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The event whereby a set of fixed coupon terms comes into force as specified in the Step Schedule.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StepSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">step schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StepScheduleListing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;StepSchedule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;StepEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">step schedule listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A schedule of dates and interest rates which take effect on those dates. At present these are assumed to always be ficxed interest rates, and are modeled as such.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasSchedule"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;StepSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stepped coupon type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;StubLength">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stub length</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The length of the Stub Period as a temporal duration (a number of days).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;TrusteeCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;EntireCall"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trustee call</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;VariableInterestCalculationFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationFormula"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">variable interest calculation formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formula for the calculation of variable interest.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This inherits all the facts about Interest Calculation Formula without alteration.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;VariableInterestExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;cap"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;floor"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">variable interest expression</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ZeroCouponAndOIDBondCallTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;includesBasisForEachDate"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">zero coupon and o i d bond call terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms defining the Call options for a Zero Coupon or OID Bond.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Fannie Mae also issues zero-coupon callable debt securities. Zero-coupon notes are debt securities on which no coupon interest is paid to the investor. Rather, the security is purchased at a discounted dollar price and matures at par. If the option on a callable zero-coupon security is exercised, it is redeemed at a higher dollar price than the original issue price. The yield for a callable zero-coupon security is based on the difference between the original discounted price and the principal payment at the call date.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCallRateBasis"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;RateBasisType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">zero coupon bond call</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Call of a Zero Coupon bond.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cft;ZeroCouponTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;fixedCouponAmount"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;fixedCouponAmount"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">zero coupon terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for payment of Interest on a Bond, where this pays a zero rate of interest.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;annualCouponRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">annual coupon rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Original annual rate of interest payable to the lender as expressed as a percentage of principal as stated in the bond&apos;s offering documents.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;baseOffsetBusinessDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">base offset business days</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;FRNTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of days before the coupon refix date, when the value of the underlying base is to be taken from. Also known as Lookback.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;callAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of the Call on the specified Call Date, expressed as a Percentage either of Par or of CAV.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;callConditions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call conditions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The conditions under which a bond can be called back by the issuer.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;callPrice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">call price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of the Call on the specified Call Date, expressed as a Percentage.</skos:definition>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amount of the Call on the specified Call Date, expressed as a Percentage. This is the price a bond issuer or preferred stock issuer must pay investors if it wants to buy back, or call, all or part of an issue before the maturity date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;callableOnlyForTaxReasons">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">callable only for tax reasons</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">whether the bond is callable only for tax reasons</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;cap">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cap</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;VariableInterestExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;condition">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">condition</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponConditionalTerm"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The condition under which the given coupon is payable. This is stated as text.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;couponAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;couponFrequencyForAccrualCalculations">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon frequency for accrual calculations</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The frequency to be used in the calculation of accruals. Supersedes the Coupon Payment Frequency.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;couponPaymentCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon payment currency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which interest payment is to be made.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;couponPaymentFrequency">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbt-cft;interestPaymentFrequency"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">coupon payment frequency</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">the established frequency for the interest payment on a bond</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;firstCouponDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">first coupon date</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">the first date on which the issuer or its agent expects or commits to make a coupon payment</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The first coupon payment period can be long or short when this date doesn&apos;t coincide with the start of a normal coupon payment period.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;fixedCouponAmount">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;annualCouponRate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed coupon amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtFixedCouponTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Fixed interest payment amount due on each Interest Payment Date. This is derived from the Annual Coupon Rate.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;floor">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;VariableInterestExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasCallCalendarType">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has call calendar type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;CalendarType"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasCallRateBasis">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has call rate basis</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;RateBasisType"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">For each call event on the schedule: whether the rate is expressed as a % of Par or % of CAV. Zero coupon bonds and OID bonds are callable at an accreted value.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasCallRedemptionType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has call redemption type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;PartialCall"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the call will be executed by Lottery or Pro-Rata.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasCouponStructureTerms">
+bubu<rdfs:label>has coupon structure terms</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasEntireOrPartialCallChoice">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has entire or partial call choice</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;EntireOrPartialCallChoice"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasExerciseType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has exercise type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-der-der-ex;ExerciseDatesConvention"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasExtraordinaryRedemptionMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has extraordinary redemption method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondExtraordinaryRedemption"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ExtraordinaryRedemptionMethod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasFormulaTerm.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has formula term</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;VariableInterestCalculationFormula"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasFormulaTerm.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has formula term</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;PrincipalPaymentCalculationFormula"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The term setting out the formula for calculating the principal paydown amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasInflationBondFactor">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;specifiesBaseRate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has inflation bond factor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasLength">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;describedInCalendarTermsBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has length</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponStubPeriodDuration"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;StubLength"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasParameter">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbt-cft;hasMarginParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has parameter</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasPercentage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has percentage</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallAllocation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasPeriodicDateSeries">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has periodic date series</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponScheduleSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponPeriodicDateSeries"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Periodic regular Coupon payments in the Coupon Schedule.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasPrincipalRepaymentTerms">
+bubu<rdfs:label>has principal repayment terms</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has schedule</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;StepSchedule"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The schedule of dates and interest amounts applicable from those dates, forming part of the terms of the Stepped Coupon.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;hasTermForOneCoupon">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has term for one coupon</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ConditionalCouponTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponConditionalTerm"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;includes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;SinkingFundAmortizationTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionSchedule"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The schedule for payment of scheduled amounts of principal on pre-defined dates.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;includesBasisForEachDate">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;schedulesPossibleEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes basis for each date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponAndOIDBondCallTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponBondCall"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;includesSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes schedule</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtBermudanCallExerciseType"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;interestAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;FixedInterestExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The percentage fixed amount of the Interest.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;isMandatory">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is mandatory</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondExtraordinaryRedemption"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;isOptional">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is optional</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondExtraordinaryRedemption"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;lockoutPeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lockout period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The lockout period refers to the amount of time for which a callable security cannot be called and only interest coupon payments are received by the security holder. For example, with a 10-year noncall 3-year (&quot;10nc3&quot;) debt security, the security cannot be called for the first three years.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;makeWholeCallBasisPointSpread">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">make whole call basis point spread</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MakeWholeCall"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;makeWholeTreasuryItem">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">make whole treasury item</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MakeWholeCall"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;mandatory">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;SinkingFundAmortizationTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the SF is mandatory or conditional on some event (No means conditional)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;mandatorySinkingFund">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandatory sinking fund</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Yes indicates there is a Mandatory Sinking fund feature.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;occursOn">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">occurs on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPaymentDate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;occursOn.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">occurs on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ScheduledCouponPaymentDate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;occursOn.2">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">occurs on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;StepEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;StepDate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;periodicAmortizationAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">periodic amortization amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The monetary amount of each amortization payment in the Amortization Schedule.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;premium">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">premium</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A premium paid to the bond owner when the bond is called.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;redemptionAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">redemption amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;RedemptionPayment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amountof the principal paid with this redemption payment.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;regularCallFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regular call frequency</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">the frequency of the periods in which redemption is scheduled to occur per year</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;ParametricCallSchedule"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;regularPeriodDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regular period days</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponRegularPeriodLength"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of days in coupon period in the series.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;regularPeriodDuration">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;hasPeriodDuration"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">regular period duration</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponPeriodicDateSeries"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponRegularPeriod"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;resetDateOffsetDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">reset date offset days</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of days from the Coupon Payment Date that the Coupon Rate is reset. Offset - Relative date e.g. 2 days before Rate rest may be the Fixing date. Payment is separate from this, so this is an Accrual term. Payment dates may also be specified relative to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;scheduledCouponPayment">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;schedules"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheduled coupon payment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CouponScheduleSpecification"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponPayment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;schedulesCallOfIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">schedules call of issue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtEuropeanCallExerciseType"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;schedulesMandatoryEvent">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">schedules mandatory event</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundScheduleListing"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;schedulesPossibleCallOfIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">schedules possible call of issue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtAmericanCallExerciseType"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;schedulesPossibleEvent">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">schedules possible event</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;CallScheduleListing"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CallOfIssue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specialRecordDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">special record date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The record date associated with an odd first interest payment date that occurs before the start of the normal accrual cycle.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specifies.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;CouponSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specifiesBaseRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies base rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The variable parameter specified in the variable terms, for the Base value in calculating variable interest rates. Note: this is also identified as the &quot;Operand&quot; for the Base part of the Formula which is included in these Terms.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specifiesIndexParameter">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies index parameter</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The term specified in the formula for determination of principal paydown amounts.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;specifiesTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;stubDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stub days</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;StubLength"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Length in days of the irregular Stub period.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cft;superSinker">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">super sinker</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A colloquial term for a term maturity, usually from a single family mortgage revenue issue with several term maturities, that will be the first to be called from a sinking fund into which all proceeds from prepayments of mortgages financed by the issue are deposited.  The maturity&apos;s priority status under the call provisions means that it is likely to be redeemed in its entirety well before the stated maturity date.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/Bonds/BondsCashflowVariants.rdf
+++ b/sec/Debt/Bonds/BondsCashflowVariants.rdf
@@ -1,571 +1,574 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
-	<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
-	<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-	<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-	<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
-	<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
+bu<!ENTITY fibo-md-temx-tem "https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/">
+bu<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bu<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bu<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
+bu<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
-	xmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
-	xmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
-	xmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
-		<rdfs:label xml:lang="en">BondsCashflowVariants</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;bondHasCoupon">
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;AmortizingSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">amortizing bond</rdfs:label>
-		<terms:description xml:lang="en">A bond with terms mandating amortization of the principal</terms:description>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cfv;BulletBond"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;BondWithMandatorySinkingFund">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;mandatesSinkingFundAsDescribedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond with mandatory sinking fund</rdfs:label>
-		<skos:definition xml:lang="en">Bonds where the amortizing is via a sinking fund the details of which are mandated in the terms of the bond itself.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;BondWithPublishedSinkingFund">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
-		<rdfs:label xml:lang="en">bond with published sinking fund</rdfs:label>
-		<terms:description xml:lang="en">Bonds where the amortizing is via a known and published schedule.</terms:description>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;BulletBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasRepaymentTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bullet bond</rdfs:label>
-		<skos:definition xml:lang="en">A bond where the principal is paid off in a single payment on the scheduled maturity date.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;ControlledAmortizationBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ControlledAmortizationStructure"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">controlled amortization bond</rdfs:label>
-		<terms:description xml:lang="en">bond that is securitized using a controlled amortization structure</terms:description>
-		<fibo-fnd-utl-av:adaptedFrom xml:lang="en">http://www.investinginbonds.com/learnmore.asp?catid=11&amp;subcatid=57&amp;id=15</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Revolving debt (primarily credit card receivables, but also HELOCs, trade receivables, dealer floor-plan loans and some leases) may be securitized using a controlled amortization structure. This is a method of providing investors with a relatively predictable repayment schedule, even though the underlying assets are nonamortizing. Controlled-amortization ABS resemble corporate bonds with a sinking fund. After a predetermined “revolving” period during which only interest payments are made, these securities attempt to return principal to investors in a series of defined periodic payments that usually occur over less than a year. A risk inherent in this kind of ABS is an early amortization event. (See “Early-Amortization Risk,” on page 20.)</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;FixedCouponBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
-				<owl:onClass rdf:resource="&fibo-md-dbtx-int;BondFixedCoupon"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;BondFixedCoupon"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;hasCouponInterestTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;DebtFixedCouponTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">fixed coupon bond</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
-		<skos:definition xml:lang="en">A bond which pays a fixed rate of interest at regular intervals.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;FloatingRateNote">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;FRNCoupon"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasCouponVariableInterestTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;FRNTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">floating rate note</rdfs:label>
-		<skos:definition xml:lang="en">A bond with a variable interest rate based on a published bank interest rate. The adjustments to the interest rate (coupon) are made periodically, usually on a quarterly or monthly basis, and are tied to a certain money-market index. Also known as a &quot;floater&quot;.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For example six months USD LIBOR + 0.20%.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;FullyAmortizingBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
-		<rdfs:label xml:lang="en">fully amortizing bond</rdfs:label>
-		<terms:description xml:lang="en">Securities that return principal to investors throughout the life of the security are said to be fully amortizing. They are designed to closely reflect the full repayment of the underlying loans through scheduled interest and principal payments.</terms:description>
-		<fibo-fnd-utl-av:definitionOrigin xml:lang="en">http://www.investinginbonds.com/learnmore.asp?catid=11&amp;subcatid=57&amp;id=15</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are typically backed by HELs, auto loans, manufactured-housing contracts and other fully amortizing assets. Prepayment risk is a key consideration with such ABS, although the rate of prepayment may vary considerably by the type of underlying asset.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;IndexAmortizingBond">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">index amortizing bond</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;IndexBasedCouponBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;IndexLinkedCoupon"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasCouponVariableInterestTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedCouponTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">index based coupon bond</rdfs:label>
-		<skos:definition xml:lang="en">A security where the coupon payments fluctuate according to an &quot;Index&quot; in the sense of non Interest rate e.g. inflation rate, GDP.</skos:definition>
-		<skos:editorialNote xml:lang="en">Might also be referred to as Index Linked, but more commonly the term Index Linked refers to principal. So this term has a made up name for this kind of bond, following OTPP review in which we dealt with the distinction between index linked interest and index linked principal amounts. .</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;IndexLinkedSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;VariablePrincipalBond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;isBasedOn"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">index linked security</rdfs:label>
-		<skos:definition xml:lang="en">A bond in which payment of income on the principal is related to a specific price index, such as the Consumer Price Index.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This feature provides protection to investors by shielding them from changes in the underlying index. The bond&apos;s cash flows are adjusted to ensure that the holder of the bond receives a known real rate of return. Notes 04 May: There may also be a kind of security where the coupon payments fluctuate according to an &quot;Index&quot; in the sense of non Interest rate e.g. inflation rate, GDP. But more commonly the term Index Linked refers to principal.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;IndexLinkedSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;specifiesCoupon"/>
-				<owl:onClass rdf:resource="&fibo-md-dbtx-int;InflationBondVariableCoupon"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;hasFactor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasCouponVariableInterestTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasInterestPaymentTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondInterestPaymentTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalBasedOn"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation bond</rdfs:label>
-		<skos:definition xml:lang="en">A bond where the principal amount is linked to an index.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Refers to an Inflation Index. This is used to define the factor or multiplier for the bond, that is the factor that you multiply the bond by. How this works is that you take the inflation rate when the security was issued, and the inflation rate at the present. The difference between these becomes the Factor, e.g. 100% -&amp;gt; 101% gives 1% so for example for a $1000 issue - calculate the principal on which the interest is paid AND the principal from the point of view of how the principal is repaid. Some inflation bonds only do this on interest, some only on interest, but most apply it to the principal and interest. Coupon interest calculated based on the adjusted amount of the bond. so a fixed coupon rate is multiplied by e.g. 1010 in the example above. Variations e.g. Italy - daily published factor published for that bond, whereas other calculate based on underlying index. Typically a CPI or a statistical number generated by the govt. typically a lagging three month index. See UK bonds on this. US and Japanese ones - look at inflation rate 3 months prior. Unlike an Amortizing Security this principal value of the bond is increasing, whereas for and Amortizing, the principal is decreasing. In Canada, these are also referred to as &quot;real return bonds&quot;. 
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
+buxmlns:fibo-md-temx-tem="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"
+buxmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
+buxmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
+buxmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
+buxmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BondsCashflowVariants</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">This ontology defines categories of bond according to variations in their cashflow behavior both for interest and for principal repayment. These includes fixed coupon versus floating rate notes, bullet versus amortizing securities, zero coupon, inflation bonds and bonds which take on different coupon payment behaviors at different times or under different conditions.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/TemporalConcepts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-md-dbtx-int;bondHasCoupon">
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;AmortizingSecurity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">amortizing bond</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">A bond with terms mandating amortization of the principal</terms:description>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cfv;BulletBond"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;BondWithMandatorySinkingFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;mandatesSinkingFundAsDescribedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond with mandatory sinking fund</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Bonds where the amortizing is via a sinking fund the details of which are mandated in the terms of the bond itself.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;BondWithPublishedSinkingFund">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond with published sinking fund</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">Bonds where the amortizing is via a known and published schedule.</terms:description>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;BulletBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasRepaymentTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bullet bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond where the principal is paid off in a single payment on the scheduled maturity date.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;ControlledAmortizationBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ControlledAmortizationStructure"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">controlled amortization bond</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">bond that is securitized using a controlled amortization structure</terms:description>
+bubu<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&rdf;langString" xml:lang="en">http://www.investinginbonds.com/learnmore.asp?catid=11&amp;subcatid=57&amp;id=15</fibo-fnd-utl-av:adaptedFrom>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Revolving debt (primarily credit card receivables, but also HELOCs, trade receivables, dealer floor-plan loans and some leases) may be securitized using a controlled amortization structure. This is a method of providing investors with a relatively predictable repayment schedule, even though the underlying assets are nonamortizing. Controlled-amortization ABS resemble corporate bonds with a sinking fund. After a predetermined “revolving” period during which only interest payments are made, these securities attempt to return principal to investors in a series of defined periodic payments that usually occur over less than a year. A risk inherent in this kind of ABS is an early amortization event. (See “Early-Amortization Risk,” on page 20.)</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;FixedCouponBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
+bubububu<owl:onClass rdf:resource="&fibo-md-dbtx-int;BondFixedCoupon"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;BondFixedCoupon"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;hasCouponInterestTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;DebtFixedCouponTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fixed coupon bond</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond which pays a fixed rate of interest at regular intervals.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;FloatingRateNote">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;FRNCoupon"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasCouponVariableInterestTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;FRNTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">floating rate note</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond with a variable interest rate based on a published bank interest rate. The adjustments to the interest rate (coupon) are made periodically, usually on a quarterly or monthly basis, and are tied to a certain money-market index. Also known as a &quot;floater&quot;.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For example six months USD LIBOR + 0.20%.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;FullyAmortizingBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fully amortizing bond</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">Securities that return principal to investors throughout the life of the security are said to be fully amortizing. They are designed to closely reflect the full repayment of the underlying loans through scheduled interest and principal payments.</terms:description>
+bubu<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&rdf;langString" xml:lang="en">http://www.investinginbonds.com/learnmore.asp?catid=11&amp;subcatid=57&amp;id=15</fibo-fnd-utl-av:definitionOrigin>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are typically backed by HELs, auto loans, manufactured-housing contracts and other fully amortizing assets. Prepayment risk is a key consideration with such ABS, although the rate of prepayment may vary considerably by the type of underlying asset.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;IndexAmortizingBond">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index amortizing bond</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;IndexBasedCouponBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;IndexLinkedCoupon"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasCouponVariableInterestTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedCouponTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index based coupon bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security where the coupon payments fluctuate according to an &quot;Index&quot; in the sense of non Interest rate e.g. inflation rate, GDP.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Might also be referred to as Index Linked, but more commonly the term Index Linked refers to principal. So this term has a made up name for this kind of bond, following OTPP review in which we dealt with the distinction between index linked interest and index linked principal amounts. .</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;IndexLinkedSecurity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;VariablePrincipalBond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;isBasedOn"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">index linked security</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond in which payment of income on the principal is related to a specific price index, such as the Consumer Price Index.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This feature provides protection to investors by shielding them from changes in the underlying index. The bond&apos;s cash flows are adjusted to ensure that the holder of the bond receives a known real rate of return. Notes 04 May: There may also be a kind of security where the coupon payments fluctuate according to an &quot;Index&quot; in the sense of non Interest rate e.g. inflation rate, GDP. But more commonly the term Index Linked refers to principal.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;IndexLinkedSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;specifiesCoupon"/>
+bubububu<owl:onClass rdf:resource="&fibo-md-dbtx-int;InflationBondVariableCoupon"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;hasFactor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasCouponVariableInterestTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;InflationBondVariableCouponTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasInterestPaymentTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondInterestPaymentTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalBasedOn"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond where the principal amount is linked to an index.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Refers to an Inflation Index. This is used to define the factor or multiplier for the bond, that is the factor that you multiply the bond by. How this works is that you take the inflation rate when the security was issued, and the inflation rate at the present. The difference between these becomes the Factor, e.g. 100% -&amp;gt; 101% gives 1% so for example for a $1000 issue - calculate the principal on which the interest is paid AND the principal from the point of view of how the principal is repaid. Some inflation bonds only do this on interest, some only on interest, but most apply it to the principal and interest. Coupon interest calculated based on the adjusted amount of the bond. so a fixed coupon rate is multiplied by e.g. 1010 in the example above. Variations e.g. Italy - daily published factor published for that bond, whereas other calculate based on underlying index. Typically a CPI or a statistical number generated by the govt. typically a lagging three month index. See UK bonds on this. US and Japanese ones - look at inflation rate 3 months prior. Unlike an Amortizing Security this principal value of the bond is increasing, whereas for and Amortizing, the principal is decreasing. In Canada, these are also referred to as &quot;real return bonds&quot;. 
 Further Notes:Additional review with OTPP May 05 2010 indicates that this is part of a classification of bonds where the principal amount itself varies according to some index, a point which was not understood at the original review session. Terms and labels revised to fit this picture.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationBondInterestPaymentTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
-		<rdfs:label xml:lang="en">inflation bond interest payment terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms for the payment of interest on an Inflation Bond.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These may for example specify that the interest payments are by way of coupone calculated with reference to the inflation rate that is referenced for that bond, or they may not (for example they may specify a fixed coupon amount). Therefore these terms may specify any potential interest payment arrangement used on bonds.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;refersTo"/>
-				<owl:onClass rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;setsOutFormula"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorFormula"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation bond principal repayment terms set</rdfs:label>
-		<skos:definition xml:lang="en">Terms specifying how the principal amount on an Inflation Bond is to be paid down. Further notes: This is typically but not necessarily with reference to the Inflation rate that is referred to for this bond. Further model action: identify and model terms for the case where the bond principal repayments are not pegged to an inflation rate.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationFactorExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;underlyingParameter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorUnderlying"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation factor expression</rdfs:label>
-		<skos:definition xml:lang="en">How the Formula is expressed i.e. the Right Hand Side of the Formula.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationFactorFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;FactorCalculationFormula"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasExpression"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorExpression"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasSubject"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorSubject"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation factor formula</rdfs:label>
-		<skos:definition xml:lang="en">The formula by which the inflation factor is determined for the bond. This is part of the formula terms.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationFactorSubject">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
-		<rdfs:label xml:lang="en">inflation factor subject</rdfs:label>
-		<skos:definition xml:lang="en">The Left Hand Side of the Formula, giving what is being expressed in terms of the Right Hand Side. This is the Inflation Bond Factor.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationFactorUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;operandIs"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">inflation factor underlying</rdfs:label>
-		<skos:definition xml:lang="en">The argument of the Inflation Factor calculation formula, which is the inflation factor itself.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;PerpetualFloatingRateNote">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;FloatingRateNote"/>
-		<rdfs:label xml:lang="en">perpetual floating rate note</rdfs:label>
-		<skos:definition xml:lang="en">A Floating Rate Note in which ... information to follow.</skos:definition>
-		<skos:editorialNote xml:lang="en">Added as part of Corporate Actions and Events reviews. THere is an action (Remarketin gAgreement) which refers explicitly to Perpetual Floating Rate Notes. These had not previously been identified as a specific class of securities. Actions: Identify what terms (hopefully existing ones) come together to classify something as a perpetual FRN (presumably, it is one where there is no Maturity date, i.e. a Perpetual Bond?)</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;StepUpBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCouponStructureTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">step up bond</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;VariableCouponBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
-				<owl:onClass rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">variable coupon bond</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;VariableDebtPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
-		<rdfs:label xml:lang="en">variable debt principal</rdfs:label>
-		<skos:definition xml:lang="en">An amount of issued debt principal which is defined in relation to some variable and so varies over time, as principal.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Not the same as principal paydown. This is when the principal itself varies over time, usually as a result of being defined in relation to some index such as an inflation index. Forms the debt principal in instruments such as inflation bonds.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;VariablePrincipalBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;setsOutTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;VariableDebtPrincipal"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">variable principal bond</rdfs:label>
-		<skos:definition xml:lang="en">A bond where the actual principal amount may vary, other than through paydown of the principal as amortization.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This would typically be a bond where the principal is not a fixed amount but is varied according to some index, that is the actual amount of the debt itself varies, independently of whether the principal is amortized or not, and regardless of whether the coupon is fixed or variable (though a coupon of a fixed percentage would translate to a variable monetary amount).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;ZeroCouponBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasZeroCouponCallTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponAndOIDBondCallTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasZeroCouponTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">zero coupon bond</rdfs:label>
-		<skos:definition xml:lang="en">A debt security that doesn&apos;t pay interest (a coupon) but is traded at a deep discount, rendering profit at maturity when the bond is redeemed for its full face value.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that a zero coupon is treated for calculation purposes as a fixed coupon bond with a coupon rate of zero, and not as a bond without a coupon rate.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasCouponVariableInterestTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-bo;hasCouponInterestTerms"/>
-		<rdfs:label xml:lang="en">has coupon variable interest terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasInterestPaymentTerms">
-		<rdfs:label xml:lang="en">has interest payment terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondInterestPaymentTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasOriginalIssueDiscountAmount">
-		<rdfs:label xml:lang="en">has original issue discount amount</rdfs:label>
-		<terms:description xml:lang="en">the difference between the stated redemption price at maturity and the issue price</terms:description>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;ZeroCouponBond"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms">
-		<rdfs:label xml:lang="en">has principal amortization terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPrincipalBasedOn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cfv;isBasedOn"/>
-		<rdfs:label xml:lang="en">has principal based on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms">
-		<rdfs:label xml:lang="en">has principal repayment terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
-		<skos:definition xml:lang="en">The terms for payment of the principal. These are linked to a published market index.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms"/>
-		<rdfs:label xml:lang="en">has principal repayment terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;IndexAmortizingBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPublishedSinkingFundAmortizationTermsDescription">
-		<rdfs:label xml:lang="en">has published sinking fund amortization terms description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;BondWithPublishedSinkingFund"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;SinkingFundAmortizationTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasRepaymentTerms">
-		<rdfs:label xml:lang="en">has repayment terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;BulletBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasZeroCouponCallTerms">
-		<rdfs:label xml:lang="en">has zero coupon call terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;ZeroCouponBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponAndOIDBondCallTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasZeroCouponTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-bo;hasCouponInterestTerms"/>
-		<rdfs:label xml:lang="en">has zero coupon terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;ZeroCouponBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;isBasedOn">
-		<rdfs:label xml:lang="en">is based on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;IndexLinkedSecurity"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;issuedDebtAmount">
-		<rdfs:label xml:lang="en">issued debt amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;VariableDebtPrincipal"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;mandatesSinkingFundAsDescribedIn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms"/>
-		<rdfs:label xml:lang="en">mandates sinking fund as described in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;BondWithMandatorySinkingFund"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;notional">
-		<rdfs:label xml:lang="en">notional</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The amortizing security pays interest only and no principal over its life.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;operandIs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasOperand"/>
-		<rdfs:label xml:lang="en">operand is</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorUnderlying"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;paysVariableCoupon">
-		<rdfs:label xml:lang="en">pays variable coupon</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondInterestPaymentTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the interest payable on the Inflation Bond is variable with reference to the Factor. If Yes, then the terms include an Inflation Bond Variable Coupon. If No, then the terms may be any coupon or set of coupons, by inheritance of this fact from the parent class of Bond Coupon Terms Set.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;peggedToInflationRate">
-		<rdfs:label xml:lang="en">pegged to inflation rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the principal repayment is made with reference to the inflation rate via the Inflation Rate Factor calculated for the bond.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;refersTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;specifiesIndexParameter"/>
-		<rdfs:label xml:lang="en">refers to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;setsOutFormula">
-		<rdfs:label xml:lang="en">sets out formula</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;specifiesCoupon">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
-		<rdfs:label xml:lang="en">specifies coupon</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
-		<rdfs:range rdf:resource="&fibo-md-dbtx-int;InflationBondVariableCoupon"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;underlyingParameter">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasArgument"/>
-		<rdfs:label xml:lang="en">underlying parameter</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorExpression"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorUnderlying"/>
-	</owl:ObjectProperty>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationBondInterestPaymentTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation bond interest payment terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for the payment of interest on an Inflation Bond.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These may for example specify that the interest payments are by way of coupone calculated with reference to the inflation rate that is referenced for that bond, or they may not (for example they may specify a fixed coupon amount). Therefore these terms may specify any potential interest payment arrangement used on bonds.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;refersTo"/>
+bubububu<owl:onClass rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;setsOutFormula"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorFormula"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation bond principal repayment terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms specifying how the principal amount on an Inflation Bond is to be paid down. Further notes: This is typically but not necessarily with reference to the Inflation rate that is referred to for this bond. Further model action: identify and model terms for the case where the bond principal repayments are not pegged to an inflation rate.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationFactorExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;underlyingParameter"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorUnderlying"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation factor expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">How the Formula is expressed i.e. the Right Hand Side of the Formula.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationFactorFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;FactorCalculationFormula"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasExpression"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorExpression"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasSubject"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorSubject"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation factor formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formula by which the inflation factor is determined for the bond. This is part of the formula terms.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationFactorSubject">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation factor subject</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Left Hand Side of the Formula, giving what is being expressed in terms of the Right Hand Side. This is the Inflation Bond Factor.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;InflationFactorUnderlying">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;operandIs"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">inflation factor underlying</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The argument of the Inflation Factor calculation formula, which is the inflation factor itself.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;PerpetualFloatingRateNote">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;FloatingRateNote"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">perpetual floating rate note</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Floating Rate Note in which ... information to follow.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Added as part of Corporate Actions and Events reviews. THere is an action (Remarketin gAgreement) which refers explicitly to Perpetual Floating Rate Notes. These had not previously been identified as a specific class of securities. Actions: Identify what terms (hopefully existing ones) come together to classify something as a perpetual FRN (presumably, it is one where there is no Maturity date, i.e. a Perpetual Bond?)</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;StepUpBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCouponStructureTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;SteppedCouponTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">step up bond</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;VariableCouponBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
+bubububu<owl:onClass rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;BondVariableCoupon"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">variable coupon bond</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;VariableDebtPrincipal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">variable debt principal</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An amount of issued debt principal which is defined in relation to some variable and so varies over time, as principal.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Not the same as principal paydown. This is when the principal itself varies over time, usually as a result of being defined in relation to some index such as an inflation index. Forms the debt principal in instruments such as inflation bonds.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;VariablePrincipalBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;setsOutTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cfv;VariableDebtPrincipal"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">variable principal bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond where the actual principal amount may vary, other than through paydown of the principal as amortization.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This would typically be a bond where the principal is not a fixed amount but is varied according to some index, that is the actual amount of the debt itself varies, independently of whether the principal is amortized or not, and regardless of whether the coupon is fixed or variable (though a coupon of a fixed percentage would translate to a variable monetary amount).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-cfv;ZeroCouponBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasZeroCouponCallTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponAndOIDBondCallTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cfv;hasZeroCouponTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">zero coupon bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A debt security that doesn&apos;t pay interest (a coupon) but is traded at a deep discount, rendering profit at maturity when the bond is redeemed for its full face value.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note that a zero coupon is treated for calculation purposes as a fixed coupon bond with a coupon rate of zero, and not as a bond without a coupon rate.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasCouponVariableInterestTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-bo;hasCouponInterestTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has coupon variable interest terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;DebtVariableCouponTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasInterestPaymentTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has interest payment terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondInterestPaymentTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasOriginalIssueDiscountAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has original issue discount amount</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">the difference between the stated redemption price at maturity and the issue price</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;ZeroCouponBond"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has principal amortization terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondAmortizationPaymentTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPrincipalBasedOn">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cfv;isBasedOn"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has principal based on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has principal repayment terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The terms for payment of the principal. These are linked to a published market index.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPrincipalRepaymentTerms.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has principal repayment terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;IndexAmortizingBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;IndexLinkedPrincipalDeterminationTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasPublishedSinkingFundAmortizationTermsDescription">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has published sinking fund amortization terms description</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;BondWithPublishedSinkingFund"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;SinkingFundAmortizationTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasRepaymentTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has repayment terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;BulletBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondBulletPrincipalRepaymentTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasZeroCouponCallTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has zero coupon call terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;ZeroCouponBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponAndOIDBondCallTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;hasZeroCouponTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-bo;hasCouponInterestTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has zero coupon terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;ZeroCouponBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;ZeroCouponTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;isBasedOn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is based on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;IndexLinkedSecurity"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;issuedDebtAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued debt amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;VariableDebtPrincipal"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-tem;DatedMonetaryAmount"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;mandatesSinkingFundAsDescribedIn">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cfv;hasPrincipalAmortizationTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">mandates sinking fund as described in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;BondWithMandatorySinkingFund"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;MandatorySinkingFundTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;notional">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">notional</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;AmortizingSecurity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The amortizing security pays interest only and no principal over its life.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;operandIs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasOperand"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">operand is</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorUnderlying"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/InflationRate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;paysVariableCoupon">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pays variable coupon</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondInterestPaymentTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the interest payable on the Inflation Bond is variable with reference to the Factor. If Yes, then the terms include an Inflation Bond Variable Coupon. If No, then the terms may be any coupon or set of coupons, by inheritance of this fact from the parent class of Bond Coupon Terms Set.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;peggedToInflationRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pegged to inflation rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the principal repayment is made with reference to the inflation rate via the Inflation Rate Factor calculated for the bond.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;refersTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;specifiesIndexParameter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refers to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-int;InflationBondFactor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;setsOutFormula">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out formula</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBondPrincipalRepaymentTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorFormula"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;specifiesCoupon">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-cft;specifiesTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">specifies coupon</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationBond"/>
+bubu<rdfs:range rdf:resource="&fibo-md-dbtx-int;InflationBondVariableCoupon"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-cfv;underlyingParameter">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasArgument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underlying parameter</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cfv;InflationFactorUnderlying"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/Bonds/BondsCommon.rdf
+++ b/sec/Debt/Bonds/BondsCommon.rdf
@@ -1,330 +1,333 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
-	<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-	<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-	<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
-	<!ENTITY fibo-sec-dbt-bo-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/">
-	<!ENTITY fibo-sec-dbt-bo-li "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/">
-	<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
-	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/">
-	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
+bu<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bu<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bu<!ENTITY fibo-sec-dbt-bo-cfv "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/">
+bu<!ENTITY fibo-sec-dbt-bo-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/">
+bu<!ENTITY fibo-sec-dbt-bo-li "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/">
+bu<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
+bu<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/">
+bu<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
-	xmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
-	xmlns:fibo-sec-dbt-bo-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"
-	xmlns:fibo-sec-dbt-bo-li="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/"
-	xmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
-	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/"
-	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-		<rdfs:label xml:lang="en">BondsCommon</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;Bond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;BondCoupon"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCouponStructureTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;isConvertible"/>
-				<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasRepaymentTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;isCallable"/>
-				<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond</rdfs:label>
-		<skos:definition xml:lang="en">A debt security, in which the authorized issuer owes the holders a debt and, depending on the terms of the bond, is obliged to pay interest (the coupon) and/or to repay the principal at a later date, termed maturity. It is a formal contract to repay borrowed money with interest at fixed intervals.</skos:definition>
-		<skos:editorialNote xml:lang="en">30 Sept 2010: Original definition updated by MBS PoC project and agreed. Tidies the language in the original Wikipedia-drived definition. Consensus attained.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;BondWithPartialCall">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;CallableBond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasCallFeature"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallFeature"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond with partial call</rdfs:label>
-		<skos:definition xml:lang="en">A bond with a feature whereby the issue can be partially called for amounts that are at the discretion of the issuer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;BondWithWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:label xml:lang="en">bond with warrant</rdfs:label>
-		<skos:definition xml:lang="en">A bond issue where the issue includes a Warrant attached. This need not be any specific type of bond.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is NOT a kind of Bond Contract but a kind of Issue Offer, and is modeled as such, in the Issuance Terms section of the model. This class of contract is retained in the model for now in order to provide traceability with the CFI term for &quot;Bond With Warrant&quot; only.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;CallableBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasCallFeature"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">callable bond</rdfs:label>
-		<terms:description xml:lang="en">A bond with call provisions, or callable bond, is a bond that can be redeemed by the issuer prior to its maturity.</terms:description>
-		<fibo-fnd-utl-av:definitionOrigin xml:lang="en">Investopedia</fibo-fnd-utl-av:definitionOrigin>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;CallableConvertibleBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;CallableBond"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;ConvertibleBond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;isCallable"/>
-				<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">callable convertible bond</rdfs:label>
-		<skos:definition xml:lang="en">A Convertible Bond which is also callable.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;ConvertibleBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;DebtConversionTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;convertibleInto"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;isConvertible"/>
-				<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">convertible bond</rdfs:label>
-		<skos:definition xml:lang="en">A Bond instrument which on maturity converts into an Equity instrument.</skos:definition>
-		<skos:editorialNote xml:lang="en">There are different types based on the available exercise windows and facts thereof. Notes from CAE review on 7 July 2011 1. Convertible - meaning a convertible Bond whi ch converts into an Equity later in its life 2. Contingent Conversion (of what? - of a Debt. So it&apos;s a kind of Convertible) - if the share price reaches a particular threshold on a particular time window = COCO. - this is a debt instrument. you get the share when it reaches that price threshold. There are time windows (like traditional options instruments - i.e. Bermudan?) - is it mandatory to take a share it&apos;s mandatory - like a digital options which are also not really optional . The distinction is the time window.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;Debenture">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;securitizationConditions.1"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-bo-bo;DebentureSecuritizationConditions"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debenture</rdfs:label>
-		<skos:definition xml:lang="en">A type of debt instrument that is not secured by physical asset or collateral. Debentures are backed only by the general creditworthiness and reputation of the issuer. Both corporations and governments frequently issue this type of bond in order to secure capital. Like other types of bonds, debentures are documented in an indenture.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">From Wikipedia: In law, a debenture is a document which either creates a debt or acknowledges it. It is a medium to long-term borrowing facility created by a company. Where repayment is secured by a charge over land, the document is called a &apos;mortgage&apos;. Where repayment is secured by a charge other assets of the company, the document is called a &apos;debenture&apos;. Where no security is involved, the document is called a note or &apos;unsecured deposit note&apos;. There are two types of debentures: 1. Convertible Debentures, which are convertible bonds or bonds that can be converted into equity shares of the issuing company after a predetermined period of time. &quot;Convertibility&quot; is a feature that corporations may add to the bonds they issue in order to make them more attractive to buyers. In other words, it is a special feature that a corporate bond may carry. As a result of the advantage a buyer gets from the ability to convert, convertible bonds typically have lower interest rates than non-convertible corporate bonds. 2. Non-Convertible Debentures, which are simply regular debentures, cannot be converted into equity shares of the liable company. They are debentures without the convertibility feature attached to them. As a result, they usually carry higher interest rates than their convertible counterparts.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;DebentureSecuritizationConditions">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label xml:lang="en">debenture securitization conditions</rdfs:label>
-		<skos:definition xml:lang="en">Terms, if any, by which a Debenture is secured. This is a description of the properties by which it is secured, being those not otherwise pledged.</skos:definition>
-		<skos:editorialNote xml:lang="en">From original model (whose?): A debenture is usually unsecured in the sense that there are no liens or pledges on specific assets. It is however, secured by all properties not otherwise pledged. From Wikipedia A debenture (also called a note) is an unsecured corporate bond or a corporate bond that does not have a certain line of income or piece of property or equipment to guarantee repayment of principal upon the bond&apos;s maturity. Debentures are long-term debt instrument used by large companies to obtain funds. Where securities are offered, loan stocks or bonds are termed &apos;debentures&apos; in the UK or &apos;mortgage bonds&apos; in the US. Summary: Therefore they are unsecured in the sense of not having a particular cash flow allocated to them, but they are therefore secured by some other asset.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;DebtConversionTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;ConversionTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;specifiesConversionInto"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt conversion terms</rdfs:label>
-		<skos:definition xml:lang="en">Contractual specifications when a Convertible Bond can be converted to another security (usually of the same issuer).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;EquityLinkedBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
-		<rdfs:label xml:lang="en">equity linked bond</rdfs:label>
-		<skos:definition xml:lang="en">A bond where the bond is based on the return on an equity over time i.e. the price and dividend payments i.e. the total return (similar to total return swaps).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;ListedBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;ExchangeTradedSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;isListedVia"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-li;BondListing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">listed bond</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-bo;UnlistedBond"/>
-		<skos:definition xml:lang="en">A security that is a bond and is traded on an exchange.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In principle this may be any type of bond other than an unlisted bond. Most exchange traded bonds are corporate bonds (but most corporate bonds are not exchange traded bonds). This is a common but not a necessary fact.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;MediumTermNote">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:label xml:lang="en">medium term note</rdfs:label>
-		<skos:definition xml:lang="en">A Medium Term Note is a Negotiable debt instrument offered under a program agreement through one or more dealers upon request of the Issuer. The Program defines the terms and conditions of the notes. An MTN issue is defined by the fact that the registration doesn&apos;t have a pre-defined maturity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">MTNs have a maturity typically of 1 to 10 years. This may vary in different jurisductions. Bonds issued with a long maturity are not redefined as MTNs when their maturity reduces. MTN typically has a long last coupon payment. Some things are different from regular bonds, e.g.: You can register one with different maturities, issued in different groups (cf tranches). See also shelf registration (issuing bond before you file the paperwork with e.g. SEC - not the same). In this case it is registered but not issued all at one time. Flexible. Difference with bond issuance is that you have indenture that says what the maturity is, so every different maturity is a different bond.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;UnlistedBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:label xml:lang="en">unlisted bond</rdfs:label>
-		<terms:description xml:lang="en">A bond that is traded over the counter rather than via an exchange or other listing facility.</terms:description>
-		<fibo-fnd-utl-av:synonym xml:lang="en">OTC Bond</fibo-fnd-utl-av:synonym>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;capitalizedInterest">
-		<rdfs:label xml:lang="en">capitalized interest</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the interest amount is capitalised until maturity date or paid out at each interest payment date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;convertibleInto">
-		<rdfs:label xml:lang="en">convertible into</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;ConvertibleBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;extraordinaryRedemptionApplicable">
-		<rdfs:label xml:lang="en">extraordinary redemption applicable</rdfs:label>
-		<terms:description xml:lang="en">whether the security is subject to extraordinary redemption</terms:description>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;hasBondMaturityRegistrar">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasThirdParty"/>
-		<rdfs:label xml:lang="en">has bond maturity registrar</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;BondMaturityRegistrar"/>
-		<skos:definition xml:lang="en">The person or entity responsible for maintaining records on behalf of the issuer that identify the owners of a registered bond issue.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;hasConversionTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has conversion terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;ConvertibleBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;DebtConversionTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;hasConvertibleDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
-		<rdfs:label xml:lang="en">has convertible date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;DebtConversionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>the date on which a bond can be converted into the specified equity security</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;hasCouponInterestTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbti;hasInterestPaymentTerms"/>
-		<rdfs:label xml:lang="en">has coupon interest terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-bo;isConvertible">
-		<rdfs:label>is convertible</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">has a conversion feature enabling it to be converted into another instrument on maturity</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;naked">
-		<rdfs:label xml:lang="en">naked</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Debenture"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the debenture is unsecured (Naked = Yes) or is secured (Naked = No).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;securitizationConditions">
-		<rdfs:label xml:lang="en">securitization conditions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;DebentureSecuritizationConditions"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Textual description of the conditions for the securitization of the Debenture.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;securitizationConditions.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">securitization conditions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Debenture"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;DebentureSecuritizationConditions"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
+buxmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
+buxmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
+buxmlns:fibo-sec-dbt-bo-cfv="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"
+buxmlns:fibo-sec-dbt-bo-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"
+buxmlns:fibo-sec-dbt-bo-li="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/"
+buxmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
+buxmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/"
+buxmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BondsCommon</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">This ontology defines the basic concept of a bond and a number of bond variants including convertible and callable bonds. Medium term notes (MTNs) and debentures are also defined.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;Bond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-int;bondHasCoupon"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;BondCoupon"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-cft;hasCouponStructureTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponStructureType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;isConvertible"/>
+bubububu<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasRepaymentTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondPrincipalRepaymentTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;isCallable"/>
+bubububu<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A debt security, in which the authorized issuer owes the holders a debt and, depending on the terms of the bond, is obliged to pay interest (the coupon) and/or to repay the principal at a later date, termed maturity. It is a formal contract to repay borrowed money with interest at fixed intervals.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">30 Sept 2010: Original definition updated by MBS PoC project and agreed. Tidies the language in the original Wikipedia-drived definition. Consensus attained.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;BondWithPartialCall">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;CallableBond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasCallFeature"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;PartialCallFeature"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond with partial call</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond with a feature whereby the issue can be partially called for amounts that are at the discretion of the issuer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;BondWithWarrant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond with warrant</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond issue where the issue includes a Warrant attached. This need not be any specific type of bond.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is NOT a kind of Bond Contract but a kind of Issue Offer, and is modeled as such, in the Issuance Terms section of the model. This class of contract is retained in the model for now in order to provide traceability with the CFI term for &quot;Bond With Warrant&quot; only.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;CallableBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasCallFeature"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-cft;BondCallTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">callable bond</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">A bond with call provisions, or callable bond, is a bond that can be redeemed by the issuer prior to its maturity.</terms:description>
+bubu<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&rdf;langString" xml:lang="en">Investopedia</fibo-fnd-utl-av:definitionOrigin>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;CallableConvertibleBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;CallableBond"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;ConvertibleBond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;isCallable"/>
+bubububu<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">callable convertible bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Convertible Bond which is also callable.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;ConvertibleBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;DebtConversionTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;convertibleInto"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;isConvertible"/>
+bubububu<owl:someValuesFrom rdf:resource="&xsd;boolean"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convertible bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Bond instrument which on maturity converts into an Equity instrument.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">There are different types based on the available exercise windows and facts thereof. Notes from CAE review on 7 July 2011 1. Convertible - meaning a convertible Bond whi ch converts into an Equity later in its life 2. Contingent Conversion (of what? - of a Debt. So it&apos;s a kind of Convertible) - if the share price reaches a particular threshold on a particular time window = COCO. - this is a debt instrument. you get the share when it reaches that price threshold. There are time windows (like traditional options instruments - i.e. Bermudan?) - is it mandatory to take a share it&apos;s mandatory - like a digital options which are also not really optional . The distinction is the time window.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;Debenture">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-bo;securitizationConditions.1"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-bo-bo;DebentureSecuritizationConditions"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debenture</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A type of debt instrument that is not secured by physical asset or collateral. Debentures are backed only by the general creditworthiness and reputation of the issuer. Both corporations and governments frequently issue this type of bond in order to secure capital. Like other types of bonds, debentures are documented in an indenture.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">From Wikipedia: In law, a debenture is a document which either creates a debt or acknowledges it. It is a medium to long-term borrowing facility created by a company. Where repayment is secured by a charge over land, the document is called a &apos;mortgage&apos;. Where repayment is secured by a charge other assets of the company, the document is called a &apos;debenture&apos;. Where no security is involved, the document is called a note or &apos;unsecured deposit note&apos;. There are two types of debentures: 1. Convertible Debentures, which are convertible bonds or bonds that can be converted into equity shares of the issuing company after a predetermined period of time. &quot;Convertibility&quot; is a feature that corporations may add to the bonds they issue in order to make them more attractive to buyers. In other words, it is a special feature that a corporate bond may carry. As a result of the advantage a buyer gets from the ability to convert, convertible bonds typically have lower interest rates than non-convertible corporate bonds. 2. Non-Convertible Debentures, which are simply regular debentures, cannot be converted into equity shares of the liable company. They are debentures without the convertibility feature attached to them. As a result, they usually carry higher interest rates than their convertible counterparts.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;DebentureSecuritizationConditions">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debenture securitization conditions</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms, if any, by which a Debenture is secured. This is a description of the properties by which it is secured, being those not otherwise pledged.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From original model (whose?): A debenture is usually unsecured in the sense that there are no liens or pledges on specific assets. It is however, secured by all properties not otherwise pledged. From Wikipedia A debenture (also called a note) is an unsecured corporate bond or a corporate bond that does not have a certain line of income or piece of property or equipment to guarantee repayment of principal upon the bond&apos;s maturity. Debentures are long-term debt instrument used by large companies to obtain funds. Where securities are offered, loan stocks or bonds are termed &apos;debentures&apos; in the UK or &apos;mortgage bonds&apos; in the US. Summary: Therefore they are unsecured in the sense of not having a particular cash flow allocated to them, but they are therefore secured by some other asset.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;DebtConversionTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;ConversionTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-sec-iss;specifiesConversionInto"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt conversion terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual specifications when a Convertible Bond can be converted to another security (usually of the same issuer).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;EquityLinkedBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cfv;VariableCouponBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity linked bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond where the bond is based on the return on an equity over time i.e. the price and dividend payments i.e. the total return (similar to total return swaps).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;ListedBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;ExchangeTradedSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-sec-lst;isListedVia"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-li;BondListing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listed bond</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-bo;UnlistedBond"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security that is a bond and is traded on an exchange.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In principle this may be any type of bond other than an unlisted bond. Most exchange traded bonds are corporate bonds (but most corporate bonds are not exchange traded bonds). This is a common but not a necessary fact.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;MediumTermNote">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">medium term note</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Medium Term Note is a Negotiable debt instrument offered under a program agreement through one or more dealers upon request of the Issuer. The Program defines the terms and conditions of the notes. An MTN issue is defined by the fact that the registration doesn&apos;t have a pre-defined maturity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">MTNs have a maturity typically of 1 to 10 years. This may vary in different jurisductions. Bonds issued with a long maturity are not redefined as MTNs when their maturity reduces. MTN typically has a long last coupon payment. Some things are different from regular bonds, e.g.: You can register one with different maturities, issued in different groups (cf tranches). See also shelf registration (issuing bond before you file the paperwork with e.g. SEC - not the same). In this case it is registered but not issued all at one time. Flexible. Difference with bond issuance is that you have indenture that says what the maturity is, so every different maturity is a different bond.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-bo;UnlistedBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unlisted bond</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">A bond that is traded over the counter rather than via an exchange or other listing facility.</terms:description>
+bubu<fibo-fnd-utl-av:synonym rdf:datatype="&rdf;langString" xml:lang="en">OTC Bond</fibo-fnd-utl-av:synonym>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;capitalizedInterest">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">capitalized interest</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the interest amount is capitalised until maturity date or paid out at each interest payment date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;convertibleInto">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convertible into</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;ConvertibleBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;extraordinaryRedemptionApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">extraordinary redemption applicable</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">whether the security is subject to extraordinary redemption</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;hasBondMaturityRegistrar">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has bond maturity registrar</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;BondMaturityRegistrar"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The person or entity responsible for maintaining records on behalf of the issuer that identify the owners of a registered bond issue.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;hasConversionTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has conversion terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;ConvertibleBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;DebtConversionTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;hasConvertibleDate">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has convertible date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;DebtConversionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&xsd;string">the date on which a bond can be converted into the specified equity security</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;hasCouponInterestTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbti;hasInterestPaymentTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has coupon interest terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-cft;BondCouponInterestTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-bo;isConvertible">
+bubu<rdfs:label>is convertible</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:range rdf:resource="&xsd;boolean"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">has a conversion feature enabling it to be converted into another instrument on maturity</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;naked">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">naked</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Debenture"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the debenture is unsecured (Naked = Yes) or is secured (Naked = No).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;securitizationConditions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securitization conditions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;DebentureSecuritizationConditions"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Textual description of the conditions for the securitization of the Debenture.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-bo;securitizationConditions.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securitization conditions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-bo;Debenture"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;DebentureSecuritizationConditions"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/Bonds/BondsIssuerVariants.rdf
+++ b/sec/Debt/Bonds/BondsIssuerVariants.rdf
@@ -1,476 +1,480 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
-	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/">
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/FND/Parties/Roles/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-	<!ENTITY fibo-sec-dbt-bo-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/">
-	<!ENTITY fibo-sec-dbt-bo-tax "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/">
-	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
+bu<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/">
+bu<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
+bu<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/FND/Parties/Roles/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bu<!ENTITY fibo-sec-dbt-bo-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/">
+bu<!ENTITY fibo-sec-dbt-bo-tax "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/">
+bu<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"
-	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
-	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:fibo-sec-dbt-bo-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"
-	xmlns:fibo-sec-dbt-bo-tax="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/"
-	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/">
-		<rdfs:label xml:lang="en">Bonds Issuer Variants</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;AdValoremTaxProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:label xml:lang="en">ad valorem tax provision</rdfs:label>
-		<skos:definition xml:lang="en">A direct tax calculated “according to value” of property. Ad valorem tax is based on an assigned valuation (market or assessed) of real property and, in certain cases, on a valuation of tangible or intangible personal property. In virtually all jurisdictions, ad valorem tax is a lien on the property enforceable by seizure and sale of the property. An ad valorem tax is normally the one substantial tax that may be raised or lowered by a local governing body without the sanction of superior levels of government (although constitutional or statutory restrictions such as tax rate limitations may limit this right).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;BondMaturityRegistrar">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;LegalAgent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
-		<rdfs:label xml:lang="en">bond maturity registrar</rdfs:label>
-		<skos:definition xml:lang="en">The person or entity responsible for maintaining records on behalf of the issuer that identify the owners of a registered bond issue. The trustee under a bond contract often also acts as registrar.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;BuildAmericaBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:label xml:lang="en">build america bond</rdfs:label>
-		<skos:definition xml:lang="en">Taxable municipal securities issued through December 31, 2010 under the American Recovery and Reinvestment Act of 2009 (ARRA). BABs may be direct pay subsidy bonds or tax credit bonds.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;CertificateOfObligation">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:label xml:lang="en">certificate of obligation</rdfs:label>
-		<skos:definition xml:lang="en">A Certificate of Obligation is a form of debt available to governing councils in case of emergency – a God-created catastrophe – that needs immediate action without time for voter referendum. For example, when a hurricane destroys the police and emergency services building, there is no time to go through the process of voter referendum. The local council must be able to borrow the money to set up provisional buildings and necessary equipment for police and emergency services so that the community is served in continuity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;CertificateOfParticipation">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:label xml:lang="en">certificate of participation</rdfs:label>
-		<skos:definition xml:lang="en">An instrument evidencing a pro rata share in a specific pledged revenue stream, usually lease payments by the issuer that are typically subject to annual appropriation. The certificate generally entitles the holder to receive a share, or participation, in the payments from a particular project. The payments are passed through the lessor to the certificate holders. The lessor typically assigns the lease and the payments to a trustee, which then distributes the payments to the certificate holders.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;CorporateBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasIssuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-iss;CorporateBondIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">corporate bond</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentBond"/>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<skos:definition xml:lang="en">A debt security issued by a corporation, as opposed to those issued by a government or municipality.</skos:definition>
-		<skos:editorialNote xml:lang="en">Added by extension from CFI Municipal. If there are Municipal Bonds in the classification hierarchy then Corporate and Government should also be included.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;CorporateBondIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">corporate bond issuer</rdfs:label>
-		<skos:definition xml:lang="en">a corporation acting in the capacity of an issuer</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;FullFaithAndCreditBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:label xml:lang="en">full faith and credit bond</rdfs:label>
-		<skos:definition xml:lang="en">[definition from Wes]</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GeneralObligationMunicipalBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;FullFaithAndCreditBond"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:label xml:lang="en">general obligation municipal bond</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-iss;RevenueBond"/>
-		<skos:definition xml:lang="en">A general obligation bond (GO) is issued by governmental entities and not backed by revenue from a specific project, such as a toll road. A general obligation bond is secured by an issuing government&apos;s pledge to use all available resources - even tax revenues - to repay holders of the bond.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GovernmentBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentIssuedDebtSecurity"/>
-		<rdfs:label xml:lang="en">government issued bond</rdfs:label>
-		<skos:definition xml:lang="en">a bond issued by some government on behalf of some polity, including sovereign and municipal bonds</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GovernmentDebtIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;Government"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;Polity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">government debt issuer</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GovernmentIssuedDebtSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasIssuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentDebtIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">government issued debt security</rdfs:label>
-		<skos:definition xml:lang="en">a debt security issued by some government on behalf of some polity, including sovereign and municipal debt</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GreenBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-		<rdfs:label xml:lang="en">green bond</rdfs:label>
-		<skos:definition xml:lang="en">A green bond is a tax-exempt bond issued by federally qualified organizations or by municipalities for the development of brownfield sites. Brownfield sites are areas of land that are underutilized, have abandoned buildings or are underdeveloped, often containing low levels of industrial pollution.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;LimitedTaxGeneralObligationBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GeneralObligationMunicipalBond"/>
-		<rdfs:label xml:lang="en">limited tax general obligation bond</rdfs:label>
-		<skos:definition xml:lang="en">A limited-tax general obligation pledge asks the issuing local government to raise property taxes if necessary to meet existing debt service obligations. However, this increase is bounded by a statutory limit. With limited-tax general obligation pledges, governments can still use a part of already-levied property taxes, use another stream of income, or raise property taxes to an amount equating to existing debt service payments to answer its debt obligations.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentBond"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-tax;bankQualifiedStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-tax;BankQualifiedTaxExemption"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">municipal bond</rdfs:label>
-		<skos:definition xml:lang="en">A debt security issued by or on behalf of a state or its political subdivision, or an agency or instrumentality of a state, its political subdivision, or a municipal corporation. Municipal bonds, for example, may be issued by states, cities, counties, special tax districts or special agencies or authorities of state or local governments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalBondCapitalType">
-		<rdfs:label xml:lang="en">municipal bond capital type</rdfs:label>
-		<skos:definition xml:lang="en">the allocation of municipal bond proceeds</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalBondRefundTerms">
-		<rdfs:label xml:lang="en">municipal bond refund terms</rdfs:label>
-		<skos:definition xml:lang="en">terms related to the refunding process of municipal securities</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalDebtFundsUsage">
-		<rdfs:label xml:lang="en">municipal debt funds usage</rdfs:label>
-		<skos:definition xml:lang="en">official statement identifying the application of funds in connection with a new issue of municipal securities</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalDebtIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentDebtIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;MunicipalGovernment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;MunicipalEntity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">municipal debt issuer</rdfs:label>
-		<skos:definition xml:lang="en">A Municipality, acting in the capacity of an Issuer. The Issuer of a Municipal Debt is a Municipality, which is identified as a State Actor governing on the part of a Municipal Area or City. This is equivalent to a Legal Entity.</skos:definition>
-		<skos:editorialNote xml:lang="en">identified as: The Issuer of a Municipal Debt is a Municipality, which is identified as a State Actor governing on the part of a Municipal Area or City. This is equivalent to a Legal Entity.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalDebtObligor">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
-		<rdfs:label xml:lang="en">municipal debt obligor</rdfs:label>
-		<skos:definition xml:lang="en">A party having a financial obligation or arrangement to make the payment of all or part of debt service on municipal securities. The obligor is often the issuer but may be a conduit borrower of municipal securities proceeds.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalDebtRemarketingAgent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
-		<rdfs:label xml:lang="en">municipal debt remarketing agent</rdfs:label>
-		<skos:definition xml:lang="en">The municipal securities dealer responsible for reselling to investors securities (such as variable rate demand obligations and other tender option bonds) that have been tendered for purchase by their owner. The remarketing agent also typically is responsible for resetting the interest rate for a variable rate issue and may act as tender agent</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalNote">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:label xml:lang="en">municipal note</rdfs:label>
-		<skos:definition xml:lang="en">A short-term obligation of an issuer to repay a specified principal amount on a certain date, together with interest at a stated rate, usually payable from a defined source of anticipated revenues. Notes usually mature in one year or less, although notes of longer maturities are also issued.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentIssuedDebtSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasIssuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalDebtIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">municipal security</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-iss;SovereignDebtInstrument"/>
-		<skos:definition xml:lang="en">Municipal Securities is a general term referring to a bond, note, warrant, certificate of participation or other obligation issued by a state or local government or their agencies or authorities (such as cities, towns, villages, counties or special districts or authorities). A prime feature of most municipal securities is that interest or other investment earnings on them are generally excluded from gross income of the bondholder for federal income tax purposes. Some municipal securities are subject to federal income tax, although the issuers or bondholders may receive other federal tax advantages for certain types of taxable municipal securities. Some examples include Build America Bonds, municipal fund securities and direct pay subsidy bonds.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalTrustee">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
-		<rdfs:label xml:lang="en">municipal trustee</rdfs:label>
-		<skos:definition xml:lang="en">A financial institution with trust powers, designated by the issuer or borrower, that acts, pursuant to a bond contract, in a fiduciary capacity for the benefit of the bondholders in enforcing the terms of the bond contract. In many cases, the trustee also acts as custodian, paying agent, registrar and/or transfer agent for the bonds</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;RevenueBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:label xml:lang="en">revenue bond</rdfs:label>
-		<skos:definition xml:lang="en">A revenue bond is a municipal bond supported by the revenue from a specific project, such as a toll bridge, highway or local stadium. Revenue bonds are municipal bonds that finance income-producing projects and are secured by a specified revenue source. Typically, revenue bonds can be issued by any government agency or fund that is managed in the manner of a business, such as entities having both operating revenues and expenses.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SovereignBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;FullFaithAndCreditBond"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentBond"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;SovereignDebtInstrument"/>
-		<rdfs:label xml:lang="en">sovereign bond</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SovereignDebtInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentIssuedDebtSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasIssuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-iss;SovereignDebtIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">sovereign debt instrument</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SovereignDebtIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentDebtIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">sovereign debt issuer</rdfs:label>
-		<skos:definition xml:lang="en">A national Government, acting in the capacity of an Issuer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SpecialAssessmentBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:label xml:lang="en">special assessment bond</rdfs:label>
-		<skos:definition xml:lang="en">An obligation payable from revenues of a special assessment. A special assessment is a charge imposed against a property in a particular locality because that property receives a special benefit by virtue of some public improvement, separate and apart from the general benefit accruing to the public at large. Special assessments may be apportioned according to the value of the benefit received, rather than merely the cost of the improvement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SpecialObligationBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:label xml:lang="en">special obligation bond</rdfs:label>
-		<skos:definition xml:lang="en">A bond secured by a limited revenue source or promise to pay.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SpecialTaxBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:label xml:lang="en">special tax bond</rdfs:label>
-		<skos:definition xml:lang="en">A bond secured by revenues derived from one or more designated taxes other than ad valorem taxes. For example, bonds for a particular purpose might be supported by sales, cigarette, fuel or business license taxes.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;TaxAllocationBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:label xml:lang="en">tax allocation bond</rdfs:label>
-		<skos:definition xml:lang="en">A bond payable from the incremental increase in tax revenues realized from any increase in property value and other economic activity, often designed to capture the economic benefit resulting from a bond financing. Tax increment bonds, also known as tax allocation bonds, often are used to finance the redevelopment of blighted areas.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;UnlimitedTaxGeneralObligationBond">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GeneralObligationMunicipalBond"/>
-		<rdfs:label xml:lang="en">unlimited tax general obligation bond</rdfs:label>
-		<skos:definition xml:lang="en">An unlimited-tax general obligation pledge is similar to the limited-tax pledge. The only difference is that the local government is asked to increase property tax rates to necessary levels - up to a maximum of 100% - to cover delinquencies from taxpayers. Local residents must first agree to increase property taxes to necessary amounts required for the bonds.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasAdValoremTaxProvision">
-		<rdfs:label xml:lang="en">has ad valorem tax provision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;AdValoremTaxProvision"/>
-		<skos:definition xml:lang="en">whether the bond has ad valorem tax provision</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasAwardDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
-		<rdfs:label xml:lang="en">has award date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">Date on which bonds are awarded to the lead manager or syndicate on negotiated deals or the date of bidding on competitive deals.</skos:definition>
-		<skos:editorialNote xml:lang="en">There are two kinds of award date in municipal securities issuance: verbal award date and formal award date</skos:editorialNote>
-		<fibo-fnd-utl-av:synonym xml:lang="en">has sale date</fibo-fnd-utl-av:synonym>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasFormalAwardDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-iss;hasAwardDate"/>
-		<rdfs:label xml:lang="en">has formal award date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalBondCapitalType">
-		<rdfs:label xml:lang="en">has municipal bond capital type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBondCapitalType"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalBondRefundTerms">
-		<rdfs:label xml:lang="en">has municipal bond refund terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBondRefundTerms"/>
-		<skos:definition xml:lang="en">has terms governing the refunding process of municipal securities</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalDebtObligor">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasThirdParty"/>
-		<rdfs:label xml:lang="en">has municipal debt obligor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalDebtObligor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalTrustee">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasThirdParty"/>
-		<rdfs:label xml:lang="en">has municipal trustee</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalTrustee"/>
-		<skos:definition xml:lang="en">The financial institution with trust powers, designated by the issuer or borrower, that acts, pursuant to a bond contract, in a fiduciary capacity for the benefit of the bondholders in enforcing the terms of the bond contract.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalUse">
-		<rdfs:label xml:lang="en">has municipal use</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalDebtFundsUsage"/>
-		<skos:definition xml:lang="en">the application of funds in connection with a new issue of municipal securities</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasRemarketingAgent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasThirdParty"/>
-		<rdfs:label xml:lang="en">has remarketing agent</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalDebtRemarketingAgent"/>
-		<skos:definition xml:lang="en">The municipal securities dealer responsible for reselling to investors securities (such as variable rate demand obligations and other tender option bonds) that have been tendered for purchase by their owner.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasVerbalAwardDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-iss;hasAwardDate"/>
-		<rdfs:label xml:lang="en">has verbal award date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">has a date on which ...</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isBankQualified">
-		<rdfs:label xml:lang="en">is bank qualified</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Designation given to a public purpose bond offering by the issuer if it reasonably expects to issue in the calendar year of such offering no more than $10 million ($30 million for bonds issued in 2009-2010) of bonds of the type required to be included in making such calculation under section 265(b)(3) of the IRS tax code. When purchased by a commercial bank for its portfolio, the bank may deduct a portion of the interest cost of carry for the position. A bond that is bank qualified is also known as a “qualified tax-exempt obligation.</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isFederalTaxable">
-		<rdfs:label xml:lang="en">is federal taxable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">whether the security is taxable by the country where it is issued</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isLimited">
-		<rdfs:label xml:lang="en">is limited</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;AdValoremTaxProvision"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">Whether the ad valorem tax is limited. An Ad Valorem Tax can be limited or unlimited</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isLocalTaxExempt">
-		<rdfs:label xml:lang="en">is local tax exempt</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">whether the security is taxable under local e.g. city taxation</skos:definition>
-		<skos:editorialNote xml:lang="en">It is not clear whether this property ever applies</skos:editorialNote>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isStateTaxable">
-		<rdfs:label xml:lang="en">is state taxable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">whether the security is taxable by the state where it is issued</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isSubjectToAlternateMinimumTax">
-		<rdfs:label xml:lang="en">is subject to alternate minimum tax</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition xml:lang="en">whether the bond is subject to the Alternative Minimum Tax for individuals</skos:definition>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;legalOpinion">
-		<rdfs:label xml:lang="en">legal opinion</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether legal opinion exists for municipal securities.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"
+buxmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"
+buxmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
+buxmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
+buxmlns:fibo-sec-dbt-bo-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"
+buxmlns:fibo-sec-dbt-bo-tax="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/"
+buxmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Bonds Issuer Variants</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology described different categories of bond defined by variations in their issuers. These are corporate bonds, government or sovereign bonds and municipal bonds, including a range of variants of each of these. 
+		Note that in reading these models, most terms for e.g. corporate bonds are inherited from bond terms more generally, while this ontology contains only the distinguishing factors by which these categories of bond are distinguished from one another.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;AdValoremTaxProvision">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ad valorem tax provision</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A direct tax calculated “according to value” of property. Ad valorem tax is based on an assigned valuation (market or assessed) of real property and, in certain cases, on a valuation of tangible or intangible personal property. In virtually all jurisdictions, ad valorem tax is a lien on the property enforceable by seizure and sale of the property. An ad valorem tax is normally the one substantial tax that may be raised or lowered by a local governing body without the sanction of superior levels of government (although constitutional or statutory restrictions such as tax rate limitations may limit this right).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;BondMaturityRegistrar">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;LegalAgent"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond maturity registrar</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The person or entity responsible for maintaining records on behalf of the issuer that identify the owners of a registered bond issue. The trustee under a bond contract often also acts as registrar.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;BuildAmericaBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">build america bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Taxable municipal securities issued through December 31, 2010 under the American Recovery and Reinvestment Act of 2009 (ARRA). BABs may be direct pay subsidy bonds or tax credit bonds.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;CertificateOfObligation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">certificate of obligation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Certificate of Obligation is a form of debt available to governing councils in case of emergency – a God-created catastrophe – that needs immediate action without time for voter referendum. For example, when a hurricane destroys the police and emergency services building, there is no time to go through the process of voter referendum. The local council must be able to borrow the money to set up provisional buildings and necessary equipment for police and emergency services so that the community is served in continuity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;CertificateOfParticipation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">certificate of participation</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An instrument evidencing a pro rata share in a specific pledged revenue stream, usually lease payments by the issuer that are typically subject to annual appropriation. The certificate generally entitles the holder to receive a share, or participation, in the payments from a particular project. The payments are passed through the lessor to the certificate holders. The lessor typically assigns the lease and the payments to a trustee, which then distributes the payments to the certificate holders.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;CorporateBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasIssuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-iss;CorporateBondIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate bond</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentBond"/>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A debt security issued by a corporation, as opposed to those issued by a government or municipality.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Added by extension from CFI Municipal. If there are Municipal Bonds in the classification hierarchy then Corporate and Government should also be included.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;CorporateBondIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">corporate bond issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">a corporation acting in the capacity of an issuer</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;FullFaithAndCreditBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">full faith and credit bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">[definition from Wes]</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GeneralObligationMunicipalBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;FullFaithAndCreditBond"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">general obligation municipal bond</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-iss;RevenueBond"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A general obligation bond (GO) is issued by governmental entities and not backed by revenue from a specific project, such as a toll road. A general obligation bond is secured by an issuing government&apos;s pledge to use all available resources - even tax revenues - to repay holders of the bond.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GovernmentBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentIssuedDebtSecurity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">government issued bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">a bond issued by some government on behalf of some polity, including sovereign and municipal bonds</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GovernmentDebtIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Issuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;Government"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;Polity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">government debt issuer</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GovernmentIssuedDebtSecurity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasIssuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentDebtIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">government issued debt security</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">a debt security issued by some government on behalf of some polity, including sovereign and municipal debt</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;GreenBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">green bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A green bond is a tax-exempt bond issued by federally qualified organizations or by municipalities for the development of brownfield sites. Brownfield sites are areas of land that are underutilized, have abandoned buildings or are underdeveloped, often containing low levels of industrial pollution.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;LimitedTaxGeneralObligationBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GeneralObligationMunicipalBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">limited tax general obligation bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A limited-tax general obligation pledge asks the issuing local government to raise property taxes if necessary to meet existing debt service obligations. However, this increase is bounded by a statutory limit. With limited-tax general obligation pledges, governments can still use a part of already-levied property taxes, use another stream of income, or raise property taxes to an amount equating to existing debt service payments to answer its debt obligations.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentBond"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-tax;bankQualifiedStatus"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-tax;BankQualifiedTaxExemption"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A debt security issued by or on behalf of a state or its political subdivision, or an agency or instrumentality of a state, its political subdivision, or a municipal corporation. Municipal bonds, for example, may be issued by states, cities, counties, special tax districts or special agencies or authorities of state or local governments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalBondCapitalType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal bond capital type</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">the allocation of municipal bond proceeds</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalBondRefundTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal bond refund terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">terms related to the refunding process of municipal securities</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalDebtFundsUsage">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal debt funds usage</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">official statement identifying the application of funds in connection with a new issue of municipal securities</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalDebtIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentDebtIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;MunicipalGovernment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;MunicipalEntity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal debt issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Municipality, acting in the capacity of an Issuer. The Issuer of a Municipal Debt is a Municipality, which is identified as a State Actor governing on the part of a Municipal Area or City. This is equivalent to a Legal Entity.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">identified as: The Issuer of a Municipal Debt is a Municipality, which is identified as a State Actor governing on the part of a Municipal Area or City. This is equivalent to a Legal Entity.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalDebtObligor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal debt obligor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party having a financial obligation or arrangement to make the payment of all or part of debt service on municipal securities. The obligor is often the issuer but may be a conduit borrower of municipal securities proceeds.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalDebtRemarketingAgent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal debt remarketing agent</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The municipal securities dealer responsible for reselling to investors securities (such as variable rate demand obligations and other tender option bonds) that have been tendered for purchase by their owner. The remarketing agent also typically is responsible for resetting the interest rate for a variable rate issue and may act as tender agent</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalNote">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal note</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A short-term obligation of an issuer to repay a specified principal amount on a certain date, together with interest at a stated rate, usually payable from a defined source of anticipated revenues. Notes usually mature in one year or less, although notes of longer maturities are also issued.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalSecurity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentIssuedDebtSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasIssuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalDebtIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal security</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-bo-iss;SovereignDebtInstrument"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Municipal Securities is a general term referring to a bond, note, warrant, certificate of participation or other obligation issued by a state or local government or their agencies or authorities (such as cities, towns, villages, counties or special districts or authorities). A prime feature of most municipal securities is that interest or other investment earnings on them are generally excluded from gross income of the bondholder for federal income tax purposes. Some municipal securities are subject to federal income tax, although the issuers or bondholders may receive other federal tax advantages for certain types of taxable municipal securities. Some examples include Build America Bonds, municipal fund securities and direct pay subsidy bonds.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;MunicipalTrustee">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal trustee</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A financial institution with trust powers, designated by the issuer or borrower, that acts, pursuant to a bond contract, in a fiduciary capacity for the benefit of the bondholders in enforcing the terms of the bond contract. In many cases, the trustee also acts as custodian, paying agent, registrar and/or transfer agent for the bonds</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;RevenueBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">revenue bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A revenue bond is a municipal bond supported by the revenue from a specific project, such as a toll bridge, highway or local stadium. Revenue bonds are municipal bonds that finance income-producing projects and are secured by a specified revenue source. Typically, revenue bonds can be issued by any government agency or fund that is managed in the manner of a business, such as entities having both operating revenues and expenses.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SovereignBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;FullFaithAndCreditBond"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentBond"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;SovereignDebtInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sovereign bond</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SovereignDebtInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentIssuedDebtSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;hasIssuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-iss;SovereignDebtIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sovereign debt instrument</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SovereignDebtIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GovernmentDebtIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;NationalGovernment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;SovereignState"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sovereign debt issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A national Government, acting in the capacity of an Issuer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SpecialAssessmentBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">special assessment bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An obligation payable from revenues of a special assessment. A special assessment is a charge imposed against a property in a particular locality because that property receives a special benefit by virtue of some public improvement, separate and apart from the general benefit accruing to the public at large. Special assessments may be apportioned according to the value of the benefit received, rather than merely the cost of the improvement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SpecialObligationBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">special obligation bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond secured by a limited revenue source or promise to pay.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;SpecialTaxBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">special tax bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond secured by revenues derived from one or more designated taxes other than ad valorem taxes. For example, bonds for a particular purpose might be supported by sales, cigarette, fuel or business license taxes.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;TaxAllocationBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">tax allocation bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond payable from the incremental increase in tax revenues realized from any increase in property value and other economic activity, often designed to capture the economic benefit resulting from a bond financing. Tax increment bonds, also known as tax allocation bonds, often are used to finance the redevelopment of blighted areas.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-iss;UnlimitedTaxGeneralObligationBond">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;GeneralObligationMunicipalBond"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">unlimited tax general obligation bond</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An unlimited-tax general obligation pledge is similar to the limited-tax pledge. The only difference is that the local government is asked to increase property tax rates to necessary levels - up to a maximum of 100% - to cover delinquencies from taxpayers. Local residents must first agree to increase property taxes to necessary amounts required for the bonds.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasAdValoremTaxProvision">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has ad valorem tax provision</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;AdValoremTaxProvision"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">whether the bond has ad valorem tax provision</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasAwardDate">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has award date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date on which bonds are awarded to the lead manager or syndicate on negotiated deals or the date of bidding on competitive deals.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">There are two kinds of award date in municipal securities issuance: verbal award date and formal award date</skos:editorialNote>
+bubu<fibo-fnd-utl-av:synonym rdf:datatype="&rdf;langString" xml:lang="en">has sale date</fibo-fnd-utl-av:synonym>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasFormalAwardDate">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-iss;hasAwardDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has formal award date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalBondCapitalType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has municipal bond capital type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBondCapitalType"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalBondRefundTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has municipal bond refund terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBondRefundTerms"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">has terms governing the refunding process of municipal securities</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalDebtObligor">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has municipal debt obligor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalDebtObligor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalTrustee">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has municipal trustee</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalTrustee"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The financial institution with trust powers, designated by the issuer or borrower, that acts, pursuant to a bond contract, in a fiduciary capacity for the benefit of the bondholders in enforcing the terms of the bond contract.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasMunicipalUse">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has municipal use</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalDebtFundsUsage"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">the application of funds in connection with a new issue of municipal securities</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasRemarketingAgent">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has remarketing agent</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalDebtRemarketingAgent"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The municipal securities dealer responsible for reselling to investors securities (such as variable rate demand obligations and other tender option bonds) that have been tendered for purchase by their owner.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;hasVerbalAwardDate">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-bo-iss;hasAwardDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has verbal award date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">has a date on which ...</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isBankQualified">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is bank qualified</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&xsd;boolean"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Designation given to a public purpose bond offering by the issuer if it reasonably expects to issue in the calendar year of such offering no more than $10 million ($30 million for bonds issued in 2009-2010) of bonds of the type required to be included in making such calculation under section 265(b)(3) of the IRS tax code. When purchased by a commercial bank for its portfolio, the bank may deduct a portion of the interest cost of carry for the position. A bond that is bank qualified is also known as a “qualified tax-exempt obligation.</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isFederalTaxable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is federal taxable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:range rdf:resource="&xsd;boolean"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">whether the security is taxable by the country where it is issued</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isLimited">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is limited</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;AdValoremTaxProvision"/>
+bubu<rdfs:range rdf:resource="&xsd;boolean"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the ad valorem tax is limited. An Ad Valorem Tax can be limited or unlimited</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isLocalTaxExempt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is local tax exempt</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:range rdf:resource="&xsd;boolean"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">whether the security is taxable under local e.g. city taxation</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">It is not clear whether this property ever applies</skos:editorialNote>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isStateTaxable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is state taxable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalSecurity"/>
+bubu<rdfs:range rdf:resource="&xsd;boolean"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">whether the security is taxable by the state where it is issued</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bo-iss;isSubjectToAlternateMinimumTax">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is subject to alternate minimum tax</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&xsd;boolean"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">whether the bond is subject to the Alternative Minimum Tax for individuals</skos:definition>
+bu</owl:DatatypeProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-iss;legalOpinion">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legal opinion</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-iss;MunicipalBond"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether legal opinion exists for municipal securities.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/Bonds/BondsListings.rdf
+++ b/sec/Debt/Bonds/BondsListings.rdf
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-dbt-bo-li "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-dbt-bo-li "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-dbt-bo-li="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/">
-		<rdfs:label xml:lang="en">BondsListings</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-li;BondListing">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
-		<rdfs:label xml:lang="en">bond listing</rdfs:label>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-dbt-bo-li="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BondsListings</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">For bonds which are listed on an exchange, this ontology provides the concept of a bond listing, as a kind of security listing.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsListings/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-li;BondListing">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond listing</rdfs:label>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/sec/Debt/Bonds/BondsTaxTreatment.rdf
+++ b/sec/Debt/Bonds/BondsTaxTreatment.rdf
@@ -1,52 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-bo-tax "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/">
-	<!ENTITY fibo-sec-secx-tax "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-bo-tax "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/">
+bu<!ENTITY fibo-sec-secx-tax "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-bo-tax="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/"
-	xmlns:fibo-sec-secx-tax="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/">
-		<rdfs:label xml:lang="en">BondsTaxTreatment</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-tax;BankQualifiedTaxExemption">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-tax;SecurityTaxTreatment"/>
-		<rdfs:label xml:lang="en">bank qualified tax exemption</rdfs:label>
-		<skos:definition xml:lang="en">Whether or not a municipal reasonably expects to issue in the calendar year of such offering no more than $10 million par amount of bonds of the type required to be included in making such calculation under the Internal Revenue Code. </skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">When purchased by a commercial bank for its portfolio, the bank may receive an 80% tax deduction for the interest cost of carry for the issue.  A bond that is bank qualified is also known as a Qualified Tax-exempt Obligation. This is a specifically US term.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-tax;bankQualified">
-		<rdfs:label xml:lang="en">bank qualified</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-tax;BankQualifiedTaxExemption"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the bond is classed as being Bank Qualified.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-tax;bankQualifiedStatus">
-		<rdfs:label>bank qualified status</rdfs:label>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-bo-tax="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/"
+buxmlns:fibo-sec-secx-tax="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">BondsTaxTreatment</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology extends the more general ontology of securities tax treatments, to define a small range of kinds of tax treatment applicable to bonds that may occur in securities reference data.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsTaxTreatment/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-tax;BankQualifiedTaxExemption">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-tax;SecurityTaxTreatment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bank qualified tax exemption</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not a municipal reasonably expects to issue in the calendar year of such offering no more than $10 million par amount of bonds of the type required to be included in making such calculation under the Internal Revenue Code. </skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">When purchased by a commercial bank for its portfolio, the bank may receive an 80% tax deduction for the interest cost of carry for the issue.  A bond that is bank qualified is also known as a Qualified Tax-exempt Obligation. This is a specifically US term.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-tax;bankQualified">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bank qualified</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-tax;BankQualifiedTaxExemption"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the bond is classed as being Bank Qualified.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-tax;bankQualifiedStatus">
+bubu<rdfs:label>bank qualified status</rdfs:label>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/Bonds/STRIPs.rdf
+++ b/sec/Debt/Bonds/STRIPs.rdf
@@ -1,109 +1,113 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-	<!ENTITY fibo-sec-dbt-bo-str "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/STRIPs/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bu<!ENTITY fibo-sec-dbt-bo-str "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/STRIPs/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/STRIPs/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:fibo-sec-dbt-bo-str="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/STRIPs/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/STRIPs/">
-		<rdfs:label xml:lang="en">STRIPs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/STRIPs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-str;InterestSTRIP">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
-		<rdfs:label xml:lang="en">interest s t r i p</rdfs:label>
-		<skos:definition xml:lang="en">A Debt Instrument which consists of the interest component alone, of a Debt Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-str;PrincipalSTRIP">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
-		<rdfs:label xml:lang="en">principal s t r i p</rdfs:label>
-		<skos:definition xml:lang="en">A Debt Instrument which consists of the principal component alone, of a Debt Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-bo-str;STRIP">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-str;isStripOfUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">s t r i p</rdfs:label>
-		<skos:definition xml:lang="en">Separate Trading of Registered Interest and Principal of Securities. A Debt Instrument which consists of either the interest component alone, or the principal component alone, of a bond.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Full definition and notes from Morningstar: STRIPS are debt securities that are created through the process of coupon stripping. They are essentially traditional Treasury bonds, except that the bond&apos;s principal (its corpus) has been separated--stripped--from its interest (its coupon). Investors may then choose to purchase securities based on either the principal or interest of the bond. STRIPS take the form of zero-coupon securities. That is, they make no periodic interest payments, as most bonds do. Instead, you buy them at a deep discount from their face value, which is the amount you receive when they mature.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;interestStrip">
-		<rdfs:label xml:lang="en">interest strip</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;InterestSTRIP"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The STRIP instrument is a strip of the Interest of the underlying Debt Instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;interestStrip.1">
-		<rdfs:label xml:lang="en">interest strip</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;PrincipalSTRIP"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The STRIP instrument is not a strip of the Interest of the underlying Debt Instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;interestStrip.2">
-		<rdfs:label xml:lang="en">interest strip</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the STRIP instrument is a strip of the Interest of the underlying Debt Instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;isStripOfUnderlying">
-		<rdfs:label xml:lang="en">is strip of underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;principalStrip">
-		<rdfs:label xml:lang="en">principal strip</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;InterestSTRIP"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The STRIP instrument is not a strip of the Principal of the underlying Debt Instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;principalStrip.1">
-		<rdfs:label xml:lang="en">principal strip</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;PrincipalSTRIP"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The STRIP instrument is a strip of the Principal of the underlying Debt Instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;principalStrip.2">
-		<rdfs:label xml:lang="en">principal strip</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the STRIP instrument is a strip of the Principal of the underlying Debt Instrument.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
+buxmlns:fibo-sec-dbt-bo-str="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/STRIPs/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/STRIPs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">STRIPs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">A STRIP is an instrument which separates out either the interest payments or the principal payments of an underlying bond, such that this part can be traded as an instrument in its own right.
+		Note that this model was originally developed with implied restrictions on the simple yes / no of whether the STRIP is a principal or an interest strip. These restrictions need to be re-introduced formally, or better still the detailed semantics needs to be modeled by referring to the interest or principal cashflow structures for a bond, as appropriate.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/STRIPs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-str;InterestSTRIP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest s t r i p</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Debt Instrument which consists of the interest component alone, of a Debt Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-str;PrincipalSTRIP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">principal s t r i p</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Debt Instrument which consists of the principal component alone, of a Debt Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-bo-str;STRIP">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-bo-str;isStripOfUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">s t r i p</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Separate Trading of Registered Interest and Principal of Securities. A Debt Instrument which consists of either the interest component alone, or the principal component alone, of a bond.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Full definition and notes from Morningstar: STRIPS are debt securities that are created through the process of coupon stripping. They are essentially traditional Treasury bonds, except that the bond&apos;s principal (its corpus) has been separated--stripped--from its interest (its coupon). Investors may then choose to purchase securities based on either the principal or interest of the bond. STRIPS take the form of zero-coupon securities. That is, they make no periodic interest payments, as most bonds do. Instead, you buy them at a deep discount from their face value, which is the amount you receive when they mature.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;interestStrip">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest strip</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;InterestSTRIP"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The STRIP instrument is a strip of the Interest of the underlying Debt Instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;interestStrip.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest strip</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;PrincipalSTRIP"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The STRIP instrument is not a strip of the Interest of the underlying Debt Instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;interestStrip.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest strip</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the STRIP instrument is a strip of the Interest of the underlying Debt Instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;isStripOfUnderlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is strip of underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-bo-bo;Bond"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;principalStrip">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">principal strip</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;InterestSTRIP"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The STRIP instrument is not a strip of the Principal of the underlying Debt Instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;principalStrip.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">principal strip</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;PrincipalSTRIP"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The STRIP instrument is a strip of the Principal of the underlying Debt Instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bo-str;principalStrip.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">principal strip</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-bo-str;STRIP"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the STRIP instrument is a strip of the Principal of the underlying Debt Instrument.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/DebtFoundations/DebtCashflowTerms.rdf
+++ b/sec/Debt/DebtFoundations/DebtCashflowTerms.rdf
@@ -1,724 +1,728 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY fibo-sec-secx-schx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/FND/MathExt/Math/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY fibo-sec-secx-schx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:fibo-sec-secx-schx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
-		<rdfs:label>DebtCashflowTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;Accreting">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
-		<rdfs:label>accreting</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;AmortizationType">
-		<rdfs:label>amortization type</rdfs:label>
-		<skos:definition>The different types of principal payments applicable to a debt security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;Base">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;roundingDecimalPlaces"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;truncatingDecimalPlaces"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasOperand"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>base</rdfs:label>
-		<skos:definition>The variable to which an additional Margin amount is added to get the Interest amount.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;BondContinuousCallType">
-		<rdfs:label>bond continuous call type</rdfs:label>
-		<terms:description>Bond may be called at any time</terms:description>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;CalendarType">
-		<rdfs:label>calendar day type</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;BusinessDay">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-fnd-tim-tim;CalendarDay">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition>Calendar is defined in terms of either a Calendar Day or a Business Day.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;DebtCallTerms">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
-		<rdfs:label>debt call terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/InterestPaymentTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;interestPaymentDayAndMonth"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">12</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;interestPaymentDayAndMonth"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasAccrualBasis"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>debt security interest payment terms</rdfs:label>
-		<skos:definition>Terms defining the interest or Coupon to be paid on a security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
-		<rdfs:label>extendable maturity redemption terms set</rdfs:label>
-		<skos:definition>Terms for the redemption of a security with extendable maturity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;FactorCalculationFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:label>factor calculation formula</rdfs:label>
-		<skos:definition>Formula for the determination of some variable factor which is then used in subsequent calculations. The result of such a formula is a parameter referred to by another formula.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Examples include the formula for determining the Factor for an Inflation Bond, which may then be used in calculation of interest payments, principal repayments or both. It is referred to separately and may be determined by a different party to the party which determines the factor itself. Consensus:Review</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasBaseParameter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;Base"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasMarginParameter"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;Margin"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>interest calculation expression</rdfs:label>
-		<skos:definition>How the Formula is expressed i.e. the Right Hand Side of the Formula. This has separate parameters for Base and Margin. The overall Expression is not modeled but may be additionally described in a free form text field.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;InterestCalculationFormula">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasExpression"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasSubject"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationSubject"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>interest calculation formula</rdfs:label>
-		<skos:definition>Formula for calculation of Interest.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;InterestCalculationSubject">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;subjectIs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;SecuritizedDebtInterest"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>interest calculation subject</rdfs:label>
-		<skos:definition>The Subject or Left Hand Side of an Interest Calculation Formula. This is by definition the Interest amount.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;InterestOnly">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
-		<rdfs:label>interest only</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;Margin">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
-		<rdfs:label>margin</rdfs:label>
-		<skos:definition>The parameter of the Expression which is added to the Base to get the Interest amount.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;NonTradableDebtInterestTerms">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/InterestPaymentTerms"/>
-		<rdfs:label>non tradable debt interest terms</rdfs:label>
-		<skos:definition>Terms for payment of interest on debt instruments that are not traded securities, i.e. over the counter, bilateral paper.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;NotificationFeature">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
-		<rdfs:label>notification feature</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PrescriptiveEvent">
-		<rdfs:label>prescriptive event</rdfs:label>
-		<skos:definition>An event whereby a debt security comes to the end of its life and the debt is paid off (redeemed).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PrincipalOnly">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
-		<rdfs:label>principal only</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PrincipalPlusInterest">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
-		<rdfs:label>principal plus interest</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutDate">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
-		<rdfs:label>put date</rdfs:label>
-		<skos:definition>Date on which the instrument may be put.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutOfIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;RedemptionEvent"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;occursOn.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;PutDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>put of issue</rdfs:label>
-		<skos:definition>The putting i.e. the giving up of units of a Traded Security by Holders.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutSchedule">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
-		<rdfs:label>put schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutScheduleListing">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;PutSchedule"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;PutOfIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>put schedule listing</rdfs:label>
-		<skos:definition>Schedule of dates on which a Traded Security may be Put by the Holder.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;includes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;PutSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;includesWindow.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;PutWindow"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>put terms</rdfs:label>
-		<skos:definition>Contractual terms for a feature that provides the bond holder the contractual option to redeem the bond prior to the scheduled maturity date.</skos:definition>
-		<skos:editorialNote>FIBIM has term &quot;Putable Date&quot; which (by implication, and comparing with definition for &quot;Next Call Date&quot;) is presumably a single calendar date in the future, at a given point in time. That does not cover the definition of formal terms defining when and how the issue may be put, which is what is modeled here.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutWindow">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasPutCalendarType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;CalendarType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>put window</rdfs:label>
-		<skos:definition>Window of number of days prior to a mandatory or optional redemption date that the issuer/agent must give notice to holders.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;RedemptionEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;PrescriptiveEvent"/>
-		<rdfs:label>redemption event</rdfs:label>
-		<skos:definition>An event whereby a debt security comes to the end of its life and the debt is paid off (redeemed).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;SecuritizedDebtInterest">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Interest"/>
-		<rdfs:label>securitized debt interest</rdfs:label>
-		<skos:definition>Interest on Debt which is the subject of a Financial Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;includesForExtendableMaturity"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>tradable debt security redemption terms set</rdfs:label>
-		<skos:definition>Terms for the redemption of the debt represented by a debt security.</skos:definition>
-		<skos:editorialNote>Debt represented by a tradable debt security may be paid as a one off payment at maturity, by paying down principal amounts periodically, or by a call of the issue by the issuer. Debt that is defined by a convertible bond are redeemed by conversion into an equity security issued by the same company. More notes from the EDMC SME Review: Distinction between call and amortizing is whether you pay off everybody at the same time or via a lottery. SF can be either. either amortize the payment of a SF or pay it off by a lottery. The terms of the instrument determine that. Mandatory - all in the schedule. Mandatory to the bond issuer. Issuer has to pay off a certain amount at a certain time - this is in the Schedule. Callable - nothing mandatory.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;amount">
-		<rdfs:label>amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;Margin"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition>A fixed, constant amount which forms the Margin parameter, expressed as a percentage.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;autoReinvestment">
-		<rdfs:label>auto reinvestment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the security provides for mandatorily &amp; automatically re-investing the interest from that security towards buying more of the same security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;callableByDebtor">
-		<rdfs:label>callable by debtor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;compoundingFrequency">
-		<rdfs:label>compounding frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition>The frequency at which the interest is compounded. This is established at the initial stages of securing the instrument. Generally, interest tends to be calculated on an annual basis although other terms may be established at the time of the loan.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;datedDate">
-		<rdfs:label>dated date</rdfs:label>
-		<terms:description>the date on which an interest paying debt instrument begins to accrue interest</terms:description>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;daysToCallNotification">
-		<rdfs:label>days to call notification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;NotificationFeature"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition>Number of days prior to a call date that the issuer/agent must give notice to holders.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;daysToPut">
-		<rdfs:label>days to put</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition>Number of days prior to a mandatory or optional redemption date that the issuer/agent must give notice to holders.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;daysToPutNotification">
-		<rdfs:label>days to put notification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutWindow"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition>Number of days prior to a mandatory or optional redemption date that the issuer/agent must give notice to holders. This term replaces the Multipler term in the Duratiojn Description.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;estateOrDeathPut">
-		<rdfs:label>estate or death put</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Specifies that a security is subject to be Redeemed upon the passing of the holder.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;expression">
-		<rdfs:label>expression</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition>Textual expression of the entire right hand side of the Formula. Note that this is additional to the modelling of the separate Arguments that make up the formula.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extendableByHolder">
-		<rdfs:label>extendable by holder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Indicates whether the expiration date or maturity date can be extended by the holder, i.e. repayment may be extended or maturity changed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extendableByIssuer">
-		<rdfs:label>extendable by issuer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the issuer has the option to extend the debt rather than refinancing. If not, the issuer may only refinance the debt by calling the issue and creating a new issue.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extendableDate">
-		<rdfs:label>extendable date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
-		<skos:definition>Date to which the Maturity Date may be extended. This date is determined at the set-up of the bond. Note this date is adjustable according to various applicable parameters or terms. May have a rolling extendable maturity date. The bond holder may choose to extend. Usually a 13 month rolling extendable maturity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extendablePeriod">
-		<rdfs:label>extendable period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition>Period during which the Maturity Date may be extended.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extraordinaryCallProvision">
-		<rdfs:label>extraordinary call provision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Indicates the existence of an Extraordinary Call provision in the bond call terms.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstInterestAccrualDate">
-		<rdfs:label>first interest accrual date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>Date from which the security begins to accrue interest.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstInterestPaymentDate">
-		<rdfs:label>first interest payment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>The day on which the first interest payment is due to the holders of the security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstParCallDate">
-		<rdfs:label>first par call date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>The first date on which bonds may be called at Par for redemption.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstParCallPrice">
-		<rdfs:label>first par call price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition>The price of the bonds on the first Par part call.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstPremiumCallDate">
-		<rdfs:label>first premium call date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>The first date on which bonds may be called for redemption at a price above par.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstPremiumCallPrice">
-		<rdfs:label>first premium call price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition>The price of the bonds on the first part call at a price above par.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasAccrualBasis">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isQualifiedBy"/>
-		<rdfs:label>has accrual basis</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasBaseParameter">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasArgument"/>
-		<rdfs:label>has base parameter</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;Base"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasFormula">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isQualifiedBy"/>
-		<rdfs:label>has formula</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationFormula"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasInterestTerms">
-		<rdfs:label>has interest terms</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasMarginParameter">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasArgument"/>
-		<rdfs:label>has margin parameter</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;Margin"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasNotificationFeature">
-		<rdfs:label>has notification feature</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;NotificationFeature"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasPerpetualCall">
-		<rdfs:label>has perpetual call</rdfs:label>
-		<terms:description>the asset has a perpetual call schedule</terms:description>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasPrincipalAmortizationType">
-		<rdfs:label>has principal amortization type</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
-		<skos:definition>The type of principal payments applicable to this security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasPutCalendarType">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
-		<rdfs:label>has put calendar type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutWindow"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;CalendarType"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasRedemptionTerms">
-		<rdfs:label>has redemption terms</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;includes">
-		<rdfs:label>includes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;PutSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;includesForExtendableMaturity">
-		<rdfs:label>includes for extendable maturity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet"/>
-		<skos:definition>In the case of terms where extendable maturity is yes, terms are included regarding the extension of the maturity on the security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;includesWindow.1">
-		<rdfs:label>includes window</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;PutWindow"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;interestPaymentDayAndMonth">
-		<rdfs:label>interest payment day and month</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition>The regular dates of interest payment in any given year during the life of the debt instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;interestPaymentFrequency">
-		<rdfs:label>interest payment frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition>Frequency of payment of Interest on the debt.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;interestRate">
-		<rdfs:label>interest rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;NonTradableDebtInterestTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition>The annual percentage rate of interest that must be paid on the debt.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;isLegallyDefeased">
-		<rdfs:label>is legally defeased</rdfs:label>
-		<terms:description>whether the maturity is legally defeased</terms:description>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;lastInterestPaymentDate">
-		<rdfs:label>last interest payment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>The day on which the final interest payment is due to the holders of the security prior to maturity. This is only needed if the last coupon is of an odd length.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;legalFinalMaturityDate">
-		<rdfs:label>legal final maturity date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>the date on which the principal must be paid to investors</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The Legal Maturity Date is later than the expected maturity date and is the date on which the principal must be paid to investors. Also called final maturity date. It is also the termination or due date on which an installment loan must be paid in full.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;makeWholeCallProvision">
-		<rdfs:label>make whole call provision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>A provision on the bond allowing the borrower to pay off remaining debt early.</skos:definition>
-		<skos:definition>A type of call provision allowing the issuer to pay off debt early that is designed to protect the investor from losses as a result of the earlier call. In order to exercise the call, the issuer must make a lump sum payment derived from a formula based on the net present value of future interest payments that will not be paid as a result of the call.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin>http://www.msrb.org/Glossary/Definition/MAKE-WHOLE-CALL.aspx</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>Because the cost can often be significant, such provisions are rarely used.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;mandatoryPut">
-		<rdfs:label>mandatory put</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the redemption prior to maturity date feature is Mandatory to the bond holder. If No, then this is optional.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;mandatorySinkingFund">
-		<rdfs:label>mandatory sinking fund</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether there is a Mandatory Sinking fund feature.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;notification">
-		<rdfs:label>notification</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;NotificationFeature"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether Call Schedule includes notification.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;occursOn.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
-		<rdfs:label>occurs on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutOfIssue"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;PutDate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;payInKind">
-		<rdfs:label>pay in kind</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>The issuer will pay additional security as part of interest disbursement. Review: This needs to be replaced wit a sub class of Interst Payment in which the additional security is specified.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;paymentInKind">
-		<rdfs:label>payment in kind</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the Principal may be repaid in kind rather than in cash.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;perpetualMaturity">
-		<rdfs:label>perpetual maturity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the debt security has perpetual maturity, i.e. there is no Maturity Date and the security remains in issue indefinitely or until recalled.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;proRated">
-		<rdfs:label>pro rated</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the coupon is pro rated to the actual number of days in the payment period versus the number of payment periods.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;putDate">
-		<rdfs:label>put date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>Date on which securities are subject to Optional or Mandatory Redemption by the bond holder.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;putFrequency">
-		<rdfs:label>put frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition>Frequency of Tender or Put period.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;rightToRetain">
-		<rdfs:label>right to retain</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the holder has an option to retain the security in the event of an issuer exercising the put option.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;roundingDecimalPlaces">
-		<rdfs:label>rounding decimal places</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;Base"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition>Number of decimal places to round to.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;scheduledMaturityDate">
-		<rdfs:label>scheduled maturity date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition>Originally specified date on which an interest bearing security becomes due and assets are to be repaid, as stated in the security&apos;s offering documents. This is the date on which the principal amount of a debt instrument becomes due and is repaid to the investor and interest payments stop.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;subjectIs">
-		<rdfs:label>subject is</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationSubject"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;SecuritizedDebtInterest"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;truncatingDecimalPlaces">
-		<rdfs:label>truncating decimal places</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;Base"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition>Number of decimal places. Note this is either/or with the Rounding number of decimal places.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:fibo-sec-secx-schx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
+bubu<rdfs:label>DebtCashflowTerms</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">This ontology describes terms common to cashflow structures in tradable debt instruments generally, including bonds and short term tradable debt. These include interest payment and principal repayment terms, including calls and puts.
+		These terms are extended further in the Bonds Cashflow Terms ontology for those variations specific to bonds. Terms in this ontology should also be mapped to or aligned with the ACTUS de-facto standard for instrument cashflows.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/ExerciseConventions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Math/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;Accreting">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
+bubu<rdfs:label>accreting</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;AmortizationType">
+bubu<rdfs:label>amortization type</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">The different types of principal payments applicable to a debt security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;Base">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;roundingDecimalPlaces"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;truncatingDecimalPlaces"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasOperand"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/IND/Indicators/Indicators/MarketRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>base</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">The variable to which an additional Margin amount is added to get the Interest amount.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;BondContinuousCallType">
+bubu<rdfs:label>bond continuous call type</rdfs:label>
+bubu<terms:description rdf:datatype="&xsd;string">Bond may be called at any time</terms:description>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;CalendarType">
+bubu<rdfs:label>calendar day type</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;BusinessDay">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-fnd-tim-tim;CalendarDay">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&xsd;string">Calendar is defined in terms of either a Calendar Day or a Business Day.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;DebtCallTerms">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
+bubu<rdfs:label>debt call terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/InterestPaymentTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;interestPaymentDayAndMonth"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">12</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;interestPaymentDayAndMonth"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasAccrualBasis"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>debt security interest payment terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Terms defining the interest or Coupon to be paid on a security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
+bubu<rdfs:label>extendable maturity redemption terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Terms for the redemption of a security with extendable maturity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;FactorCalculationFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:label>factor calculation formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Formula for the determination of some variable factor which is then used in subsequent calculations. The result of such a formula is a parameter referred to by another formula.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Examples include the formula for determining the Factor for an Inflation Bond, which may then be used in calculation of interest payments, principal repayments or both. It is referred to separately and may be determined by a different party to the party which determines the factor itself. Consensus:Review</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaExpression"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasBaseParameter"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;Base"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasMarginParameter"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;Margin"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>interest calculation expression</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">How the Formula is expressed i.e. the Right Hand Side of the Formula. This has separate parameters for Base and Margin. The overall Expression is not modeled but may be additionally described in a free form text field.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;InterestCalculationFormula">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;Formula"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasExpression"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-math-math;hasSubject"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationSubject"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>interest calculation formula</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Formula for calculation of Interest.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;InterestCalculationSubject">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaSubject"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;subjectIs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;SecuritizedDebtInterest"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>interest calculation subject</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">The Subject or Left Hand Side of an Interest Calculation Formula. This is by definition the Interest amount.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;InterestOnly">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
+bubu<rdfs:label>interest only</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;Margin">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-math-math;FormulaArgument"/>
+bubu<rdfs:label>margin</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">The parameter of the Expression which is added to the Base to get the Interest amount.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;NonTradableDebtInterestTerms">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/InterestPaymentTerms"/>
+bubu<rdfs:label>non tradable debt interest terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Terms for payment of interest on debt instruments that are not traded securities, i.e. over the counter, bilateral paper.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;NotificationFeature">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
+bubu<rdfs:label>notification feature</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PrescriptiveEvent">
+bubu<rdfs:label>prescriptive event</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">An event whereby a debt security comes to the end of its life and the debt is paid off (redeemed).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PrincipalOnly">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
+bubu<rdfs:label>principal only</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PrincipalPlusInterest">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
+bubu<rdfs:label>principal plus interest</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutDate">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
+bubu<rdfs:label>put date</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Date on which the instrument may be put.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutOfIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;RedemptionEvent"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;occursOn.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;PutDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>put of issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">The putting i.e. the giving up of units of a Traded Security by Holders.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutSchedule">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Schedule"/>
+bubu<rdfs:label>put schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutScheduleListing">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;AdHocSchedule"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;PutSchedule"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;PutOfIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>put schedule listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Schedule of dates on which a Traded Security may be Put by the Holder.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;includes"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;PutSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;includesWindow.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;PutWindow"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>put terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Contractual terms for a feature that provides the bond holder the contractual option to redeem the bond prior to the scheduled maturity date.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&xsd;string">FIBIM has term &quot;Putable Date&quot; which (by implication, and comparing with definition for &quot;Next Call Date&quot;) is presumably a single calendar date in the future, at a given point in time. That does not cover the definition of formal terms defining when and how the issue may be put, which is what is modeled here.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;PutWindow">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasPutCalendarType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;CalendarType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>put window</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Window of number of days prior to a mandatory or optional redemption date that the issuer/agent must give notice to holders.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;RedemptionEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-cft;PrescriptiveEvent"/>
+bubu<rdfs:label>redemption event</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">An event whereby a debt security comes to the end of its life and the debt is paid off (redeemed).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;SecuritizedDebtInterest">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Interest"/>
+bubu<rdfs:label>securitized debt interest</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Interest on Debt which is the subject of a Financial Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;includesForExtendableMaturity"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label>tradable debt security redemption terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">Terms for the redemption of the debt represented by a debt security.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&xsd;string">Debt represented by a tradable debt security may be paid as a one off payment at maturity, by paying down principal amounts periodically, or by a call of the issue by the issuer. Debt that is defined by a convertible bond are redeemed by conversion into an equity security issued by the same company. More notes from the EDMC SME Review: Distinction between call and amortizing is whether you pay off everybody at the same time or via a lottery. SF can be either. either amortize the payment of a SF or pay it off by a lottery. The terms of the instrument determine that. Mandatory - all in the schedule. Mandatory to the bond issuer. Issuer has to pay off a certain amount at a certain time - this is in the Schedule. Callable - nothing mandatory.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;amount">
+bubu<rdfs:label>amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;Margin"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">A fixed, constant amount which forms the Margin parameter, expressed as a percentage.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;autoReinvestment">
+bubu<rdfs:label>auto reinvestment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the security provides for mandatorily &amp; automatically re-investing the interest from that security towards buying more of the same security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;callableByDebtor">
+bubu<rdfs:label>callable by debtor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;compoundingFrequency">
+bubu<rdfs:label>compounding frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The frequency at which the interest is compounded. This is established at the initial stages of securing the instrument. Generally, interest tends to be calculated on an annual basis although other terms may be established at the time of the loan.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;datedDate">
+bubu<rdfs:label>dated date</rdfs:label>
+bubu<terms:description rdf:datatype="&xsd;string">the date on which an interest paying debt instrument begins to accrue interest</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;daysToCallNotification">
+bubu<rdfs:label>days to call notification</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;NotificationFeature"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Number of days prior to a call date that the issuer/agent must give notice to holders.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;daysToPut">
+bubu<rdfs:label>days to put</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Number of days prior to a mandatory or optional redemption date that the issuer/agent must give notice to holders.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;daysToPutNotification">
+bubu<rdfs:label>days to put notification</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutWindow"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Number of days prior to a mandatory or optional redemption date that the issuer/agent must give notice to holders. This term replaces the Multipler term in the Duratiojn Description.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;estateOrDeathPut">
+bubu<rdfs:label>estate or death put</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Specifies that a security is subject to be Redeemed upon the passing of the holder.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;expression">
+bubu<rdfs:label>expression</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Textual expression of the entire right hand side of the Formula. Note that this is additional to the modelling of the separate Arguments that make up the formula.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extendableByHolder">
+bubu<rdfs:label>extendable by holder</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Indicates whether the expiration date or maturity date can be extended by the holder, i.e. repayment may be extended or maturity changed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extendableByIssuer">
+bubu<rdfs:label>extendable by issuer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the issuer has the option to extend the debt rather than refinancing. If not, the issuer may only refinance the debt by calling the issue and creating a new issue.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extendableDate">
+bubu<rdfs:label>extendable date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DeterminedDate"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Date to which the Maturity Date may be extended. This date is determined at the set-up of the bond. Note this date is adjustable according to various applicable parameters or terms. May have a rolling extendable maturity date. The bond holder may choose to extend. Usually a 13 month rolling extendable maturity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extendablePeriod">
+bubu<rdfs:label>extendable period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Period during which the Maturity Date may be extended.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;extraordinaryCallProvision">
+bubu<rdfs:label>extraordinary call provision</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Indicates the existence of an Extraordinary Call provision in the bond call terms.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstInterestAccrualDate">
+bubu<rdfs:label>first interest accrual date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Date from which the security begins to accrue interest.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstInterestPaymentDate">
+bubu<rdfs:label>first interest payment date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The day on which the first interest payment is due to the holders of the security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstParCallDate">
+bubu<rdfs:label>first par call date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The first date on which bonds may be called at Par for redemption.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstParCallPrice">
+bubu<rdfs:label>first par call price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The price of the bonds on the first Par part call.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstPremiumCallDate">
+bubu<rdfs:label>first premium call date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The first date on which bonds may be called for redemption at a price above par.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;firstPremiumCallPrice">
+bubu<rdfs:label>first premium call price</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The price of the bonds on the first part call at a price above par.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasAccrualBasis">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isQualifiedBy"/>
+bubu<rdfs:label>has accrual basis</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasBaseParameter">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasArgument"/>
+bubu<rdfs:label>has base parameter</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;Base"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasFormula">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isQualifiedBy"/>
+bubu<rdfs:label>has formula</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationFormula"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasInterestTerms">
+bubu<rdfs:label>has interest terms</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasMarginParameter">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-math-math;hasArgument"/>
+bubu<rdfs:label>has margin parameter</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationExpression"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;Margin"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasNotificationFeature">
+bubu<rdfs:label>has notification feature</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;NotificationFeature"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasPerpetualCall">
+bubu<rdfs:label>has perpetual call</rdfs:label>
+bubu<terms:description rdf:datatype="&xsd;string">the asset has a perpetual call schedule</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasPrincipalAmortizationType">
+bubu<rdfs:label>has principal amortization type</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;AmortizationType"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The type of principal payments applicable to this security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasPutCalendarType">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
+bubu<rdfs:label>has put calendar type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutWindow"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;CalendarType"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;hasRedemptionTerms">
+bubu<rdfs:label>has redemption terms</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;includes">
+bubu<rdfs:label>includes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;PutSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;includesForExtendableMaturity">
+bubu<rdfs:label>includes for extendable maturity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;ExtendableMaturityRedemptionTermsSet"/>
+bubu<skos:definition rdf:datatype="&xsd;string">In the case of terms where extendable maturity is yes, terms are included regarding the extension of the maturity on the security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;includesWindow.1">
+bubu<rdfs:label>includes window</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;PutWindow"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;interestPaymentDayAndMonth">
+bubu<rdfs:label>interest payment day and month</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The regular dates of interest payment in any given year during the life of the debt instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;interestPaymentFrequency">
+bubu<rdfs:label>interest payment frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Frequency of payment of Interest on the debt.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;interestRate">
+bubu<rdfs:label>interest rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;NonTradableDebtInterestTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The annual percentage rate of interest that must be paid on the debt.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;isLegallyDefeased">
+bubu<rdfs:label>is legally defeased</rdfs:label>
+bubu<terms:description rdf:datatype="&xsd;string">whether the maturity is legally defeased</terms:description>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;lastInterestPaymentDate">
+bubu<rdfs:label>last interest payment date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The day on which the final interest payment is due to the holders of the security prior to maturity. This is only needed if the last coupon is of an odd length.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;legalFinalMaturityDate">
+bubu<rdfs:label>legal final maturity date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&xsd;string">the date on which the principal must be paid to investors</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">The Legal Maturity Date is later than the expected maturity date and is the date on which the principal must be paid to investors. Also called final maturity date. It is also the termination or due date on which an installment loan must be paid in full.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;makeWholeCallProvision">
+bubu<rdfs:label>make whole call provision</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">A provision on the bond allowing the borrower to pay off remaining debt early.</skos:definition>
+bubu<skos:definition rdf:datatype="&xsd;string">A type of call provision allowing the issuer to pay off debt early that is designed to protect the investor from losses as a result of the earlier call. In order to exercise the call, the issuer must make a lump sum payment derived from a formula based on the net present value of future interest payments that will not be paid as a result of the call.</skos:definition>
+bubu<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">http://www.msrb.org/Glossary/Definition/MAKE-WHOLE-CALL.aspx</fibo-fnd-utl-av:definitionOrigin>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Because the cost can often be significant, such provisions are rarely used.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;mandatoryPut">
+bubu<rdfs:label>mandatory put</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the redemption prior to maturity date feature is Mandatory to the bond holder. If No, then this is optional.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;mandatorySinkingFund">
+bubu<rdfs:label>mandatory sinking fund</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether there is a Mandatory Sinking fund feature.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;notification">
+bubu<rdfs:label>notification</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;NotificationFeature"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether Call Schedule includes notification.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;occursOn.1">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
+bubu<rdfs:label>occurs on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutOfIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;PutDate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;payInKind">
+bubu<rdfs:label>pay in kind</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The issuer will pay additional security as part of interest disbursement. Review: This needs to be replaced wit a sub class of Interst Payment in which the additional security is specified.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;paymentInKind">
+bubu<rdfs:label>payment in kind</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the Principal may be repaid in kind rather than in cash.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;perpetualMaturity">
+bubu<rdfs:label>perpetual maturity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the debt security has perpetual maturity, i.e. there is no Maturity Date and the security remains in issue indefinitely or until recalled.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;proRated">
+bubu<rdfs:label>pro rated</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the coupon is pro rated to the actual number of days in the payment period versus the number of payment periods.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;putDate">
+bubu<rdfs:label>put date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Date on which securities are subject to Optional or Mandatory Redemption by the bond holder.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;putFrequency">
+bubu<rdfs:label>put frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Frequency of Tender or Put period.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;rightToRetain">
+bubu<rdfs:label>right to retain</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;PutTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the holder has an option to retain the security in the event of an issuer exercising the put option.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;roundingDecimalPlaces">
+bubu<rdfs:label>rounding decimal places</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;Base"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Number of decimal places to round to.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;scheduledMaturityDate">
+bubu<rdfs:label>scheduled maturity date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Originally specified date on which an interest bearing security becomes due and assets are to be repaid, as stated in the security&apos;s offering documents. This is the date on which the principal amount of a debt instrument becomes due and is repaid to the investor and interest payments stop.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;subjectIs">
+bubu<rdfs:label>subject is</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;InterestCalculationSubject"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;SecuritizedDebtInterest"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-cft;truncatingDecimalPlaces">
+bubu<rdfs:label>truncating decimal places</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-cft;Base"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Number of decimal places. Note this is either/or with the Rounding number of decimal places.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/DebtFoundations/DebtFinance.rdf
+++ b/sec/Debt/DebtFoundations/DebtFinance.rdf
@@ -1,257 +1,261 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-dbt-dbt-fin "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-ptyx-prc "https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-dbt-dbt-fin "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-dbt-dbt-fin="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/">
-		<rdfs:label xml:lang="en">DebtFinance</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/RevolvingLineOfCredit">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
-				<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/LoanCollateral"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/LoanCollateral"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/CollateralizedSecuredLoan">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
-				<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/LoanCollateral"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/LoanCollateral"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/CollateralizedDebt">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
-				<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/DebtCollateral"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/DebtCollateral"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;Borrower">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debtor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;partyTo.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">borrower</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;Collateral">
-		<rdfs:subClassOf rdf:resource="&owl;Thing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/takesForm"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/Asset"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">collateral</rdfs:label>
-		<skos:definition xml:lang="en">Assets pledged in the provision of debt or loan products or securities.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See also &quot;Loan collateral&quot; which is defined specifically in the context of an individual loan or mortage. These terms may be duplicates, depending on whether there is some more abstract meaning for collateralization of securitized debt.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractTermsSet"/>
-		<rdfs:label xml:lang="en">debt terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out the formal rights and obligations of borrower and lender under a contract in which funds are lent from the one party to the other.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These may be terms in a Loan Contract (incliding for example Mportage ContracT) or they may be the contractual terms of a Debt security.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;DebtFinance">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-fin;MoniesOwing"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-dbt-fin;Collateral"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;hasBorrowingParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;Borrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;hasLendingParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;Lender"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;hasfibo-fnd-accx-dtt"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt finance</rdfs:label>
-		<skos:definition xml:lang="en">Funds loaned or extended from one party to another for some purpose. Further notes: This is a loan or a debt security principal amount. This term is distinguished from &quot;Debt&quot; or &quot;Credit&quot; in that the latter are balances at a point in time; however it is also referred to as debt for example in debt securities, since a loaned or securitized amount constitutes a debt when it is advanced (and ceases to constitute a debt when it is paid off). As such, this usually has interest payable and may have collateral. In Islamic products there is no interest. This may be a loan (realized as a draw-down on a credit facillity) or it may be a debt set up as part of the issuance of a debt security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;Lender">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;partyTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">lender</rdfs:label>
-		<skos:editorialNote xml:lang="en">lender: The lender of a loan is some form of Legal Entity.</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For formal loans, the entity will be an Artificial Person. For loans more generally, it may be any legal entity.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;MoniesOwing">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/Commitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/isMeasuredAs"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/DatedBalance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;owedBy"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debtor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;owedTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt</rdfs:label>
-		<skos:definition xml:lang="en">A sum of money owed by one party to another party.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is an amount of money regarded as a debt by one party, or as credit by another party. Note that the sub terms Credit and Debt are also balance sheet entries, that is these can be anything in which monies are owed by one party to another. Monies Owing may therefore also be goods payable/receivable. This term is therefore independent of the existence of any formal credit facility provided by a credit provider. Change note Reviewed 18 Oct 2012 and determined that Monies Owing is a mediating thing (context0 in which Credit and Debt are defined, and not a common parent of those two things. Credit and Debt changed to be sub classes of Relative Thing and not cub classes of Monies Owing as before. New relationship fact &apos;viewpoint&apos; added to Credit and similarly to Debt, with Monies Owing as the target of that fact, in place of the previous superclass relationship.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;collateralizedBy">
-		<rdfs:label xml:lang="en">collateralized by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;Collateral"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;hasBorrowingParty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-prc;hasPartyInRole"/>
-		<rdfs:label xml:lang="en">has borrowing party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;Borrower"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;hasDebtTerms">
-		<rdfs:label>has debt terms</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;hasLendingParty">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-prc;hasPartyInRole"/>
-		<rdfs:label xml:lang="en">has lending party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;Lender"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;hasfibo-fnd-accx-dtt">
-		<rdfs:label xml:lang="en">has debt terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;isAmortizationOf">
-		<rdfs:label xml:lang="en">is amortization of</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Amortization"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;owedBy">
-		<rdfs:label xml:lang="en">owed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;MoniesOwing"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debtor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;owedTo">
-		<rdfs:label xml:lang="en">owed to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;MoniesOwing"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;partyTo">
-		<rdfs:label xml:lang="en">party to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;Lender"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;partyTo.1">
-		<rdfs:label xml:lang="en">party to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;Borrower"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-ptyx-prc="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-dbt-dbt-fin="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtFinance</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the core abstractions behind the notions of debt and debt finance. 
+		This model is intended to be general both to tradable debt instruments and to non tradable debt such as loans and certain money market instruments. The concepts in this ontology are sufficiently fundamental that it is likely they are also included in more recently introduced ontologies both in the Securities domain and in Financial Business and Commerce, as part of the drive to unify these models more closely.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PartiesExt/PartyRoleContext/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/CreditProducts/RevolvingLineOfCredit">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
+bubububu<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/LoanCollateral"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/LoanCollateral"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/LOAN/LoanTypes/SecuredLoans/CollateralizedSecuredLoan">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
+bubububu<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/LoanCollateral"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoansCollateral/LoanCollateral"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/CollateralizedDebt">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
+bubububu<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/DebtCollateral"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/DebtCollateral"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;Borrower">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debtor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;partyTo.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">borrower</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;Collateral">
+bubu<rdfs:subClassOf rdf:resource="&owl;Thing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/takesForm"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/Asset"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateral</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Assets pledged in the provision of debt or loan products or securities.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">See also &quot;Loan collateral&quot; which is defined specifically in the context of an individual loan or mortage. These terms may be duplicates, depending on whether there is some more abstract meaning for collateralization of securitized debt.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractTermsSet"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out the formal rights and obligations of borrower and lender under a contract in which funds are lent from the one party to the other.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These may be terms in a Loan Contract (incliding for example Mportage ContracT) or they may be the contractual terms of a Debt security.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;DebtFinance">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debt"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-ptyx-prc;RelationshipContext"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-fin;MoniesOwing"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;collateralizedBy"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-dbt-fin;Collateral"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;hasBorrowingParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;Borrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;hasLendingParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;Lender"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;hasfibo-fnd-accx-dtt"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt finance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Funds loaned or extended from one party to another for some purpose. Further notes: This is a loan or a debt security principal amount. This term is distinguished from &quot;Debt&quot; or &quot;Credit&quot; in that the latter are balances at a point in time; however it is also referred to as debt for example in debt securities, since a loaned or securitized amount constitutes a debt when it is advanced (and ceases to constitute a debt when it is paid off). As such, this usually has interest payable and may have collateral. In Islamic products there is no interest. This may be a loan (realized as a draw-down on a credit facillity) or it may be a debt set up as part of the issuance of a debt security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;Lender">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;partyTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lender</rdfs:label>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">lender: The lender of a loan is some form of Legal Entity.</skos:editorialNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For formal loans, the entity will be an Artificial Person. For loans more generally, it may be any legal entity.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-fin;MoniesOwing">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/Commitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/isMeasuredAs"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/DatedBalance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;owedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debtor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-fin;owedTo"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A sum of money owed by one party to another party.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is an amount of money regarded as a debt by one party, or as credit by another party. Note that the sub terms Credit and Debt are also balance sheet entries, that is these can be anything in which monies are owed by one party to another. Monies Owing may therefore also be goods payable/receivable. This term is therefore independent of the existence of any formal credit facility provided by a credit provider. Change note Reviewed 18 Oct 2012 and determined that Monies Owing is a mediating thing (context0 in which Credit and Debt are defined, and not a common parent of those two things. Credit and Debt changed to be sub classes of Relative Thing and not cub classes of Monies Owing as before. New relationship fact &apos;viewpoint&apos; added to Credit and similarly to Debt, with Monies Owing as the target of that fact, in place of the previous superclass relationship.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;collateralizedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateralized by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;Collateral"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;hasBorrowingParty">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-prc;hasPartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has borrowing party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;Borrower"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;hasDebtTerms">
+bubu<rdfs:label>has debt terms</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;hasLendingParty">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-ptyx-prc;hasPartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has lending party</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;Lender"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;hasfibo-fnd-accx-dtt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has debt terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;isAmortizationOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is amortization of</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Amortization"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;owedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">owed by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;MoniesOwing"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Debtor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;owedTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">owed to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;MoniesOwing"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Creditor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;partyTo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">party to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;Lender"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-fin;partyTo.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">party to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-fin;Borrower"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtContractTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/definesTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/sec/Debt/DebtFoundations/DebtInstrumentGuaranties.rdf
+++ b/sec/Debt/DebtFoundations/DebtInstrumentGuaranties.rdf
@@ -1,226 +1,229 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/">
-	<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-dbt-gty "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtInstrumentGuaranties/">
-	<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/">
+bu<!ENTITY fibo-fnd-inf-doc "https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-dbt-gty "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtInstrumentGuaranties/">
+bu<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtInstrumentGuaranties/"
-	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"
-	xmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-dbt-gty="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtInstrumentGuaranties/"
-	xmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtInstrumentGuaranties/">
-		<rdfs:label xml:lang="en">DebtInstrumentGuaranties</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtInstrumentGuaranties/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;BondInsurance">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-gty;InsuranceBackedGuaranty"/>
-		<rdfs:label xml:lang="en">bond insurance</rdfs:label>
-		<skos:definition xml:lang="en">Insurance on bond.</skos:definition>
-		<skos:editorialNote xml:lang="en">From April 21 Review: For cash CDOs: External e.g. Bond insurance that is bought from a 3rd party. NB Does not apply to synthetics. Also CDOs may have internal crefit enhancement instead. See main diagram note on this.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;CollateralizedGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-gty;takesFormOfCollateral"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Collateral"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">collateralized guaranty</rdfs:label>
-		<skos:definition xml:lang="en">Guaranty which takes the form of some Collateral. e.g. if a Security is guaranteed by collateral, assets (the Collateral) are pledged to a lender until a loan is repaid.</skos:definition>
-		<skos:editorialNote xml:lang="en">Some models have Collateral as a type of Guaranty, but actually it is a way of mechanizing the Guaranty and is not the same type of Thing. Details: Seems that in collateralized guaranty you are asking for some collateral from the Guarantor. So this distinguishes it from what is just a Collateral. The process is that the guarantor offers something, the lender might say this is not adequate and will ask for additional collateral. CollateralDefinition Origin:FIBIM Extended</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;GovernmentGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/isGuaranteedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-gty;StateGuarantor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">government guaranty</rdfs:label>
-		<skos:definition xml:lang="en">Guaranty is provided by a government, e.g. a security is guaranteed by a Government.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;InsuranceBackedGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-gty;SecuritiesGuarantyInsurancePolicy"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">insurance backed guaranty</rdfs:label>
-		<skos:definition xml:lang="en">Security is guaranteed by an insurance policy.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;JointGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/isGuaranteedBy"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">joint guaranty</rdfs:label>
-		<skos:definition xml:lang="en">Guaranty provided by two or more parties jointly and severally.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;LetterOfCredit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-gty;issuedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCreditIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">letter of credit</rdfs:label>
-		<skos:definition xml:lang="en">A letter from a bank or other creditworthy institution setting out the holder&apos;s ability to access credit.</skos:definition>
-		<skos:editorialNote xml:lang="en">It should be possible to source a formal, legal definition for this.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;LetterOfCreditGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCredit"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">letter of credit guaranty</rdfs:label>
-		<skos:definition xml:lang="en">Guaranty takes the form of a letter of credit, ie, a document issued by a bank guaranteeing the payment up to a stated amount for a specified period.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;LetterOfCreditIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
-		<rdfs:label xml:lang="en">letter of credit issuer</rdfs:label>
-		<skos:definition xml:lang="en">The party which issues a Letter of Credit.</skos:definition>
-		<skos:editorialNote xml:lang="en">Term added by inspection of the ISO 20022 FIBIM terms and definitions.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;LienGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-gty;lien"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">lien guaranty</rdfs:label>
-		<skos:definition xml:lang="en">Guaranty takes the form of a lien, that is a creditor&apos;s claim against property, eg, a mortgage is a lien against a house.</skos:definition>
-		<skos:editorialNote xml:lang="en">Looks like this should be a child of &quot;Collateralized Guaranty&quot; but we need to research this further. Or they may in fact be the same meaning, or we may need to look at the collateral contract. Look at the collateral contract for the asset, which says &quot;I am going to deliver this asset as settlement for the loan&quot;. the &quot;I&quot; is the Guarantor if it&apos;s a kind of collateralized guaranty, and it&apos;s the Borrower if it&apos;s just Collateral on the Loan. Effectively the Guarantor becomes like theb borrower in terms of being who is chased for the loan amount outsstanding. For instances, differences between how you would foreclose on a moartgage between the US and Commonwealth countries. Relates to how you take ownership of the asset.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;NegativePledge">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:label xml:lang="en">negative pledge</rdfs:label>
-		<skos:definition xml:lang="en">Guaranty whereby the issuer will not pledge any assets if doing so would result in less security for the investors.</skos:definition>
-		<skos:editorialNote xml:lang="en">This also exists in loans, so revise the wording to reflect this. Also clarify that the pledge to one potential lender is not to pledge assets to some other potential lender at some time in the future. These are often broken. An agreement which gives someone a right to seize those assets? No, that&apos;s implicit in the loan i.e. secured loan. So the pledge does not introduce anything with any new legal standing, other than that having broken the pledge, you have de facto defauled on the loan even if you have not default ed on laon payments. It gies the lender the right to recall the loan as there is a technical default when this happens.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;SecuritiesGuarantyInsurancePolicy">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;InsurancePolicy"/>
-		<rdfs:label xml:lang="en">securities guaranty insurance policy</rdfs:label>
-		<skos:definition xml:lang="en">Some policy by which some party (directly or more usually through an intermediary who writes this policy) agrees to cover some risk as identified in this policy, on behalf of the holder of the policy. further Notes: Added specifically to cover financial instruments modeling of insurance backed Guaranty. This term would belong within a separate section of specialist insurance terms if there were such a section.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;SimpleGuaranty">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:label xml:lang="en">simple guaranty</rdfs:label>
-		<skos:definition xml:lang="en">No definition</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;StateGuarantor">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guarantor"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-gty;identifiedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">state guarantor</rdfs:label>
-		<skos:definition xml:lang="en">A State, acting as Party to some participatory context such as issuance, guaranty provision.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;identifiedAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantorHasIdentity"/>
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;StateGuarantor"/>
-		<rdfs:range rdf:resource="&fibo-be-ge-ge;SovereignState"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;issuedBy">
-		<rdfs:label xml:lang="en">issued by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCredit"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCreditIssuer"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;lien">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
-		<rdfs:label xml:lang="en">is encumbrance on</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;LienGuaranty"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;loCDetails">
-		<rdfs:label xml:lang="en">lo c details</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCreditGuaranty"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Details of the Letter of Credit</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;policyDetails">
-		<rdfs:label xml:lang="en">policy details</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;InsuranceBackedGuaranty"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Details of the Insurance Policy which make up this Guaranty.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;takesFormOfCollateral">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
-		<rdfs:label xml:lang="en">takes form of collateral</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;CollateralizedGuaranty"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Collateral"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"
+buxmlns:fibo-fnd-inf-doc="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-dbt-gty="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtInstrumentGuaranties/"
+buxmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtInstrumentGuaranties/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtInstrumentGuaranties</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the range of kinds of guaranty which may be provided for debt instruments.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/Documentation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/RealEstate/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtInstrumentGuaranties/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;BondInsurance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-gty;InsuranceBackedGuaranty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond insurance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Insurance on bond.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From April 21 Review: For cash CDOs: External e.g. Bond insurance that is bought from a 3rd party. NB Does not apply to synthetics. Also CDOs may have internal crefit enhancement instead. See main diagram note on this.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;CollateralizedGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-gty;takesFormOfCollateral"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Collateral"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">collateralized guaranty</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Guaranty which takes the form of some Collateral. e.g. if a Security is guaranteed by collateral, assets (the Collateral) are pledged to a lender until a loan is repaid.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Some models have Collateral as a type of Guaranty, but actually it is a way of mechanizing the Guaranty and is not the same type of Thing. Details: Seems that in collateralized guaranty you are asking for some collateral from the Guarantor. So this distinguishes it from what is just a Collateral. The process is that the guarantor offers something, the lender might say this is not adequate and will ask for additional collateral. CollateralDefinition Origin:FIBIM Extended</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;GovernmentGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/isGuaranteedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-gty;StateGuarantor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">government guaranty</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Guaranty is provided by a government, e.g. a security is guaranteed by a Government.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;InsuranceBackedGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-gty;SecuritiesGuarantyInsurancePolicy"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">insurance backed guaranty</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Security is guaranteed by an insurance policy.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;JointGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/isGuaranteedBy"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
+bubububu<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:qualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">joint guaranty</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Guaranty provided by two or more parties jointly and severally.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;LetterOfCredit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;WrittenInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-gty;issuedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCreditIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">letter of credit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A letter from a bank or other creditworthy institution setting out the holder&apos;s ability to access credit.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">It should be possible to source a formal, legal definition for this.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;LetterOfCreditGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCredit"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">letter of credit guaranty</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Guaranty takes the form of a letter of credit, ie, a document issued by a bank guaranteeing the payment up to a stated amount for a specified period.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;LetterOfCreditIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">letter of credit issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which issues a Letter of Credit.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Term added by inspection of the ISO 20022 FIBIM terms and definitions.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;LienGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-gty;lien"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lien guaranty</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Guaranty takes the form of a lien, that is a creditor&apos;s claim against property, eg, a mortgage is a lien against a house.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Looks like this should be a child of &quot;Collateralized Guaranty&quot; but we need to research this further. Or they may in fact be the same meaning, or we may need to look at the collateral contract. Look at the collateral contract for the asset, which says &quot;I am going to deliver this asset as settlement for the loan&quot;. the &quot;I&quot; is the Guarantor if it&apos;s a kind of collateralized guaranty, and it&apos;s the Borrower if it&apos;s just Collateral on the Loan. Effectively the Guarantor becomes like theb borrower in terms of being who is chased for the loan amount outsstanding. For instances, differences between how you would foreclose on a moartgage between the US and Commonwealth countries. Relates to how you take ownership of the asset.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;NegativePledge">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">negative pledge</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Guaranty whereby the issuer will not pledge any assets if doing so would result in less security for the investors.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This also exists in loans, so revise the wording to reflect this. Also clarify that the pledge to one potential lender is not to pledge assets to some other potential lender at some time in the future. These are often broken. An agreement which gives someone a right to seize those assets? No, that&apos;s implicit in the loan i.e. secured loan. So the pledge does not introduce anything with any new legal standing, other than that having broken the pledge, you have de facto defauled on the loan even if you have not default ed on laon payments. It gies the lender the right to recall the loan as there is a technical default when this happens.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;SecuritiesGuarantyInsurancePolicy">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-doc;InsurancePolicy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities guaranty insurance policy</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some policy by which some party (directly or more usually through an intermediary who writes this policy) agrees to cover some risk as identified in this policy, on behalf of the holder of the policy. further Notes: Added specifically to cover financial instruments modeling of insurance backed Guaranty. This term would belong within a separate section of specialist insurance terms if there were such a section.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;SimpleGuaranty">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">simple guaranty</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">No definition</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-gty;StateGuarantor">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guarantor"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-gty;identifiedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;SovereignState"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">state guarantor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A State, acting as Party to some participatory context such as issuance, guaranty provision.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;identifiedAs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantorHasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;StateGuarantor"/>
+bubu<rdfs:range rdf:resource="&fibo-be-ge-ge;SovereignState"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;issuedBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issued by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCredit"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCreditIssuer"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;lien">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is encumbrance on</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;LienGuaranty"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/RealEstate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;loCDetails">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lo c details</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;LetterOfCreditGuaranty"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Details of the Letter of Credit</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;policyDetails">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">policy details</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;InsuranceBackedGuaranty"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Details of the Insurance Policy which make up this Guaranty.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-gty;takesFormOfCollateral">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">takes form of collateral</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-gty;CollateralizedGuaranty"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/Collateral"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/DebtFoundations/DebtIssuanceTerms.rdf
+++ b/sec/Debt/DebtFoundations/DebtIssuanceTerms.rdf
@@ -1,419 +1,423 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-fctx-spv "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
-	<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-der-rgt-raw "https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
-	<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
-	<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
-	<!ENTITY fibo-sec-eq-iss "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-fctx-spv "https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/">
+bu<!ENTITY fibo-bp-iss-doc "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-der-rgt-raw "https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-arrxx-ins "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-bo-bo "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/">
+bu<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
+bu<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
+bu<!ENTITY fibo-sec-eq-iss "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
-	xmlns:fibo-be-fctx-spv="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"
-	xmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-der-rgt-raw="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
-	xmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
-	xmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
-	xmlns:fibo-sec-eq-iss="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
-		<rdfs:label xml:lang="en">DebtIssuanceTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;AdvancedRefunding">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;RefundingPurpose"/>
-		<rdfs:label xml:lang="en">advance refunding</rdfs:label>
-		<skos:definition xml:lang="en">A bond issuance in which new bonds are sold at a lower rate than outstanding ones. The proceeds are then invested, and when the older bonds become callable they are paid off with the invested proceeds.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin xml:lang="en">http://www.investopedia.com/terms/a/advancedrefunding.asp#ixzz4K90cVzeN</fibo-fnd-utl-av:definitionOrigin>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondIssuanceProgram">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProgram"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;isANumberOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;BondOfferIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond issuance program</rdfs:label>
-		<skos:definition xml:lang="en">A series of bond issuances over time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondIssueInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
-		<rdfs:label xml:lang="en">bond issue information</rdfs:label>
-		<skos:definition xml:lang="en">Information about the Issuance of a Bond, which is maintained throughout the life of the Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondIssueProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus"/>
-		<rdfs:label xml:lang="en">bond issue prospectus</rdfs:label>
-		<skos:definition xml:lang="en">The prospectus for the bond issue describes the terms of the issue and each of the instruments included in the bond issue. Term origin:SMER</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondOfferIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;describedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;BondIssueProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond offer issue</rdfs:label>
-		<skos:definition xml:lang="en">An Issue of one or more Bonds, as all or part of an Offering of these bonds to the market.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondOfferIssueWithWarrant">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;BondOfferIssue"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
-				<owl:allValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-rgt-raw;TraditionalWarrant">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-bo-bo;Bond">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:allValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
-				<owl:onClass>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-der-rgt-raw;TraditionalWarrant">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-dbt-bo-bo;Bond">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:onClass>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond offer issue with warrant</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-iss;MTNIssue"/>
-		<skos:definition xml:lang="en">A bond issue where the issue includes a Warrant attached. Further notes: ISO 10962 CFI definition is A bond that is issued together with one or more warrant(s) attached as part of the offer, the warrant(s) granting the holder the right to purchase a designated security, often the common stock of the issuer of the debt, at a specified price. Review notes: This need not be any specific type of bond. The warrant is used as a sweetener to encourage people to subscribe to a new bond issue. The Bond and the Warrant trade together as a unit (called &quot;Bond Unit&quot;).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtGuarantor">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
-		<rdfs:label xml:lang="en">debt guarantor</rdfs:label>
-		<skos:definition xml:lang="en">Some party which insures lenders against loss due to a borrower&apos;s default, death, disability, or bankruptcy.</skos:definition>
-		<skos:editorialNote xml:lang="en">(loans session 19 May) This is the party that guarantees to make good on the debt in the event that the borrower defaults. Definiton (student loans context: Sallie Mae definition: A state agency or private non-profit agency, such as USA Funds, which insures lenders against loss due to a student loan borrower&apos;s default, death, disability, or bankruptcy. The guarantor would go after the Borrower if the SErvicer fdoe snot.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:label xml:lang="en">debt instrument issue information</rdfs:label>
-		<skos:definition xml:lang="en">Information about the Issuance of a Debt Security, which is maintained throughout the life of the Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssuanceProcessInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;hasDebtIssuancePurpose"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;becomesPartOfTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt issuance process information</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-iss;EquityIssuanceProcessInformation"/>
-		<skos:definition xml:lang="en">Information specific to the Issuance of a Debt security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssuanceProgram">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;IssuanceProgram"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;isANumberOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt issuance program</rdfs:label>
-		<skos:definition xml:lang="en">A series of debt security issuances over time.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
-		<rdfs:label xml:lang="en">debt issuance purpose</rdfs:label>
-		<skos:definition xml:lang="en">Purpose for the Issuance of a Debt Security. Also defines processes to be followed in some instances.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
-		<rdfs:label xml:lang="en">debt issue prospectus</rdfs:label>
-		<skos:definition xml:lang="en">The prospectus for the debt issue, describing the terms of the issue and each of the instruments included in the debt issue. Term origin:SMER</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityUnderwriter"/>
-		<rdfs:label xml:lang="en">debt issue underwriter</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtOfferIssue">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;underwrittenBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;describedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">debt offer issue</rdfs:label>
-		<skos:definition xml:lang="en">An Issue of one or more debt securities, as all or part of an Offering of securities to the market.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;MTNIssue">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;BondOfferIssue"/>
-		<rdfs:label xml:lang="en">m t n issue</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;MTNOfferProgram">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;BondIssuanceProgram"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;issues"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;MTNIssue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">m t n offer program</rdfs:label>
-		<skos:definition xml:lang="en">A program of offerings of Medium Term Note debt securities. This is a set of issues where the maturity is defined after the rest of the terms have been registered with some authority. These are registered up front so that then the company wants to borrow more money they don&apos;t have to go through the registration period but have the facility up front to issue another security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;MunicipalBondIssuanceProcessInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProcessInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;hasDebtIssuancePurpose"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;becomesPartOfTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;MunicipalBondIssueInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;hasDebtIssuancePurpose"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">municipal bond issuance process information</rdfs:label>
-		<skos:definition xml:lang="en">Information specific to the Issuance of a Municipal Bond.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;MunicipalBondIssueInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;BondIssueInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;debtIssuancePurpose"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;debtIssuancePurpose"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">municipal bond issue information</rdfs:label>
-		<skos:definition xml:lang="en">Information about the Issuance of a Municipal Bond, which is maintained throughout the life of the Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;NewMoneyPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
-		<rdfs:label xml:lang="en">new money purpose</rdfs:label>
-		<skos:definition xml:lang="en">Securities Issued for new Project or Purpose.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;RefundingPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
-		<rdfs:label xml:lang="en">refunding purpose</rdfs:label>
-		<skos:definition xml:lang="en">A procedure whereby an issuer refinances outstanding bonds by issuing new bonds.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;RemarketingPurpose">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
-		<rdfs:label xml:lang="en">remarketing purpose</rdfs:label>
-		<skos:definition xml:lang="en">The process of reselling securities to the public that have been tendered for purchase by the previous owners thereof.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;SecuritiesIssuance">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SPVPurpose"/>
-		<rdfs:label xml:lang="en">securities issuance</rdfs:label>
-		<skos:definition xml:lang="en">The SPV is set up to issue securities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;SecuritiesIssuanceSPV">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fctx-spv;isSetUpFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuance"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;holdsPool"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/SecuritizedDebtPool"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">securities issuance s p v</rdfs:label>
-		<skos:definition xml:lang="en">An SPV set up specifically to issue securities.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;UnderwriterTakedownForDebt">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
-		<rdfs:label xml:lang="en">underwriter takedown for debt</rdfs:label>
-		<skos:definition xml:lang="en">Infomation on Takedown quantity of the Debt security handled by the underwriter (that will be brought into DTC).</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;bankQualified.1">
-		<rdfs:label xml:lang="en">bank qualified</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;MunicipalBondIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Designation given to a public purpose bond offering by the issuer if it reasonably expects to issue in the calendar year of such offering no more than $10 million par amount of bonds of the type required to be included in making such calculation under the Internal Revenue Code.  When purchased by a commercial bank for its portfolio, the bank may receive an 80% tax deduction for the interest cost of carry for the issue.  A bond that is bank qualified is also known as a qualified tax-exempt obligation.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;becomesPartOfTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;becomesPartOf"/>
-		<rdfs:label xml:lang="en">becomes part of terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProcessInformation"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
-		<skos:definition xml:lang="en">The information required throughout the life of the Security becomes the Issuance information maintained for that security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;debtIssuancePurpose">
-		<rdfs:label xml:lang="en">debt issuance purpose</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Purpose of the Issue of a Debt Security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;describedIn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;finalStateDescribedIn"/>
-		<rdfs:label xml:lang="en">described in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;hasDebtIssuancePurpose">
-		<rdfs:label xml:lang="en">has debt issuance purpose</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProcessInformation"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;holdsPool">
-		<rdfs:label xml:lang="en">holds pool</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuanceSPV"/>
-		<skos:definition xml:lang="en">The Issuance Special Purpose Vehicle holds assets in the form of a pool of securities.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Securities are purchased by an SPV or other entity for the purpose of issuing notes against those securities. Term Implied by Pool v SPV structure as applied to Participation Notes</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;isANumberOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;isCollectionOf"/>
-		<rdfs:label xml:lang="en">is a number of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProgram"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;issueNominalAmount">
-		<rdfs:label xml:lang="en">issue nominal amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Total original amount issued, expressed as a monetary amount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;issues">
-		<rdfs:label xml:lang="en">issues</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;MTNOfferProgram"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;MTNIssue"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;oID">
-		<rdfs:label xml:lang="en">o i d</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;BondIssueInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Discount from par value at the time a bond or other debt instrument is issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;toBeBankQualified">
-		<rdfs:label xml:lang="en">to be bank qualified</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;MunicipalBondIssuanceProcessInformation"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Designation given to a public purpose bond offering by the issuer if it reasonably expects to issue in the calendar year of such offering no more than $10 million par amount of bonds of the type required to be included in making such calculation under the Internal Revenue Code.  When purchased by a commercial bank for its portfolio, the bank may receive an 80% tax deduction for the interest cost of carry for the issue.  A bond that is bank qualified is also known as a qualified tax-exempt obligation.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;underwriterTakedownAmount">
-		<rdfs:label xml:lang="en">underwriter takedown amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;UnderwriterTakedownForDebt"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Takedown amount of the security handled by the underwriter(that will be brought into DTC).</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-fctx-spv="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"
+buxmlns:fibo-bp-iss-doc="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-der-rgt-raw="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-arrxx-ins="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-bo-bo="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"
+buxmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
+buxmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
+buxmlns:fibo-sec-eq-iss="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtIssuanceTerms</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines a number of kinds of information which arise out of the various issuance processes by which debt instruments may be issued, such as auction and syndication. 
+		These concepts have been derived with reference to the process models in the Business Process domain for various kinds of debt instrument issuance process. Different processes generate and consume different kinds of information, documents etc., and a sub set of these variants will appear in security master file data for these different kinds of instrument. That is the sub set modeled here, ased on earlier ISO TC68 Working Group 11 work.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntitiesExt/SPVs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceDocuments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/RightsInstruments/RightsAndWarrants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/ToolsAndInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCommon/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/Pools/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;AdvancedRefunding">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;RefundingPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">advance refunding</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond issuance in which new bonds are sold at a lower rate than outstanding ones. The proceeds are then invested, and when the older bonds become callable they are paid off with the invested proceeds.</skos:definition>
+bubu<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&rdf;langString" xml:lang="en">http://www.investopedia.com/terms/a/advancedrefunding.asp#ixzz4K90cVzeN</fibo-fnd-utl-av:definitionOrigin>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondIssuanceProgram">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProgram"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;isANumberOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;BondOfferIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond issuance program</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A series of bond issuances over time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondIssueInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond issue information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the Issuance of a Bond, which is maintained throughout the life of the Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondIssueProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond issue prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The prospectus for the bond issue describes the terms of the issue and each of the instruments included in the bond issue. Term origin:SMER</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondOfferIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;describedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;BondIssueProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond offer issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Issue of one or more Bonds, as all or part of an Offering of these bonds to the market.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;BondOfferIssueWithWarrant">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;BondOfferIssue"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
+bubububu<owl:allValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-rgt-raw;TraditionalWarrant">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-bo-bo;Bond">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:allValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
+bubububu<owl:onClass>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-der-rgt-raw;TraditionalWarrant">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-sec-dbt-bo-bo;Bond">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:onClass>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bond offer issue with warrant</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-iss;MTNIssue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bond issue where the issue includes a Warrant attached. Further notes: ISO 10962 CFI definition is A bond that is issued together with one or more warrant(s) attached as part of the offer, the warrant(s) granting the holder the right to purchase a designated security, often the common stock of the issuer of the debt, at a specified price. Review notes: This need not be any specific type of bond. The warrant is used as a sweetener to encourage people to subscribe to a new bond issue. The Bond and the Warrant trade together as a unit (called &quot;Bond Unit&quot;).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtGuarantor">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt guarantor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Some party which insures lenders against loss due to a borrower&apos;s default, death, disability, or bankruptcy.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">(loans session 19 May) This is the party that guarantees to make good on the debt in the event that the borrower defaults. Definiton (student loans context: Sallie Mae definition: A state agency or private non-profit agency, such as USA Funds, which insures lenders against loss due to a student loan borrower&apos;s default, death, disability, or bankruptcy. The guarantor would go after the Borrower if the SErvicer fdoe snot.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt instrument issue information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the Issuance of a Debt Security, which is maintained throughout the life of the Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssuanceProcessInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;hasDebtIssuancePurpose"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;becomesPartOfTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt issuance process information</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-iss;EquityIssuanceProcessInformation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information specific to the Issuance of a Debt security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssuanceProgram">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;IssuanceProgram"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;isANumberOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt issuance program</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A series of debt security issuances over time.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-ins;Purpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt issuance purpose</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Purpose for the Issuance of a Debt Security. Also defines processes to be followed in some instances.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt issue prospectus</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The prospectus for the debt issue, describing the terms of the issue and each of the instruments included in the debt issue. Term origin:SMER</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityUnderwriter"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt issue underwriter</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;DebtOfferIssue">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;isIssueOf"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;underwrittenBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueUnderwriter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;describedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt offer issue</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An Issue of one or more debt securities, as all or part of an Offering of securities to the market.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;MTNIssue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;BondOfferIssue"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m t n issue</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;MTNOfferProgram">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;BondIssuanceProgram"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;issues"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;MTNIssue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">m t n offer program</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A program of offerings of Medium Term Note debt securities. This is a set of issues where the maturity is defined after the rest of the terms have been registered with some authority. These are registered up front so that then the company wants to borrow more money they don&apos;t have to go through the registration period but have the facility up front to issue another security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;MunicipalBondIssuanceProcessInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProcessInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;hasDebtIssuancePurpose"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;becomesPartOfTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;MunicipalBondIssueInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;hasDebtIssuancePurpose"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal bond issuance process information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information specific to the Issuance of a Municipal Bond.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;MunicipalBondIssueInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;BondIssueInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;debtIssuancePurpose"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;debtIssuancePurpose"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">municipal bond issue information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the Issuance of a Municipal Bond, which is maintained throughout the life of the Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;NewMoneyPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">new money purpose</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Securities Issued for new Project or Purpose.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;RefundingPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">refunding purpose</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A procedure whereby an issuer refinances outstanding bonds by issuing new bonds.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;RemarketingPurpose">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">remarketing purpose</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The process of reselling securities to the public that have been tendered for purchase by the previous owners thereof.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;SecuritiesIssuance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SPVPurpose"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issuance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The SPV is set up to issue securities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;SecuritiesIssuanceSPV">
+bubu<rdfs:subClassOf rdf:resource="&fibo-be-fctx-spv;SpecialPurposeVehicle"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-fctx-spv;isSetUpFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuance"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-iss;holdsPool"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/PoolBackedSecurities/SecuritizedDebtPool"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">securities issuance s p v</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An SPV set up specifically to issue securities.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-iss;UnderwriterTakedownForDebt">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;UnderwriterTakedown"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriter takedown for debt</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Infomation on Takedown quantity of the Debt security handled by the underwriter (that will be brought into DTC).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;bankQualified.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bank qualified</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;MunicipalBondIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Designation given to a public purpose bond offering by the issuer if it reasonably expects to issue in the calendar year of such offering no more than $10 million par amount of bonds of the type required to be included in making such calculation under the Internal Revenue Code.  When purchased by a commercial bank for its portfolio, the bank may receive an 80% tax deduction for the interest cost of carry for the issue.  A bond that is bank qualified is also known as a qualified tax-exempt obligation.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;becomesPartOfTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;becomesPartOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes part of terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProcessInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The information required throughout the life of the Security becomes the Issuance information maintained for that security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;debtIssuancePurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">debt issuance purpose</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Purpose of the Issue of a Debt Security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;describedIn">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;finalStateDescribedIn"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">described in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssueProspectus"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;hasDebtIssuancePurpose">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has debt issuance purpose</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProcessInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuancePurpose"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;holdsPool">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds pool</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuanceSPV"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Issuance Special Purpose Vehicle holds assets in the form of a pool of securities.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Securities are purchased by an SPV or other entity for the purpose of issuing notes against those securities. Term Implied by Pool v SPV structure as applied to Participation Notes</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;isANumberOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;isCollectionOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is a number of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtIssuanceProgram"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtOfferIssue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;issueNominalAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue nominal amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Total original amount issued, expressed as a monetary amount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;issues">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issues</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;MTNOfferProgram"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;MTNIssue"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;oID">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">o i d</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;BondIssueInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Discount from par value at the time a bond or other debt instrument is issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;toBeBankQualified">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">to be bank qualified</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;MunicipalBondIssuanceProcessInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Designation given to a public purpose bond offering by the issuer if it reasonably expects to issue in the calendar year of such offering no more than $10 million par amount of bonds of the type required to be included in making such calculation under the Internal Revenue Code.  When purchased by a commercial bank for its portfolio, the bank may receive an 80% tax deduction for the interest cost of carry for the issue.  A bond that is bank qualified is also known as a qualified tax-exempt obligation.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-iss;underwriterTakedownAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">underwriter takedown amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-iss;UnderwriterTakedownForDebt"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Takedown amount of the security handled by the underwriter(that will be brought into DTC).</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/DebtFoundations/ParityVariants.rdf
+++ b/sec/Debt/DebtFoundations/ParityVariants.rdf
@@ -1,102 +1,106 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
-	<!ENTITY fibo-sec-dbt-dbt-par "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY terms "http://purl.org/dc/terms/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
+bu<!ENTITY fibo-sec-dbt-dbt-par "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY terms "http://purl.org/dc/terms/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
-	xmlns:fibo-sec-dbt-dbt-par="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:terms="http://purl.org/dc/terms/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/">
-		<rdfs:label xml:lang="en">ParityVariants</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection">
-		<rdfs:label xml:lang="en">DebtRelativeValueSelection</rdfs:label>
-		<skos:definition xml:lang="en">A relative value of a debt instrument at some point in time. This is exhaustively either par value, a discount or a premium.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;DiscountValue">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
-		<rdfs:label xml:lang="en">discount value</rdfs:label>
-		<terms:description xml:lang="en">A discount to the face (or par) value i.e. a value which is less than the par value of the instrument.</terms:description>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;DiscountedInstrument">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasYield"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DiscountedInstrumentYield"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DiscountValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">discounted instrument</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-par;InstrumentIssuedAtPar"/>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-par;PremiumInstrument"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;InstrumentIssuedAtPar">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">instrument issued at par</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-par;PremiumInstrument"/>
-		<skos:definition xml:lang="en">Instrument is issued at par. These instruments are issued at some face value and mature for a value equal to that face value plus interest.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This classification of debt instruments is stated in terms of how an investor buys it. A debt instrument is bought either at discount, par or premium.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;ParValue">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
-		<rdfs:label xml:lang="en">par value</rdfs:label>
-		<terms:description xml:lang="en">The same value as the face value of the instrument, also known as parity.</terms:description>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">For an instrument which redeems at par, the par or face value is repaid upon redemption.  Par value is synonymous with face value and nominal value for bonds.  Par value is an amount in a currency.  Each asset class has a standard for par value.  The standard par value of a U.S. corporate bond is $1000.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;PremiumInstrument">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;PremiumValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">premium instrument</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;PremiumValue">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
-		<rdfs:label xml:lang="en">premium value</rdfs:label>
-		<terms:description xml:lang="en">A premium over the face (or par) value, i.e. some amount greater than the par value of the instrument.</terms:description>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
+buxmlns:fibo-sec-dbt-dbt-par="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:terms="http://purl.org/dc/terms/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ParityVariants</rdfs:label>
+bubu<terms:abstract rdf:datatype="&xsd;string">This ontology sets out the three ways in which a security may be issued or may be traded, namely at par, at a premium or at a discount. Not all of these are used, but this provides an exhaustive set of these possibilities. 
+		These parity variants may vary over time, and these are referenced both in defining instruments that are issue at par or at a discount (e.g. in money markets) and instruments that are currently trading in one or another state at a point in time.</terms:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DebtRelativeValueSelection</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A relative value of a debt instrument at some point in time. This is exhaustively either par value, a discount or a premium.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;DiscountValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">discount value</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">A discount to the face (or par) value i.e. a value which is less than the par value of the instrument.</terms:description>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;DiscountedInstrument">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasYield"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-py;DiscountedInstrumentYield"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DiscountValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">discounted instrument</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-par;InstrumentIssuedAtPar"/>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-par;PremiumInstrument"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;InstrumentIssuedAtPar">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">instrument issued at par</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-dbt-par;PremiumInstrument"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Instrument is issued at par. These instruments are issued at some face value and mature for a value equal to that face value plus interest.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This classification of debt instruments is stated in terms of how an investor buys it. A debt instrument is bought either at discount, par or premium.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;ParValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">par value</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">The same value as the face value of the instrument, also known as parity.</terms:description>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">For an instrument which redeems at par, the par or face value is repaid upon redemption.  Par value is synonymous with face value and nominal value for bonds.  Par value is an amount in a currency.  Each asset class has a standard for par value.  The standard par value of a U.S. corporate bond is $1000.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;PremiumInstrument">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;PremiumValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">premium instrument</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-par;PremiumValue">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">premium value</rdfs:label>
+bubu<terms:description rdf:datatype="&rdf;langString" xml:lang="en">A premium over the face (or par) value, i.e. some amount greater than the par value of the instrument.</terms:description>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/sec/Debt/DebtFoundations/ParticipationNotes.rdf
+++ b/sec/Debt/DebtFoundations/ParticipationNotes.rdf
@@ -1,88 +1,92 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
-	<!ENTITY fibo-sec-dbt-dbt-pn "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParticipationNotes/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
+bu<!ENTITY fibo-sec-dbt-dbt-pn "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParticipationNotes/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParticipationNotes/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
-	xmlns:fibo-sec-dbt-dbt-pn="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParticipationNotes/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParticipationNotes/">
-		<rdfs:label xml:lang="en">ParticipationNotes</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParticipationNotes/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-pn;ParticipationNote">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-pn;ParticipationNoteIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-pn;hasUnderlying"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">participation note</rdfs:label>
-		<skos:definition xml:lang="en">A tradable note issued by an entity for sale in a jurisdiction other than the one in which the entity is registered, and based on the holding by that entity of underlying securities issued in the jurisdiction in which that entity is registered.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically P-Notes are SPVs that are created to allow participation from outside that market. The SPV purchases a security on shore and issues a note that represents that security to offshore investors. Similar to an ADR but is always a debt security. All underlying securities come from another market from the one where the PN is issued.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbt-pn;ParticipationNoteIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-pn;describedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuanceSPV"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">participation note issuer</rdfs:label>
-		<skos:definition xml:lang="en">The party which is the issuer of a Participation Note.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-pn;describedAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
-		<rdfs:label xml:lang="en">described as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-pn;ParticipationNoteIssuer"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuanceSPV"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-pn;hasUnderlying">
-		<rdfs:label xml:lang="en">has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-pn;ParticipationNote"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<skos:definition xml:lang="en">THe underlying for the Participation Note.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
+buxmlns:fibo-sec-dbt-dbt-pn="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParticipationNotes/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParticipationNotes/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ParticipationNotes</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Participation notes, in the sense modeled here, are debt instruments issued in some jurisdiction, to give eligible investors the ability to participate in the returns of a debt instrument issued in another jurisdiction, to which they would not have access for regulatory or other reasons. 
+		Note that this is not the same thing as a Loan Participation Note.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParticipationNotes/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-pn;ParticipationNote">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-pn;ParticipationNoteIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-pn;hasUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">participation note</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A tradable note issued by an entity for sale in a jurisdiction other than the one in which the entity is registered, and based on the holding by that entity of underlying securities issued in the jurisdiction in which that entity is registered.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Typically P-Notes are SPVs that are created to allow participation from outside that market. The SPV purchases a security on shore and issues a note that represents that security to offshore investors. Similar to an ADR but is always a debt security. All underlying securities come from another market from the one where the PN is issued.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbt-pn;ParticipationNoteIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-pn;describedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuanceSPV"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">participation note issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is the issuer of a Participation Note.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-pn;describedAs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;securityIssuerDescribedAs"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">described as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-pn;ParticipationNoteIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;SecuritiesIssuanceSPV"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbt-pn;hasUnderlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbt-pn;ParticipationNote"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">THe underlying for the Participation Note.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/DebtFoundationsExt/DebtInstrumentsExt.rdf
+++ b/sec/Debt/DebtFoundationsExt/DebtInstrumentsExt.rdf
@@ -1,391 +1,394 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
-	<!ENTITY fibo-sec-dbt-dbt-fin "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/">
-	<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
-	<!ENTITY fibo-sec-dbt-dbt-par "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-aly "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-sec-dbt-dbt-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/">
+bu<!ENTITY fibo-sec-dbt-dbt-fin "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/">
+bu<!ENTITY fibo-sec-dbt-dbt-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/">
+bu<!ENTITY fibo-sec-dbt-dbt-par "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
-	xmlns:fibo-sec-dbt-dbt-fin="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"
-	xmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
-	xmlns:fibo-sec-dbt-dbt-par="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-		<rdfs:label>DebtInstruments</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DebtInstrument">
-		<owl:equivalentClass rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis">
-		<rdfs:label>day count convention</rdfs:label>
-		<skos:definition>The convention used to calculate the number of days in an interest payment period.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin>http://www.investinginbonds.com/story.asp?id=3140</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>A 30/360 convention assumes 30 days in a month and 360 days in a year. An actual/360 convention assumes the actual number of days in the given month and 360 days in the year. An actual/ actual convention uses the actual number of days in the given interest period and year.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
-		<rdfs:label>debt instrument</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-sec-dbt-dbt-par;DiscountedInstrument">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-dbt-par;InstrumentIssuedAtPar">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-dbt-par;PremiumInstrument">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition>A paper or electronic obligation that enables the issuing party to raise funds by promising to repay a lender in accordance with terms of a contract. Types of debt instruments include notes, bonds, certificates, mortgages, leases or other agreements between a lender and a borrower.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/IssuedDebt"/>
-		<rdfs:label>publicly issued debt</rdfs:label>
-		<skos:definition>An amount of Debt issued under a given Debt security.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;callable">
-		<rdfs:label>callable</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the writer of the debt contract (the debtor) can call the debt prior to maturity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;callable.1">
-		<rdfs:label>callable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the issuer of the debt instrument can call the debt prior to maturity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;debtAmount">
-		<rdfs:label>debt amount</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/IssuedDebt"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition>The monetary amount of the debt that is securitized.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;defaultLotSize">
-		<rdfs:label>default lot size</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
-		<skos:definition>The number of units of the security that may be held at any one time. This is the minimum denomination required for transfer or change of ownership of a tradable debt security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;definesTermsFor">
-		<rdfs:label>defines terms for</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;denomination">
-		<rdfs:label>denomination</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition>The face value of an individual note of the security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;exchangeable">
-		<rdfs:label>exchangeable</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the security can be exchanged for another security at the issuers discretion.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasCallTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasRepaymentTerms"/>
-		<rdfs:label>has call terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasDebtGuarantor">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;hasContractGuarantor"/>
-		<rdfs:label>has debt guarantor</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtGuarantor"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasRedemptionTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label>has redemption terms</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtRedemptionProvision"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasRepaymentTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label>has repayment terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue">
-		<rdfs:label>has value at issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
-		<skos:definition>The relative value at which the instrument is issued, namely par, premium or discount.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity">
-		<rdfs:label>has value at maturity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
-		<skos:definition>The value at which the instrument matures, namely par, discount or premium.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;issuedDebtAmount">
-		<rdfs:label>issued debt amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition>The amount of Debt issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;maturityDuration">
-		<rdfs:label>maturity duration</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
-		<skos:definition>Length of time of the life of the Tradable Debt Instrument in days, months and years. This is the duration from the issue date to the scheduled maturity date.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo">
-		<rdfs:label>may be subordinated to</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;poolNumber">
-		<rdfs:label>pool number</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition>The Pool Number of the debt.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;priceAndYieldDayCountConvention">
-		<rdfs:label>price and yield day count convention</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis"/>
-		<skos:definition>The number of days in a month and days in a year that are counted when performing calculations for yield and price figures.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;putable">
-		<rdfs:label>putable</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the holder has the right to ask for redemption of the security prior to final maturity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;puttable">
-		<rdfs:label>puttable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the holder has the right to ask for redemption of the security prior to final maturity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;relatesTo">
-		<rdfs:label>relates to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;series">
-		<rdfs:label>series</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition>A series number, identified by the issuer in the event that debt is issued in several series (also known as tranches).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;setsOutTermsFor">
-		<rdfs:label>sets out terms for</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;strippable">
-		<rdfs:label>strippable</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether or not the instrument can be stripped, so that interest and principal may be traded separately.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;subordinated">
-		<rdfs:label>subordinated</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition>Whether the security is a subordinated security. This means that the security has a lower priority than another security so that when the assets are liquidated this one is not first in line.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/IssuedDebt">
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasCallTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasRedemptionTerms"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtRedemptionProvision"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/hasInterestPaymentTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;NonTradableDebtInterestTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo"/>
-				<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasIssuanceInformation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasAnalyticsDetails"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasInterestTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasRedemptionTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasCallTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasDebtGuarantor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtGuarantor"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;setsOutTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<owl:equivalentClass rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<skos:definition>A debt instrument which can be bought and sold by the holder. This typically has a security identifier.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Details from Ecofin: A [debt] instrument can be traded, if its features depend only on one borrower. If the instrument has no bilateral or multilateral obligations, the investor can easily transfer it to another investor without asking the borrower (except the terms prohibit this explicitly). This is simplified with securitised instruments, where the debt is already split into handy denominations which trade easily (e.g. in round thousands or millions as with bonds, commercial paper, etc.). But in principle it works also with interbank loans and similar instruments. FIBIM Definition: Financial instruments evidencing moneys owed by the issuer to the holder on terms as specified.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-aly="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-sec-dbt-dbt-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"
+buxmlns:fibo-sec-dbt-dbt-fin="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"
+buxmlns:fibo-sec-dbt-dbt-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"
+buxmlns:fibo-sec-dbt-dbt-par="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bubu<rdfs:label>DebtInstruments</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional debt instrument concepts and properties of debt instruments.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/CreditDerivatives/CreditDefaultSwaps/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/CreditIndices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/Loans/LoanBasicTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtAnalytics/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/CreditEvents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtFinance/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/DebtIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DebtInstrument">
+bubu<owl:equivalentClass rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis">
+bubu<rdfs:label>day count convention</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">The convention used to calculate the number of days in an interest payment period.</skos:definition>
+bubu<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;string">http://www.investinginbonds.com/story.asp?id=3140</fibo-fnd-utl-av:definitionOrigin>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">A 30/360 convention assumes 30 days in a month and 360 days in a year. An actual/360 convention assumes the actual number of days in the given month and 360 days in the year. An actual/ actual convention uses the actual number of days in the given interest period and year.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;WrittenContract"/>
+bubu<rdfs:label>debt instrument</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-dbt-par;DiscountedInstrument">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-dbt-par;InstrumentIssuedAtPar">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-dbt-par;PremiumInstrument">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&xsd;string">A paper or electronic obligation that enables the issuing party to raise funds by promising to repay a lender in accordance with terms of a contract. Types of debt instruments include notes, bonds, certificates, mortgages, leases or other agreements between a lender and a borrower.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/IssuedDebt"/>
+bubu<rdfs:label>publicly issued debt</rdfs:label>
+bubu<skos:definition rdf:datatype="&xsd;string">An amount of Debt issued under a given Debt security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;callable">
+bubu<rdfs:label>callable</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the writer of the debt contract (the debtor) can call the debt prior to maturity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;callable.1">
+bubu<rdfs:label>callable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the issuer of the debt instrument can call the debt prior to maturity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;debtAmount">
+bubu<rdfs:label>debt amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/IssuedDebt"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The monetary amount of the debt that is securitized.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;defaultLotSize">
+bubu<rdfs:label>default lot size</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DecimalValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The number of units of the security that may be held at any one time. This is the minimum denomination required for transfer or change of ownership of a tradable debt security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;definesTermsFor">
+bubu<rdfs:label>defines terms for</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;denomination">
+bubu<rdfs:label>denomination</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The face value of an individual note of the security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;exchangeable">
+bubu<rdfs:label>exchangeable</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the security can be exchanged for another security at the issuers discretion.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasCallTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasRepaymentTerms"/>
+bubu<rdfs:label>has call terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasDebtGuarantor">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-dbt-dbtx-gtyx;hasContractGuarantor"/>
+bubu<rdfs:label>has debt guarantor</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-iss;DebtGuarantor"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasRedemptionTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label>has redemption terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtRedemptionProvision"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasRepaymentTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label>has repayment terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Debt/PrincipalRepaymentTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue">
+bubu<rdfs:label>has value at issue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The relative value at which the instrument is issued, namely par, premium or discount.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity">
+bubu<rdfs:label>has value at maturity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The value at which the instrument matures, namely par, discount or premium.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;issuedDebtAmount">
+bubu<rdfs:label>issued debt amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The amount of Debt issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;maturityDuration">
+bubu<rdfs:label>maturity duration</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;KnownCalendarDuration"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Length of time of the life of the Tradable Debt Instrument in days, months and years. This is the duration from the issue date to the scheduled maturity date.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo">
+bubu<rdfs:label>may be subordinated to</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;poolNumber">
+bubu<rdfs:label>pool number</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The Pool Number of the debt.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;priceAndYieldDayCountConvention">
+bubu<rdfs:label>price and yield day count convention</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DayCountBasis"/>
+bubu<skos:definition rdf:datatype="&xsd;string">The number of days in a month and days in a year that are counted when performing calculations for yield and price figures.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;putable">
+bubu<rdfs:label>putable</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the holder has the right to ask for redemption of the security prior to final maturity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;puttable">
+bubu<rdfs:label>puttable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the holder has the right to ask for redemption of the security prior to final maturity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;relatesTo">
+bubu<rdfs:label>relates to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbt-fin;DebtFinance"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;series">
+bubu<rdfs:label>series</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">A series number, identified by the issuer in the event that debt is issued in several series (also known as tranches).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;setsOutTermsFor">
+bubu<rdfs:label>sets out terms for</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;strippable">
+bubu<rdfs:label>strippable</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether or not the instrument can be stripped, so that interest and principal may be traded separately.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-dbtx;subordinated">
+bubu<rdfs:label>subordinated</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&xsd;string">Whether the security is a subordinated security. This means that the security has a lower priority than another security so that when the assets are liquidated this one is not first in line.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/IssuedDebt">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasCallTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasRedemptionTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtRedemptionProvision"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/hasInterestPaymentTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;NonTradableDebtInterestTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbtx-dbtx;DebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;mayBeSubordinatedTo"/>
+bubububu<owl:onClass rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasIssuanceInformation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtInstrumentIssueInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasAnalyticsDetails"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-aly;DebtInstrumentAnalyticalParameter"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasInterestTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;DebtSecurityInterestPaymentTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbt-cft;hasRedemptionTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;TradableDebtSecurityRedemptionTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasCallTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-cft;DebtCallTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasDebtGuarantor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-iss;DebtGuarantor"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DebtRelativeValueSelection"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;setsOutTermsFor"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbtx-dbtx;PubliclyIssuedDebt"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<owl:equivalentClass rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<skos:definition rdf:datatype="&xsd;string">A debt instrument which can be bought and sold by the holder. This typically has a security identifier.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&xsd;string">Details from Ecofin: A [debt] instrument can be traded, if its features depend only on one borrower. If the instrument has no bilateral or multilateral obligations, the investor can easily transfer it to another investor without asking the borrower (except the terms prohibit this explicitly). This is simplified with securitised instruments, where the debt is already split into handy denominations which trade easily (e.g. in round thousands or millions as with bonds, commercial paper, etc.). But in principle it works also with interbank loans and similar instruments. FIBIM Definition: Financial instruments evidencing moneys owed by the issuer to the holder on terms as specified.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
 
 </rdf:RDF>

--- a/sec/Debt/DebtFoundationsExt/GuarantyExt.rdf
+++ b/sec/Debt/DebtFoundationsExt/GuarantyExt.rdf
@@ -1,84 +1,87 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/FND/Parties/Roles/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/FND/Parties/Roles/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-dbt-dbtx-gtyx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
-		<rdfs:label xml:lang="en">GuarantyExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
-				<owl:allValuesFrom rdf:resource="&owl;Thing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<skos:definition xml:lang="en">Arrangement whereby cash flows on the debt security, e.g., interest payment, are guaranteed by a firm other than the issuer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
-		<owl:equivalentClass rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guarantor"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
-		<rdfs:label xml:lang="en">contract guarantor</rdfs:label>
-		<skos:definition xml:lang="en">A Party which guarantees to underwrite some cash flow obligation on behalf of some other party.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-gtyx;guarantorHasIdentity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-		<rdfs:label xml:lang="en">guarantor has identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
-		<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-		<rdfs:label xml:lang="en">guaranty takes form of</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
-		<rdfs:range rdf:resource="&owl;Thing"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-gtyx;hasContractGuarantor">
-		<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/hasGuarantor"/>
-		<rdfs:label xml:lang="en">has contract guarantor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-dbt-dbtx-gtyx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">GuarantyExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional guaranty concept, for contract based guaranties.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/GuarantyExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf"/>
+bubububu<owl:allValuesFrom rdf:resource="&owl;Thing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Arrangement whereby cash flows on the debt security, e.g., interest payment, are guaranteed by a firm other than the issuer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-agr-ctr;Contract">
+bubu<owl:equivalentClass rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guarantor"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractThirdParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contract guarantor</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Party which guarantees to underwrite some cash flow obligation on behalf of some other party.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-gtyx;guarantorHasIdentity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">guarantor has identity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
+bubu<rdfs:range rdf:resource="&fibo-be-le-fbo;FormallyConstitutedOrganization"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-gtyx;guarantyTakesFormOf">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">guaranty takes form of</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/Guaranty"/>
+bubu<rdfs:range rdf:resource="&owl;Thing"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbtx-gtyx;hasContractGuarantor">
+bubu<rdfs:subPropertyOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/Guaranty/hasGuarantor"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has contract guarantor</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;Contract"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-dbtx-gtyx;ContractGuarantor"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/MoneyMarkets/LoanParticipationNotes.rdf
+++ b/sec/Debt/MoneyMarkets/LoanParticipationNotes.rdf
@@ -1,127 +1,130 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fbc-dae-crf "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-dbt-mm-lpn "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/LoanParticipationNotes/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fbc-dae-crf "https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-dbt-mm-lpn "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/LoanParticipationNotes/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/LoanParticipationNotes/"
-	xmlns:fibo-fbc-dae-crf="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-dbt-mm-lpn="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/LoanParticipationNotes/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/LoanParticipationNotes/">
-		<rdfs:label xml:lang="en">LoanParticipationNotes</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/LoanParticipationNotes/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;LPNTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;definesFacility"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">l p n terms</rdfs:label>
-		<skos:definition xml:lang="en">The terms of the LPN contract which define the facliity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;LeadManager">
-		<rdfs:label xml:lang="en">lead manager</rdfs:label>
-		<skos:definition xml:lang="en">The manager of the syndicated loan is the party whic horganizes the potential lenders into a syndicate and arranges the details of the or any potential loan.</skos:definition>
-		<skos:editorialNote xml:lang="en">This is the party which determines which potential lender (syndicate member) is going to lend which amount. When interest is paid this party applies the payments to the different lenders. Meanwhile the note is the means to trade this - it is an asset whic evidences the obligation to pay someone (the holder of this particular document). Hence there is a secondary market in the Note, that is the piece of paper, which is the asset. If you sell the note, do you cease to be a syndicate member and the holder becomes one instead? No, syndicate membership is specific to the primary, creation of the instrument, in the same way as a bond issue takes place. What we don&apos;t know: whether the participation is freely negotiable, or has limited negotiability. What we think is that as a minimum it gives you rights to the interest and principal, but does not bring you into the facility as a whole. there are (separately) structures which allow you to buy ito the syndicate. These are called &quot;Pariticipations&quot;. This would (presumably) give you access into new loans. For this piece of paper, if you are the holder of the note you would be part of the syndicate. We need additional clarificaiton on how syndicates work.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;hasLeadManager"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LeadManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;hasSyndicateMember"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteSyndicateMember"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">loan participation note facility</rdfs:label>
-		<skos:definition xml:lang="en">A facility formed as part of a LPN which can be drawn down by the borrower.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteSyndicateMember">
-		<rdfs:label xml:lang="en">loan participation note syndicate member</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;SyndicatedLoanParticipationNote">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;hasTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LPNTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LeadManager"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">syndicated loan participation note</rdfs:label>
-		<skos:definition xml:lang="en">Loan Participation Note: A fixed-income security that permits investors to buy portions of an outstanding loan or package of loans. LPN holders participate, on a pro rata basis, in collecting interest and principal payments. Banks or other financial institutions often enter into loan participation agreements with local businesses, and also offer loan participation notes as a type of short-term investment.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML has &quot;Syndicated Loan&quot;. Assume this is the same thing. Review session notes (pre-OTC SMER): [From: Investopedia: Loan Participation Note] Review: 1. Add terms e.g. contractual terms for participation 2. Are there other types of Participation Note which allow for participation in other forms of Asset / Collateral? 3. Can these be traded or not? Definition suggests a bilateral contract. 14 July: The note is documentation. That is, this is evidence for the securirty. An underwriting document (?) is similar. Someone promises to issue the notes for you. This is similar to how debt securities begin life - the underwriter sets the limits on what you will pay fo rthe ssecurity, and of course the amount. Two step orocess of creating the security and then selling it. See Bond / Debt Issuance diagrams and models. (see diagram notes etc. here) Note = tradeability. Indicates that someone has made a commitment at large. Loan Participation Note is either the other end of the loan, or a way of participating in the loan facility. If the latter, it would be a way of documenting the loan facility in a way that you can freely trade it. The alternative (non LPN) would be different. Circles - trading groups - members of the circle. Have to tell the other members of the circle what&apos;s going on, and get their permission from the members of that circle before you can assign those rights to someone else. This would mark out the OTC variant of these things. Then: risk participany, who has no original participation, but (later) agrees to take all of your risk off you. So now we have something with a secondary market and something without. Which is which, and what are they called? Which is the one described in FpML (presumably OTC). Generally, if you document your commitment to lend money, then other members of hte syndicate also have a risk in that you might not stump up your obligations. This has implicatiojns for being able to make this a security. This differs from a bond, where there is no intervening credit facility, you just buyt the thing that way you have become the lender. So there remain some doubts about how a participation note works. There is an element of credit embedded against the purchaser of any such note that gave someone membership ofa syndicate. There are also two sets of words in play: - Syndicated Loan - Loan Participation Note. So one of these probably gives you membership of the syndicate, and the other just gives you participation in the loan. It is less likely that there is a secondary market in the note that gives you participationm in a syndicate (because of the credit risk) but in theory at least, it is possible to create an instrument for this. We just don&apos;t know if it exists.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;definesFacility">
-		<rdfs:label xml:lang="en">defines facility</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;LPNTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;hasLeadManager">
-		<rdfs:label xml:lang="en">has lead manager</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LeadManager"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;hasSyndicateMember">
-		<rdfs:label xml:lang="en">has syndicate member</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteSyndicateMember"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;hasTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has l p n terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;SyndicatedLoanParticipationNote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LPNTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;issuer">
-		<rdfs:label xml:lang="en">issuer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;SyndicatedLoanParticipationNote"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LeadManager"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fbc-dae-crf="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-dbt-mm-lpn="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/LoanParticipationNotes/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/LoanParticipationNotes/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LoanParticipationNotes</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Contracts which give the holder some formal participation in some loan.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/DebtAndEquities/CreditFacilities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/LoanParticipationNotes/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;LPNTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;definesFacility"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">l p n terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The terms of the LPN contract which define the facliity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;LeadManager">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lead manager</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The manager of the syndicated loan is the party whic horganizes the potential lenders into a syndicate and arranges the details of the or any potential loan.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This is the party which determines which potential lender (syndicate member) is going to lend which amount. When interest is paid this party applies the payments to the different lenders. Meanwhile the note is the means to trade this - it is an asset whic evidences the obligation to pay someone (the holder of this particular document). Hence there is a secondary market in the Note, that is the piece of paper, which is the asset. If you sell the note, do you cease to be a syndicate member and the holder becomes one instead? No, syndicate membership is specific to the primary, creation of the instrument, in the same way as a bond issue takes place. What we don&apos;t know: whether the participation is freely negotiable, or has limited negotiability. What we think is that as a minimum it gives you rights to the interest and principal, but does not bring you into the facility as a whole. there are (separately) structures which allow you to buy ito the syndicate. These are called &quot;Pariticipations&quot;. This would (presumably) give you access into new loans. For this piece of paper, if you are the holder of the note you would be part of the syndicate. We need additional clarificaiton on how syndicates work.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-crf;CreditFacilityTranche"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;hasLeadManager"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LeadManager"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;hasSyndicateMember"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteSyndicateMember"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan participation note facility</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A facility formed as part of a LPN which can be drawn down by the borrower.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteSyndicateMember">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">loan participation note syndicate member</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-lpn;SyndicatedLoanParticipationNote">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;hasTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LPNTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-lpn;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-lpn;LeadManager"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">syndicated loan participation note</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Loan Participation Note: A fixed-income security that permits investors to buy portions of an outstanding loan or package of loans. LPN holders participate, on a pro rata basis, in collecting interest and principal payments. Banks or other financial institutions often enter into loan participation agreements with local businesses, and also offer loan participation notes as a type of short-term investment.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">FpML has &quot;Syndicated Loan&quot;. Assume this is the same thing. Review session notes (pre-OTC SMER): [From: Investopedia: Loan Participation Note] Review: 1. Add terms e.g. contractual terms for participation 2. Are there other types of Participation Note which allow for participation in other forms of Asset / Collateral? 3. Can these be traded or not? Definition suggests a bilateral contract. 14 July: The note is documentation. That is, this is evidence for the securirty. An underwriting document (?) is similar. Someone promises to issue the notes for you. This is similar to how debt securities begin life - the underwriter sets the limits on what you will pay fo rthe ssecurity, and of course the amount. Two step orocess of creating the security and then selling it. See Bond / Debt Issuance diagrams and models. (see diagram notes etc. here) Note = tradeability. Indicates that someone has made a commitment at large. Loan Participation Note is either the other end of the loan, or a way of participating in the loan facility. If the latter, it would be a way of documenting the loan facility in a way that you can freely trade it. The alternative (non LPN) would be different. Circles - trading groups - members of the circle. Have to tell the other members of the circle what&apos;s going on, and get their permission from the members of that circle before you can assign those rights to someone else. This would mark out the OTC variant of these things. Then: risk participany, who has no original participation, but (later) agrees to take all of your risk off you. So now we have something with a secondary market and something without. Which is which, and what are they called? Which is the one described in FpML (presumably OTC). Generally, if you document your commitment to lend money, then other members of hte syndicate also have a risk in that you might not stump up your obligations. This has implicatiojns for being able to make this a security. This differs from a bond, where there is no intervening credit facility, you just buyt the thing that way you have become the lender. So there remain some doubts about how a participation note works. There is an element of credit embedded against the purchaser of any such note that gave someone membership ofa syndicate. There are also two sets of words in play: - Syndicated Loan - Loan Participation Note. So one of these probably gives you membership of the syndicate, and the other just gives you participation in the loan. It is less likely that there is a secondary market in the note that gives you participationm in a syndicate (because of the credit risk) but in theory at least, it is possible to create an instrument for this. We just don&apos;t know if it exists.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;definesFacility">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines facility</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;LPNTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;hasLeadManager">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has lead manager</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LeadManager"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;hasSyndicateMember">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has syndicate member</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteFacility"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LoanParticipationNoteSyndicateMember"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;hasTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has l p n terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;SyndicatedLoanParticipationNote"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LPNTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-lpn;issuer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issuer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-lpn;SyndicatedLoanParticipationNote"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-mm-lpn;LeadManager"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/MoneyMarkets/REPOs.rdf
+++ b/sec/Debt/MoneyMarkets/REPOs.rdf
@@ -1,154 +1,157 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-mm-repo "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-mm-repo "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-mm-repo="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/">
-		<rdfs:label xml:lang="en">REPOs</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;AssetRepurchaseAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;definedFromPerspectiveOfRepoLender"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RepoLender"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">asset repurchase agreement</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-mm-repo;LiabilityRepurchaseAgreement"/>
-		<skos:definition xml:lang="en">A Repurchase Agreement defined from the point of view of the lender, where it is seen as an asset repo.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;LiabilityRepurchaseAgreement">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;definedFromPerspectiveOfRepoBorrower"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RepoBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">liability repurchase agreement</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;RePoParty">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<rdfs:label xml:lang="en">re po party</rdfs:label>
-		<skos:definition xml:lang="en">A party to a repurchase agreement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;RepoBorrower">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-repo;RePoParty"/>
-		<rdfs:label xml:lang="en">repo borrower</rdfs:label>
-		<skos:definition xml:lang="en">The borrower in the repurchase agreement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;RepoLender">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-repo;RePoParty"/>
-		<rdfs:label xml:lang="en">repo lender</rdfs:label>
-		<skos:definition xml:lang="en">The lender in the repurchase agreement.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;RepurchaseAgreement">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DebtInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;period"/>
-				<owl:onClass rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RePoParty"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;repurchaseAgreeementHasLender"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RepoLender"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;repurchaseAgreementHasBorrower"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RepoBorrower"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">repurchase agreement</rdfs:label>
-		<skos:definition xml:lang="en">A repurchase agreement (or repo) is an agreement between two parties whereby one party lends the other a security at a specified price with a commitment to take the security back at a later date for another specified price.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Most repos are overnight transactions, with the sale taking place one day and being reversed the next day. Long-term repos - called term repos - can extend for a month or more. Usually, repos are for a fixed period of time, but open-ended deals are also possible. Reverse repo is a term used to describe the opposite side of a repo transaction. The party who sells and later repurchases a security is said to perform a repo. The other party - who purchases and later resells the security - is said to perform a reverse repo. While a repo functions like the sale and subsequent repurchase of a security, but the legal reality and the economic effect is that of a secured loan. This is a loan as the original owner retains the rights to the cashflows of the underlying security. Economically, the party purchasing the security makes funds available to the seller and holds the security as collateral. If the repoed security pays a dividend, coupon or partial redemptions during the repo, this is returned to the original owner. The difference between the sale and repurchase prices paid for the security represent interest on the loan. Indeed, repos are quoted as interest rates. A repo always pays interest at maturity i.e. there are no periodic interest payments. Status: The above facts were agreed at review, definition to be reviewed for completeness after this reworking.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;definedFromPerspectiveOfRepoBorrower">
-		<rdfs:label xml:lang="en">defined from perspective of repo borrower</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;LiabilityRepurchaseAgreement"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mm-repo;RepoBorrower"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;definedFromPerspectiveOfRepoLender">
-		<rdfs:label xml:lang="en">defined from perspective of repo lender</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;AssetRepurchaseAgreement"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mm-repo;RepoLender"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;openEnded">
-		<rdfs:label xml:lang="en">open ended</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the repo is open ended.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;period">
-		<rdfs:label xml:lang="en">period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-		<skos:definition xml:lang="en">The duration of the repurchase agreement, where there is one.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;repurchaseAgreeementHasLender">
-		<rdfs:label xml:lang="en">repurchase agreeement has lender</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mm-repo;RepoLender"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;repurchaseAgreementHasBorrower">
-		<rdfs:label xml:lang="en">repurchase agreement has borrower</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
-		<rdfs:range rdf:resource="&fibo-sec-dbt-mm-repo;RepoBorrower"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-mm-repo="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">REPOs</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Repurchase Orders (RePos) are contracts in which one party lends a given security to the other party at a specified price with a commitment to take the security back at a later date for another specified price. This ontology describes RePos and reverse RePos with their distinguishing characteristics.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;AssetRepurchaseAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;definedFromPerspectiveOfRepoLender"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RepoLender"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">asset repurchase agreement</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-mm-repo;LiabilityRepurchaseAgreement"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Repurchase Agreement defined from the point of view of the lender, where it is seen as an asset repo.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;LiabilityRepurchaseAgreement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;definedFromPerspectiveOfRepoBorrower"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RepoBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">liability repurchase agreement</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;RePoParty">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">re po party</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party to a repurchase agreement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;RepoBorrower">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-repo;RePoParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repo borrower</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The borrower in the repurchase agreement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;RepoLender">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-repo;RePoParty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repo lender</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The lender in the repurchase agreement.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-repo;RepurchaseAgreement">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DebtInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;MutualContractualAgreement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;period"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractParty"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RePoParty"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;repurchaseAgreeementHasLender"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RepoLender"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-repo;repurchaseAgreementHasBorrower"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-repo;RepoBorrower"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repurchase agreement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A repurchase agreement (or repo) is an agreement between two parties whereby one party lends the other a security at a specified price with a commitment to take the security back at a later date for another specified price.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Most repos are overnight transactions, with the sale taking place one day and being reversed the next day. Long-term repos - called term repos - can extend for a month or more. Usually, repos are for a fixed period of time, but open-ended deals are also possible. Reverse repo is a term used to describe the opposite side of a repo transaction. The party who sells and later repurchases a security is said to perform a repo. The other party - who purchases and later resells the security - is said to perform a reverse repo. While a repo functions like the sale and subsequent repurchase of a security, but the legal reality and the economic effect is that of a secured loan. This is a loan as the original owner retains the rights to the cashflows of the underlying security. Economically, the party purchasing the security makes funds available to the seller and holds the security as collateral. If the repoed security pays a dividend, coupon or partial redemptions during the repo, this is returned to the original owner. The difference between the sale and repurchase prices paid for the security represent interest on the loan. Indeed, repos are quoted as interest rates. A repo always pays interest at maturity i.e. there are no periodic interest payments. Status: The above facts were agreed at review, definition to be reviewed for completeness after this reworking.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;definedFromPerspectiveOfRepoBorrower">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined from perspective of repo borrower</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;LiabilityRepurchaseAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-mm-repo;RepoBorrower"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;definedFromPerspectiveOfRepoLender">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defined from perspective of repo lender</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;AssetRepurchaseAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-mm-repo;RepoLender"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;openEnded">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">open ended</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the repo is open ended.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;period">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The duration of the repurchase agreement, where there is one.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;repurchaseAgreeementHasLender">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repurchase agreeement has lender</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-mm-repo;RepoLender"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-repo;repurchaseAgreementHasBorrower">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">repurchase agreement has borrower</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-repo;RepurchaseAgreement"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-dbt-mm-repo;RepoBorrower"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/MoneyMarkets/TermDeposits.rdf
+++ b/sec/Debt/MoneyMarkets/TermDeposits.rdf
@@ -1,85 +1,89 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
-	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-dbt-mm-td "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TermDeposits/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/">
+bu<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-dbt-mm-td "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TermDeposits/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TermDeposits/"
-	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
-	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-dbt-mm-td="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TermDeposits/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TermDeposits/">
-		<rdfs:label xml:lang="en">Term Deposits</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TermDeposits/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-td;TermDeposit">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;CashInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-td;TermDepositSettlementTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">term deposit</rdfs:label>
-		<skos:definition xml:lang="en">A money deposit at a bank that cannot be withdrawn for a certain &quot;term&quot; or period of time. When the term is over it can be withdrawn or it can be held for another term. The longer the term the better the yield on the money. A certificate of deposit is a time deposit product.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-td;TermDepositSettlementTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
-		<rdfs:label xml:lang="en">term deposit settlement terms</rdfs:label>
-		<skos:definition xml:lang="en">contractual terms for the settlement of a term deposit</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-td;termDepositRate">
-		<rdfs:label xml:lang="en">term deposit rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-td;TermDeposit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">The rate of return on the deposit.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-td;termDuration">
-		<rdfs:label xml:lang="en">term duration</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-td;TermDeposit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-		<skos:definition xml:lang="en">The duration of the term specified in days, months, quarters or years.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"
+buxmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-dbt-mm-td="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TermDeposits/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TermDeposits/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Term Deposits</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Term deposits are money deposited at a bank under the condition that this cannot be withdrawn for a specified time (the term). 
+		Note that this ontology provides part of a future requirement to model deposit accounts, these being sub divided into sight deposit and term deposit accounts among others. Those would be characterized as kinds of account whereas the term deposit as defined here refers to an instrument (contract) representing the deposited funds themselves, with the instrument known as a certificate of deposit being a kind of one of these.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TermDeposits/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-td;TermDeposit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;CashInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-td;TermDepositSettlementTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">term deposit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A money deposit at a bank that cannot be withdrawn for a certain &quot;term&quot; or period of time. When the term is over it can be withdrawn or it can be held for another term. The longer the term the better the yield on the money. A certificate of deposit is a time deposit product.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-td;TermDepositSettlementTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">term deposit settlement terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">contractual terms for the settlement of a term deposit</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-td;termDepositRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">term deposit rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-td;TermDeposit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rate of return on the deposit.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-td;termDuration">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">term duration</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-td;TermDeposit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The duration of the term specified in days, months, quarters or years.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Debt/MoneyMarkets/TradedShortTermDebt.rdf
+++ b/sec/Debt/MoneyMarkets/TradedShortTermDebt.rdf
@@ -1,387 +1,390 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
-	<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
-	<!ENTITY fibo-sec-dbt-bo-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/">
-	<!ENTITY fibo-sec-dbt-dbt-par "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/">
-	<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
-	<!ENTITY fibo-sec-dbt-mm-repo "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/">
-	<!ENTITY fibo-sec-dbt-mm-trd "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-ge-ge "https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/">
+bu<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-accx-acc "https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-dbtx-int "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/">
+bu<!ENTITY fibo-md-dbtx-py "https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/">
+bu<!ENTITY fibo-sec-dbt-bo-iss "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/">
+bu<!ENTITY fibo-sec-dbt-dbt-par "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/">
+bu<!ENTITY fibo-sec-dbt-dbtx-dbtx "https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/">
+bu<!ENTITY fibo-sec-dbt-mm-repo "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/">
+bu<!ENTITY fibo-sec-dbt-mm-trd "https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"
-	xmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
-	xmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
-	xmlns:fibo-sec-dbt-bo-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"
-	xmlns:fibo-sec-dbt-dbt-par="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"
-	xmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
-	xmlns:fibo-sec-dbt-mm-repo="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/"
-	xmlns:fibo-sec-dbt-mm-trd="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/">
-		<rdfs:label xml:lang="en">TradedShortTermDebt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-ge-ge;Government">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;BankersAcceptance">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Draft"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DiscountValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bankers acceptance</rdfs:label>
-		<skos:definition xml:lang="en">A Draft where the drawer and drawee of the draft are distinct parties and the drawee is a bank.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In drafts where the payee may submit the draft to the drawee for confirmation that the draft is a legitimate order and that the drawee will make payment on the specified date. Such confirmation is called acceptance - the drawee accepts the order to pay as legitimate. The drawee stamps ACCEPTED on the draft and is thereafter obligated to make the specified payment when it is due. If the drawee is a bank, the acceptance is called a bankers acceptance (BA). A bankers acceptance is an obligation of the accepting bank. Depending on the bank&apos;s reputation, a payee may be able to sell the bankers acceptance - that is, sell the time draft accepted by the bank. It will sell for the discounted value of the future payment. In this manner, the bankers acceptance becomes a discount instrument traded in the money market. Paying discounted value for a time draft is called discounting the draft. Matures at par, the same as discounted CP or a short term TBill.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments are issued at a discount.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments mature at par.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;BillOfExchange">
-		<rdfs:label xml:lang="en">bill of exchange</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;CPTypicalDurationDescription">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;CalendarDay"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">c p typical duration description</rdfs:label>
-		<skos:definition xml:lang="en">The formal description of the typical period of time which is the mayturity of a Commercial Paper instrument.</skos:definition>
-		<skos:editorialNote xml:lang="en">For US Commercial Paper this is 270 with a denomination of Day; for UK CP this would be 1 with a denomination of Year. This does not need to be specified but may be specified in order to define the typical duration for Commercial Paper as defined in a particular market or jurisduction. Note that Commercial Paper is defined as being part of the set of instruments which are &quot;Money Market&quot; instruments without this term needing to be specified, as this may vary from one market to another. However this term may be used in any such market as a defining fact about Commercial Paper.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;CertificateOfDeposit">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">certificate of deposit</rdfs:label>
-		<skos:definition xml:lang="en">A certificate of deposit (CD) is a money market instrument issued by a depository institution as evidence of a time deposit.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Small denomination certificates of deposit are issued to retail investors. In the United States, these usually are covered by deposit insurance. A certificate of deposit has a fixed term. At the end of the term, the deposit is returned with interest. The vast majority of certificates of deposit have terms of under a year, with three months being typical. Certificates of deposit with terms of a year or more are called term CDs. Terms of five years are not unheard of. Most certificates of deposit credit a fixed rate of interest, but there are also floating-rate certificates of deposit. A fee must be paid to withdraw funds early. This is called a CD interest penalty or a withdrawal penalty. Because most certificates of deposit are negotiable, investors usually sell an unwanted certificate of deposit rather than pay a fee and withdraw the funds. To facilitate transferability, most certificates of deposit are issued in bearer form, but some are registered. Can be interest at maturity or it can be periodic payments.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments are issued at par.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments mature at par with interest.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;CommercialPaper">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-trd;hasMaturityDuration"/>
-				<owl:onClass rdf:resource="&fibo-fnd-tim-tim;TypicalDuration"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaperIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commercial paper</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-mm-trd;TreasuryBill"/>
-		<skos:definition xml:lang="en">Commercial paper (CP) is unsecured short-term promissory notes issued primarily by corporations, although there are also municipal and sovereign issuers (not included in this definition).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments mature at par.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is tradable in the sense that it can be sold back to the issuer. Can also be more widely traded. Term is typically 270 days or less. There are two types of Commercial Paper: Discounted CP and Interest Bearing CP.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;CommercialPaperIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-trd;identifiedAs"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-be-ge-ge;Government">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">commercial paper issuer</rdfs:label>
-		<skos:definition xml:lang="en">Any entity that issues Commercial Paper. This includes corporations but the Special Purpose Entities that issue Asset Backed Commercial Paper (ABCP) and some mutual funds also issue CP. Can also be a banks, an institution, pretty much anything. There are no hard and fast criteria for this. Therefore this is defined as being any kind of Organization or any kind of Government.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;DiscountedCP">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DiscountValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">discounted c p</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-dbt-mm-trd;InterestBearingCP"/>
-		<skos:definition xml:lang="en">A Discounted CP is similar to a Treasury Bill except the maturity is 270 days or less. Therefore (draft definition): A Money Market instrument (short term debt instrument) issued by a corporation for the purposes of raising funds. This is tradable and accretes interest i.e. it is a Discounted Instrument. It has a maturity of 270 days or less.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments are issued at a discount.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;EurodollarDeposit">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit"/>
-		<rdfs:label xml:lang="en">eurodollar deposit</rdfs:label>
-		<skos:definition xml:lang="en">A US dollar deposit or other currency deposit made outside the US or the country that issues that currency.</skos:definition>
-		<skos:editorialNote xml:lang="en">From riskglossary.com (part of Money Market Deposit article): The Eurodollar market has become global, so its name is a bit of a misnomer. A bank in Japan or Singapore may accept dollar deposits, but these are still called Eurodollar deposits. The market also includes other currencies, so there are Eurosterling, Euroyen, Euroswiss, etc. To confuse matters, in 1999, the European Union embraced the euro as its new currency, so you can now hear of Euroeuro. Eurocurrency is the general term for any currency deposited in bank branches outside countries where it is the national currency. Comment: Should this not rather be labeled as Eurocurrency Deposit, corresponding with the above definition? Eurodollar deposit would be a dollar-denominated sub type of this.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;InterestBearingCP">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">interest bearing c p</rdfs:label>
-		<skos:definition xml:lang="en">Interest Bearing Commercial Paper is sold at par and has interest rate but only pays interest at maturity.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments are issued at par.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments mature at par and pay interest.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;MoneyMarketDebtInstrument">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DebtInstrument"/>
-		<rdfs:label xml:lang="en">money market debt instrument</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-sec-dbt-mm-repo;RepurchaseAgreement">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;BankersAcceptance">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;CertificateOfDeposit">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;CommercialPaper">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;TreasuryBill">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition xml:lang="en">Money Market Debt Instrument is a kind of short term debt security. This is defined as the logical union of all the securities that are commonly referred to as Money Market instruments.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">money market deposit</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments are issued at par.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments mature at par.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;TermCertificateOfDeposit">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-trd;CertificateOfDeposit"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-trd;maturityDuration"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">term certificate of deposit</rdfs:label>
-		<skos:definition xml:lang="en">A Certificate of Deposit with a maturity duration of more than one year.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;TreasuryBill">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;SovereignDebtInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasInterestRate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;TreasuryBillReferenceRate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DiscountValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">treasury bill</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments are issued at a discount.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These instruments mature at par.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;callable">
-		<rdfs:label xml:lang="en">callable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;BankersAcceptance"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CertificateOfDeposit"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;TreasuryBill"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the issuer of the debt instrument can call the debt prior to maturity. This instrument is not callable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;callable.3">
-		<rdfs:label xml:lang="en">callable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the writer of the debt contract (the debtor) can call the debt prior to maturity. This instrument is not callable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;hasInterestPaymentTerms">
-		<rdfs:label>has interest payment terms</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;hasMaturityDuration">
-		<rdfs:label xml:lang="en">has maturity duration</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TypicalDuration"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;identifiedAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;identity"/>
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaperIssuer"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-be-ge-ge;Government">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;maturityDuration">
-		<rdfs:label xml:lang="en">maturity duration</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;TermCertificateOfDeposit"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;multiplier">
-		<rdfs:label xml:lang="en">multiplier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CPTypicalDurationDescription"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The typical duration for the CP instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;putable">
-		<rdfs:label xml:lang="en">putable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;BankersAcceptance"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CertificateOfDeposit"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;TreasuryBill"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the holder has the right to ask for redemption of the security prior to final maturity. This instrument is not putable.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;strippable">
-		<rdfs:label xml:lang="en">strippable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;BankersAcceptance"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CertificateOfDeposit"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;TreasuryBill"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the instrument can be stripped, so that interest and principal may be traded separately. This instrument cannot be stripped.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;typicalMaturityDuration">
-		<rdfs:label xml:lang="en">typical maturity duration</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDebtInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;UpToOneYear"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-ge-ge="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"
+buxmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-accx-acc="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-dbtx-int="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"
+buxmlns:fibo-md-dbtx-py="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"
+buxmlns:fibo-sec-dbt-bo-iss="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"
+buxmlns:fibo-sec-dbt-dbt-par="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"
+buxmlns:fibo-sec-dbt-dbtx-dbtx="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"
+buxmlns:fibo-sec-dbt-mm-repo="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/"
+buxmlns:fibo-sec-dbt-mm-trd="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">TradedShortTermDebt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology describes all those money market instruments that may be freely traded. Includes commercial paper, certificates of deposit, treasury bills, bankers acceptances and bills of exchange.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/AccountsMain/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/MathExt/Amounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/QuantitiesExt/QuantitiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtInterestAmounts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/DebtTemporal/DebtPricingYields/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsIssuerVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundations/ParityVariants/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtFoundationsExt/DebtInstrumentsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/REPOs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/MoneyMarkets/TradedShortTermDebt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-ge-ge;Government">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;BankersAcceptance">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-acc;Draft"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DiscountValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bankers acceptance</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Draft where the drawer and drawee of the draft are distinct parties and the drawee is a bank.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">In drafts where the payee may submit the draft to the drawee for confirmation that the draft is a legitimate order and that the drawee will make payment on the specified date. Such confirmation is called acceptance - the drawee accepts the order to pay as legitimate. The drawee stamps ACCEPTED on the draft and is thereafter obligated to make the specified payment when it is due. If the drawee is a bank, the acceptance is called a bankers acceptance (BA). A bankers acceptance is an obligation of the accepting bank. Depending on the bank&apos;s reputation, a payee may be able to sell the bankers acceptance - that is, sell the time draft accepted by the bank. It will sell for the discounted value of the future payment. In this manner, the bankers acceptance becomes a discount instrument traded in the money market. Paying discounted value for a time draft is called discounting the draft. Matures at par, the same as discounted CP or a short term TBill.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments are issued at a discount.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments mature at par.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;BillOfExchange">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bill of exchange</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;CPTypicalDurationDescription">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;hasCalendarDenomination"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;CalendarDay"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">c p typical duration description</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formal description of the typical period of time which is the mayturity of a Commercial Paper instrument.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">For US Commercial Paper this is 270 with a denomination of Day; for UK CP this would be 1 with a denomination of Year. This does not need to be specified but may be specified in order to define the typical duration for Commercial Paper as defined in a particular market or jurisduction. Note that Commercial Paper is defined as being part of the set of instruments which are &quot;Money Market&quot; instruments without this term needing to be specified, as this may vary from one market to another. However this term may be used in any such market as a defining fact about Commercial Paper.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;CertificateOfDeposit">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">certificate of deposit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A certificate of deposit (CD) is a money market instrument issued by a depository institution as evidence of a time deposit.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Small denomination certificates of deposit are issued to retail investors. In the United States, these usually are covered by deposit insurance. A certificate of deposit has a fixed term. At the end of the term, the deposit is returned with interest. The vast majority of certificates of deposit have terms of under a year, with three months being typical. Certificates of deposit with terms of a year or more are called term CDs. Terms of five years are not unheard of. Most certificates of deposit credit a fixed rate of interest, but there are also floating-rate certificates of deposit. A fee must be paid to withdraw funds early. This is called a CD interest penalty or a withdrawal penalty. Because most certificates of deposit are negotiable, investors usually sell an unwanted certificate of deposit rather than pay a fee and withdraw the funds. To facilitate transferability, most certificates of deposit are issued in bearer form, but some are registered. Can be interest at maturity or it can be periodic payments.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments are issued at par.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments mature at par with interest.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;CommercialPaper">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-trd;hasMaturityDuration"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-tim-tim;TypicalDuration"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaperIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commercial paper</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-mm-trd;TreasuryBill"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Commercial paper (CP) is unsecured short-term promissory notes issued primarily by corporations, although there are also municipal and sovereign issuers (not included in this definition).</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments mature at par.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is tradable in the sense that it can be sold back to the issuer. Can also be more widely traded. Term is typically 270 days or less. There are two types of Commercial Paper: Discounted CP and Interest Bearing CP.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;CommercialPaperIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-trd;identifiedAs"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-be-ge-ge;Government">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">commercial paper issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Any entity that issues Commercial Paper. This includes corporations but the Special Purpose Entities that issue Asset Backed Commercial Paper (ABCP) and some mutual funds also issue CP. Can also be a banks, an institution, pretty much anything. There are no hard and fast criteria for this. Therefore this is defined as being any kind of Organization or any kind of Government.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;DiscountedCP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DiscountValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">discounted c p</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-dbt-mm-trd;InterestBearingCP"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Discounted CP is similar to a Treasury Bill except the maturity is 270 days or less. Therefore (draft definition): A Money Market instrument (short term debt instrument) issued by a corporation for the purposes of raising funds. This is tradable and accretes interest i.e. it is a Discounted Instrument. It has a maturity of 270 days or less.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments are issued at a discount.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;EurodollarDeposit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">eurodollar deposit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A US dollar deposit or other currency deposit made outside the US or the country that issues that currency.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">From riskglossary.com (part of Money Market Deposit article): The Eurodollar market has become global, so its name is a bit of a misnomer. A bank in Japan or Singapore may accept dollar deposits, but these are still called Eurodollar deposits. The market also includes other currencies, so there are Eurosterling, Euroyen, Euroswiss, etc. To confuse matters, in 1999, the European Union embraced the euro as its new currency, so you can now hear of Euroeuro. Eurocurrency is the general term for any currency deposited in bank branches outside countries where it is the national currency. Comment: Should this not rather be labeled as Eurocurrency Deposit, corresponding with the above definition? Eurodollar deposit would be a dollar-denominated sub type of this.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;InterestBearingCP">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interest bearing c p</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Interest Bearing Commercial Paper is sold at par and has interest rate but only pays interest at maturity.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments are issued at par.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments mature at par and pay interest.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;MoneyMarketDebtInstrument">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/DebtInstrument"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">money market debt instrument</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-mm-repo;RepurchaseAgreement">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;BankersAcceptance">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;CertificateOfDeposit">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;CommercialPaper">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-dbt-mm-trd;TreasuryBill">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Money Market Debt Instrument is a kind of short term debt security. This is defined as the logical union of all the securities that are commonly referred to as Money Market instruments.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/DebtInstruments/NonTradableDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">money market deposit</rdfs:label>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments are issued at par.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments mature at par.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;TermCertificateOfDeposit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-mm-trd;CertificateOfDeposit"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-mm-trd;maturityDuration"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">term certificate of deposit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Certificate of Deposit with a maturity duration of more than one year.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-dbt-mm-trd;TreasuryBill">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-iss;SovereignDebtInstrument"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-dbtx-py;hasInterestRate"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-dbtx-int;TreasuryBillReferenceRate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtIssue"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;DiscountValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-dbt-dbtx-dbtx;hasValueAtMaturity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbt-par;ParValue"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">treasury bill</rdfs:label>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments are issued at a discount.</fibo-fnd-utl-av:explanatoryNote>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These instruments mature at par.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;callable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">callable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;BankersAcceptance"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CertificateOfDeposit"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;TreasuryBill"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the issuer of the debt instrument can call the debt prior to maturity. This instrument is not callable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;callable.3">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">callable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the writer of the debt contract (the debtor) can call the debt prior to maturity. This instrument is not callable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;hasInterestPaymentTerms">
+bubu<rdfs:label>has interest payment terms</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;hasMaturityDuration">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has maturity duration</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;TypicalDuration"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;identifiedAs">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;identity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaperIssuer"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-be-le-fbo;FormallyConstitutedOrganization">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-be-ge-ge;Government">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;maturityDuration">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity duration</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;TermCertificateOfDeposit"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationOfMoreThanOneYear"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;multiplier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiplier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CPTypicalDurationDescription"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The typical duration for the CP instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;putable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">putable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;BankersAcceptance"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CertificateOfDeposit"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDeposit"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;TreasuryBill"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the holder has the right to ask for redemption of the security prior to final maturity. This instrument is not putable.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;strippable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">strippable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;BankersAcceptance"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CertificateOfDeposit"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;CommercialPaper"/>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;TreasuryBill"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the instrument can be stripped, so that interest and principal may be traded separately. This instrument cannot be stripped.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-dbt-mm-trd;typicalMaturityDuration">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">typical maturity duration</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-dbt-mm-trd;MoneyMarketDebtInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;UpToOneYear"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Equities/DepositaryReceipts.rdf
+++ b/sec/Equities/DepositaryReceipts.rdf
@@ -1,126 +1,129 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-eq-dr "https://spec.edmcouncil.org/fibo/SEC/Equities/DepositaryReceipts/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-eq-dr "https://spec.edmcouncil.org/fibo/SEC/Equities/DepositaryReceipts/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Equities/DepositaryReceipts/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-eq-dr="https://spec.edmcouncil.org/fibo/SEC/Equities/DepositaryReceipts/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/DepositaryReceipts/">
-		<rdfs:label xml:lang="en">DepositaryReceipts</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/DepositaryReceipts/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-dr;DepositaryBank">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/Bank"/>
-		<rdfs:label xml:lang="en">depositary bank</rdfs:label>
-		<skos:definition xml:lang="en">A bank which is set up and authorized to issue Depositary Receipts.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-dr;DepositaryReceiptIssuer">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-dr;identifiedAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-dr;DepositaryBank"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">depositary receipt issuer</rdfs:label>
-		<skos:definition xml:lang="en">The party which is the issuer of a Depository Receipt in some jurisdiciton.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-dr;InternationalDepositaryReceipt">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/EquityInstrument"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/ExchangeTradedSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-dr;DepositaryReceiptIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-dr;authorizedUnder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-dr;hasUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">international depositary receipt</rdfs:label>
-		<skos:definition xml:lang="en">Certificate which represent ownership of an underlying Equity.</skos:definition>
-		<skos:editorialNote xml:lang="en">Additional facts which are not shown as they do not define the instrument as such. but could be added, uinclude the fact that the underlying is a security which has a restriction on owner domicile. These may also funge back after the restriction period. This could be shown but does not need to be.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;authorizedUnder">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-sec;legallyRecordedIn"/>
-		<rdfs:label xml:lang="en">authorized under</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-dr;InternationalDepositaryReceipt"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;hasUnderlying">
-		<rdfs:label xml:lang="en">has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-dr;InternationalDepositaryReceipt"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;identifiedAs">
-		<rdfs:label xml:lang="en">identified as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-dr;DepositaryReceiptIssuer"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-dr;DepositaryBank"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;multiplier">
-		<rdfs:label xml:lang="en">multiplier</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-dr;InternationalDepositaryReceipt"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of underlying shares (whether multiple or fractional) represented by a single Depositary Receipt.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;numberOfCertificatesIssued">
-		<rdfs:label xml:lang="en">number of certificates issued</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-dr;InternationalDepositaryReceipt"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of certificates issued to the general public.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-eq-dr="https://spec.edmcouncil.org/fibo/SEC/Equities/DepositaryReceipts/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/DepositaryReceipts/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">DepositaryReceipts</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Depositary receipts are certificates which represent ownership of some underlying equity instruments. These are issued by a bank and give the holder the ability to participate in the returns of an equity instruments they may not be able to hold directly.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/DepositaryReceipts/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-dr;DepositaryBank">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/FinancialServicesEntities/Bank"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">depositary bank</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A bank which is set up and authorized to issue Depositary Receipts.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-dr;DepositaryReceiptIssuer">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-dr;identifiedAs"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-dr;DepositaryBank"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">depositary receipt issuer</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which is the issuer of a Depository Receipt in some jurisdiciton.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-dr;InternationalDepositaryReceipt">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/EquityInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/ExchangeTradedSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-dr;DepositaryReceiptIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-dr;authorizedUnder"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-dr;hasUnderlying"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">international depositary receipt</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Certificate which represent ownership of an underlying Equity.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Additional facts which are not shown as they do not define the instrument as such. but could be added, uinclude the fact that the underlying is a security which has a restriction on owner domicile. These may also funge back after the restriction period. This could be shown but does not need to be.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;authorizedUnder">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-sec;legallyRecordedIn"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">authorized under</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-dr;InternationalDepositaryReceipt"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;hasUnderlying">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has underlying</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-dr;InternationalDepositaryReceipt"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;identifiedAs">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">identified as</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-dr;DepositaryReceiptIssuer"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-dr;DepositaryBank"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;multiplier">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiplier</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-dr;InternationalDepositaryReceipt"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of underlying shares (whether multiple or fractional) represented by a single Depositary Receipt.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-dr;numberOfCertificatesIssued">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of certificates issued</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-dr;InternationalDepositaryReceipt"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of certificates issued to the general public.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Equities/EquityInstruments.rdf
+++ b/sec/Equities/EquityInstruments.rdf
@@ -1,556 +1,559 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/">
-	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
-	<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/">
-	<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/">
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-eqx-pri "https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-eq-iss "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/">
-	<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
-	<!ENTITY fibo-sec-eq-she "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/">
+bu<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
+bu<!ENTITY fibo-be-oac-opty "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/">
+bu<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-eqx-pri "https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-eq-iss "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/">
+bu<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
+bu<!ENTITY fibo-sec-eq-she "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"
-	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"
-	xmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/"
-	xmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-eqx-pri="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-eq-iss="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"
-	xmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
-	xmlns:fibo-sec-eq-she="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-		<rdfs:label xml:lang="en">EquityInstruments</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-oac-cown;Shareholder">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oac-opty;holdsEquityIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;StockholdersEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;holdsSomeShareholderEquity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-oac-opty;ConstitutionalOwner">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;holdsSomeShareholderEquity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;StockholdersEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-ptr-ptr;LimitedPartnerEquity">
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;DistributionByPayment">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
-		<rdfs:label xml:lang="en">distribution by payment</rdfs:label>
-		<skos:definition xml:lang="en">Distribution by payment of a monetary amount.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;DistributionByReinvestment">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
-		<rdfs:label xml:lang="en">distribution by reinvestment</rdfs:label>
-		<skos:definition xml:lang="en">Distribution by reinvestment in the same equity or fund.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;DistributionBySecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
-		<rdfs:label xml:lang="en">distribution by security</rdfs:label>
-		<skos:definition xml:lang="en">Pay by Security</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;DividendsDistributionMethod">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DistributionMethod"/>
-		<rdfs:label xml:lang="en">dividends distribution method</rdfs:label>
-		<skos:definition xml:lang="en">The method by which amounts owing to a holder of an equity or a fund, are distributed, e.g. by payment of a monetary amount or by reinvestment in the same company or fund.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note that this may be defined in a contract or instrument, in which case it will be referred to in contractual terms. In many cases it is not defined in the product, but will be defined in a Corporate Action message at the time that the distribution is made. In this case, this selection will be referred to in the Corporate Action / Event message.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;FoundersShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PrivatelyHeldShare"/>
-		<rdfs:label xml:lang="en">founders share</rdfs:label>
-		<skos:definition xml:lang="en">A share which is not tradable and which is held by founders of the compsny. Ths is stock that pre-dates any flotation of the company.</skos:definition>
-		<skos:editorialNote xml:lang="en">Question: is there a distinction between this specific thing and the more general class of non traded shares? If not they are synonyms. Original review note: Founders share: not a traded stock.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;FullyPaid">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SecurityPaymentStatus"/>
-		<rdfs:label xml:lang="en">fully paid</rdfs:label>
-		<skos:definition xml:lang="en">Fully paid</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;Junior">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Seniority"/>
-		<rdfs:label xml:lang="en">junior</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;MultipleVotingShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingShare"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersTwoOrMoreVotingRight"/>
-				<owl:onClass rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">multiple voting share</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
-		<skos:definition xml:lang="en">A share which confers upon the holder multiple voting rights.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;NilPaid">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SecurityPaymentStatus"/>
-		<rdfs:label xml:lang="en">nil paid</rdfs:label>
-		<skos:definition xml:lang="en">Nil paid</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;NonVotingShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:label xml:lang="en">non voting share</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;VotingShare"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;OtherSeniority">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Seniority"/>
-		<rdfs:label xml:lang="en">other seniority</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;PartlyPaid">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SecurityPaymentStatus"/>
-		<rdfs:label xml:lang="en">partly paid</rdfs:label>
-		<skos:definition xml:lang="en">Partly paid</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;PrivateEquity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<rdfs:label xml:lang="en">private equity</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;PrivatelyHeldShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfPrivateEquity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PrivateEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">privately held share</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;PublicPrivateIssueFacet">
-		<rdfs:label xml:lang="en">public private issue facet</rdfs:label>
-		<owl:equivalentClass>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-sec-eq-eq;PrivatelyHeldShare">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-sec-eq-eq;PubliclyTradedShare">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</owl:equivalentClass>
-		<skos:definition xml:lang="en">Classification facet.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;PubliclyIssuedEquity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasCurrentStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CurrentEquityStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">publicly issued equity</rdfs:label>
-		<skos:definition xml:lang="en">The equity which exists in an incorporated company, which has been issued to the public in the form of shares. This class defines the equity itself, as distinct from the shares which give a holder the ownership of that equity, i.e. this is what is owned by the share holder.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Equity is generally issued in various classes, the precise definitions of which may be defined by the issuer. These are identified as senior or junior, or other classes as defined by the issuer.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;PubliclyTradedShare">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/EquityInstrument"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/ExchangeTradedSecurity"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/RegisteredSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasIssuanceInformation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-iss;EquityInstrumentIssueInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CurrentShareStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfIssuedEquity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;isHeldBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-oac-cown;PublicShareholder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;hasListing"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;EquityListing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">publicly traded share</rdfs:label>
-		<skos:definition xml:lang="en">A publicly traded security that signifies ownership in a corporation and represents a claim on part of the corporation&apos;s assets and earnings.</skos:definition>
-		<skos:editorialNote xml:lang="en">Publicly traded can only be traded if registered (in US with the SEC). At this level this may be traded over the counter or on an exchange or other listing. MEANING: It has been registered with the Regulator for public sale. Q: Can that same co also issues shares which cannot be publicly traded: A: Yes but they have to be registered. Are there shares that cannot be listed due to liimitations on their transfers. See different conditions on different classes of stock. So there are some classes of stock meant for specific audiences. See e.g. Buffet. Privately negotiated txns. This defines different classes. In general: there are prerequisites to being able to publicly trade shares.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;SecurityPaymentStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
-		<rdfs:label xml:lang="en">security payment status</rdfs:label>
-		<skos:definition xml:lang="en">The Payment Status of a Unit or other Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;Senior">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Seniority"/>
-		<rdfs:label xml:lang="en">senior</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;Seniority">
-		<rdfs:label xml:lang="en">Seniority</rdfs:label>
-		<skos:definition xml:lang="en">The seniority of a tranche of equity or debt. The precise implications of the different levels of seniority are defined for the instrument class in question.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;nonPaidAmount"/>
-				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfEquity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;isHeldBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-oac-cown;Shareholder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;isSeniorTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">share</rdfs:label>
-		<skos:definition xml:lang="en">A security that signifies ownership in a corporation and represents a claim on part of the corporation&apos;s assets and earnings. What a share confers: 1. Voting rights 2. Entitlement to Income 3. Entitlements to Assets</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;ShareholderEquity">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;IssuedEquity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;isSeniorToAnotherClassOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;stockholderEquityRepresents"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-she;hasPriorityAsDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">shareholder equity</rdfs:label>
-		<skos:definition xml:lang="en">The equity in the company in the form of shares.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;SingleVotingShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingShare"/>
-		<rdfs:label xml:lang="en">single voting share</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;VotingRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;votingRestrictions"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">voting right</rdfs:label>
-		<skos:definition xml:lang="en">The right of a stockholder to vote on matters of corporate policy as well as on who is to compose the board of directors.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Most voting involves decisions on issuing securities, initiating stock splits, and making substantial changes in the corporation&apos;s operations.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;VotingShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersSome"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">voting share</rdfs:label>
-		<skos:definition xml:lang="en">A share which confers upon the holder some voting rights.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersExactlyOneVotingRight">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;confersSome"/>
-		<rdfs:label xml:lang="en">confers exactly one voting right</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<skos:definition xml:lang="en">The share confers exactly one voting right on the Holder.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersNo">
-		<rdfs:label xml:lang="en">confers no</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<skos:definition xml:lang="en">The share confers no voting rights on the Holder.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersOwnershipOfEquity">
-		<rdfs:label xml:lang="en">confers ownership of equity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<skos:definition xml:lang="en">Equity represented by the Share and owned by the Holder of the Share in proportion to the amount of the Issue that they hold.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A person or organization that holds at least a partial share of stock is called a shareholder.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersOwnershipOfIssuedEquity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfEquity"/>
-		<rdfs:label xml:lang="en">confers ownership of issued equity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
-		<skos:definition xml:lang="en">A share confers on the holder the legal right of ownership of issued equity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersOwnershipOfPrivateEquity">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfEquity"/>
-		<rdfs:label xml:lang="en">confers ownership of private equity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PrivatelyHeldShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PrivateEquity"/>
-		<skos:definition xml:lang="en">Equity represented by the Private Equity security and owned by the Holder of the share in proportion to the amount of the issue that they hold.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A person or organization that holds at least a partial share of stock is called a shareholder.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersSome">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agrx-con;confers"/>
-		<rdfs:label xml:lang="en">confers some</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;VotingShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<skos:definition xml:lang="en">The share confers one or more voting rights on the Holder.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersTwoOrMoreVotingRight">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;confersSome"/>
-		<rdfs:label xml:lang="en">confers two or more voting right</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;MultipleVotingShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<skos:definition xml:lang="en">The share confers multiple voting rights on the Holder.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;equityAmount">
-		<rdfs:label xml:lang="en">equity amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The Monetary Amount (capital amount) represented by the Issued Equity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;freeFloat">
-		<rdfs:label xml:lang="en">free float</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The total number of shares publicly owned and available for trading. The float is calculated by subtracting restricted shares from outstanding shares.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasPaymentStatus">
-		<rdfs:label>has payment status</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;holdsSomeShareholderEquity">
-		<rdfs:label xml:lang="en">holds some shareholder equity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-oac-cown;Shareholder"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<skos:definition xml:lang="en">The shareholder holds some of the issued shareholder equity in the company, by way of the shares that they hold.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;isHeldBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-		<rdfs:label xml:lang="en">is held by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-cown;Shareholder"/>
-		<skos:definition xml:lang="en">A party which holds the share.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;isSeniorTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;isSeniorToAnotherClassOf"/>
-		<rdfs:label xml:lang="en">is senior to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<skos:definition xml:lang="en">The share has a higher seniority than the related share, meaning that it gives the holder a higher claim on the assets of the issuing entity in the event of the winding up of that entity.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;isSeniorToAnotherClassOf">
-		<rdfs:label xml:lang="en">is senior to another class of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<skos:definition xml:lang="en">A class of equity may have a higher claim on the assets of the issuing entity in the event of the winding up of that entity than another class of equity. This is referred to as taking precedence or priority over that other class of equity. It is also referred to as the first class being senior to that other class of issued equity.</skos:definition>
-		<skos:editorialNote xml:lang="en">This information is also embodied in the property of Priority for the class of equity. These are two indications of the same information, relating to the equity and the share that gives ownership of that equity, respectively.</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;nonPaidAmount">
-		<rdfs:label xml:lang="en">non paid amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Nominal amount which is not paid yet.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;numberOfSharesInIssue">
-		<rdfs:label xml:lang="en">number of shares in issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The total number of shares issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;numberOfVotes">
-		<rdfs:label xml:lang="en">number of votes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;MultipleVotingShare"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of votes which are conferred upon the holder of each such share.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;parValue">
-		<rdfs:label xml:lang="en">par value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">A dollar amount that is assigned to a security when representing the value contributed for each share in cash or goods. (definition from Investor Words) Further notes: from Wikipedia: Par value is a nominal value of a security which is determined by an issuer company at a minimum price. Par value of an equity (a stock) is a somewhat archaic concept. The par value of a stock was the share price upon initial offering; the issuing company promised not to issue further shares below par value, so investors could be confident that no one else was receiving a more favorable issue price. This was far more important in unregulated equity markets than in the regulated markets that exist today. Most common stocks issued today do not have par values; those that do (usually only in jurisdictions where par values are required by law) have extremely low par values (often the smallest unit of currency commonly used), for example a penny par value on a stock issued at USD$25/share. Most states do not allow a company to issue stock below par value. No-par stocks have no par value printed on its certificates. Instead of par value, some U.S. states allow no-par stocks to have a stated value, set by the board of directors of the corporation, which serves the same purpose as par value in setting the minimum legal capital that the corporation must have after paying any dividends or buying back its stock.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;priority">
-		<rdfs:label xml:lang="en">priority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Seniority"/>
-		<skos:definition xml:lang="en">The Seniority of the Equity. This is the order of precedence in which holders of different classes of equity (whether through private equity or publicly issued shares) will have a call on the assets of the company in the event of it winding up.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;stockholderEquityRepresents">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-aeq;takesForm"/>
-		<rdfs:label xml:lang="en">stockholder equity represents</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The Monetary Amount (capital amount) represented by the Stockholder Equity. This is the total equity in the firm in the form of shares (that is, the total equity other than additional paid in capital).</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;votingRestrictions">
-		<rdfs:label xml:lang="en">voting restrictions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Details of restrictions on voting rights, for the case where type of voting is Restricted.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;votingRightsPerShare">
-		<rdfs:label xml:lang="en">voting rights per share</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Number of voting rights per share.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"
+buxmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"
+buxmlns:fibo-be-oac-opty="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/"
+buxmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-eqx-pri="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-eq-iss="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"
+buxmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
+buxmlns:fibo-sec-eq-she="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">EquityInstruments</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Core terms are those fundamental to all equity instruments. These terms are referred to in Business Entity models (for ownership relationships of incorporated companies). THs ontology also distinguishes between privately held and publicly traded equity instruments, and defines a number of sub types of equities, such as types of voting rights, distribution methods etc. that are not specific to publicly traded equity.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetBaskets/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/DER/AssetDerivatives/AssetDerivatives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/IND/MarketIndicesExt/BasketIndices/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-oac-cown;Shareholder">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-be-oac-opty;holdsEquityIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;StockholdersEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;holdsSomeShareholderEquity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-oac-opty;ConstitutionalOwner">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;holdsSomeShareholderEquity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;StockholdersEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-be-ptr-ptr;LimitedPartnerEquity">
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;DistributionByPayment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">distribution by payment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Distribution by payment of a monetary amount.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;DistributionByReinvestment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">distribution by reinvestment</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Distribution by reinvestment in the same equity or fund.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;DistributionBySecurity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">distribution by security</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Pay by Security</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;DividendsDistributionMethod">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DistributionMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividends distribution method</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The method by which amounts owing to a holder of an equity or a fund, are distributed, e.g. by payment of a monetary amount or by reinvestment in the same company or fund.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Note that this may be defined in a contract or instrument, in which case it will be referred to in contractual terms. In many cases it is not defined in the product, but will be defined in a Corporate Action message at the time that the distribution is made. In this case, this selection will be referred to in the Corporate Action / Event message.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;FoundersShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PrivatelyHeldShare"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">founders share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A share which is not tradable and which is held by founders of the compsny. Ths is stock that pre-dates any flotation of the company.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Question: is there a distinction between this specific thing and the more general class of non traded shares? If not they are synonyms. Original review note: Founders share: not a traded stock.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;FullyPaid">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SecurityPaymentStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fully paid</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Fully paid</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;Junior">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Seniority"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">junior</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;MultipleVotingShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingShare"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersTwoOrMoreVotingRight"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">multiple voting share</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A share which confers upon the holder multiple voting rights.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;NilPaid">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SecurityPaymentStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">nil paid</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Nil paid</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;NonVotingShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non voting share</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;VotingShare"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;OtherSeniority">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Seniority"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">other seniority</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;PartlyPaid">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SecurityPaymentStatus"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">partly paid</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Partly paid</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;PrivateEquity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">private equity</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;PrivatelyHeldShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfPrivateEquity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PrivateEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">privately held share</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;PublicPrivateIssueFacet">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">public private issue facet</rdfs:label>
+bubu<owl:equivalentClass>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-sec-eq-eq;PrivatelyHeldShare">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-sec-eq-eq;PubliclyTradedShare">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</owl:equivalentClass>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Classification facet.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;PubliclyIssuedEquity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasCurrentStatus"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CurrentEquityStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">publicly issued equity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The equity which exists in an incorporated company, which has been issued to the public in the form of shares. This class defines the equity itself, as distinct from the shares which give a holder the ownership of that equity, i.e. this is what is owned by the share holder.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Equity is generally issued in various classes, the precise definitions of which may be defined by the issuer. These are identified as senior or junior, or other classes as defined by the issuer.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;PubliclyTradedShare">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/EquityInstrument"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/ExchangeTradedSecurity"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/RegisteredSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasIssuanceInformation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-iss;EquityInstrumentIssueInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;hasStatus"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;CurrentShareStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfIssuedEquity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;isHeldBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-oac-cown;PublicShareholder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;hasListing"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;EquityListing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">publicly traded share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A publicly traded security that signifies ownership in a corporation and represents a claim on part of the corporation&apos;s assets and earnings.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Publicly traded can only be traded if registered (in US with the SEC). At this level this may be traded over the counter or on an exchange or other listing. MEANING: It has been registered with the Regulator for public sale. Q: Can that same co also issues shares which cannot be publicly traded: A: Yes but they have to be registered. Are there shares that cannot be listed due to liimitations on their transfers. See different conditions on different classes of stock. So there are some classes of stock meant for specific audiences. See e.g. Buffet. Privately negotiated txns. This defines different classes. In general: there are prerequisites to being able to publicly trade shares.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;SecurityPaymentStatus">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-tem;Status"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security payment status</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Payment Status of a Unit or other Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;Senior">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Seniority"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">senior</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;Seniority">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Seniority</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority of a tranche of equity or debt. The precise implications of the different levels of seniority are defined for the instrument class in question.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;nonPaidAmount"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfEquity"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;isHeldBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-oac-cown;Shareholder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;isSeniorTo"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security that signifies ownership in a corporation and represents a claim on part of the corporation&apos;s assets and earnings. What a share confers: 1. Voting rights 2. Entitlement to Income 3. Entitlements to Assets</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;ShareholderEquity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;IssuedEquity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;isSeniorToAnotherClassOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;stockholderEquityRepresents"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-she;hasPriorityAsDefinedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">shareholder equity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The equity in the company in the form of shares.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;SingleVotingShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingShare"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">single voting share</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;VotingRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;votingRestrictions"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voting right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right of a stockholder to vote on matters of corporate policy as well as on who is to compose the board of directors.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Most voting involves decisions on issuing securities, initiating stock splits, and making substantial changes in the corporation&apos;s operations.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-eq;VotingShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersSome"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voting share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A share which confers upon the holder some voting rights.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersExactlyOneVotingRight">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;confersSome"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers exactly one voting right</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;SingleVotingShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The share confers exactly one voting right on the Holder.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersNo">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers no</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;NonVotingShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The share confers no voting rights on the Holder.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersOwnershipOfEquity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers ownership of equity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Equity represented by the Share and owned by the Holder of the Share in proportion to the amount of the Issue that they hold.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A person or organization that holds at least a partial share of stock is called a shareholder.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersOwnershipOfIssuedEquity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfEquity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers ownership of issued equity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A share confers on the holder the legal right of ownership of issued equity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersOwnershipOfPrivateEquity">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;confersOwnershipOfEquity"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers ownership of private equity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PrivatelyHeldShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;PrivateEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Equity represented by the Private Equity security and owned by the Holder of the share in proportion to the amount of the issue that they hold.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">A person or organization that holds at least a partial share of stock is called a shareholder.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersSome">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agrx-con;confers"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers some</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;VotingShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The share confers one or more voting rights on the Holder.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;confersTwoOrMoreVotingRight">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;confersSome"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers two or more voting right</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;MultipleVotingShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The share confers multiple voting rights on the Holder.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;equityAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Monetary Amount (capital amount) represented by the Issued Equity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;freeFloat">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">free float</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The total number of shares publicly owned and available for trading. The float is calculated by subtracting restricted shares from outstanding shares.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasPaymentStatus">
+bubu<rdfs:label>has payment status</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;holdsSomeShareholderEquity">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holds some shareholder equity</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-oac-cown;Shareholder"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The shareholder holds some of the issued shareholder equity in the company, by way of the shares that they hold.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;isHeldBy">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is held by</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:range rdf:resource="&fibo-be-oac-cown;Shareholder"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A party which holds the share.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;isSeniorTo">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;isSeniorToAnotherClassOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is senior to</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The share has a higher seniority than the related share, meaning that it gives the holder a higher claim on the assets of the issuing entity in the event of the winding up of that entity.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;isSeniorToAnotherClassOf">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is senior to another class of</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A class of equity may have a higher claim on the assets of the issuing entity in the event of the winding up of that entity than another class of equity. This is referred to as taking precedence or priority over that other class of equity. It is also referred to as the first class being senior to that other class of issued equity.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This information is also embodied in the property of Priority for the class of equity. These are two indications of the same information, relating to the equity and the share that gives ownership of that equity, respectively.</skos:editorialNote>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;nonPaidAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non paid amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Nominal amount which is not paid yet.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;numberOfSharesInIssue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of shares in issue</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The total number of shares issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;numberOfVotes">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of votes</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;MultipleVotingShare"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of votes which are conferred upon the holder of each such share.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;parValue">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">par value</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A dollar amount that is assigned to a security when representing the value contributed for each share in cash or goods. (definition from Investor Words) Further notes: from Wikipedia: Par value is a nominal value of a security which is determined by an issuer company at a minimum price. Par value of an equity (a stock) is a somewhat archaic concept. The par value of a stock was the share price upon initial offering; the issuing company promised not to issue further shares below par value, so investors could be confident that no one else was receiving a more favorable issue price. This was far more important in unregulated equity markets than in the regulated markets that exist today. Most common stocks issued today do not have par values; those that do (usually only in jurisdictions where par values are required by law) have extremely low par values (often the smallest unit of currency commonly used), for example a penny par value on a stock issued at USD$25/share. Most states do not allow a company to issue stock below par value. No-par stocks have no par value printed on its certificates. Instead of par value, some U.S. states allow no-par stocks to have a stated value, set by the board of directors of the corporation, which serves the same purpose as par value in setting the minimum legal capital that the corporation must have after paying any dividends or buying back its stock.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;priority">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">priority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Seniority"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Seniority of the Equity. This is the order of precedence in which holders of different classes of equity (whether through private equity or publicly issued shares) will have a call on the assets of the company in the event of it winding up.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;stockholderEquityRepresents">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-aeq;takesForm"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stockholder equity represents</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The Monetary Amount (capital amount) represented by the Stockholder Equity. This is the total equity in the firm in the form of shares (that is, the total equity other than additional paid in capital).</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;votingRestrictions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voting restrictions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Details of restrictions on voting rights, for the case where type of voting is Restricted.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;votingRightsPerShare">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">voting rights per share</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Number of voting rights per share.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Equities/EquityIssuanceTerms.rdf
+++ b/sec/Equities/EquityIssuanceTerms.rdf
@@ -1,55 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-eq-iss "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-eq-iss "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-eq-iss="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/">
-		<rdfs:label xml:lang="en">EquityIssuanceTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-iss;EquityInstrumentIssueInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-		<rdfs:label xml:lang="en">equity instrument issue information</rdfs:label>
-		<skos:definition xml:lang="en">Information about the Issuance of an Equity Security, which is maintained throughout the life of the Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-iss;EquityIssuanceProcessInformation">
-		<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-iss;becomesPartOfTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-iss;EquityInstrumentIssueInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity issuance process information</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-iss;becomesPartOfTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;becomesPartOf"/>
-		<rdfs:label xml:lang="en">becomes part of terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-iss;EquityIssuanceProcessInformation"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-iss;EquityInstrumentIssueInformation"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-eq-iss="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">EquityIssuanceTerms</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Terms that arise from the issuance processes of equity instruments, and that would form part of some securities master file data. 
+		This model is defined with reference to the issuance process models in the Business Process domain. At present there is just a framework for such terms, with no specific terms in place. This ontology can be ignored until such time as detailed terms are added to this framework.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityIssuanceTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-iss;EquityInstrumentIssueInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity instrument issue information</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Information about the Issuance of an Equity Security, which is maintained throughout the life of the Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-iss;EquityIssuanceProcessInformation">
+bubu<rdfs:subClassOf rdf:resource="&fibo-bp-iss-trm;TradedInstrumentIssuanceProcessInformation"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-iss;becomesPartOfTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-iss;EquityInstrumentIssueInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity issuance process information</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-iss;becomesPartOfTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-bp-iss-trm;becomesPartOf"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">becomes part of terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-iss;EquityIssuanceProcessInformation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-iss;EquityInstrumentIssueInformation"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Equities/LimitedPartnershipEquities.rdf
+++ b/sec/Equities/LimitedPartnershipEquities.rdf
@@ -1,113 +1,116 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-eq-lpe "https://spec.edmcouncil.org/fibo/SEC/Equities/LimitedPartnershipEquities/">
-	<!ENTITY fibo-sec-secx-resx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-ptr-ptr "https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-eq-lpe "https://spec.edmcouncil.org/fibo/SEC/Equities/LimitedPartnershipEquities/">
+bu<!ENTITY fibo-sec-secx-resx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Equities/LimitedPartnershipEquities/"
-	xmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-eq-lpe="https://spec.edmcouncil.org/fibo/SEC/Equities/LimitedPartnershipEquities/"
-	xmlns:fibo-sec-secx-resx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/LimitedPartnershipEquities/">
-		<rdfs:label xml:lang="en">LimitedPartnershipEquities</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/LimitedPartnershipEquities/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-lpe;LimitedPartnershipUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasPaymentStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;SecurityPaymentStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-lpe;definesRestrictions"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-lpe;limitedPartnerhipUnitHasHolderLimitedPartner"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-ptr-ptr;LimitedPartner"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">limited partnership unit</rdfs:label>
-		<skos:definition xml:lang="en">A limited partnership is a form of partnership similar to a general partnership, except that in addition to one or more general partners (GPs) there are one or more limited partners (LPs).</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Like shareholders in a corporation, the LPs have limited liability, i.e. they are only liable on debts incurred by the firm to the extent of their registered investment, and they have no management authority. The GPs pay the LPs the equivalent of a dividend on their investment, the nature and extent of which is usually defined in the partnership agreement.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-resx;SecurityContractualRestriction"/>
-		<rdfs:label xml:lang="en">limited partnership unit restriction</rdfs:label>
-		<skos:definition xml:lang="en">Restrictions on ownership or transfer of the Units.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-lpe;definesRestrictions">
-		<rdfs:label xml:lang="en">defines restrictions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnit"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-lpe;investorType">
-		<rdfs:label xml:lang="en">defines investor type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-resx;InvestorType"/>
-		<skos:definition xml:lang="en">Type of investor that is allowed to hold the security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-lpe;limitedPartnerhipUnitHasHolderLimitedPartner">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-		<rdfs:label xml:lang="en">limited partnerhip unit has holder limited partner</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnit"/>
-		<rdfs:range rdf:resource="&fibo-be-ptr-ptr;LimitedPartner"/>
-		<skos:definition xml:lang="en">The holder of the Limited Partnership Unit is a Limited Partner.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-lpe;restricted">
-		<rdfs:label xml:lang="en">restricted</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Yes = Restricted; No = Free.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-ptr-ptr="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-eq-lpe="https://spec.edmcouncil.org/fibo/SEC/Equities/LimitedPartnershipEquities/"
+buxmlns:fibo-sec-secx-resx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/LimitedPartnershipEquities/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">LimitedPartnershipEquities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Where limited partnerships are incorporated by means of equity, the equity is defined in this ontology in the form of limited partnership units. These are a kind of equity instrument but not a kind of share.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/LimitedPartnershipEquities/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-lpe;LimitedPartnershipUnit">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-agrx-con;confers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasPaymentStatus"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;SecurityPaymentStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-lpe;definesRestrictions"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-lpe;limitedPartnerhipUnitHasHolderLimitedPartner"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-ptr-ptr;LimitedPartner"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">limited partnership unit</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A limited partnership is a form of partnership similar to a general partnership, except that in addition to one or more general partners (GPs) there are one or more limited partners (LPs).</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Like shareholders in a corporation, the LPs have limited liability, i.e. they are only liable on debts incurred by the firm to the extent of their registered investment, and they have no management authority. The GPs pay the LPs the equivalent of a dividend on their investment, the nature and extent of which is usually defined in the partnership agreement.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-resx;SecurityContractualRestriction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">limited partnership unit restriction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Restrictions on ownership or transfer of the Units.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-lpe;definesRestrictions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines restrictions</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-lpe;investorType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">defines investor type</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-resx;InvestorType"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Type of investor that is allowed to hold the security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-lpe;limitedPartnerhipUnitHasHolderLimitedPartner">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">limited partnerhip unit has holder limited partner</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnit"/>
+bubu<rdfs:range rdf:resource="&fibo-be-ptr-ptr;LimitedPartner"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The holder of the Limited Partnership Unit is a Limited Partner.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-lpe;restricted">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">restricted</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-lpe;LimitedPartnershipUnitRestriction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Yes = Restricted; No = Free.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Equities/ShareTerms.rdf
+++ b/sec/Equities/ShareTerms.rdf
@@ -1,606 +1,609 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-eqx-pri "https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/">
-	<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
-	<!ENTITY fibo-sec-eq-she "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/">
-	<!ENTITY fibo-sec-eq-shr "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-agrx-con "https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-eqx-pri "https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/">
+bu<!ENTITY fibo-sec-dbt-bo-cft "https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
+bu<!ENTITY fibo-sec-eq-she "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/">
+bu<!ENTITY fibo-sec-eq-shr "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
-	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-eqx-pri="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"
-	xmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
-	xmlns:fibo-sec-eq-she="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"
-	xmlns:fibo-sec-eq-shr="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
-		<rdfs:label xml:lang="en">ShareTerms</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-oac-exec;ArticlesOfIncorporation">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<skos:definition xml:lang="en">proxy</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;CompanyEquityTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label xml:lang="en">company equity terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out the equity in a company, including the various kinds of rights, the shares that embody those rights etc.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleCommonShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ConvertibleShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
-		<rdfs:label xml:lang="en">convertible common share</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-sha;ConvertiblePreferenceShare"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleIntoFacet">
-		<rdfs:label xml:lang="en">convertible into facet</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleIntoFacet.1">
-		<rdfs:label xml:lang="en">ConvertibleIntoFacet.1</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleParticipatingPreferenceShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ConvertiblePreferenceShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ParticipatingPreferenceShare"/>
-		<rdfs:label xml:lang="en">convertible participating preference share</rdfs:label>
-		<skos:definition xml:lang="en">A preference share that can be converted into common shares at a fixed conversion price. Preference or preferred shares entitle a holder to a prior claim on any dividend paid by the company before payment is made on ordinary shares.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertiblePreferenceShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ConvertibleShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;convertibleInto"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">convertible preference share</rdfs:label>
-		<skos:definition xml:lang="en">A Preferred Share which is convertible into another security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;convertibleInto"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;hasConversionTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;EquityConversionTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">convertible share</rdfs:label>
-		<skos:definition xml:lang="en">A Share which is convertible into another security, usually a share in the same company.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;CumulativeFacet">
-		<rdfs:label xml:lang="en">cumulative facet</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;CumulativeFacet.1">
-		<rdfs:label xml:lang="en">CumulativeFacet.1</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;CumulativePreferenceShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:label xml:lang="en">cumulative preference share</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-sha;NonCumulativePreferenceShare"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;DividendTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;hasDistributionMethod"/>
-				<owl:onClass rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dividend terms</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;EquityConversionTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/ConversionTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/specifiesConversionInto"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity conversion terms</rdfs:label>
-		<skos:definition xml:lang="en">Contractual specifications when an Equity security can be converted to another security (usually of the same issuer).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;EquityListing">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
-		<rdfs:label xml:lang="en">equity listing</rdfs:label>
-		<skos:definition xml:lang="en">The listing of an equity security (stock) on an equities exchange or multilateral trading facility.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is not the security or the exchange but the listing of the security on the exchange. Facts defined for Equity Listing are facts about that security listed on that exchange or trading facility.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;NonCumulativePreferenceShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:label xml:lang="en">non cumulative preference share</rdfs:label>
-		<skos:definition xml:lang="en">Non Cumulative Preference Shares are preference shares where the payment of the fixed dividend, if not made in a given trading year, is not carried forward to the next trading year.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">All preference shares are either cumulative or non cumulative.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;NonParticipatingPreferenceShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;NonParticipatingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:label xml:lang="en">non participating preference share</rdfs:label>
-		<skos:definition xml:lang="en">The usual type of preference share, which is not a Participating Preference Share</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;NonParticipatingShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:label xml:lang="en">non participating share</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-sha;ParticipatingShare"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;OneVotePerHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;RestrictedVotingRight"/>
-		<rdfs:label xml:lang="en">one vote per holder</rdfs:label>
-		<skos:definition xml:lang="en">Voting rights limited rights to one vote per person, or institution, to avoid any party taking control. Further notes: Not in ISO FIBIM selection. Identified from new article on UK building societies. Note that further types of voting rights can be defined any time in the prospectus for a new security. Original Article quotation: &quot;Adrian Coles, director general of the Building Societies Association, said it would be helpful if building societies could issue shares to investors to raise funds, but limit voting rights to one vote per person, or institution, to avoid any party taking control. Article Source:article on Profit Participating Deferred Shares in relation to West Bromwich Building society By Philip Aldrick,[citation missing], 12 June 2009</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;OrdinaryDividendTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;NonBindingTerms"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;dividendPaymentDate"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">12</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;dividendPaymentDate"/>
-				<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">ordinary dividend terms</rdfs:label>
-		<skos:definition xml:lang="en">Formal terms about the Dividend payments on an Ordinary Share.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are terms that are not contractually binding on the company.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;OrdinaryShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;pays"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-she;confersOwnershipOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;JuniorEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">ordinary share</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<skos:definition xml:lang="en">A security that represents ownership in a corporation. Holders of common share exercise control by electing a board of directors and voting on corporate policy.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Common stockholders are on the bottom of the priority ladder for ownership structure. In the event of liquidation, common shareholders have rights to a company&apos;s assets only after bondholders, preferred shareholders and other debtholders have been paid in full.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ParticipatingFacet">
-		<rdfs:label xml:lang="en">participating facet</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ParticipatingFacet.1">
-		<rdfs:label xml:lang="en">ParticipatingFacet.1</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ParticipatingPreferenceShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ParticipatingShare"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;optionallyPays"/>
-				<owl:onClass rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;participatingPreferenceShareSeniorToPreferenceShare"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">participating preference share</rdfs:label>
-		<skos:definition xml:lang="en">Like the preferred shares, participating preference shares have a prior claim on dividends, and on assets in an event of corporate liquidation or dissolution. But preferred stock would take precedence over preference stock in respect of dividends and assets that may be available for distribution.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ParticipatingShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:label xml:lang="en">participating share</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;PrecedenceRight">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
-		<rdfs:label xml:lang="en">precedence right</rdfs:label>
-		<skos:definition xml:lang="en">The rights of various parties in respect of the assets of some entity in the event of that entity being wound up.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Some of these rights are enshrined in law. A special case of these is shareholder rights which are defined, for different classes of equity, by the Company Articles of Association or equivalent Documentation. These are the rights defined in the Equity Priority Terms Set.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;PreferenceShare">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;hasCoupon"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-md-eqx-pri;OrdinaryShareDividend">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-md-eqx-pri;PreferenceShareCoupon">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;mayConfer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-shr;ExtraordinaryVotingRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;preferenceShareSeniorToOrdinaryShare"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-she;confersOwnershipOf.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;SeniorEquity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">preference share</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-sha;includesScheduleTerm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;ShareCouponSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">preferred coupon payment term set</rdfs:label>
-		<skos:definition xml:lang="en">Terms for payment of a Dividend on a Preferred Stock.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These, like the Dividend terms, are not contractually binding terms; the dividend is paid at the discretion of the company but takes precedence over the ordinary share dividend.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;RestrictedVotingRight">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<rdfs:label xml:lang="en">restricted voting right</rdfs:label>
-		<skos:definition xml:lang="en">Restricted Voting. The holder has the right to vote but there are restrictions on these rights.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The restrictions are described in a separate term about the Voting rights.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ShareCouponSchedule">
-		<rdfs:label xml:lang="en">share coupon schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ShareCouponScheduleSpecification">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CouponScheduleSpecification"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-eqx-pri;scheduledDividendPayment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;EquityDividendPayment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">share coupon schedule specification</rdfs:label>
-		<skos:definition xml:lang="en">Schedule of dates on which a Share Coupon Payment is to take place.</skos:definition>
-		<skos:editorialNote xml:lang="en">At present it is assumed that this has all and only the same sceduleing specification terms as for debt coupon payment events.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ShareholderPrecedenceRightsFacet">
-		<rdfs:label xml:lang="en">shareholder precedence rights facet</rdfs:label>
-		<skos:definition xml:lang="en">Facet based on the class or seniority of the equity represented by the shares i.e. ordinary, preference and so on.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;ShareholderPrecedenceRightsFacet.1">
-		<rdfs:label xml:lang="en">ShareholderPrecedenceRightsFacet.1</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-sha;SubordinatedVotingRight">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<rdfs:label xml:lang="en">subordinated voting right</rdfs:label>
-		<skos:definition xml:lang="en">Subordinated Voting. Action: this is a self-referential non definition, from ISO FIBIM.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;autoReinvestment">
-		<rdfs:label xml:lang="en">auto reinvestment</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the security provides for mandatorily &amp;amp; automatically re-investing the dividend from that security towards buying more of the same security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;conversionDate">
-		<rdfs:label xml:lang="en">conversion date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;EquityConversionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">Date on or after which the specified conversion may take place.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;convertibleInto">
-		<rdfs:label xml:lang="en">convertible into</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ConvertibleShare"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<skos:definition xml:lang="en">The security into which the convertible share can be converted. It is assumed this can be any tradable security.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;cumulative">
-		<rdfs:label xml:lang="en">cumulative</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;CumulativePreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the payment of the fixed dividend, if not made in a given trading year, is carried forward to the next trading year. This is no: skipped payments are not carried forward.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;cumulative.1">
-		<rdfs:label xml:lang="en">cumulative</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;NonCumulativePreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the payment of the fixed dividend, if not made in a given trading year, is carried forward to the next trading year. This is yes: skipped dividend payments are accumulated until they are finally paid.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;cumulative.2">
-		<rdfs:label xml:lang="en">cumulative</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the payment of the fixed dividend, if not made in a given trading year, is carried forward to the next trading year. If yes, skipped dividend payments are accumulated until they are finally paid. If no, skipped payments are not carried forward.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendAmount">
-		<rdfs:label xml:lang="en">dividend amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">Planned dividend amount for preferred shares</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendDate">
-		<rdfs:label xml:lang="en">dividend date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition xml:lang="en">Planned dividend date (day and month) for regular dividend payment commitment.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendExDate">
-		<rdfs:label xml:lang="en">dividend ex date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition xml:lang="en">The day and month on which the security is traded &quot;Ex Dividend&quot;.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendPaymentDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isQualifiedBy"/>
-		<rdfs:label xml:lang="en">dividend payment date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;OrdinaryDividendTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
-		<skos:definition xml:lang="en">The day and month on which dividends are to be paid.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendPaymentFrequency">
-		<rdfs:label xml:lang="en">dividend payment frequency</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
-		<skos:definition xml:lang="en">The frequency with which dividends are expected to be paid out.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendRate">
-		<rdfs:label xml:lang="en">dividend rate</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Planned dividend rate, for preferred shares.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;gracePeriod">
-		<rdfs:label xml:lang="en">grace period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;hasConversionTerms">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-		<rdfs:label xml:lang="en">has conversion terms</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ConvertibleShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-sha;EquityConversionTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;hasCoupon">
-		<rdfs:label xml:lang="en">has coupon</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:range>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-md-eqx-pri;OrdinaryShareDividend">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-md-eqx-pri;PreferenceShareCoupon">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:range>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;hasDistributionMethod">
-		<rdfs:label xml:lang="en">has distribution method</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
-		<skos:definition xml:lang="en">Method by which Dividend payments are to be distributed.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;hasListing">
-		<rdfs:label>has listing</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;includesScheduleTerm">
-		<rdfs:label xml:lang="en">includes schedule term</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-sha;ShareCouponSchedule"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;isSeniorToAClassOfOrdinaryShare">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;isSeniorTo"/>
-		<rdfs:label xml:lang="en">is senior to a class of ordinary share</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;isSeniorToAClassOfPreferenceShare">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;isSeniorTo"/>
-		<rdfs:label xml:lang="en">is senior to a class of preference share</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;maturityDate">
-		<rdfs:label xml:lang="en">maturity date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ParticipatingShare"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">Date/time at which the security will no longer exist, eg, redeemable preference shares. Definition:FIBIM</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;maturityDate.1">
-		<rdfs:label xml:lang="en">maturity date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<skos:definition xml:lang="en">Date/time at which the security will no longer exist, eg, redeemable preference shares. Definition:FIBIM</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;mayConfer">
-		<rdfs:label xml:lang="en">may confer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-shr;ExtraordinaryVotingRight"/>
-		<skos:definition xml:lang="en">The right of the holder of the Preference Shares to vote on matters affecting the business of the issuing company. A preference share may confer some voting rights whereby the holder may vote in extraordinary general meetings. These are not the same as the ordinary voting rights conferred by ordinary shares.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;numberOfSecurities">
-		<rdfs:label xml:lang="en">number of securities</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;EquityConversionTerms"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The number of units of the target security into which this security is converted upon conversion.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;optionallyPays">
-		<rdfs:label xml:lang="en">optionally pays</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ParticipatingPreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;participatingPreferenceShareSeniorToPreferenceShare">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-sha;isSeniorToAClassOfPreferenceShare"/>
-		<rdfs:label xml:lang="en">participating preference share senior to preference share</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ParticipatingPreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;payInKind">
-		<rdfs:label xml:lang="en">pay in kind</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The issuer will pay additional security as part of interest disbursement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;pays">
-		<rdfs:label xml:lang="en">pays</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
-		<rdfs:range rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;perpetual">
-		<rdfs:label xml:lang="en">perpetual</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Signifies that there is NO set term involved. It pays its stated dividend forever or &quot;in perpetuity&quot;. For a fixed-rate a set dividend upon issue is agreed to, usually declared and paid quarterly (fixed dollar or a percent of the par value). For a floating-rate provide for a dividend that is paid by reference to a market interest rate.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;preferenceShareSeniorToOrdinaryShare">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;isSeniorTo"/>
-		<rdfs:label xml:lang="en">preference share senior to ordinary share</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;setsOut">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;softRetractable">
-		<rdfs:label xml:lang="en">soft retractable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">A soft retraction value means it is payable in either &quot;hard cash&quot; or in an equal value of common stock of the issuer, at the choice of the issuer.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-agrx-con="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-eqx-pri="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"
+buxmlns:fibo-sec-dbt-bo-cft="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
+buxmlns:fibo-sec-eq-she="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"
+buxmlns:fibo-sec-eq-shr="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ShareTerms</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines the kinds of terms that different clases of share may have, and that distinguish these from one another. These includes different combinations of voting rights, dividend terms, share coupons, participating and precedence terms as well as terms for convertible shares. This ontology also defines classes of share that are defined by differences in these rights and precedences, and the class of convertible shares.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgreementsExt/ContractualConstructs/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/Bonds/BondsCashflowTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-be-oac-exec;ArticlesOfIncorporation">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">proxy</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;CompanyEquityTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">company equity terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out the equity in a company, including the various kinds of rights, the shares that embody those rights etc.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleCommonShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ConvertibleShare"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convertible common share</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-sha;ConvertiblePreferenceShare"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleIntoFacet">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convertible into facet</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleIntoFacet.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ConvertibleIntoFacet.1</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleParticipatingPreferenceShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ConvertiblePreferenceShare"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ParticipatingPreferenceShare"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convertible participating preference share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A preference share that can be converted into common shares at a fixed conversion price. Preference or preferred shares entitle a holder to a prior claim on any dividend paid by the company before payment is made on ordinary shares.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertiblePreferenceShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ConvertibleShare"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;convertibleInto"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;PubliclyTradedShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convertible preference share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Preferred Share which is convertible into another security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ConvertibleShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;convertibleInto"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;hasConversionTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;EquityConversionTerms"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convertible share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Share which is convertible into another security, usually a share in the same company.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;CumulativeFacet">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cumulative facet</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;CumulativeFacet.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">CumulativeFacet.1</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;CumulativePreferenceShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cumulative preference share</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-sha;NonCumulativePreferenceShare"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;DividendTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;hasDistributionMethod"/>
+bubububu<owl:onClass rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend terms</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;EquityConversionTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/ConversionTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIssuance/specifiesConversionInto"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity conversion terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual specifications when an Equity security can be converted to another security (usually of the same issuer).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;EquityListing">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity listing</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The listing of an equity security (stock) on an equities exchange or multilateral trading facility.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is not the security or the exchange but the listing of the security on the exchange. Facts defined for Equity Listing are facts about that security listed on that exchange or trading facility.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;NonCumulativePreferenceShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non cumulative preference share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Non Cumulative Preference Shares are preference shares where the payment of the fixed dividend, if not made in a given trading year, is not carried forward to the next trading year.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">All preference shares are either cumulative or non cumulative.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;NonParticipatingPreferenceShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;NonParticipatingShare"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non participating preference share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The usual type of preference share, which is not a Participating Preference Share</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;NonParticipatingShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non participating share</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-sha;ParticipatingShare"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;OneVotePerHolder">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;RestrictedVotingRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">one vote per holder</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Voting rights limited rights to one vote per person, or institution, to avoid any party taking control. Further notes: Not in ISO FIBIM selection. Identified from new article on UK building societies. Note that further types of voting rights can be defined any time in the prospectus for a new security. Original Article quotation: &quot;Adrian Coles, director general of the Building Societies Association, said it would be helpful if building societies could issue shares to investors to raise funds, but limit voting rights to one vote per person, or institution, to avoid any party taking control. Article Source:article on Profit Participating Deferred Shares in relation to West Bromwich Building society By Philip Aldrick,[citation missing], 12 June 2009</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;OrdinaryDividendTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;NonBindingTerms"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;dividendPaymentDate"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">12</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;dividendPaymentDate"/>
+bubububu<owl:onClass rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubububu<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ordinary dividend terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Formal terms about the Dividend payments on an Ordinary Share.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are terms that are not contractually binding on the company.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;OrdinaryShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;pays"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-she;confersOwnershipOf"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;JuniorEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ordinary share</rdfs:label>
+bubu<owl:disjointWith rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security that represents ownership in a corporation. Holders of common share exercise control by electing a board of directors and voting on corporate policy.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Common stockholders are on the bottom of the priority ladder for ownership structure. In the event of liquidation, common shareholders have rights to a company&apos;s assets only after bondholders, preferred shareholders and other debtholders have been paid in full.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ParticipatingFacet">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">participating facet</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ParticipatingFacet.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ParticipatingFacet.1</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ParticipatingPreferenceShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;ParticipatingShare"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;optionallyPays"/>
+bubububu<owl:onClass rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
+bubububu<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;participatingPreferenceShareSeniorToPreferenceShare"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">participating preference share</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Like the preferred shares, participating preference shares have a prior claim on dividends, and on assets in an event of corporate liquidation or dissolution. But preferred stock would take precedence over preference stock in respect of dividends and assets that may be available for distribution.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ParticipatingShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">participating share</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;PrecedenceRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agrx-con;ContractualRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">precedence right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rights of various parties in respect of the assets of some entity in the event of that entity being wound up.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">Some of these rights are enshrined in law. A special case of these is shareholder rights which are defined, for different classes of equity, by the Company Articles of Association or equivalent Documentation. These are the rights defined in the Equity Priority Terms Set.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;PreferenceShare">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;hasCoupon"/>
+bubububu<owl:someValuesFrom>
+bububububu<owl:Class>
+bubububububu<owl:unionOf rdf:parseType="Collection">
+bububububububu<rdf:Description rdf:about="&fibo-md-eqx-pri;OrdinaryShareDividend">
+bububububububu</rdf:Description>
+bububububububu<rdf:Description rdf:about="&fibo-md-eqx-pri;PreferenceShareCoupon">
+bububububububu</rdf:Description>
+bubububububu</owl:unionOf>
+bububububu</owl:Class>
+bubububu</owl:someValuesFrom>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;mayConfer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-shr;ExtraordinaryVotingRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;preferenceShareSeniorToOrdinaryShare"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-she;confersOwnershipOf.1"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;SeniorEquity"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">preference share</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-sha;includesScheduleTerm"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-sha;ShareCouponSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">preferred coupon payment term set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms for payment of a Dividend on a Preferred Stock.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These, like the Dividend terms, are not contractually binding terms; the dividend is paid at the discretion of the company but takes precedence over the ordinary share dividend.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;RestrictedVotingRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">restricted voting right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Restricted Voting. The holder has the right to vote but there are restrictions on these rights.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The restrictions are described in a separate term about the Voting rights.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ShareCouponSchedule">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share coupon schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ShareCouponScheduleSpecification">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bo-cft;CouponScheduleSpecification"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-eqx-pri;scheduledDividendPayment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-eqx-pri;EquityDividendPayment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">share coupon schedule specification</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Schedule of dates on which a Share Coupon Payment is to take place.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">At present it is assumed that this has all and only the same sceduleing specification terms as for debt coupon payment events.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ShareholderPrecedenceRightsFacet">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">shareholder precedence rights facet</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Facet based on the class or seniority of the equity represented by the shares i.e. ordinary, preference and so on.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;ShareholderPrecedenceRightsFacet.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ShareholderPrecedenceRightsFacet.1</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-sha;SubordinatedVotingRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">subordinated voting right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Subordinated Voting. Action: this is a self-referential non definition, from ISO FIBIM.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;autoReinvestment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">auto reinvestment</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the security provides for mandatorily &amp;amp; automatically re-investing the dividend from that security towards buying more of the same security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;conversionDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">conversion date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;EquityConversionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date on or after which the specified conversion may take place.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;convertibleInto">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">convertible into</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ConvertibleShare"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The security into which the convertible share can be converted. It is assumed this can be any tradable security.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;cumulative">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cumulative</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;CumulativePreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the payment of the fixed dividend, if not made in a given trading year, is carried forward to the next trading year. This is no: skipped payments are not carried forward.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;cumulative.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cumulative</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;NonCumulativePreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the payment of the fixed dividend, if not made in a given trading year, is carried forward to the next trading year. This is yes: skipped dividend payments are accumulated until they are finally paid.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;cumulative.2">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cumulative</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the payment of the fixed dividend, if not made in a given trading year, is carried forward to the next trading year. If yes, skipped dividend payments are accumulated until they are finally paid. If no, skipped payments are not carried forward.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendAmount">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend amount</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Planned dividend amount for preferred shares</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Planned dividend date (day and month) for regular dividend payment commitment.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendExDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend ex date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The day and month on which the security is traded &quot;Ex Dividend&quot;.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendPaymentDate">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isQualifiedBy"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend payment date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;OrdinaryDividendTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;DayMonthValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The day and month on which dividends are to be paid.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendPaymentFrequency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend payment frequency</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The frequency with which dividends are expected to be paid out.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;dividendRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">dividend rate</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Planned dividend rate, for preferred shares.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;gracePeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">grace period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Duration"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;hasConversionTerms">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has conversion terms</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ConvertibleShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-sha;EquityConversionTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;hasCoupon">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has coupon</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:range>
+bububu<owl:Class>
+bubububu<owl:unionOf rdf:parseType="Collection">
+bububububu<rdf:Description rdf:about="&fibo-md-eqx-pri;OrdinaryShareDividend">
+bububububu</rdf:Description>
+bububububu<rdf:Description rdf:about="&fibo-md-eqx-pri;PreferenceShareCoupon">
+bububububu</rdf:Description>
+bubububu</owl:unionOf>
+bububu</owl:Class>
+bubu</rdfs:range>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;hasDistributionMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has distribution method</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;DividendTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;DividendsDistributionMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Method by which Dividend payments are to be distributed.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;hasListing">
+bubu<rdfs:label>has listing</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;includesScheduleTerm">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">includes schedule term</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-sha;ShareCouponSchedule"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;isSeniorToAClassOfOrdinaryShare">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;isSeniorTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is senior to a class of ordinary share</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;isSeniorToAClassOfPreferenceShare">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;isSeniorTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is senior to a class of preference share</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;maturityDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ParticipatingShare"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date/time at which the security will no longer exist, eg, redeemable preference shares. Definition:FIBIM</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;maturityDate.1">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">maturity date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date/time at which the security will no longer exist, eg, redeemable preference shares. Definition:FIBIM</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;mayConfer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">may confer</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-shr;ExtraordinaryVotingRight"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right of the holder of the Preference Shares to vote on matters affecting the business of the issuing company. A preference share may confer some voting rights whereby the holder may vote in extraordinary general meetings. These are not the same as the ordinary voting rights conferred by ordinary shares.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;numberOfSecurities">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">number of securities</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;EquityConversionTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The number of units of the target security into which this security is converted upon conversion.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;optionallyPays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">optionally pays</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ParticipatingPreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;participatingPreferenceShareSeniorToPreferenceShare">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-sha;isSeniorToAClassOfPreferenceShare"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">participating preference share senior to preference share</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;ParticipatingPreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;payInKind">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pay in kind</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferredCouponPaymentTermSet"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The issuer will pay additional security as part of interest disbursement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;pays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">pays</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
+bubu<rdfs:range rdf:resource="&fibo-md-eqx-pri;OrdinaryShareDividend"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;perpetual">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">perpetual</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Signifies that there is NO set term involved. It pays its stated dividend forever or &quot;in perpetuity&quot;. For a fixed-rate a set dividend upon issue is agreed to, usually declared and paid quarterly (fixed dollar or a percent of the par value). For a floating-rate provide for a dividend that is paid by reference to a market interest rate.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;preferenceShareSeniorToOrdinaryShare">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;isSeniorTo"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">preference share senior to ordinary share</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-sha;OrdinaryShare"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;setsOut">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-sha;softRetractable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">soft retractable</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-sha;PreferenceShare"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A soft retraction value means it is payable in either &quot;hard cash&quot; or in an equal value of common stock of the issuer, at the choice of the issuer.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Equities/ShareholderEquity.rdf
+++ b/sec/Equities/ShareholderEquity.rdf
@@ -1,164 +1,167 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
-	<!ENTITY fibo-sec-eq-she "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
+bu<!ENTITY fibo-sec-eq-she "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"
-	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
-	xmlns:fibo-sec-eq-she="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/">
-		<rdfs:label xml:lang="en">ShareholderEquity</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-she;EquityPriorityTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-she;confers"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;ShareholderPrecedenceRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity priority terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out the priority of a given class of Equity. These are the terms under which the holder of that class of equity has a call on the equity in the event of the issuing entity being wound up.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">this is one of the three kinds of term conferring three kinds of rights to the holder.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-she;JuniorEquity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-she;hasPriorityAsDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;JuniorEquityPriorityTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">junior equity</rdfs:label>
-		<skos:definition xml:lang="en">The most junior class of equity issued by a company. On the event of the company being wound up, holders of this class of equity have a call on the assets of the company only after the more senior classes of equity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-she;JuniorEquityPriorityTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
-		<rdfs:label xml:lang="en">junior equity priority terms set</rdfs:label>
-		<skos:definition xml:lang="en">The precise terms which define the seniority of this class of Equity. This is equity which has the lowest call on the assets of the issuer in the event of it being wound up, i.e. after Senior Equity and (if issued) other classes of equity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-she;OtherEquityPriorityTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
-		<rdfs:label xml:lang="en">other equity priority terms set</rdfs:label>
-		<skos:definition xml:lang="en">The precise terms which define the seniority of this class of Equity. These will set it apart from the highest of lowest seniority (senior or junior debt) and may be defined for more than one additional class of equity. These terms are defined by the issuer.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-she;OtherSeniorityEquity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-she;hasPriorityAsDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;OtherEquityPriorityTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">other seniority equity</rdfs:label>
-		<skos:definition xml:lang="en">Equity which is neither the most senior nor the most junior. The precise terms under which this equity is held, and the definition of the call on the assets of the company in the event of it winding up, will be defined by the issuing company and are not modelled here as they may vary from one company to another. There may be more than one class of such equity issued by a company.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-she;SeniorEquity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-she;hasPriorityAsDefinedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;SeniorEquityPriorityTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">senior equity</rdfs:label>
-		<skos:definition xml:lang="en">The most senior class of equity issued in the company. Holders of this class of equity will receive first call on the assets of the company in the event of it being wound up.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-she;SeniorEquityPriorityTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
-		<rdfs:label xml:lang="en">senior equity priority terms set</rdfs:label>
-		<skos:definition xml:lang="en">The precise terms which define the seniority of this class of Equity. These terms set out that the holder has the first call among equity holders, on the assets of the issuing entity in the event of it being wound up, ahead of the holders of other classes of equity.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-she;ShareholderPrecedenceRight">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PrecedenceRight"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">shareholder precedence right</rdfs:label>
-		<skos:definition xml:lang="en">The rights of shareholderes in respect of the assets of the limited company in which they hold those shares, in the event of that company being wound up.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are defined, for different classes of equity, by the Company Articles of Association or equivalent Documentation. These are the rights defined in the Equity Priority Terms Set.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;confers">
-		<rdfs:label xml:lang="en">confers</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-she;ShareholderPrecedenceRight"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;confersOwnershipOf">
-		<rdfs:label>confers ownership of</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;confersOwnershipOf.1">
-		<rdfs:label>confers ownership of</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;hasPriorityAsDefinedIn">
-		<rdfs:label xml:lang="en">has priority as defined in</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;juniorEquityPriority">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;priority"/>
-		<rdfs:label xml:lang="en">junior equity priority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-she;JuniorEquity"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Junior"/>
-		<skos:definition xml:lang="en">The seniority of the equity. This is the order of precedence in which holders of different classes of equity will have a call on the assets of the company in the event of it winding up. In the case of ordinary equity this is the lowest seniority i.e. it has the last call on the assets of the company.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;otherEquityPriority">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;priority"/>
-		<rdfs:label xml:lang="en">other equity priority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-she;OtherSeniorityEquity"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;OtherSeniority"/>
-		<skos:definition xml:lang="en">The seniority of the equity. This is the order of precedence in which holders of different classes of equity will have a call on the assets of the company in the event of it winding up. In this class of equity this is defined as being &quot;Other&quot; than highest or lowest, with the precise terms and order of precedence being defined in the priority terms.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;seniorEquityPriority">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;priority"/>
-		<rdfs:label xml:lang="en">senior equity priority</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-she;SeniorEquity"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;Senior"/>
-		<skos:definition xml:lang="en">The seniority of the equity. This is the order of precedence in which holders of different classes of equity will have a call on the assets of the company in the event of it winding up. In this class of equity this is the highest in senioity.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
+buxmlns:fibo-sec-eq-she="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ShareholderEquity</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Shares are defined as instruments which confer equity on the holder. This ontology defines that equity and the various forms of equity that may be conferred on the holders of different share classes. These classes of equity have priority relationships between them so that for example senior equity has priority over more junior equity.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderEquity/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-she;EquityPriorityTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-she;confers"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;ShareholderPrecedenceRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity priority terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out the priority of a given class of Equity. These are the terms under which the holder of that class of equity has a call on the equity in the event of the issuing entity being wound up.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">this is one of the three kinds of term conferring three kinds of rights to the holder.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-she;JuniorEquity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-she;hasPriorityAsDefinedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;JuniorEquityPriorityTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">junior equity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The most junior class of equity issued by a company. On the event of the company being wound up, holders of this class of equity have a call on the assets of the company only after the more senior classes of equity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-she;JuniorEquityPriorityTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">junior equity priority terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The precise terms which define the seniority of this class of Equity. This is equity which has the lowest call on the assets of the issuer in the event of it being wound up, i.e. after Senior Equity and (if issued) other classes of equity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-she;OtherEquityPriorityTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">other equity priority terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The precise terms which define the seniority of this class of Equity. These will set it apart from the highest of lowest seniority (senior or junior debt) and may be defined for more than one additional class of equity. These terms are defined by the issuer.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-she;OtherSeniorityEquity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-she;hasPriorityAsDefinedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;OtherEquityPriorityTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">other seniority equity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Equity which is neither the most senior nor the most junior. The precise terms under which this equity is held, and the definition of the call on the assets of the company in the event of it winding up, will be defined by the issuing company and are not modelled here as they may vary from one company to another. There may be more than one class of such equity issued by a company.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-she;SeniorEquity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-she;hasPriorityAsDefinedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-she;SeniorEquityPriorityTermsSet"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">senior equity</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The most senior class of equity issued in the company. Holders of this class of equity will receive first call on the assets of the company in the event of it being wound up.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-she;SeniorEquityPriorityTermsSet">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">senior equity priority terms set</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The precise terms which define the seniority of this class of Equity. These terms set out that the holder has the first call among equity holders, on the assets of the issuing entity in the event of it being wound up, ahead of the holders of other classes of equity.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-she;ShareholderPrecedenceRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;PrecedenceRight"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isConferredBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">shareholder precedence right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The rights of shareholderes in respect of the assets of the limited company in which they hold those shares, in the event of that company being wound up.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are defined, for different classes of equity, by the Company Articles of Association or equivalent Documentation. These are the rights defined in the Equity Priority Terms Set.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;confers">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">confers</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-she;ShareholderPrecedenceRight"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;confersOwnershipOf">
+bubu<rdfs:label>confers ownership of</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;confersOwnershipOf.1">
+bubu<rdfs:label>confers ownership of</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;hasPriorityAsDefinedIn">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has priority as defined in</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-she;EquityPriorityTerms"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;juniorEquityPriority">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;priority"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">junior equity priority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-she;JuniorEquity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Junior"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority of the equity. This is the order of precedence in which holders of different classes of equity will have a call on the assets of the company in the event of it winding up. In the case of ordinary equity this is the lowest seniority i.e. it has the last call on the assets of the company.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;otherEquityPriority">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;priority"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">other equity priority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-she;OtherSeniorityEquity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;OtherSeniority"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority of the equity. This is the order of precedence in which holders of different classes of equity will have a call on the assets of the company in the event of it winding up. In this class of equity this is defined as being &quot;Other&quot; than highest or lowest, with the precise terms and order of precedence being defined in the priority terms.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-she;seniorEquityPriority">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-eq;priority"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">senior equity priority</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-she;SeniorEquity"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;Senior"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The seniority of the equity. This is the order of precedence in which holders of different classes of equity will have a call on the assets of the company in the event of it winding up. In this class of equity this is the highest in senioity.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/Equities/ShareholderRights.rdf
+++ b/sec/Equities/ShareholderRights.rdf
@@ -1,64 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
-	<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
-	<!ENTITY fibo-sec-eq-shr "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
+bu<!ENTITY fibo-sec-eq-sha "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/">
+bu<!ENTITY fibo-sec-eq-shr "https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
-	xmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
-	xmlns:fibo-sec-eq-shr="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/">
-		<rdfs:label xml:lang="en">ShareholderRights</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-shr;EquityVotingRightsTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-eq-shr;setsOut"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity voting rights terms</rdfs:label>
-		<skos:definition xml:lang="en">Terms setting out the voting rights of the Holder.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-shr;ExtraordinaryVotingRight">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<rdfs:label xml:lang="en">extraordinary voting right</rdfs:label>
-		<skos:definition xml:lang="en">The right to vote at extraordinary meetings, as opposed to being able to vote at annual general meetings.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-shr;OrdinaryVotingRight">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<rdfs:label xml:lang="en">ordinary voting right</rdfs:label>
-		<skos:definition xml:lang="en">The voting rights conferred on holders of Ordinary Shares in the company. The precise details of these rights such as what shareholders may vote on and how their voting right is exercised, are defined in the Company Constitution or Articles of Incorporation / Articles of Association.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-eq-shr;setsOut">
-		<rdfs:label xml:lang="en">sets out</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-shr;EquityVotingRightsTerms"/>
-		<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
+buxmlns:fibo-sec-eq-sha="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"
+buxmlns:fibo-sec-eq-shr="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ShareholderRights</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Shares generally confer rights on the holder, principally in the form of voting rights. This ontology sets out the kinds of voting rights that may be conferred on the holders by different classes of share, and the terms describing these. 
+		Note that some detailed kinds of voting rights are still to be found in the Share Terms ontology, and should either be moved to this ontology or the two ontologies re-combined.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareholderRights/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-shr;EquityVotingRightsTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-sha;CompanyEquityTermsSet"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-eq-shr;setsOut"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">equity voting rights terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Terms setting out the voting rights of the Holder.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-shr;ExtraordinaryVotingRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">extraordinary voting right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The right to vote at extraordinary meetings, as opposed to being able to vote at annual general meetings.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-eq-shr;OrdinaryVotingRight">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ordinary voting right</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The voting rights conferred on holders of Ordinary Shares in the company. The precise details of these rights such as what shareholders may vote on and how their voting right is exercised, are defined in the Company Constitution or Articles of Incorporation / Articles of Association.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-eq-shr;setsOut">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">sets out</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-eq-shr;EquityVotingRightsTerms"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/SecuritiesExt/SchedulesExt.rdf
+++ b/sec/SecuritiesExt/SchedulesExt.rdf
@@ -1,110 +1,114 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/Occurrences/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-secx-schx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
+bu<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/Occurrences/">
+bu<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-secx-schx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"
-	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/Occurrences/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-secx-schx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/">
-		<rdfs:label xml:lang="en">SchedulesExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/Occurrences/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-dt-fd;AdHocSchedule">
-		<owl:equivalentClass rdf:resource="&fibo-sec-secx-schx;AdHocSchedule"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-dt-fd;RegularSchedule">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-schx;schedules"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-schx;ScheduledEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-schx;AdHocSchedule">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">ad hoc schedule</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-schx;ExplicitlyScheduledEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">explicitly scheduled event</rdfs:label>
-		<skos:definition xml:lang="en">An event which is scheduled in advance to take place on some specific date.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is as distinct from an event the date for which is specified in terms of some formula or heuristic for determining that date.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-schx;ScheduledEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-schx;scheduledBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">scheduled event</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-schx;ScheduledEventDate">
-		<rdfs:label xml:lang="en">scheduled event date</rdfs:label>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-schx;hasEventDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
-		<rdfs:label xml:lang="en">has event date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-schx;listsScheduledEvent">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-		<rdfs:label xml:lang="en">lists scheduled event</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-schx;AdHocSchedule"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-schx;scheduledBy">
-		<rdfs:label xml:lang="en">scheduled by</rdfs:label>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-schx;schedules">
-		<rdfs:label xml:lang="en">schedules</rdfs:label>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"
+buxmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/Occurrences/"
+buxmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-secx-schx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SchedulesExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional conceptual terms for schedules. 
+		This ontology is now redundant. It reflects elements of the conceptual approach whereby a schedule and the specification of the schedule were modeled as ontologically distinct tihngs.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/Occurrences/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SchedulesExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-dt-fd;AdHocSchedule">
+bubu<owl:equivalentClass rdf:resource="&fibo-sec-secx-schx;AdHocSchedule"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-fnd-dt-fd;RegularSchedule">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-schx;schedules"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-schx;ScheduledEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-schx;AdHocSchedule">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-schx;listsScheduledEvent"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">ad hoc schedule</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-schx;ExplicitlyScheduledEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-schx;hasEventDate"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">explicitly scheduled event</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An event which is scheduled in advance to take place on some specific date.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is as distinct from an event the date for which is specified in terms of some formula or heuristic for determining that date.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-schx;ScheduledEvent">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-schx;scheduledBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;RegularSchedule"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheduled event</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-schx;ScheduledEventDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheduled event date</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-schx;hasEventDate">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has event date</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-schx;ScheduledEventDate"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-schx;listsScheduledEvent">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">lists scheduled event</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-schx;AdHocSchedule"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-schx;ExplicitlyScheduledEvent"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-schx;scheduledBy">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">scheduled by</rdfs:label>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-schx;schedules">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">schedules</rdfs:label>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/SecuritiesExt/SecuritiesExt.rdf
+++ b/sec/SecuritiesExt/SecuritiesExt.rdf
@@ -1,370 +1,373 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
-	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
-	<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-pub-con "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-md-temx-trs "https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/">
-	<!ENTITY fibo-sec-secx-resx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/">
-	<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
-	<!ENTITY fibo-sec-secx-tax "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-iss-trm "https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/">
+bu<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-inf-inf "https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/">
+bu<!ENTITY fibo-fnd-inf-tem "https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-pub-con "https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-md-temx-trs "https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/">
+bu<!ENTITY fibo-sec-secx-resx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/">
+bu<!ENTITY fibo-sec-secx-sec "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
+bu<!ENTITY fibo-sec-secx-tax "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
-	xmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
-	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
-	xmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-pub-con="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-md-temx-trs="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"
-	xmlns:fibo-sec-secx-resx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"
-	xmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
-	xmlns:fibo-sec-secx-tax="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
-		<rdfs:label xml:lang="en">Securities</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-sec;hasStructuredName"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasIssuanceInformation"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;hasStatus"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasPrice"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-sec;denominationCurrency"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-sec;hasDefaultSettlementTerms"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-sec;hasStructuredName"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-sec;legallyRecordedIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-tax;hasTaxTreatment"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-tax;SecurityTaxTreatment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/ExchangeTradedSecurity">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;TradingRegisteredSecurity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-resx;hasRestrictions"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-resx;InvestmentRestriction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;CashSecuritiesDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecurityDeliveryType"/>
-		<rdfs:label xml:lang="en">cash securities delivery</rdfs:label>
-		<skos:definition xml:lang="en">Delivery of a security in cash</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;NonCashSecuritiesDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecurityDeliveryType"/>
-		<rdfs:label xml:lang="en">non cash securities delivery</rdfs:label>
-		<skos:definition xml:lang="en">Delivery is by some other means.</skos:definition>
-		<skos:editorialNote xml:lang="en">Review: There may be more applicable values for this selection. Used in settlement terms and (if required) in settlement conventions for the security.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;SecurityContractTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:label xml:lang="en">security contract terms</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms of a negotiable financial security</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;SecurityDeliveryType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DeliveryMethod"/>
-		<rdfs:label xml:lang="en">security delivery type  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Type of delivery as used in settlement terms for a financial security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;SecurityNote">
-		<rdfs:label xml:lang="en">security note  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">An individually denominated note within a security or tranche of a security, where this is issued in notes of different denominations.</skos:definition>
-		<skos:editorialNote xml:lang="en">Introduced for MBS Proof of Concept, to model MBS tranches where one tranche may have notes of multiple denominations. Other applications of this concept are not known at present. Trivially, all securities could be said to be in &quot;notes&quot; in this sense but the term is not normally referred to.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;SecuritySettlementConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SettlementConvention"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-sec;hasDeliveryMethod"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityDeliveryType"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security settlement convention</rdfs:label>
-		<skos:definition xml:lang="en">Default Terms for the settlement of a Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;SecurityStructuredName">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;StructuredName"/>
-		<rdfs:label xml:lang="en">security structured name</rdfs:label>
-		<skos:definition xml:lang="en">The formal, structured name of a Security.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;SettlementConvention">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-con;Convention"/>
-		<rdfs:label xml:lang="en">settlement convention</rdfs:label>
-		<skos:definition xml:lang="en">A convention for settlement of a trade or transaction.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is usually stated in the form &apos;T+n&apos; where n is the Settlement Business Days. There are no date roll rules, the T+n simply refers to the next available business days and is specified as a whole number. Note that this term has been created for the OTC model, but on review of the existing terms for security settlement conventions in the common model for tradable securities, this term has been separated out as a more general term, with the securities-specific in a sub-type of this item, renamed to Security Settlement Convention.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;Stake">
-		<rdfs:label xml:lang="en">stake</rdfs:label>
-		<skos:definition xml:lang="en">The holding of some portion of some venture or something of value, by some party. The stake may be represented by some form of formal document such as a share or some debt unit.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-sec;TradingRegisteredSecurity">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/hasListing"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">trading registered security</rdfs:label>
-		<skos:definition xml:lang="en">A security which is traded on some trading venue.</skos:definition>
-		<skos:editorialNote xml:lang="en">Define the three types of these as per the MIFID definitions of types of trading facility. Also need to allow for jurisdiction variation. Renamed March 2013 from Listed Security to Trading Registered Security (Citi review session). The rationale is that any security which is listed on some facility is registered, and the fact of it being registered is more significant. This is still to be reviewed more widely with the SME review group.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;allowsContractualSettlement">
-		<rdfs:label xml:lang="en">allows contractual settlement  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the market allows contractual settlement. This is a settlement term related to the market.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;bearer">
-		<rdfs:label xml:lang="en">bearer  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The owner is not registered in the books of the issuer or of the registrar.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;deemedRiskCurrency">
-		<rdfs:label xml:lang="en">deemed risk currency  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The currency in which any risks relating to the instrument are seen to take place. Further notes: This is a risk specific term identified during SME Reviews of common securities terms. It was agreed at a review with a risk firm that this term is applicable within the context of risk management only and is not a fundamental fact about the security. It therefore needs to be disposed in some way to show it in the context of risk.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;denominationCurrency">
-		<rdfs:label xml:lang="en">denomination currency  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">The default currency in which units of the Security are denominated.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;denominationIncrement">
-		<rdfs:label xml:lang="en">denomination increment  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">The multiples above the smallest possible denomination (Default Lot Size) in which the security can be held.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;fASTApplicable">
-		<rdfs:label xml:lang="en">f a s t applicable  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the security is to be held at the transfer agent as part of the FAST (Fully Automated Securities Transfer) program. Further notes: Term is specific to DTCC / US context. Is there a more generic meaning similar to this which applies across different jurisdictions? If not this term should be defined with reference to this specific context.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;fractionalEligible">
-		<rdfs:label xml:lang="en">fractional eligible  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the security can contain Fractional Share/amount component.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;fullName">
-		<rdfs:label xml:lang="en">full name  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Full name of the security</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;hasDefaultSettlementTerms">
-		<rdfs:label xml:lang="en">has default settlement terms  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;hasDeliveryMethod">
-		<rdfs:label xml:lang="en">has delivery method  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityDeliveryType"/>
-		<skos:definition xml:lang="en">Has a method by which securities are delivered at settlement.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;hasStructuredName">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;hasName"/>
-		<rdfs:label xml:lang="en">has structured name</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;interchangeable">
-		<rdfs:label xml:lang="en">interchangeable  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the security is freely interchangeable with other of the same securities. Yes indicates that the security is interchangeable; no indicates that it is not.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;isListed">
-		<rdfs:label xml:lang="en">is listed  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-sec;TradingRegisteredSecurity"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">The security is listed on some exchange or trading facility (Listed = Yes)</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;issueDate">
-		<rdfs:label xml:lang="en">issue date  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
-		<skos:definition xml:lang="en">Date that the Security was issued.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;legallyRecordedIn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasGoverningJurisdiction"/>
-		<rdfs:label xml:lang="en">legally recorded in  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<skos:definition xml:lang="en">Jurisdiction (country, county, state, province, city) in which the security is legally recorded for regulatory and/or tax purposes.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;listed">
-		<rdfs:label xml:lang="en">listed  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether or not the security is listed on some exchange or trading facility.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;preferredSettlementCurrency">
-		<rdfs:label xml:lang="en">preferred settlement currency  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
-		<skos:definition xml:lang="en">Preferred currency in which the instrument is to be settled. Securities may be settled in a currency other than this.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;registered">
-		<rdfs:label xml:lang="en">registered  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Securities are recorded in the name of the owner on the books of the issuer or the issuer&apos;s registrar.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;settlementBusinessDays">
-		<rdfs:label xml:lang="en">settlement business days  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SettlementConvention"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
-		<skos:definition xml:lang="en">Default number of business days for settlement e.g. T+1, T+3 and so on.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;shortName">
-		<rdfs:label xml:lang="en">short name  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">Short name of the security.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-iss-trm="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"
+buxmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-inf-inf="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"
+buxmlns:fibo-fnd-inf-tem="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-pub-con="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-md-temx-trs="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"
+buxmlns:fibo-sec-secx-resx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"
+buxmlns:fibo-sec-secx-sec="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"
+buxmlns:fibo-sec-secx-tax="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">Securities</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Additional conceptual features of securities, such as structured names, along with further details like settlement and delivery conventions.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/InfoCore/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/InformationExt/TemporalInfo/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PublicationsExt/Conventions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/SecurityTradingStatuses/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Debt/AssetBacked/MortgageBackedSecurities/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContract"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-sec;hasStructuredName"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;hasIssuanceInformation"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;IssuedSecurityIssueInformation"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-iss-trm;issuer"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-bp-iss-trm;SecurityIssuer"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-inf-tem;hasStatus"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-trs;SecurityLifecycleStatus"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-md-temx-ins;hasPrice"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;TradedSecurityPublishedPrice"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-sec;denominationCurrency"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-sec;hasDefaultSettlementTerms"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-sec;hasStructuredName"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-sec;legallyRecordedIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-tax;hasTaxTreatment"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-tax;SecurityTaxTreatment"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/ExchangeTradedSecurity">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;TradingRegisteredSecurity"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-resx;hasRestrictions"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-resx;InvestmentRestriction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;CashSecuritiesDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecurityDeliveryType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">cash securities delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery of a security in cash</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;NonCashSecuritiesDelivery">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SecurityDeliveryType"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">non cash securities delivery</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Delivery is by some other means.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Review: There may be more applicable values for this selection. Used in settlement terms and (if required) in settlement conventions for the security.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;SecurityContractTerms">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security contract terms</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms of a negotiable financial security</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;SecurityDeliveryType">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;DeliveryMethod"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security delivery type  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Type of delivery as used in settlement terms for a financial security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;SecurityNote">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security note  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">An individually denominated note within a security or tranche of a security, where this is issued in notes of different denominations.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Introduced for MBS Proof of Concept, to model MBS tranches where one tranche may have notes of multiple denominations. Other applications of this concept are not known at present. Trivially, all securities could be said to be in &quot;notes&quot; in this sense but the term is not normally referred to.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;SecuritySettlementConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-sec;SettlementConvention"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-sec;hasDeliveryMethod"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-sec;SecurityDeliveryType"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security settlement convention</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Default Terms for the settlement of a Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;SecurityStructuredName">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-inf-inf;StructuredName"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security structured name</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The formal, structured name of a Security.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;SettlementConvention">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-pub-con;Convention"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement convention</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A convention for settlement of a trade or transaction.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">This is usually stated in the form &apos;T+n&apos; where n is the Settlement Business Days. There are no date roll rules, the T+n simply refers to the next available business days and is specified as a whole number. Note that this term has been created for the OTC model, but on review of the existing terms for security settlement conventions in the common model for tradable securities, this term has been separated out as a more general term, with the securities-specific in a sub-type of this item, renamed to Security Settlement Convention.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;Stake">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">stake</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The holding of some portion of some venture or something of value, by some party. The stake may be represented by some form of formal document such as a share or some debt unit.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-sec;TradingRegisteredSecurity">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/ShareTerms/hasListing"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecurityListing"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading registered security</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A security which is traded on some trading venue.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">Define the three types of these as per the MIFID definitions of types of trading facility. Also need to allow for jurisdiction variation. Renamed March 2013 from Listed Security to Trading Registered Security (Citi review session). The rationale is that any security which is listed on some facility is registered, and the fact of it being registered is more significant. This is still to be reviewed more widely with the SME review group.</skos:editorialNote>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;allowsContractualSettlement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">allows contractual settlement  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the market allows contractual settlement. This is a settlement term related to the market.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;bearer">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bearer  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The owner is not registered in the books of the issuer or of the registrar.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;deemedRiskCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">deemed risk currency  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The currency in which any risks relating to the instrument are seen to take place. Further notes: This is a risk specific term identified during SME Reviews of common securities terms. It was agreed at a review with a risk firm that this term is applicable within the context of risk management only and is not a fundamental fact about the security. It therefore needs to be disposed in some way to show it in the context of risk.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;denominationCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination currency  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The default currency in which units of the Security are denominated.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;denominationIncrement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">denomination increment  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The multiples above the smallest possible denomination (Default Lot Size) in which the security can be held.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;fASTApplicable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">f a s t applicable  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the security is to be held at the transfer agent as part of the FAST (Fully Automated Securities Transfer) program. Further notes: Term is specific to DTCC / US context. Is there a more generic meaning similar to this which applies across different jurisdictions? If not this term should be defined with reference to this specific context.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;fractionalEligible">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">fractional eligible  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the security can contain Fractional Share/amount component.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;fullName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">full name  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Full name of the security</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;hasDefaultSettlementTerms">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has default settlement terms  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;hasDeliveryMethod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has delivery method  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityDeliveryType"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Has a method by which securities are delivered at settlement.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;hasStructuredName">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-inf-inf;hasName"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has structured name</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;interchangeable">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">interchangeable  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the security is freely interchangeable with other of the same securities. Yes indicates that the security is interchangeable; no indicates that it is not.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;isListed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is listed  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-sec;TradingRegisteredSecurity"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The security is listed on some exchange or trading facility (Listed = Yes)</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;issueDate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">issue date  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Date that the Security was issued.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;legallyRecordedIn">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasGoverningJurisdiction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">legally recorded in  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Jurisdiction (country, county, state, province, city) in which the security is legally recorded for regulatory and/or tax purposes.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;listed">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">listed  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether or not the security is listed on some exchange or trading facility.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;preferredSettlementCurrency">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">preferred settlement currency  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecuritySettlementConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Preferred currency in which the instrument is to be settled. Securities may be settled in a currency other than this.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;registered">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">registered  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Securities are recorded in the name of the owner on the books of the issuer or the issuer&apos;s registrar.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;settlementBusinessDays">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">settlement business days  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SettlementConvention"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;IntegerValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Default number of business days for settlement e.g. T+1, T+3 and so on.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-sec;shortName">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">short name  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-sec;SecurityStructuredName"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Short name of the security.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/SecuritiesExt/SecuritiesListingsExt.rdf
+++ b/sec/SecuritiesExt/SecuritiesListingsExt.rdf
@@ -1,128 +1,131 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
-	<!ENTITY fibo-fnd-plcx-vrtx "https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
-	<!ENTITY fibo-sec-secx-lisx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/">
+bu<!ENTITY fibo-fnd-plcx-vrtx "https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-md-temx-ins "https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/">
+bu<!ENTITY fibo-sec-secx-lisx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"
-	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
-	xmlns:fibo-fnd-plcx-vrtx="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
-	xmlns:fibo-sec-secx-lisx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/">
-		<rdfs:label xml:lang="en">SecuritiesListingsExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-vrtx;NotionalPlace"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecuritiesExchange">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-lisx;hasOfficialClosingPriceType"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<skos:definition xml:lang="en">A stock exchange, (formerly a securities exchange) is a corporation or mutual organization which provides &quot;trading&quot; facilities for stock brokers and traders, to trade stocks and other securities. Stock exchanges also provide facilities for the issue and redemption of securities as well as other financial instruments and capital events including the payment of income and dividends.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The securities traded on a stock exchange include: shares issued by companies, unit trusts, derivatives, pooled investment products and bonds. To be able to trade a security on a certain stock exchange, it has to be listed there. Usually there is a central location at least for recordkeeping, but trade is less and less linked to such a physical place, as modern markets are electronic networks, which gives them advantages of speed and cost of transactions. Trade on an exchange is by members only. The initial offering of stocks and bonds to investors is by definition done in the primary market and subsequent trading is do This is distinguished by providing a formal listing for the securities that are traded on that venue. Many exchanges also play a defined role in the issuance of new securities.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-lisx;BulldogMarket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
-		<rdfs:label xml:lang="en">bulldog market</rdfs:label>
-		<skos:definition xml:lang="en">As for Yankee bond market but in UK instead of the US.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-lisx;DomesticMarket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
-		<rdfs:label xml:lang="en">domestic market</rdfs:label>
-		<skos:definition xml:lang="en">Bonds issued and traded in the country to which the debt and currency apply.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-lisx;EurobondMarket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
-		<rdfs:label xml:lang="en">eurobond market</rdfs:label>
-		<skos:definition xml:lang="en">The non domestic market (note this does not relate to the Euro as a currency).</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-lisx;GlobalMarket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
-		<rdfs:label xml:lang="en">global market</rdfs:label>
-		<skos:definition xml:lang="en">Definition needed</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-lisx;PrimaryGlobal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-lisx;TradingLocationPreference"/>
-		<rdfs:label xml:lang="en">primary global</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-lisx;PrimaryLocal">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-lisx;TradingLocationPreference"/>
-		<rdfs:label xml:lang="en">primary local</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-lisx;SamuraiMarket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
-		<rdfs:label xml:lang="en">samurai market</rdfs:label>
-		<skos:definition xml:lang="en">As for Yankee bond market but in Japan instead of the US.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-lisx;TradingLocationPreference">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Preference"/>
-		<rdfs:label xml:lang="en">trading location preference</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-lisx;YankeeMarket">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
-		<rdfs:label xml:lang="en">yankee market</rdfs:label>
-		<skos:definition xml:lang="en">A Yankee bond is a bond denominated in U.S. dollars and is publicly issued in the U.S. by foreign banks and corporations.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-lisx;hasOfficialClosingPriceType">
-		<rdfs:label xml:lang="en">has official closing price type</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecuritiesExchange"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
-		<skos:definition xml:lang="en">What the exchange determines as the official close price.</skos:definition>
-		<skos:editorialNote xml:lang="en">This may have a number of complex rules such as disregarding certain trades. Europe: KASSA Price, Listino Price in Italy etc. special types based on different exchanges. Not calculation methods as such. Action: look for a list of these</skos:editorialNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"
+buxmlns:fibo-fnd-plcx-vrtx="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-md-temx-ins="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"
+buxmlns:fibo-sec-secx-lisx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SecuritiesListingsExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">Extended terms for security listings These define kinds of market such as the samurai and bulldog markets, which are a reflection of trading location preferences.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/CurrencyAmount/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/ArrangementsExt/MethodsAndRules/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Locations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/Geophysical/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/PlacesExt/VirtualPlaces/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TransactionsExt/EconomicResources/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/EquityTemporal/EquityPricing/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/MD/TemporalCore/InstrumentTemporalTerms/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesIdentification/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesExt/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesListingsExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-plcx-vrtx;NotionalPlace"/>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecuritiesExchange">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-lisx;hasOfficialClosingPriceType"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A stock exchange, (formerly a securities exchange) is a corporation or mutual organization which provides &quot;trading&quot; facilities for stock brokers and traders, to trade stocks and other securities. Stock exchanges also provide facilities for the issue and redemption of securities as well as other financial instruments and capital events including the payment of income and dividends.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The securities traded on a stock exchange include: shares issued by companies, unit trusts, derivatives, pooled investment products and bonds. To be able to trade a security on a certain stock exchange, it has to be listed there. Usually there is a central location at least for recordkeeping, but trade is less and less linked to such a physical place, as modern markets are electronic networks, which gives them advantages of speed and cost of transactions. Trade on an exchange is by members only. The initial offering of stocks and bonds to investors is by definition done in the primary market and subsequent trading is do This is distinguished by providing a formal listing for the securities that are traded on that venue. Many exchanges also play a defined role in the issuance of new securities.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-lisx;BulldogMarket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">bulldog market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">As for Yankee bond market but in UK instead of the US.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-lisx;DomesticMarket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">domestic market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Bonds issued and traded in the country to which the debt and currency apply.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-lisx;EurobondMarket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">eurobond market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The non domestic market (note this does not relate to the Euro as a currency).</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-lisx;GlobalMarket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">global market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Definition needed</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-lisx;PrimaryGlobal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-lisx;TradingLocationPreference"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary global</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-lisx;PrimaryLocal">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-lisx;TradingLocationPreference"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">primary local</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-lisx;SamuraiMarket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">samurai market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">As for Yankee bond market but in Japan instead of the US.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-lisx;TradingLocationPreference">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-arrxx-meth;Preference"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">trading location preference</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-lisx;YankeeMarket">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/NotionalFinancialMarketplace"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">yankee market</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Yankee bond is a bond denominated in U.S. dollars and is publicly issued in the U.S. by foreign banks and corporations.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-lisx;hasOfficialClosingPriceType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has official closing price type</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesListings/SecuritiesExchange"/>
+bubu<rdfs:range rdf:resource="&fibo-md-temx-ins;ClosingPriceDeterminationMethod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">What the exchange determines as the official close price.</skos:definition>
+bubu<skos:editorialNote rdf:datatype="&rdf;langString" xml:lang="en">This may have a number of complex rules such as disregarding certain trades. Europe: KASSA Price, Listino Price in Italy etc. special types based on different exchanges. Not calculation methods as such. Action: look for a list of these</skos:editorialNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/SecuritiesExt/SecuritiesRestrictionsExt.rdf
+++ b/sec/SecuritiesExt/SecuritiesRestrictionsExt.rdf
@@ -1,167 +1,170 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-bp-reg-req "https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
-	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
-	<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-secx-resx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-bp-reg-req "https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/">
+bu<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
+bu<!ENTITY fibo-fnd-lawx-rst "https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/">
+bu<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-secx-resx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"
-	xmlns:fibo-bp-reg-req="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"
-	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
-	xmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-secx-resx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/">
-		<rdfs:label xml:lang="en">SecuritiesRestrictionsExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-resx;contractuallyDefinesRestrictions"/>
-				<owl:allValuesFrom rdf:resource="&fibo-sec-secx-resx;SecurityContractualRestriction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-resx;holderRestrictions"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/LegalHoldingRestriction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-resx;InvestmentRegulatoryLaw">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
-		<rdfs:label xml:lang="en">investment regulatory law</rdfs:label>
-		<skos:definition xml:lang="en">A body of law dealing with investment regulation.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-resx;InvestmentRegulatoryRequirement">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-reg-req;mandatedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-secx-resx;InvestmentRegulatoryLaw"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">investment regulatory requirement</rdfs:label>
-		<skos:definition xml:lang="en">A requirement laid down in law for investment regulation.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-resx;InvestmentRestriction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;LegalRestriction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-lawx-rst;restrictionAppliesIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">investment restriction</rdfs:label>
-		<skos:definition xml:lang="en">Restrictions applicable to a financial instrument as provided for in a body of Law.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-resx;InvestorDomicileType">
-		<rdfs:label xml:lang="en">investor domicile type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-resx;InvestorType">
-		<rdfs:label xml:lang="en">investor type</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-resx;SecurityContractualRestriction">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/ContractualRestriction"/>
-		<rdfs:label xml:lang="en">security contractual restriction</rdfs:label>
-		<skos:definition xml:lang="en">Contractual terms setting out restrictions on either the holder or the issuer of the security.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These are restrictions defined in the contractual terms of the security itself and form part of the terms of the security, as distinct from restrictions defined in some body of law and being applicable to the security, which are defined separately.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-resx;SecurityRegistrationRequirement">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/RegistrationRequirement"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-resx;InvestmentRegulatoryRequirement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/appliesTo"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">security registration requirement</rdfs:label>
-		<skos:definition xml:lang="en">A Requirement for Registraton of a Security within some Country, Jurisdiction or Federal Province.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;contractuallyDefinesRestrictions">
-		<rdfs:label xml:lang="en">contractually defines restrictions</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-resx;SecurityContractualRestriction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;hasEffectivePeriod">
-		<rdfs:label xml:lang="en">has effective period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-resx;InvestmentRestriction"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
-		<skos:definition xml:lang="en">Period during which the restriction applies.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;hasRegistrationRequirement">
-		<rdfs:label xml:lang="en">has registration requirement</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-resx;SecurityRegistrationRequirement"/>
-		<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/appliesTo"/>
-		<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/appliesTo"/>
-		<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/appliesTo"/>
-		<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/appliesTo"/>
-		<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/appliesTo"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;hasRestriction">
-		<rdfs:label xml:lang="en">has restriction</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-resx;InvestmentRestriction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;hasRestrictions">
-		<rdfs:label xml:lang="en">has restrictions  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-resx;InvestmentRestriction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;holderRestrictions">
-		<rdfs:label xml:lang="en">holder restrictions</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/LegalHoldingRestriction"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;isInclusive">
-		<rdfs:label xml:lang="en">is inclusive</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-resx;SecurityRegistrationRequirement"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the Restriction is defined inclusively (the stated terms put something within the Restriction), or Exclusively (the stated terms put something outside the reach or remit of the Restriction). Yes = Inclusive.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-bp-reg-req="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"
+buxmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"
+buxmlns:fibo-fnd-lawx-rst="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"
+buxmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-secx-resx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SecuritiesRestrictionsExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology provides the conceptual framework for securities trading restrictions. These include regulatory and contractual restrictions on the trading of a security, based on investor domicile and investor types. Specific restrictions found in securities references data, such as Regulation S and 144A, may be framed in terms of these descriptions.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BP/Regulatory/RegulatoryRequirements/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/LawExt/RegulatoryRestrictions/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/TimeExt/Time/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRestrictionsExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-resx;contractuallyDefinesRestrictions"/>
+bubububu<owl:allValuesFrom rdf:resource="&fibo-sec-secx-resx;SecurityContractualRestriction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-resx;holderRestrictions"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/LegalHoldingRestriction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-resx;InvestmentRegulatoryLaw">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;StatuteLaw"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment regulatory law</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A body of law dealing with investment regulation.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-resx;InvestmentRegulatoryRequirement">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;RegulatoryRequirement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-bp-reg-req;mandatedBy"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-sec-secx-resx;InvestmentRegulatoryLaw"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment regulatory requirement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A requirement laid down in law for investment regulation.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-resx;InvestmentRestriction">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-lawx-rst;LegalRestriction"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-fnd-lawx-rst;restrictionAppliesIn"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investment restriction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Restrictions applicable to a financial instrument as provided for in a body of Law.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-resx;InvestorDomicileType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investor domicile type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-resx;InvestorType">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">investor type</rdfs:label>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-resx;SecurityContractualRestriction">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/ContractualRestriction"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security contractual restriction</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Contractual terms setting out restrictions on either the holder or the issuer of the security.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">These are restrictions defined in the contractual terms of the security itself and form part of the terms of the security, as distinct from restrictions defined in some body of law and being applicable to the security, which are defined separately.</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-resx;SecurityRegistrationRequirement">
+bubu<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/RegistrationRequirement"/>
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-resx;InvestmentRegulatoryRequirement"/>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/appliesTo"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security registration requirement</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">A Requirement for Registraton of a Security within some Country, Jurisdiction or Federal Province.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;contractuallyDefinesRestrictions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">contractually defines restrictions</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-resx;SecurityContractualRestriction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;hasEffectivePeriod">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has effective period</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-resx;InvestmentRestriction"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Period during which the restriction applies.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;hasRegistrationRequirement">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has registration requirement</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-resx;SecurityRegistrationRequirement"/>
+bubu<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/BP/SecuritiesIssuance/IssuanceProcessTerms/appliesTo"/>
+bubu<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/CIV/Funds/CIV/appliesTo"/>
+bubu<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/BalanceSheetBalances/appliesTo"/>
+bubu<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/appliesTo"/>
+bubu<owl:inverseOf rdf:resource="https://spec.edmcouncil.org/fibo/MD/CIVTemporal/FundsTemporal/appliesTo"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;hasRestriction">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has restriction</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-resx;InvestmentRestriction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;hasRestrictions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has restrictions  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-resx;InvestmentRestriction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;holderRestrictions">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">holder restrictions</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecuritiesRestrictions/LegalHoldingRestriction"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-resx;isInclusive">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">is inclusive</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-resx;SecurityRegistrationRequirement"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the Restriction is defined inclusively (the stated terms put something within the Restriction), or Exclusively (the stated terms put something outside the reach or remit of the Restriction). Yes = Inclusive.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/SecuritiesExt/SecuritiesRisk.rdf
+++ b/sec/SecuritiesExt/SecuritiesRisk.rdf
@@ -1,80 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-secx-risk "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRisk/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-plc-cty "https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-secx-risk "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRisk/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRisk/"
-	xmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-secx-risk="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRisk/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRisk/">
-		<rdfs:label xml:lang="en">SecuritiesRisk</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRisk/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-risk;countryOfEconomicRisk"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-risk;countryOfPoliticalRisk"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-risk;incomeSourceCountry"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-risk;countryOfEconomicRisk">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-risk;countryOfRisk"/>
-		<rdfs:label xml:lang="en">country of economic risk  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-risk;countryOfPoliticalRisk">
-		<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-risk;countryOfRisk"/>
-		<rdfs:label xml:lang="en">country of political risk  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-risk;countryOfRisk">
-		<rdfs:label xml:lang="en">country of risk  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-		<skos:definition xml:lang="en">The country where any risks are inherent in the hierarcrhy that the issuer is part of.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-risk;incomeSourceCountry">
-		<rdfs:label xml:lang="en">income source country  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-plc-cty="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-secx-risk="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRisk/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRisk/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SecuritiesRisk</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines risk properties of a security, including countries of political, economic and currency risk.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Places/Countries/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesRisk/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-risk;countryOfEconomicRisk"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-risk;countryOfPoliticalRisk"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-risk;incomeSourceCountry"/>
+bubububu<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-risk;countryOfEconomicRisk">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-risk;countryOfRisk"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">country of economic risk  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-risk;countryOfPoliticalRisk">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-sec-secx-risk;countryOfRisk"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">country of political risk  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-risk;countryOfRisk">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">country of risk  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The country where any risks are inherent in the hierarcrhy that the issuer is part of.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-risk;incomeSourceCountry">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">income source country  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-plc-cty;Country"/>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/SecuritiesExt/SecuritiesTaxTreatment.rdf
+++ b/sec/SecuritiesExt/SecuritiesTaxTreatment.rdf
@@ -1,77 +1,81 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-accx-tax "https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
-	<!ENTITY fibo-sec-secx-tax "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-accx-tax "https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-fnd-utlx-val "https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/">
+bu<!ENTITY fibo-sec-secx-tax "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"
-	xmlns:fibo-fnd-accx-tax="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
-	xmlns:fibo-sec-secx-tax="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/">
-		<rdfs:label xml:lang="en">SecuritiesTaxTreatment</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument">
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-tax;FinancialInstrumentTaxTreatment">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-tax;TaxTreatment"/>
-		<rdfs:label xml:lang="en">financial instrument tax treatment  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">The treatment of the financial instrument for taxation purposes. This is the most general form of tax treatment for financial instruments, including cash.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-secx-tax;SecurityTaxTreatment">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-secx-tax;FinancialInstrumentTaxTreatment"/>
-		<rdfs:label xml:lang="en">security tax treatment  (please review)</rdfs:label>
-		<skos:definition xml:lang="en">Amount of money due to the government or tax authority, according to various pre-defined parameters such as thresholds or income.</skos:definition>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-tax;exempt">
-		<rdfs:label xml:lang="en">exempt  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-tax;FinancialInstrumentTaxTreatment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
-		<skos:definition xml:lang="en">Whether the tax rule applies within the jurisdiction as a condition of this instrument.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-tax;frankedRate">
-		<rdfs:label xml:lang="en">franked rate  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-tax;SecurityTaxTreatment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
-		<skos:definition xml:lang="en">Percentage of dividend for which tax is already paid.</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-tax;hasTaxTreatment">
-		<rdfs:label xml:lang="en">has tax treatment  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
-		<rdfs:range rdf:resource="&fibo-sec-secx-tax;FinancialInstrumentTaxTreatment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-tax;securityTaxCode">
-		<rdfs:label xml:lang="en">security tax code  (please review)</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-secx-tax;SecurityTaxTreatment"/>
-		<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
-		<skos:definition xml:lang="en">The tax code of the security in the stated tax jurisdiction.</skos:definition>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-accx-tax="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-fnd-utlx-val="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"
+buxmlns:fibo-sec-secx-tax="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SecuritiesTaxTreatment</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology defines features of the tax treatment of a security. 
+		These concepts are frequently seen in securities master files but are not definitive of the security itself.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/AccountingExt/Taxation/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/UtilitiesExt/Values/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecuritiesTaxTreatment/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument">
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-tax;FinancialInstrumentTaxTreatment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-fnd-accx-tax;TaxTreatment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">financial instrument tax treatment  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The treatment of the financial instrument for taxation purposes. This is the most general form of tax treatment for financial instruments, including cash.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:Class rdf:about="&fibo-sec-secx-tax;SecurityTaxTreatment">
+bubu<rdfs:subClassOf rdf:resource="&fibo-sec-secx-tax;FinancialInstrumentTaxTreatment"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security tax treatment  (please review)</rdfs:label>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Amount of money due to the government or tax authority, according to various pre-defined parameters such as thresholds or income.</skos:definition>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-tax;exempt">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">exempt  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-tax;FinancialInstrumentTaxTreatment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TrueFalseValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Whether the tax rule applies within the jurisdiction as a condition of this instrument.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-tax;frankedRate">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">franked rate  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-tax;SecurityTaxTreatment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;PercentageValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">Percentage of dividend for which tax is already paid.</skos:definition>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-tax;hasTaxTreatment">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has tax treatment  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/FinancialInstrument"/>
+bubu<rdfs:range rdf:resource="&fibo-sec-secx-tax;FinancialInstrumentTaxTreatment"/>
+bu</owl:ObjectProperty>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-tax;securityTaxCode">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">security tax code  (please review)</rdfs:label>
+bubu<rdfs:domain rdf:resource="&fibo-sec-secx-tax;SecurityTaxTreatment"/>
+bubu<rdfs:range rdf:resource="&fibo-fnd-utlx-val;TextValue"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The tax code of the security in the stated tax jurisdiction.</skos:definition>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/sec/SecuritiesExt/SecurityAssetsExt.rdf
+++ b/sec/SecuritiesExt/SecurityAssetsExt.rdf
@@ -1,53 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
-	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
-	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-sec-secx-assx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/">
-	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
-	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
-	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+bu<!ENTITY dct "http://purl.org/dc/terms/">
+bu<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
+bu<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+bu<!ENTITY fibo-sec-secx-assx "https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/">
+bu<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+bu<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+bu<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+bu<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+bu<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/"
-	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
-	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-sec-secx-assx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/"
-	xmlns:owl="http://www.w3.org/2002/07/owl#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/">
-		<rdfs:label xml:lang="en">SecurityAssetsExt</rdfs:label>
-		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
-	</owl:Ontology>
-	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-secx-assx;hasHolder"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-sec-secx-assx;hasHolder">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
-		<rdfs:label xml:lang="en">has holder</rdfs:label>
-		<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
-		<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
-		<skos:definition xml:lang="en">The party which holds the security and is entitled to the rights contractually defined in the security terms.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The holder is anonymous to the issuer and may transfer their holding in the open marketplace without reference to the issuer (subject to any holding restrictions set out for the Security either in the security contractual terms or in the laws of the applicable jurisdiction).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:ObjectProperty>
+<rdf:RDF
+buxmlns:dct="http://purl.org/dc/terms/"
+buxmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"
+buxmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+buxmlns:fibo-sec-secx-assx="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/"
+buxmlns:owl="http://www.w3.org/2002/07/owl#"
+buxmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+buxmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+buxmlns:skos="http://www.w3.org/2004/02/skos/core#"
+buxmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+bu
+bu<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/">
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">SecurityAssetsExt</rdfs:label>
+bubu<dct:abstract rdf:datatype="&xsd;string">This ontology extends the Security Assets ontology to define the property whereby a security has a holder. 
+		This ontology consists of just this one property and is included for when anything may need to make reference to that property directly, this being replaced by a restriction in the published Release ontology for Security Assets.</dct:abstract>
+bubu<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
+bubu<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/"/>
+bubu<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/SecuritiesExt/SecurityAssetsExt/"/>
+bubu<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
+bu</owl:Ontology>
+bu
+bu<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security">
+bubu<rdfs:subClassOf>
+bububu<owl:Restriction>
+bubububu<owl:onProperty rdf:resource="&fibo-sec-secx-assx;hasHolder"/>
+bubububu<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
+bububu</owl:Restriction>
+bubu</rdfs:subClassOf>
+bu</owl:Class>
+bu
+bu<owl:ObjectProperty rdf:about="&fibo-sec-secx-assx;hasHolder">
+bubu<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasCounterparty"/>
+bubu<rdfs:label rdf:datatype="&rdf;langString" xml:lang="en">has holder</rdfs:label>
+bubu<rdfs:domain rdf:resource="https://spec.edmcouncil.org/fibo/FBC/FinancialInstruments/FinancialInstruments/Security"/>
+bubu<rdfs:range rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Securities/SecurityAssets/SecurityHolder"/>
+bubu<skos:definition rdf:datatype="&rdf;langString" xml:lang="en">The party which holds the security and is entitled to the rights contractually defined in the security terms.</skos:definition>
+bubu<fibo-fnd-utl-av:explanatoryNote rdf:datatype="&rdf;langString" xml:lang="en">The holder is anonymous to the issuer and may transfer their holding in the open marketplace without reference to the issuer (subject to any holding restrictions set out for the Security either in the security contractual terms or in the laws of the applicable jurisdiction).</fibo-fnd-utl-av:explanatoryNote>
+bu</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION
Addition of Abstracts (using dct:abstract) to all Provisional and Informative ontologies, along with addition of dct Entity declarations and namespace declarations in each of these. Also added dct declarations to 2 Values ontologies (one in UtilitiesExt which is to be deprecated). Also changed declaration of license in one ontology from terms:license to dct:license (terms is present in several ontologies and refers to the same namespace as dct as these declarations appear not to have been standardized yet).