### PR TITLE
Infra 214

### DIFF
--- a/be/Corporations/Corporations.rdf
+++ b/be/Corporations/Corporations.rdf
@@ -41,7 +41,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/Corporations/Corporations/">
 		<rdfs:label>Corporations Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/be/FunctionalEntities/FunctionalEntities.rdf
+++ b/be/FunctionalEntities/FunctionalEntities.rdf
@@ -40,7 +40,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/FunctionalEntities/FunctionalEntities/">
 		<rdfs:label>Functional Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for entities defined by their function, such as the relationship to the various forms which one or another functionally-defined entity may take. It also includes a number of basic types of entity defined by function, such as business and non-profit. The concepts in this ontology are intended to be extensible in other ontologies which may be dedicated to specific kinds of functionally-defined business entity or organization.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/be/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf
+++ b/be/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions.rdf
@@ -33,7 +33,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/EuropeanJurisdiction/EUGovernmentEntitiesAndJurisdictions/">
 		<rdfs:label>European Government Entities and Jurisdictions Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016 EDM Council, Inc.

--- a/be/GovernmentEntities/GovernmentEntities.rdf
+++ b/be/GovernmentEntities/GovernmentEntities.rdf
@@ -46,7 +46,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/GovernmentEntities/GovernmentEntities/">
 		<rdfs:label>Government Entities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines the fundamental concepts for representing polities and government entities and their relations.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016-2017 EDM Council, Inc.

--- a/be/LegalEntities/CorporateBodies.rdf
+++ b/be/LegalEntities/CorporateBodies.rdf
@@ -43,7 +43,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
 		<rdfs:label>Corporate Bodies Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/be/LegalEntities/FormalBusinessOrganizations.rdf
+++ b/be/LegalEntities/FormalBusinessOrganizations.rdf
@@ -48,7 +48,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntities/FormalBusinessOrganizations/">
 		<rdfs:label>Formal Business Organizations Ontology</rdfs:label>
 		<dct:abstract>This ontology defines formal business organizations and related concepts. The ontology covers parts of organizations, membership, classification, address relations and other properties which are applicable to formal business organizations generally. The concept of a formal business organization forms the basis for articulation of types of organization, both incorporated and non-incorporated, in other FIBO-BE ontologies.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/be/LegalEntities/LEIEntities.rdf
+++ b/be/LegalEntities/LEIEntities.rdf
@@ -35,7 +35,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LEIEntities/">
 		<rdfs:label>Legal Entity Identifier (LEI) Entities Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/be/LegalEntities/LegalPersons.rdf
+++ b/be/LegalEntities/LegalPersons.rdf
@@ -47,7 +47,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/LegalEntities/LegalPersons/">
 		<rdfs:label>Legal Persons Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/be/OwnershipAndControl/ControlParties.rdf
+++ b/be/OwnershipAndControl/ControlParties.rdf
@@ -45,7 +45,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/ControlParties/">
 		<rdfs:label>Control Parties Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/be/OwnershipAndControl/CorporateControl.rdf
+++ b/be/OwnershipAndControl/CorporateControl.rdf
@@ -45,7 +45,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateControl/">
 		<rdfs:label>Corporate Control Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/be/OwnershipAndControl/CorporateOwnership.rdf
+++ b/be/OwnershipAndControl/CorporateOwnership.rdf
@@ -31,7 +31,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/CorporateOwnership/">
 		<rdfs:label>Corporate Ownership Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/be/OwnershipAndControl/Executives.rdf
+++ b/be/OwnershipAndControl/Executives.rdf
@@ -51,7 +51,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
 		<rdfs:label>Executives Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/be/OwnershipAndControl/OwnershipParties.rdf
+++ b/be/OwnershipAndControl/OwnershipParties.rdf
@@ -41,7 +41,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/OwnershipParties/">
 		<rdfs:label>Ownership Parties Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/be/Partnerships/Partnerships.rdf
