### PR TITLE
FBC-203 #comment - moved the CreditEvents ontology from MD/TemporalCo…

### DIFF
--- a/DER/CreditDerivatives/CreditDefaultSwaps.rdf
+++ b/DER/CreditDerivatives/CreditDefaultSwaps.rdf
@@ -4,6 +4,7 @@
 	<!ENTITY fibo-der-cr-cds "https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
+	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -20,7 +21,6 @@
 	<!ENTITY fibo-fnd-txn-sec "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-fnd-utl-val "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/">
-	<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -32,6 +32,7 @@
 	xmlns:fibo-der-cr-cds="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
+	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -48,7 +49,6 @@
 	xmlns:fibo-fnd-txn-sec="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/SecuritiesTransactions/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-fnd-utl-val="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/"
-	xmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -61,6 +61,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -79,7 +80,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/LoanBasicTerms/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
@@ -187,7 +187,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-cr-cds;CDSCreditEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-cr-cds;notifiedBy"/>
@@ -831,7 +831,7 @@
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-cr-cds;pertainsTo">
-		<rdfs:subPropertyOf rdf:resource="&fibo-md-temx-cre;pertainsTo"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-dae-cre;pertainsTo"/>
 		<rdfs:label xml:lang="en">pertains to by reference</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-cr-cds;CDSCreditEvent"/>
 		<rdfs:range rdf:resource="&fibo-der-cr-cds;CDSCreditEventReference"/>

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-drc-ma "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/">
+	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-agrx-ele "https://spec.edmcouncil.org/fibo/ontology/FND/AgreementsExt/ContractElements/">
@@ -14,7 +15,6 @@
 	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/">
 	<!ENTITY fibo-fnd-txn-txnx "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionsExtended/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -26,6 +26,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-drc-ma="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/"
+	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-agrx-ele="https://spec.edmcouncil.org/fibo/ontology/FND/AgreementsExt/ContractElements/"
@@ -37,7 +38,6 @@
 	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"
 	xmlns:fibo-fnd-txn-txnx="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionsExtended/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -53,6 +53,7 @@
 		<sm:copyright>Copyright (c) 2015-2018 EDM Council, Inc.
 Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgreementsExt/ContractElements/"/>
@@ -66,7 +67,6 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionsExtended/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
@@ -77,7 +77,7 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;definesTermsFor"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit event definition</rdfs:label>
@@ -107,8 +107,8 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;CreditSupportDefaultEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-ma;isFailureInForceOf"/>
@@ -277,7 +277,7 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-drc-ma;invokedInEventOf.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -544,7 +544,7 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;invokedInEventOf.1">
 		<rdfs:label xml:lang="en">invoked in event of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-ma;MasterAgreementRightToTerminationFollowingDefaultEvent"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+		<rdfs:range rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;isFailureInForceOf">

--- a/FBC/DebtAndEquities/CreditEvents.rdf
+++ b/FBC/DebtAndEquities/CreditEvents.rdf
@@ -2,69 +2,78 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
+	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
+	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/">
+	<!ENTITY fibo-fnd-arr-cd "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Codes/">
+	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
-	<!ENTITY fibo-fnd-utl-val "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/">
-	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/LoanCore/">
-	<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
 	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
 ]>
-<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
+	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
+	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"
+	xmlns:fibo-fnd-arr-cd="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Codes/"
+	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
-	xmlns:fibo-fnd-utl-val="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/"
-	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/LoanCore/"
-	xmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
-	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/">
-		<rdfs:label xml:lang="en">CreditEvents</rdfs:label>
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
+		<rdfs:label xml:lang="en">Credit Events Ontology</rdfs:label>
 		<dct:abstract>This ontology defines a range of credit events, that is events in which some payment or payments are not made. These include credit events relating to a specific debt obligation and events relating to the business entity as a whole. 
 		Note: these were derived from the credit default swaps model, with extensive reference to the FpML standard for those instruments. Additional kinds of credit event may be needed for loan and other contexts.</dct:abstract>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Codes/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/LoanCore/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;Bankruptcy">
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;Bankruptcy">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 		<rdfs:label xml:lang="en">bankruptcy</rdfs:label>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Bankruptcy would not be a Credit Event since the defined creti events are set up as earlier identification of the risk.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition xml:lang="en">a state or condition in which a party is insolvent or unable to meet debt obligations</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Banking Terms, Sixth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://thelawdictionary.org/bankruptcy/</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;CreditEvent">
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;CreditEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;OccurrenceKind"/>
 		<rdfs:label xml:lang="en">credit event</rdfs:label>
