### PR TITLE
Added dct:abstract to all Metadata files that did not have them, in F…

### DIFF
--- a/MetadataFIBO.rdf
+++ b/MetadataFIBO.rdf
@@ -21,6 +21,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/">
 		<rdfs:label>Metadata for the EDMC-FIBO Specification</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the FIBO Specification.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/bp/Process/MetadataBPProcess.rdf
+++ b/bp/Process/MetadataBPProcess.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/Process/MetadataBPProcess/">
 		<rdfs:label>Metadata for the EDMC-FIBO Business Process (BP) Process Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the BP Process Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/bp/Regulatory/MetadataBPRegulatory.rdf
+++ b/bp/Regulatory/MetadataBPRegulatory.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/Regulatory/MetadataBPRegulatory/">
 		<rdfs:label>Metadata for the EDMC-FIBO Business Process (BP) Regulatory Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the BP Regulatory Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/bp/SecuritiesIssuance/MetadataBPSecuritiesIssuance.rdf
+++ b/bp/SecuritiesIssuance/MetadataBPSecuritiesIssuance.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MetadataBPSecuritiesIssuance/">
 		<rdfs:label>Metadata for the EDMC-FIBO Business Process (BP) Securities Issuance Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the BP Securities Issuance Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/cae/CorporateEvents/MetadataCAECorporateEvents.rdf
+++ b/cae/CorporateEvents/MetadataCAECorporateEvents.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/">
 		<rdfs:label>Metadata for the EDMC-FIBO Corporate Actions and Events (CAE) CorporateEvents Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the CAE Corporate Events Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/civ/Funds/MetadataCIVFunds.rdf
+++ b/civ/Funds/MetadataCIVFunds.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/MetadataCIVFunds/">
 		<rdfs:label>Metadata for the EDMC-FIBO Collective Investment Vehicles (CIV) Funds Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the CIV Funds Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/civ/FundsExt/MetadataCIVFundsExt.rdf
