### PR TITLE
INFRA-288 Change fibo-infra version in Jenkinsfile to be "master"

### DIFF
--- a/etc/process/Jenkinsfile
+++ b/etc/process/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
   agent none
 
   environment {
-    FIBO_INFRA_BRANCH = 'INFRA-225'
+    FIBO_INFRA_BRANCH = 'master'
     LC_ALL = 'en_US.UTF-8'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'


### PR DESCRIPTION
Jenkinsfile had a bad reference to a version of fibo-infra.   