-		<skos:definition xml:lang="en">An event which has some bearing on the credit worthiness of the Reference Entity.</skos:definition>
+		<skos:definition xml:lang="en">a sudden change in a borrower&apos;s credit standing, such as bankruptcy or a violation of a bond indenture or loan agreement, that raises doubts about the borrower&apos;s ability to meet current or future obligations</skos:definition>
 		<skos:editorialNote xml:lang="en">ISDA has combinations of credit event types. These are: Bankruptcy Failure to pay principal Failure to pay interest Obligation Default Obligation Acceleration Repudiation / Moratorium Distressed Ratings Downgrade Maturity Extension Writedown Not yes/no: Restructuring (Restructuring structure) Failure to Pay (Failure to Pay structure) Default Requirement (Monetary Amount) - applies to: Obligation Acceleration, Obligation Default, Repudiation/Moratorium, Restructuring Credit Event notice (Notice) Review note: term not in FpML, called Failure to Repair event (May equate to ISDA &quot;Failure To Pay&quot;) Conclusion: It is the same thing. Added as synonym Modeling note: Note that some of these are simple &quot;Yes/no&quot; conditions i.e. the event has happened or it has not. Others comprise more detailed information. However, 4 of those that are given as &quot;yes/no&quot; in FpML do in fact have the additional fact of Default Requirement. So almost none are simple yes/no or list entry terms. Modeled accordingly. Note also that the term Credit Event is defined more widely than just in CDS, for example in credit indices or just as business events generally. Therefore some of the CDS-specific terms here won&apos;t apply in those other contexts. Review comment: 22 styles of ISDA agreements for CDS as well, with different combinations of terms. FpML Full Definition: &apos;This element contains all the ISDA terms relating to credit events.&apos;</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;DistressedRatingsDowngrade">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;DistressedRatingsDowngrade">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationCreditEvent"/>
 		<rdfs:label xml:lang="en">distressed ratings downgrade</rdfs:label>
 		<skos:definition xml:lang="en">The fact that the rating of the reference obligation is downgraded to a distressed rating level. Further notes: From a usage standpoint, this credit event is typically not applicable in case of RMBS trades. A credit event. FpML full definition: &apos;A credit event. Results from the fact that the rating of the reference obligation is downgraded to a distressed rating level. From a usage standpoint, this credit event is typically not applicable in case of RMBS trades.&apos;</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;EntityCreditEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;EntityCreditEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-cre;pertainsTo"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-cre;pertainsTo"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-le-cb;Corporation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -73,12 +82,12 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The Reference Entity is some business entity, i.e. the company or other entity to which the Credit Event relates. Some CDS terms define some terms in relation to the entity, and some with reference to a specific debt obligation, called the Reference Obligation. Scope Note: There are open questions about events which relate to some debt obligation which is not the Reference Obligation of a specific CDS contract.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;FailureToPay">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;FailureToPay">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationCreditEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-cre;gracePeriod"/>