+++ b/be/Partnerships/Partnerships.rdf
@@ -47,7 +47,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/Partnerships/Partnerships/">
 		<rdfs:label>Partnerships Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/be/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
+++ b/be/PrivateLimitedCompanies/PrivateLimitedCompanies.rdf
@@ -27,7 +27,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/PrivateLimitedCompanies/PrivateLimitedCompanies/">
 		<rdfs:label>Private Limited Companies Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016 EDM Council, Inc.

--- a/be/SoleProprietorships/SoleProprietorships.rdf
+++ b/be/SoleProprietorships/SoleProprietorships.rdf
@@ -39,7 +39,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/SoleProprietorships/SoleProprietorships/">
 		<rdfs:label>Sole Proprietorships Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016 EDM Council, Inc.

--- a/be/Trusts/Trusts.rdf
+++ b/be/Trusts/Trusts.rdf
@@ -33,7 +33,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/Trusts/Trusts/">
 		<rdfs:label>Trusts Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2015 EDM Council, Inc.

--- a/der/1.0/AboutDER-1.0-ReferenceIndividuals.rdf
+++ b/der/1.0/AboutDER-1.0-ReferenceIndividuals.rdf
@@ -331,7 +331,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2016-2017 EDM Council, Inc.
 Copyright (c) 2016-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Derivatives (DER) Specification Version 1.0, Reference Individuals Version -->

--- a/der/1.0/AboutDER-1.0.rdf
+++ b/der/1.0/AboutDER-1.0.rdf
@@ -290,7 +290,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2016-2017 EDM Council, Inc.
 Copyright (c) 2016-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Derivatives (DER) Specification Version 1.0 -->

--- a/fbc/1.0/AboutFBC-1.0-NorthAmerica.rdf
+++ b/fbc/1.0/AboutFBC-1.0-NorthAmerica.rdf
@@ -242,7 +242,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2016 EDM Council, Inc.
 Copyright (c) 2015-2016 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Financial Business and Commerce (FBE) Specification Version 1.0, North American Version -->

--- a/fbc/1.0/AboutFBC-1.0-test.rdf
+++ b/fbc/1.0/AboutFBC-1.0-test.rdf
@@ -246,7 +246,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2016 EDM Council, Inc.
 Copyright (c) 2015-2016 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Financial Business and Commerce (FBE) Specification Version 1.0, North American Test Version -->

--- a/fbc/1.0/AboutFBC-1.0.rdf
+++ b/fbc/1.0/AboutFBC-1.0.rdf
@@ -230,7 +230,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2016 EDM Council, Inc.
 Copyright (c) 2015-2016 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Financial Business and Commerce (FBE) Specification Version 1.0 -->

--- a/fbc/1.1/AboutFBC-1.1-Europe.rdf
+++ b/fbc/1.1/AboutFBC-1.1-Europe.rdf
@@ -257,7 +257,7 @@
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2017 EDM Council, Inc.
 Copyright (c) 2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Financial Business and Commerce (FBC) Specification Version 1.1, European Version -->

--- a/fbc/1.1/AboutFBC-1.1-EuropeAndNorthAmerica.rdf
+++ b/fbc/1.1/AboutFBC-1.1-EuropeAndNorthAmerica.rdf
@@ -276,7 +276,7 @@
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Financial Business and Commerce (FBC) Specification Version 1.1, European and North American Version -->

--- a/fbc/1.1/AboutFBC-1.1-NorthAmerica.rdf
+++ b/fbc/1.1/AboutFBC-1.1-NorthAmerica.rdf
@@ -264,7 +264,7 @@
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Financial Business and Commerce (FBC) Specification Version 1.1, North American Version -->

--- a/fbc/1.1/AboutFBC-1.1.rdf
+++ b/fbc/1.1/AboutFBC-1.1.rdf
@@ -244,7 +244,7 @@
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Financial Business and Commerce (FBC) Specification Version 1.1 -->

