### PR TITLE
DER-50 #comment - corrected label on swap terms and also revised pare…

### DIFF
--- a/der/DerivativesContracts/Swaps.rdf
+++ b/der/DerivativesContracts/Swaps.rdf
@@ -340,7 +340,7 @@ Copyright (c) 2016-2018 Object Management Group, Inc.</sm:copyright>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;SecuritiesTransactionIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-aap-agt;identifies"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 				<owl:onClass rdf:resource="&fibo-der-drc-swp;Swap"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>


### PR DESCRIPTION
…nt of unique swap identifier to be a securities transaction identifier rather than a unique trade identifier, since the former is more general and appropriate in this case