-				<owl:onClass rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-cre;gracePeriod"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
 				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -87,52 +96,44 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This credit event corresponds to a failure to pay principal or interest after the applicable grace period, and is therefore not the common super-type of Failure to pay Interest and Failure to pay Principal - those are simple missed payments. By implication therefore, this event comes under the more serious heading (Hard Credit Event).</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;FailureToPayInterest">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;FailureToPayInterest">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationCreditEvent"/>
 		<rdfs:label xml:lang="en">failure to pay interest</rdfs:label>
 		<skos:definition xml:lang="en">The failure by the Reference Entity to pay an expected interest amount or the payment of an actual interest amount that is less than the expected interest amount. Further notes: A credit event. ISDA 2003 Term: Failure to Pay Interest. FpML full definition: &apos;A credit event. Corresponds to the failure by the Reference Entity to pay an expected interest amount or the payment of an actual interest amount that is less than the expected interest amount. ISDA 2003 Term: Failure to Pay Interest.&apos;</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;FailureToPayPrincipal">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;FailureToPayPrincipal">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationCreditEvent"/>
 		<rdfs:label xml:lang="en">failure to pay principal</rdfs:label>
 		<skos:definition xml:lang="en">The failure by the Reference Entity to pay an expected principal amount or the payment of an actual principal amount that is less than the expected principal amount. Further notes: A credit event. ISDA 2003 Term: Failure to Pay Principal.&apos; FpML full definition: &apos;A credit event. Corresponds to the failure by the Reference Entity to pay an expected principal amount or the payment of an actual principal amount that is less than the expected principal amount. ISDA 2003 Term: Failure to Pay Principal.&apos;</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;FilingForBankruptcy">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;EntityCreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;FilingForBankruptcy">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;EntityCreditEvent"/>
 		<rdfs:label xml:lang="en">filing for bankruptcy</rdfs:label>
 		<skos:definition xml:lang="en">An event in which an organization files for bankruptcy.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This may be defined as the Credit Event in a CDS.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;HardCreditEvent">
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;HardCreditEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 		<rdfs:label xml:lang="en">hard credit event</rdfs:label>
 		<skos:definition xml:lang="en">Hard default. This is defined by the event not being repairable.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Soft and Hard defaults are defined by whether or not the event is repairable. Typically defined by the crossing of some threshold in some measurement. If you don&apos;t repair, this becomes a &quot;failure to repair&quot; credit event. The &quot;failure to repair&quot; triggers either a hard default or there is a whole lot of possible terms about the extension of the grace period.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;MaturityExtension">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;MaturityExtension">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationCreditEvent"/>
 		<rdfs:label xml:lang="en">maturity extension</rdfs:label>
 		<skos:definition xml:lang="en">The fact that the underlier fails to make principal payments as expected. Further notes: A credit event. REVIEW: The definition from FpML appears to be a variant on that for Failure To Pay Principal. The definition given here is the definition of a failure to pay principal but the FpML definition for Failure to pay Principal is more detailed. This definition alone does not justify an extension of the maturity. FpML full definition: &apos;A credit event. Results from the fact that the underlier fails to make principal payments as expected.&apos;</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;ObligationCreditEvent">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;ObligationCreditEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-cre;pertainsTo"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-loan-ln-ln;LoanContract">
-							</rdf:Description>
-							<rdf:Description rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/TradableDebtInstrument">
-							</rdf:Description>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-cre;pertainsTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;CreditAgreement"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">obligation credit event</rdfs:label>
@@ -140,19 +141,19 @@
 		<skos:editorialNote xml:lang="en">From inspection of the ISDA definitions it is clear that some Credit Events relate to a business entity (legal entity since it is incurring debts) while others relate specifically to an individual instrument. The distinction may be of minor interest in practice since most entities would presumably only have one debt instrument in issue. This term added to pick up the explicit relationship to the Reference Obligation for these Credit Event types. The others are deemed to relate to the Reference Entity directly and to the Reference Obligation by extension.</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;RepudiationOrMoratorium">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;EntityCreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;RepudiationOrMoratorium">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;EntityCreditEvent"/>
 		<rdfs:label xml:lang="en">repudiation or moratorium</rdfs:label>
 		<skos:definition xml:lang="en">The reference entity, or a governmental authority, either refuses to recognise or challenges the validity of one or more obligations of the reference entity, or imposes a moratorium thereby postponing payments on one or more of the obligations of the reference entity.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Subject to the default requirement amount. This is a Credit Event. ISDA 2003 Term: Repudiation/Moratorium FpML full definition: &apos;A credit event. The reference entity, or a governmental authority, either refuses to recognise or challenges the validity of one or more obligations of the reference entity, or imposes a moratorium thereby postponing payments on one or more of the obligations of the reference entity. Subject to the default requirement amount. ISDA 2003 Term: Repudiation/Moratorium.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;Restructuring">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;EntityCreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;Restructuring">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;EntityCreditEvent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-md-temx-cre;hasRestructuringTypeCode"/>
