### PR TITLE
INFRA-318 Updated jena mirror URL and upgraded to 3.8.0

### DIFF
--- a/etc/process/Jenkinsfile-hygiene
+++ b/etc/process/Jenkinsfile-hygiene
@@ -123,10 +123,10 @@ pipeline {
         // we can refer to it further down this file without having to explicitly mention the version number.
         //
         echo 'Checked it all out'
-        sh 'curl --location -O --url http://apache.mirror.anlx.net/jena/binaries/apache-jena-3.7.0.tar.gz'
-        sh 'tar xvzf apache-jena-3.7.0.tar.gz'
-        sh 'rm apache-jena-3.7.0.tar.gz'
-        sh 'mv apache-jena-3.7.0 jena'
+        sh 'curl --location -O --url http://www-us.apache.org/dist/jena/binaries/apache-jena-3.8.0.tar.gz'
+        sh 'tar xvzf apache-jena-3.8.0.tar.gz'
+        sh 'rm apache-jena-3.8.0.tar.gz'
+        sh 'mv apache-jena-3.8.0 jena'
         //
         // Install SPIN
         //


### PR DESCRIPTION
Fixes the tar xvzf error in the hygiene job.
https://jira.edmcouncil.org/browse/INFRA-318