### PR TITLE
BE-169 #comment - moved the CorporationEquity ontology, which still n…

### DIFF
--- a/sec/Equities/CorporationEquity.rdf
+++ b/sec/Equities/CorporationEquity.rdf
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-corx-ceq "https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/">
 	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-sec-eq-ceq "https://spec.edmcouncil.org/fibo/SEC/Equities/CorporationEquity/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -12,12 +13,13 @@
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/"
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/SEC/Equities/CorporationEquity/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-corx-ceq="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"
 	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-sec-eq-ceq="https://spec.edmcouncil.org/fibo/SEC/Equities/CorporationEquity/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -25,26 +27,30 @@
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/">
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/SEC/Equities/CorporationEquity/">
 		<rdfs:label xml:lang="en">CorporationEquity</rdfs:label>
 		<dct:abstract>This ontology describes equity held in corporations by other corporations. These are mainly relationships.</dct:abstract>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Accounting/AccountingEquity/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/EquityInstruments/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/BE/CorporationsExt/CorporationEquity/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/SEC/Equities/CorporationEquity/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Informative"/>
 	</owl:Ontology>
 	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;governedBy">
-		<rdfs:label xml:lang="en">governed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
-		<skos:definition xml:lang="en">The Company constitution or Articles of Inforporation, Articles of Association etc. which defines the terms for equity instruments issued by that company.</skos:definition>
-	</owl:ObjectProperty>
+	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-ceq;hasCapital"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;hasCapital">
+	<owl:ObjectProperty rdf:about="&fibo-sec-eq-ceq;hasCapital">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-le-cb;issuesEquity"/>
 		<rdfs:label xml:lang="en">has capital</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
@@ -53,41 +59,37 @@
 		<skos:editorialNote xml:lang="en">Review comment: Participation is not necessarily a share. Ownership of the capital.</skos:editorialNote>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;hasHoldingOfAnotherCompanys">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-corx-ceq;hasCapital"/>
+	<owl:ObjectProperty rdf:about="&fibo-sec-eq-ceq;hasHoldingOfAnotherCompanys">
+		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-ceq;hasCapital"/>
 		<rdfs:label xml:lang="en">has holding of another companys</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
 		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
 		<skos:definition xml:lang="en">Equity held by the company, in another company. This is assumed to be publicly issued equity.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;hasMajorityHoldingOfAnotherCompanys">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-corx-ceq;hasHoldingOfAnotherCompanys"/>
+	<owl:ObjectProperty rdf:about="&fibo-sec-eq-ceq;hasMajorityHoldingOfAnotherCompanys">
+		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-ceq;hasHoldingOfAnotherCompanys"/>
 		<rdfs:label xml:lang="en">has majority holding of another companys</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
 		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PubliclyIssuedEquity"/>
 		<skos:definition xml:lang="en">Majority Equity held by the company, in another company. This is assumed to be publicly issued equity.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-be-corx-ceq;mayHaveCapitalAs">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-corx-ceq;hasCapital"/>
+	<owl:ObjectProperty rdf:about="&fibo-sec-eq-ceq;mayHaveCapitalAs">
+		<rdfs:subPropertyOf rdf:resource="&fibo-sec-eq-ceq;hasCapital"/>
 		<rdfs:label xml:lang="en">may have capital as</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
 		<rdfs:range rdf:resource="&fibo-sec-eq-eq;PrivateEquity"/>
 		<skos:definition xml:lang="en">Additional privately held equity in the company, which is not held as publicly issued shares.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+	<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-corx-ceq;hasCapital"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ShareholderEquity"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-oac-exec;ArticlesOfIncorporation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<owl:equivalentClass rdf:resource="&fibo-be-le-cb;StockCorporation"/>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
 	</owl:Class>
 
 </rdf:RDF>


### PR DESCRIPTION
…eeds review, to SEC/Equities, since it depends heavily on other ontologies in that subdomain and thus cannot be in BE due to circular dependencies