### PR TITLE
FND-210 remove the annotation property nameOrigin

### DIFF
--- a/fnd/Utilities/AnnotationVocabulary.rdf
+++ b/fnd/Utilities/AnnotationVocabulary.rdf
@@ -111,6 +111,13 @@ Note that any of the original properties provided in Dublin Core and SKOS can be
 		<skos:definition>identifies the date a model element in the body of an ontology was changed</skos:definition>
 	</owl:AnnotationProperty>
 	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;nameOrigin">
+		<rdfs:subPropertyOf rdf:resource="&sm;directSource"/>
+		<rdfs:label>name origin</rdfs:label>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<skos:definition>provides the means to document the name of the original term in the source referenced via termOrigin; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
+	</owl:AnnotationProperty>
+	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;synonym">
 		<rdfs:subPropertyOf rdf:resource="&skos;altLabel"/>
 		<rdfs:label>synonym</rdfs:label>


### PR DESCRIPTION
Deletion of the Annotation Property nameOrigin. 

Check before actioning this Pull Request: 
1. that the rule about deprecating elements don't apply to metadata annotations (otherwise why have this JIRA at all?)
2. That the apparent movement of the texts shown in the diffs for logicalDefinition (for which no change was made in the scope of this JIRA) are harmless. Note that this appears to be an annotation property with an incorrect rdfs label, again not in scope but is an error so needs a new JIRA. Perhaps the serializer tripped on that?
3. That I have followed this process correctly, this being my first go. 
