### PR TITLE
LOAN-135 #comment - restore use of TextValue in intersection instead of xsd:string

### DIFF
--- a/loan/LoanContracts/LoanCore.rdf
+++ b/loan/LoanContracts/LoanCore.rdf
@@ -30,6 +30,7 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-fnd-utl-val "https://spec.edmcouncil.org/fibo/FND/Utilities/Values/">
 	<!ENTITY fibo-ln-ln-lgn "https://spec.edmcouncil.org/fibo/LOAN/LoanContracts/LoanGeneric/">
 	<!ENTITY fibo-ln-ln-ln "https://spec.edmcouncil.org/fibo/LOAN/LoanContracts/LoanCore/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -70,6 +71,7 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-fnd-utl-val="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/"
 	xmlns:fibo-ln-ln-lgn="https://spec.edmcouncil.org/fibo/LOAN/LoanContracts/LoanGeneric/"
 	xmlns:fibo-ln-ln-ln="https://spec.edmcouncil.org/fibo/LOAN/LoanContracts/LoanCore/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -116,6 +118,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/BusinessFacingTypes/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/Values/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanContracts/LoanGeneric/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/LOAN/LoanContracts/LoanCore/"/>
 		<owl:versionInfo>Created with e6Tools Graphical OWL Editor from D:\SEMANTIC-ARTS\NAS\ClientsAndPartners\EDM Council\fibo ontologies\LoanOntology\loans.vsdx Page:loanCore</owl:versionInfo>
@@ -369,7 +372,7 @@
 		<rdfs:subClassOf>
 			<owl:Class>
 				<owl:intersectionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&xsd;string">
+					<rdf:Description rdf:about="&fibo-fnd-utl-val;TextValue">
 					</rdf:Description>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isClassifiedBy"/>


### PR DESCRIPTION
Since it's invalid to intersect a datatype and class