-				<owl:allValuesFrom rdf:resource="&fibo-md-temx-cre;RestructuringTypeCode"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-cre;hasRestructuringTypeCode"/>
+				<owl:allValuesFrom rdf:resource="&fibo-fbc-dae-cre;RestructuringTypeCode"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">restructuring</rdfs:label>
@@ -160,11 +161,12 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This is a Credit Event. ISDA 2003 Term: Restructuring. FpML full definition: &apos;A credit event. A restructuring is an event that materially impacts the reference entity\&apos;s obligations, such as an interest rate reduction, principal reduction, deferral of interest or principal, change in priority ranking, or change in currency or composition of payment. ISDA 2003 Term: Restructuring.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;RestructuringTypeCode">
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;RestructuringTypeCode">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cd;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/hasDefinition"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;RestructuringTypeScheme"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasDefinition"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-cre;RestructuringTypeScheme"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">restructuring type code</rdfs:label>
@@ -184,105 +186,106 @@ Consensus:Review</skos:editorialNote>
 		<skos:editorialNote xml:lang="en">is of type defined in: The scheme which defines the type of restructuring that is applicable. (former property)</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;RestructuringTypeScheme">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Codes/CodeSet"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;RestructuringTypeScheme">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cd;CodeSet"/>
 		<rdfs:label xml:lang="en">restructuring type scheme</rdfs:label>
 		<skos:definition xml:lang="en">The scheme which defines the restructuring type in a Restructuring credit event.</skos:definition>
 		<skos:editorialNote xml:lang="en">No definition given in the FpML schema. This is given as a URI with which to identify the scheme.</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;SoftCreditEvent">
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;SoftCreditEvent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 		<rdfs:label xml:lang="en">soft credit event</rdfs:label>
 		<skos:definition xml:lang="en">Soft default. This is defined by the event being repairable.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Soft and Hard defaults are defined by whether or not the event is repairable. Typically defined by the crossing of some threshold in some measurement. If you don&apos;t repair, this becomes a &quot;failure to repair&quot; credit event. The &quot;failure to repair&quot; (Failure To Pay) triggers either a hard default or there is a whole lot of possible terms about the extension of the grace period. Grace period extension applicability would in principle apply to the soft credit event. The hard credit event (e.g. Failure to Repair) is after such a period, if it exists, has passed.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-md-temx-cre;Writedown">
-		<rdfs:subClassOf rdf:resource="&fibo-md-temx-cre;ObligationCreditEvent"/>
+	<owl:Class rdf:about="&fibo-fbc-dae-cre;Writedown">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-cre;ObligationCreditEvent"/>
 		<rdfs:label xml:lang="en">writedown</rdfs:label>
 		<skos:definition xml:lang="en">The fact that the underlier writes down its outstanding principal amount. Further notes: A credit event. FpML full definition: &apos;A credit event. Results from the fact that the underlier writes down its outstanding principal amount.&apos;</skos:definition>
 	</owl:Class>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-md-temx-cre;applicable">
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-cre;applicable">
 		<rdfs:label xml:lang="en">applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;FailureToPay"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether the failure to pay provision is applicable Further notes: FpML full definition: &apos;Indicates whether the failure to pay provision is applicable.&apos;</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-md-temx-cre;applicable.1">
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-cre;applicable.1">
 		<rdfs:label xml:lang="en">applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;Restructuring"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether the restructuring provision is applicable.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;defaultRequirement">
+	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-cre;defaultRequirement">
 		<rdfs:label xml:lang="en">default requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;RepudiationOrMoratorium"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;RepudiationOrMoratorium"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">The threshold for Repudiation/Moratorium.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;defaultRequirement.1">
+	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-cre;defaultRequirement.1">
 		<rdfs:label xml:lang="en">default requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;Restructuring"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">The threshold for Restructuring.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;gracePeriod">
+	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-cre;gracePeriod">
 		<rdfs:label xml:lang="en">grace period</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DatePeriod"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;FailureToPay"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
 		<skos:definition xml:lang="en">The period of days after any due date that the reference entity has to fulfil its obligations before a failure to pay credit event is deemed to have occurred. Further notes: ISDA 2003 Term: Grace Period. Note this may be a period denominated in business days or calendar days - this is a qualifying fact about the referenced term &quot;Date Period&quot;. FpML full definition: &apos;The number of calendar or business days after any due date that the reference entity has to fulfil its obligations before a failure to pay credit event is deemed to have occurred. ISDA 2003 Term: Grace Period.&apos;</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-md-temx-cre;gracePeriodExtensionApplicable">
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-cre;gracePeriodExtensionApplicable">
 		<rdfs:label xml:lang="en">grace period extension applicable</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;FailureToPay"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Whether the grace period extension provision is applicable. Further notes: Whether this is applicable or not would vary by jurisdiction. Would in fact be a clause in the Loan Contract. There may also be statutory clauses that would override those in a contract, for a given jurisidction. FpML full definition: &apos;Indicates whether the grace period extension provision is applicable.&apos;</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;hasRestructuringTypeCode">
+	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-cre;hasRestructuringTypeCode">
 		<rdfs:label xml:lang="en">has restructuring type code</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