+++ b/civ/FundsExt/MetadataCIVFundsExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CIV/FundsExt/MetadataCIVFundsExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Collective Investment Vehicles (CIV) FundsExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the CIV Funds Extensions Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/Accounting/MetadataFNDAccounting.rdf
+++ b/fnd/Accounting/MetadataFNDAccounting.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/MetadataFNDAccounting/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Accounting Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Accounting Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/AccountingExt/MetadataFNDAccountingExt.rdf
+++ b/fnd/AccountingExt/MetadataFNDAccountingExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/AccountingExt/MetadataFNDAccountingExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) AccountingExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Accounting ExtensionsX Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/AgentsAndPeople/MetadataFNDAgentsAndPeople.rdf
+++ b/fnd/AgentsAndPeople/MetadataFNDAgentsAndPeople.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/MetadataFNDAgentsAndPeople/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Agents and People Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Agents and People Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/Agreements/MetadataFNDAgreements.rdf
+++ b/fnd/Agreements/MetadataFNDAgreements.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/MetadataFNDAgreements/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Agreements Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Agreements Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/AgreementsExt/MetadataFNDAgreementsExt.rdf
+++ b/fnd/AgreementsExt/MetadataFNDAgreementsExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/AgreementsExt/MetadataFNDAgreementsExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) AgreementsExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Agreements Extensions Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/Arrangements/MetadataFNDArrangements.rdf
+++ b/fnd/Arrangements/MetadataFNDArrangements.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/MetadataFNDArrangements/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Arrangements Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Arrangements Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/ArrangementsExt/MetadataFNDArrangementsExt.rdf
+++ b/fnd/ArrangementsExt/MetadataFNDArrangementsExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/ArrangementsExt/MetadataFNDArrangementsExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) ArrangementsExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Arrangements Extensions Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/BusinessExt/MetadataFNDBusinessExt.rdf
+++ b/fnd/BusinessExt/MetadataFNDBusinessExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/BusinessExt/MetadataFNDBusinessExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) BusinessExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Business Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/Communication/MetadataFNDCommunication.rdf
+++ b/fnd/Communication/MetadataFNDCommunication.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Communication/MetadataFNDCommunication/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Communication Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Communications Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/DatesAndTimes/MetadataFNDDatesAndTimes.rdf
+++ b/fnd/DatesAndTimes/MetadataFNDDatesAndTimes.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/MetadataFNDDatesAndTimes/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Dates and Times Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Dates and Times Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/GoalsAndObjectives/MetadataFNDGoalsAndObjectives.rdf
+++ b/fnd/GoalsAndObjectives/MetadataFNDGoalsAndObjectives.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/MetadataFNDGoalsAndObjectives/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Goals and Objectives Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Goals and Objectives Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/GoalsAndObjectivesExt/MetadataFNDGoalsAndObjectivesExt.rdf
+++ b/fnd/GoalsAndObjectivesExt/MetadataFNDGoalsAndObjectivesExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectivesExt/MetadataFNDGoalsAndObjectivesExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Goals and Objectives Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Goals and Objectives Extensions Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/InformationExt/MetadataFNDInformationExt.rdf
+++ b/fnd/InformationExt/MetadataFNDInformationExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/InformationExt/MetadataFNDInformationExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) InformationExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Information Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/Law/MetadataFNDLaw.rdf
+++ b/fnd/Law/MetadataFNDLaw.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Law/MetadataFNDLaw/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Law Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Law Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/LawExt/MetadataFNDLawExt.rdf
+++ b/fnd/LawExt/MetadataFNDLawExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/LawExt/MetadataFNDLawExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) LawExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Law Extensions Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/MathExt/MetadataFNDMathExt.rdf
+++ b/fnd/MathExt/MetadataFNDMathExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/MathExt/MetadataFNDMathExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) MathExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Math Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/Organizations/MetadataFNDOrganizations.rdf
+++ b/fnd/Organizations/MetadataFNDOrganizations.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/MetadataFNDOrganizations/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Organizations Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Organizations Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/OwnershipAndControl/MetadataFNDOwnershipAndControl.rdf
+++ b/fnd/OwnershipAndControl/MetadataFNDOwnershipAndControl.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/MetadataFNDOwnershipAndControl/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Ownership and Control Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Ownership and Control Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/Parties/MetadataFNDParties.rdf
+++ b/fnd/Parties/MetadataFNDParties.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/MetadataFNDParties/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Parties Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Parties Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/PartiesExt/MetadataFNDPartiesExt.rdf
+++ b/fnd/PartiesExt/MetadataFNDPartiesExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/PartiesExt/MetadataFNDPartiesExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) PartiesExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Parties Extensions Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/PhysicalExt/MetadataFNDPhysicalExt.rdf
+++ b/fnd/PhysicalExt/MetadataFNDPhysicalExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/PhysicalExt/MetadataFNDPhysicalExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) PhysicalExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Physical Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/Places/MetadataFNDPlaces.rdf
+++ b/fnd/Places/MetadataFNDPlaces.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Places/MetadataFNDPlaces/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Places Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Places Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/PlacesExt/MetadataFNDPlacesExt.rdf
+++ b/fnd/PlacesExt/MetadataFNDPlacesExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/PlacesExt/MetadataFNDPlacesExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) PlacesExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Places Extensions Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/ProductsAndServices/MetadataFNDProductsAndServices.rdf
+++ b/fnd/ProductsAndServices/MetadataFNDProductsAndServices.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/MetadataFNDProductsAndServices/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Products and Services Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Products and Services Module.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2015-2017 EDM Council, Inc.</sm:copyright>