--- a/fbc/DebtAndEquities/AboutDebtAndEquities.rdf
+++ b/fbc/DebtAndEquities/AboutDebtAndEquities.rdf
@@ -36,7 +36,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2016-2017 EDM Council, Inc.
 Copyright (c) 2016-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO FBC Debt and Equities Module -->

--- a/fbc/FunctionalEntities/BusinessRegistries.rdf
+++ b/fbc/FunctionalEntities/BusinessRegistries.rdf
@@ -38,7 +38,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/BusinessRegistries/">
 		<rdfs:label>Business Registries Ontology</rdfs:label>
 		<dct:abstract>This ontology extends the Registration Authorities ontology to define specific kinds of registries, such as business entity registries, registries for identifiers and codes of various sorts, and registries for financial institutions and intermediaries based on jurisdiction, who regulates them, and the services they provide.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015 EDM Council, Inc.

--- a/fbc/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities.rdf
+++ b/fbc/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/NorthAmericanEntities/CAFinancialServicesEntities/">
 		<rdfs:label>Canadian Financial Services Entities Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016 EDM Council, Inc.

--- a/fbc/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/fbc/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -35,7 +35,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/">
 		<rdfs:label>Canadian Regulatory Agencies Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016 EDM Council, Inc.

--- a/fbc/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/fbc/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -83,7 +83,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/">
 		<rdfs:label>US Example Individuals</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2017 EDM Council, Inc.

--- a/fbc/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf
+++ b/fbc/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities.rdf
@@ -31,7 +31,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntities/">
 		<rdfs:label>US Financial Services Entities Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2016 EDM Council, Inc.

--- a/fbc/FunctionalEntities/RegistrationAuthorities.rdf
+++ b/fbc/FunctionalEntities/RegistrationAuthorities.rdf
@@ -50,7 +50,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FBC/FunctionalEntities/RegistrationAuthorities/">
 		<rdfs:label>Registration Authorities Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts for representation of registration authorities, registrars, registration-specific identifiers and related identification schemes, and registration authorities specific to ISO and the financial industry.  Examples of financial industry registration authorities in the US include the Federal Deposit Insurance Corporation (FDIC) and the Securities Exchange Commission (SEC).</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2017 EDM Council, Inc.

--- a/fbc/ProductsAndServices/AboutFBCProductsAndServices.rdf
+++ b/fbc/ProductsAndServices/AboutFBCProductsAndServices.rdf
@@ -36,7 +36,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO FBC Products and Services Module -->

--- a/fnd/1.1/AboutFND-1.1.rdf
+++ b/fnd/1.1/AboutFND-1.1.rdf
@@ -177,7 +177,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2016 EDM Council, Inc.
 Copyright (c) 2015-2016 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Foundations (FND) Specification Version 1.1 -->

--- a/fnd/1.2/AboutFND-1.2.rdf
+++ b/fnd/1.2/AboutFND-1.2.rdf
@@ -177,7 +177,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Foundations (FND) Specification Version 1.2 -->

--- a/fnd/1.3/AboutFND-1.3.rdf
+++ b/fnd/1.3/AboutFND-1.3.rdf
@@ -187,7 +187,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Foundations (FND) Specification Version 1.3 -->

--- a/fnd/Accounting/AccountingEquity.rdf
+++ b/fnd/Accounting/AccountingEquity.rdf
@@ -31,7 +31,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/">
 		<rdfs:label>Accounting Equity Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/fnd/Accounting/CurrencyAmount.rdf
+++ b/fnd/Accounting/CurrencyAmount.rdf
@@ -44,7 +44,7 @@
 		<dct:abstract>This ontology defines currency and monetary amount related concepts for use in defining other FIBO ontology elements. There are two distinct kinds of concepts that correspond to money and amounts: a concrete, actual amount of money, and the monetary measure of something denominated in some currency. These are dimensionally the same but whereas &apos;money amount&apos; is defined as an amount of money, &apos;monetary amount&apos; is an abstract monetary measure.
 
 The definition of currency provided herein is compliant with the definitions given in ISO 4217.  ISO 4217 provides universally applicable coded representations of names of currencies and funds, used internationally for financial transaction support.  The ontology has been partitioned into 2 parts: (1) the essential concept system describing the standard (this module), and (2) ISO4217-1-CurrencyCodes, which contains all of the individuals specified in ISO 4217.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/Accounting/ISO4217-CurrencyCodes.rdf