-		<rdfs:range rdf:resource="&fibo-md-temx-cre;RestructuringTypeCode"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;Restructuring"/>
+		<rdfs:range rdf:resource="&fibo-fbc-dae-cre;RestructuringTypeCode"/>
 		<skos:definition xml:lang="en">has a code representing the kind of restructuring event in relation to some defined scheme of such</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-md-temx-cre;hasSchemeReference">
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-cre;hasSchemeReference">
 		<rdfs:label xml:lang="en">has scheme reference</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;RestructuringTypeScheme"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;RestructuringTypeScheme"/>
 		<rdfs:range rdf:resource="&xsd;anyURI"/>
 		<skos:definition xml:lang="en">The reference by which the scheme is identified, as a URI.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-md-temx-cre;multipleCreditEvent">
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-cre;multipleCreditEvent">
 		<rdfs:label xml:lang="en">multiple credit event</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;Restructuring"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">Section 3.9 of the ISDA 2003 Credit Derivatives Definitions shall apply.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-md-temx-cre;multipleHolderObligation">
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-dae-cre;multipleHolderObligation">
 		<rdfs:label xml:lang="en">multiple holder obligation</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;Restructuring"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;Restructuring"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition xml:lang="en">A multiple holder obligation means an obligation that is held by more than three holders that are not affiliates of each other and where at least two thirds of the holders must agree to the event that constitutes the restructuring credit event.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;paymentRequirement">
+	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-cre;paymentRequirement">
 		<rdfs:label xml:lang="en">payment requirement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;FailureToPay"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;FailureToPay"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">A threshold for the failure to pay credit event. Further notes: Market standard is USD 1,000,000 (JPY 100,000,000 for Japanese Yen trades) or its equivalent in the relevant obligation currency. This is applied on an aggregate basis across all Obligations of the Reference Entity. Intended to prevent technical/operational errors from triggering credit events. ISDA 2003 Term: Payment Requirement. FpML full definition: &apos;Specifies a threshold for the failure to pay credit event. Market standard is USD 1,000,000 (JPY 100,000,000 for Japanese Yen trades) or its equivalent in the relevant obligation currency. This is applied on an aggregate basis across all Obligations of the Reference Entity. Intended to prevent technical/operational errors from triggering credit events. ISDA 2003 Term: Payment Requirement.&apos;</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-md-temx-cre;pertainsTo">
+	<owl:ObjectProperty rdf:about="&fibo-fbc-dae-cre;pertainsTo">
 		<rdfs:label xml:lang="en">pertains to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 		<rdfs:range rdf:resource="&owl;Thing"/>
 	</owl:ObjectProperty>
 

--- a/IND/MarketIndices/BasketIndices.rdf
+++ b/IND/MarketIndices/BasketIndices.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fbc-dae-cre "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
@@ -16,7 +17,6 @@
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY fibo-ind-ind-ind "https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/">
 	<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/">
-	<!ENTITY fibo-md-temx-cre "https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/">
 	<!ENTITY fibo-sec-sec-bsk "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -27,6 +27,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fbc-dae-cre="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
@@ -42,7 +43,6 @@
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:fibo-ind-ind-ind="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"
 	xmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"
-	xmlns:fibo-md-temx-cre="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"
 	xmlns:fibo-sec-sec-bsk="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -64,6 +64,7 @@
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-ind-mkt-bas</sm:fileAbbreviation>
 		<sm:filename>BasketIndices.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -78,7 +79,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/Baskets/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -134,7 +134,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-md-temx-cre;CreditEvent"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-cre;CreditEvent"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">credit index reference constituent</rdfs:label>

--- a/LOAN/Loans/LoanBasicTerms.rdf
+++ b/LOAN/Loans/LoanBasicTerms.rdf
@@ -81,7 +81,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/LoansGuaranties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/LoansParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansTemporal/LoanPhases/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/TemporalConcepts/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/LoanBasicTerms/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>

--- a/MD/TemporalCore/MetadataMDTemporalCore.rdf
+++ b/MD/TemporalCore/MetadataMDTemporalCore.rdf
@@ -37,7 +37,6 @@
 		<rdfs:label>Temporal Core</rdfs:label>
 		<dct:abstract>This module contains ontologies of temporally variable concepts common to all instruments, funds and loans. These are concepts for variables that have past, presented and projected future values, such as pricing, yields and analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/AnalysisCurves/"/>
-		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditEvents/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/CreditRatings/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/InstrumentTemporalTerms/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityCreditStatuses/"/>


### PR DESCRIPTION
…re to FBC/DebtAndEquities; revised all references to point to the new location; updated the ontology to eliminate references to other provisional ontologies and better integrated content with the current FIBO class hierarchy as a first pass to clean it up a bit