--- a/fnd/PublicationsExt/MetadataFNDPublicationsExt.rdf
+++ b/fnd/PublicationsExt/MetadataFNDPublicationsExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/PublicationsExt/MetadataFNDPublicationsExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) PublicationsExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Publications Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/Quantities/MetadataFNDQuantities.rdf
+++ b/fnd/Quantities/MetadataFNDQuantities.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/MetadataFNDQuantities/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Quantities Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Quantities Module.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/QuantitiesExt/MetadataFNDQuantitiesExt.rdf
+++ b/fnd/QuantitiesExt/MetadataFNDQuantitiesExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/QuantitiesExt/MetadataFNDQuantitiesExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) QuantitiesExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Quantities Extensions Module.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/Relations/MetadataFNDRelations.rdf
+++ b/fnd/Relations/MetadataFNDRelations.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/MetadataFNDRelations/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Relations Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Relations Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/fnd/RiskExt/MetadataFNDRiskExt.rdf
+++ b/fnd/RiskExt/MetadataFNDRiskExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/RiskExt/MetadataFNDRiskExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) RiskExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Risk Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/SocialConstructsExt/MetadataFNDSocialConstructsExt.rdf
+++ b/fnd/SocialConstructsExt/MetadataFNDSocialConstructsExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/SocialConstructsExt/MetadataFNDSocialConstructsExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) SocialConstructsExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Social Constructs Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/TimeExt/MetadataFNDTimeExt.rdf
+++ b/fnd/TimeExt/MetadataFNDTimeExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/MetadataFNDTimeExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) TimeExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Time Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/TransactionsExt/MetadataFNDTransactionsExt.rdf
+++ b/fnd/TransactionsExt/MetadataFNDTransactionsExt.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/MetadataFNDTransactionsExt/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) TransactionsExt Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Transactions Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-07-02T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/fnd/Utilities/MetadataFNDUtilities.rdf
+++ b/fnd/Utilities/MetadataFNDUtilities.rdf
@@ -25,6 +25,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/MetadataFNDUtilities/">
 		<rdfs:label>Metadata for the EDMC-FIBO Foundations (FND) Utilities Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the Foundations Utilities Module.</dct:abstract>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>

--- a/loan/LoanContracts/MetadataLOANLoanContracts.rdf
+++ b/loan/LoanContracts/MetadataLOANLoanContracts.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/MetadataLOANLoanContracts/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) LoanContracts Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the LOAN Loan Contracts Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/loan/LoanTypes/MetadataLOANLoanTypes.rdf
+++ b/loan/LoanTypes/MetadataLOANLoanTypes.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/MetadataLOANLoanTypes/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) LoanTypes Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the LOAN Loan Types Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/loan/Loans/MetadataLOANLoans.rdf
+++ b/loan/Loans/MetadataLOANLoans.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/MetadataLOANLoans/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) Loans Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the LOAN Loans Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/loan/LoansTemporal/MetadataLOANLoansTemporal.rdf
+++ b/loan/LoansTemporal/MetadataLOANLoansTemporal.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansTemporal/MetadataLOANLoansTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) LoansTemporal Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the LOAN Loans Temporal Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/md/CIVTemporal/MetadataMDCIVTemporal.rdf
+++ b/md/CIVTemporal/MetadataMDCIVTemporal.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) CIVTemporal Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the MD CIV Temporal Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/md/DebtTemporal/MetadataMDDebtTemporal.rdf
+++ b/md/DebtTemporal/MetadataMDDebtTemporal.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) DebtTemporal Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the MD Debt Temporal Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/md/DerivativesTemporal/MetadataMDDerivativesTemporal.rdf
+++ b/md/DerivativesTemporal/MetadataMDDerivativesTemporal.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) DerivativesTemporal Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the MD Derivatives Temporal Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/md/EquityTemporal/MetadataMDEquityTemporal.rdf
+++ b/md/EquityTemporal/MetadataMDEquityTemporal.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/EquityTemporal/MetadataMDEquityTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) EquityTemporal Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the MD Equity Temporal Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>

--- a/md/TemporalCore/MetadataMDTemporalCore.rdf
+++ b/md/TemporalCore/MetadataMDTemporalCore.rdf
@@ -23,6 +23,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) TemporalCore Module</rdfs:label>
+		<dct:abstract>This is the metadata ontology used to describe the MD Temporal Core Module.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
 		<dct:license rdf:resource="&sm;MITLicense"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>


### PR DESCRIPTION
…ND, for FIBO metadata file, and in non-Release domain modules, in response to Hygiene test issues in FND-208.