### PR TITLE
BE-114 #comment - modified the parent of License from Agreement to Le…

### DIFF
--- a/fnd/Law/LegalCapacity.rdf
+++ b/fnd/Law/LegalCapacity.rdf
@@ -299,6 +299,7 @@
 		<rdfs:label>license</rdfs:label>
 		<skos:definition>grant of permission needed to do something</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>Note that in some cases, a license may also be considered an agreement or contract, depending on the specifics of the license and jurisdiction.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-lcap;LicenseIdentifier">


### PR DESCRIPTION
…galDocument, which is more appropriate (all licenses, including fishing licenses, business licenses, and software licenses are legal documents, but not necessarily agreements since they are often unilateral)