+++ b/fnd/Accounting/ISO4217-CurrencyCodes.rdf
@@ -37,7 +37,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Accounting/ISO4217-CurrencyCodes/">
 		<rdfs:label>ISO 4217-1 Currency Codes Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>

--- a/fnd/Accounting/Valuation.rdf
+++ b/fnd/Accounting/Valuation.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Accounting/Valuation/">
 		<rdfs:label>Valuation Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/fnd/AgentsAndPeople/Agents.rdf
+++ b/fnd/AgentsAndPeople/Agents.rdf
@@ -25,7 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/">
 		<rdfs:label>Agents Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/AgentsAndPeople/People.rdf
+++ b/fnd/AgentsAndPeople/People.rdf
@@ -44,7 +44,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/People/">
 		<rdfs:label>People Ontology</rdfs:label>
 		<dct:abstract>This ontology defines concepts for people and human related terms, for use in other FIBO ontology elements. People as defined here are human persons only. This ontology sets out a number of basic properties which are held by people or are definitive of a small number of specific types of people such as minors or adults. Primary use cases for determining the set of personal information definitions included are the common elements required to (1) open a bank account, (2) identify a sophisticated investor, and (3) establish foreign account ownership for money laundering purposes.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/Agreements/Agreements.rdf
+++ b/fnd/Agreements/Agreements.rdf
@@ -27,7 +27,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Agreements/Agreements/">
 		<rdfs:label>Agreements Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/fnd/Agreements/Contracts.rdf
+++ b/fnd/Agreements/Contracts.rdf
@@ -37,7 +37,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Agreements/Contracts/">
 		<rdfs:label>Contracts Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/Arrangements/Arrangements.rdf
+++ b/fnd/Arrangements/Arrangements.rdf
@@ -26,7 +26,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Arrangements/Arrangements/">
 		<rdfs:label>Arrangements Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract structural concepts, including arrangement and collection, for use in other FIBO ontology elements. These abstract concepts are further refined to support definition of identifiers, codes, quantities, and schemata that organize and classify such identifiers and codes.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/fnd/Arrangements/ClassificationSchemes.rdf
+++ b/fnd/Arrangements/ClassificationSchemes.rdf
@@ -28,7 +28,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Arrangements/ClassificationSchemes/">
 		<rdfs:label>Classification Schemes Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation of classification schemes that themselves are intended to permit the classification of arbitrary concepts into hierarchies (or partial orders) for use in other FIBO ontology elements.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2017 EDM Council, Inc.

--- a/fnd/Arrangements/Codes.rdf
+++ b/fnd/Arrangements/Codes.rdf
@@ -28,7 +28,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Arrangements/Codes/">
 		<rdfs:label>Codes and Code Sets Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation of codes and coding schemes for use in other FIBO ontology elements.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/fnd/Arrangements/Documents.rdf
+++ b/fnd/Arrangements/Documents.rdf
@@ -34,7 +34,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Arrangements/Documents/">
 		<rdfs:label>Documents Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation documents for use in other FIBO ontology elements.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/fnd/Arrangements/IdentifiersAndIndices.rdf
+++ b/fnd/Arrangements/IdentifiersAndIndices.rdf
@@ -30,7 +30,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Arrangements/IdentifiersAndIndices/">
 		<rdfs:label>Identifiers and Indices Ontology</rdfs:label>
 		<dct:abstract>This ontology defines abstract concepts for representation of identifiers, identification schemes, indices and indexing schemes for use in other FIBO ontology elements.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/fnd/Arrangements/Lifecycles.rdf
+++ b/fnd/Arrangements/Lifecycles.rdf
@@ -36,7 +36,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Arrangements/Lifecycles/">
 		<rdfs:label>Lifecycles Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a set of basic concepts for lifecycles, including the various stages and events that make up a given lifecycle, for use in describing product, trade, instrument, production, and other lifecycles in FIBO.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2017 EDM Council, Inc.

--- a/fnd/Communication/Communication.rdf
+++ b/fnd/Communication/Communication.rdf
@@ -37,7 +37,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Communication/Communication/">
 		<rdfs:label>Communication Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/fnd/DatesAndTimes/BusinessDates.rdf
+++ b/fnd/DatesAndTimes/BusinessDates.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/BusinessDates/">
 		<rdfs:label>Business Dates Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/fnd/DatesAndTimes/FinancialDates.rdf
+++ b/fnd/DatesAndTimes/FinancialDates.rdf
@@ -30,7 +30,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/FinancialDates/">
 		<rdfs:label>Financial Dates Ontology</rdfs:label>
 		<dct:abstract>This ontology provides definitions of date and schedule concepts for use in other FIBO ontologies.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/fnd/DatesAndTimes/Occurrences.rdf
+++ b/fnd/DatesAndTimes/Occurrences.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/DatesAndTimes/Occurrences/">
 		<rdfs:label>Occurrences Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/fnd/GoalsAndObjectives/Goals.rdf
+++ b/fnd/GoalsAndObjectives/Goals.rdf
@@ -23,7 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Goals/">
 		<rdfs:label>Goals Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/GoalsAndObjectives/Objectives.rdf
+++ b/fnd/GoalsAndObjectives/Objectives.rdf
@@ -23,7 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/GoalsAndObjectives/Objectives/">
 		<rdfs:label>Objectives Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/Law/Jurisdiction.rdf
+++ b/fnd/Law/Jurisdiction.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Law/Jurisdiction/">
 		<rdfs:label>Jurisdiction Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/Law/LegalCapacity.rdf
+++ b/fnd/Law/LegalCapacity.rdf
@@ -41,7 +41,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Law/LegalCapacity/">
 		<rdfs:label>Legal Capacity Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/fnd/Law/LegalCore.rdf
+++ b/fnd/Law/LegalCore.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Law/LegalCore/">
 		<rdfs:label>Legal Core Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/Organizations/FormalOrganizations.rdf
+++ b/fnd/Organizations/FormalOrganizations.rdf
@@ -33,7 +33,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Organizations/FormalOrganizations/">
 		<rdfs:label>Formal Organizations Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/Organizations/LegitimateOrganizations.rdf
+++ b/fnd/Organizations/LegitimateOrganizations.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Organizations/LegitimateOrganizations/">
 		<rdfs:label>Legitimate Organizations Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/Organizations/Organizations.rdf
+++ b/fnd/Organizations/Organizations.rdf
@@ -32,7 +32,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Organizations/Organizations/">
 		<rdfs:label>Organizations Ontology</rdfs:label>
 		<dct:abstract>This ontology defines high-level concepts for organizations and related terms, for use in other FIBO ontology elements.  It is purposefully underspecified to facilitate mapping to specific organization ontologies, such as the emerging W3C organization ontology, organization from a BMM or BPMN perspective, organization from a records management (RMS) perspective, and so forth.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/OwnershipAndControl/Control.rdf
+++ b/fnd/OwnershipAndControl/Control.rdf
@@ -35,7 +35,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Control/">
 		<rdfs:label>Control Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/OwnershipAndControl/Ownership.rdf
+++ b/fnd/OwnershipAndControl/Ownership.rdf
@@ -33,7 +33,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/Ownership/">
 		<rdfs:label>Ownership Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/OwnershipAndControl/OwnershipAndControl.rdf
+++ b/fnd/OwnershipAndControl/OwnershipAndControl.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/OwnershipAndControl/OwnershipAndControl/">
 		<rdfs:label>Ownership and Control Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014 EDM Council, Inc.

--- a/fnd/Parties/Parties.rdf
+++ b/fnd/Parties/Parties.rdf
@@ -33,7 +33,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Parties/Parties/">
 		<rdfs:label>Parties Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/Parties/Roles.rdf
+++ b/fnd/Parties/Roles.rdf
@@ -27,7 +27,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Parties/Roles/">
 		<rdfs:label>Roles Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/Places/Addresses.rdf
+++ b/fnd/Places/Addresses.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Places/Addresses/">
 		<rdfs:label>Addresses Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2016 EDM Council, Inc.

--- a/fnd/Places/Countries.rdf
+++ b/fnd/Places/Countries.rdf
@@ -25,7 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Places/Countries/">
 		<rdfs:label>Countries Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/Places/Facilities.rdf
+++ b/fnd/Places/Facilities.rdf
@@ -31,7 +31,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Places/Facilities/">
 		<rdfs:label>Facilities Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014 EDM Council, Inc.

--- a/fnd/Places/Locations.rdf
+++ b/fnd/Places/Locations.rdf
@@ -23,7 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Places/Locations/">
 		<rdfs:label>Locations Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/Places/VirtualPlaces.rdf
+++ b/fnd/Places/VirtualPlaces.rdf
@@ -31,7 +31,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Places/VirtualPlaces/">
 		<rdfs:label>Virtual Places Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014 EDM Council, Inc.

--- a/fnd/ProductsAndServices/AboutProductsAndServices.rdf
+++ b/fnd/ProductsAndServices/AboutProductsAndServices.rdf
@@ -32,7 +32,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO FND Products and Services Module -->

--- a/fnd/ProductsAndServices/PaymentsAndSchedules.rdf
+++ b/fnd/ProductsAndServices/PaymentsAndSchedules.rdf
@@ -43,7 +43,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/PaymentsAndSchedules/">
 		<rdfs:label>Payments and Schedules Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2017 EDM Council, Inc.

--- a/fnd/ProductsAndServices/ProductsAndServices.rdf
+++ b/fnd/ProductsAndServices/ProductsAndServices.rdf
@@ -46,7 +46,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/ProductsAndServices/ProductsAndServices/">
 		<rdfs:label>Products and Services Ontology</rdfs:label>
 		<dct:abstract>This ontology defines fundamental concepts for buyers, sellers, clients, customers, products, goods and services for use in other FIBO ontologies.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2017 EDM Council, Inc.

--- a/fnd/Quantities/AboutQuantities.rdf
+++ b/fnd/Quantities/AboutQuantities.rdf
@@ -33,7 +33,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2014-2017 EDM Council, Inc.
 Copyright (c) 2014-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+        <dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Foundations Quantities Module -->

--- a/fnd/Quantities/QuantitiesAndUnits.rdf
+++ b/fnd/Quantities/QuantitiesAndUnits.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Quantities/QuantitiesAndUnits/">
 		<rdfs:label>Quantities and Units Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2016 EDM Council, Inc.

--- a/fnd/Relations/Relations.rdf
+++ b/fnd/Relations/Relations.rdf
@@ -28,7 +28,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
 		<rdfs:label>Relations Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a set of general purpose relations for use in other FIBO ontology elements.  These include a number of properties required for reuse across the foundations and business entities models.</dct:abstract>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/Utilities/Analytics.rdf
+++ b/fnd/Utilities/Analytics.rdf
@@ -27,7 +27,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/">
 		<rdfs:label>Analytics Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2017 EDM Council, Inc.

--- a/fnd/Utilities/AnnotationVocabulary.rdf
+++ b/fnd/Utilities/AnnotationVocabulary.rdf
@@ -21,7 +21,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
 		<rdfs:label>Annotation Vocabulary</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/fnd/Utilities/BusinessFacingTypes.rdf
+++ b/fnd/Utilities/BusinessFacingTypes.rdf
@@ -23,7 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/">
 		<rdfs:label>Business Facing Types Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2014 EDM Council, Inc.

--- a/ind/1.1/AboutIND-1.1-NorthAmerica.rdf
+++ b/ind/1.1/AboutIND-1.1-NorthAmerica.rdf
@@ -291,7 +291,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Indices and Indicators (IND) Specification Version 1.1, North American Version -->

--- a/ind/1.1/AboutIND-1.1-ReferenceRates.rdf
+++ b/ind/1.1/AboutIND-1.1-ReferenceRates.rdf
@@ -297,7 +297,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2017 EDM Council, Inc.
 Copyright (c) 2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Indices and Indicators (IND) Specification Version 1.1, Reference Rates Version -->

--- a/ind/1.1/AboutIND-1.1.rdf
+++ b/ind/1.1/AboutIND-1.1.rdf
@@ -265,7 +265,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Indices and Indicators (IND) Specification Version 1.1 -->

--- a/ind/EconomicIndicators/EconomicIndicatorPublishers.rdf
+++ b/ind/EconomicIndicators/EconomicIndicatorPublishers.rdf
@@ -33,7 +33,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicatorPublishers/">
 		<rdfs:label>Economic Indicator Publishers Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2016 EDM Council, Inc.

--- a/ind/EconomicIndicators/EconomicIndicators.rdf
+++ b/ind/EconomicIndicators/EconomicIndicators.rdf
@@ -77,7 +77,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/EconomicIndicators/">
 		<rdfs:label>Economic Indicators Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2017 EDM Council, Inc.

--- a/ind/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf
+++ b/ind/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators.rdf
@@ -53,7 +53,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/NorthAmericanIndicators/CAEconomicIndicators/">
 		<rdfs:label>Canadian Economic Indicators Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016-2017 EDM Council, Inc.

--- a/ind/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf
+++ b/ind/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators.rdf
@@ -57,7 +57,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/EconomicIndicators/NorthAmericanIndicators/USEconomicIndicators/">
 		<rdfs:label>American Economic Indicators Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2016-2017 EDM Council, Inc.

--- a/ind/InterestRates/InterestRatePublishers.rdf
+++ b/ind/InterestRates/InterestRatePublishers.rdf
@@ -37,7 +37,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRatePublishers/">
 		<rdfs:label>Interest Rate Publishers Ontology</rdfs:label>
-		<dct:license rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense</dct:license>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.omg.org/spec/ODM/</sm:contentLanguage>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2016 EDM Council, Inc.

--- a/loan/AboutLOAN.rdf
+++ b/loan/AboutLOAN.rdf
@@ -31,7 +31,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2015-2017 EDM Council, Inc.
 Copyright (c) 2015-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for AboutLOAN -->

--- a/sec/1.0/AboutSEC-1.0-ReferenceIndividuals.rdf
+++ b/sec/1.0/AboutSEC-1.0-ReferenceIndividuals.rdf
@@ -320,7 +320,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2016-2017 EDM Council, Inc.
 Copyright (c) 2016-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Securities (SEC) Specification Version 1.0, Reference Individuals Version -->

--- a/sec/1.0/AboutSEC-1.0.rdf
+++ b/sec/1.0/AboutSEC-1.0.rdf
@@ -280,7 +280,7 @@ xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
 
         <sm:copyright rdf:datatype="&xsd;string">Copyright (c) 2016-2017 EDM Council, Inc.
 Copyright (c) 2016-2017 Object Management Group, Inc.</sm:copyright>
-        <dct:license rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/MITLicense"/>
+        <dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 
 
     <!-- Ontology/File-Level Metadata for About the EDMC-FIBO Securities (SEC) Specification Version 1.0 -->


### PR DESCRIPTION
Changing the license URL to the opensource URL. This will help widoco in generating the license section in the ontology documentation page.  @dallemang @jgeluk .   