### PR TITLE
DER-60 #comment - replaced references to the TimeExt ontology with th…

### DIFF
--- a/DER/DerivativesContracts/ContractsForDifference.rdf
+++ b/DER/DerivativesContracts/ContractsForDifference.rdf
@@ -8,7 +8,6 @@
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -25,7 +24,6 @@
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -44,7 +42,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ContractsForDifference/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -112,7 +109,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-cfd;rollingFrequency">
 		<rdfs:label xml:lang="en">rolling frequency</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-cfd;ContractForDifference"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Frequency"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RecurrenceInterval"/>
 		<skos:definition xml:lang="en">In principle they can be rolled on any agreed basis. Usually no firm idea on when the parties want to settle, will hold untilo they feel like terminating, nbut there&apos;s no reason why this might not be made weekly or monthly.</skos:definition>
 	</owl:ObjectProperty>
 	

--- a/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
+++ b/DER/DerivativesContracts/DerivativesMasterAgreements.rdf
@@ -7,12 +7,12 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-agrx-ele "https://spec.edmcouncil.org/fibo/ontology/FND/AgreementsExt/ContractElements/">
+	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/ontology/FND/ArrangementsExt/MethodsAndRules/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/">
 	<!ENTITY fibo-fnd-txn-txnx "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionsExtended/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -30,12 +30,12 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-agrx-ele="https://spec.edmcouncil.org/fibo/ontology/FND/AgreementsExt/ContractElements/"
+	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/ontology/FND/ArrangementsExt/MethodsAndRules/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"
 	xmlns:fibo-fnd-txn-txnx="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionsExtended/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -50,8 +50,8 @@
 		<dct:abstract>Terms that make up the OTC Derivatives Master agreement as defined in the ISDA literature. This is an experimental ontology and needs considerable re-work if it is to be considered for release.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2018 EDM Council, Inc.
-Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2019 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2019 Object Management Group, Inc.</sm:copyright>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/CreditEvents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -63,7 +63,6 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionsExtended/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
@@ -165,20 +164,23 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 		<skos:example xml:lang="en">Sample preamble to one of these: &quot;EXAMPLE BANK, a Michigan banking corporation and SAMPLECOMPANY US, INC. a Delaware corporation have entered and/or anticipate entering into one or more transactions (each a &quot;Transaction&quot;) that are or will be governed by this Master Agreement, which includes the schedule (the &quot;Schedule&quot;), and the documents and other confirming evidence (each a &quot;Confirmation&quot;) exchanged between the parties confirming those Transactions. &quot;</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-drc-ma;EarlyTerminationDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;Date"/>
-		<rdfs:label xml:lang="en">early termination date</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-drc-ma;EarlyTerminationDateDeterminingAgent">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-tim-tim;DateDeterminingAgent"/>
+	<owl:Class rdf:about="&fibo-der-drc-ma;EarlyTermination">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-tim-tim;determines"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;EarlyTerminationDate"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-ma;hasEarlyTerminationDate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;Date"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">early termination date determining agent</rdfs:label>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasExpirationDate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>early termination</rdfs:label>
+		<skos:definition>termination of an agreement for any reason prior to its expiration date</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Early termination may be automatically triggered by an event of default with respect to any contract obligation, due to corporate action, or for other reasons.  An early termination date may be calculated per the terms of the agreement or specified explicitly at the time the termination event occurs.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;MasterAgreementAccountChangeNotificationObligation">
@@ -345,12 +347,6 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 	
 	<owl:Class rdf:about="&fibo-der-drc-ma;NonDefaultingParty">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractParty"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-ma;actsAs"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-ma;EarlyTerminationDateDeterminingAgent"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">non-defaulting party</rdfs:label>
 	</owl:Class>
 	
@@ -426,12 +422,6 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 		<rdfs:label xml:lang="en">tax withholding obligation</rdfs:label>
 		<skos:definition xml:lang="en">An obligation with regard to the payment of taxes.</skos:definition>
 	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;actsAs">
-		<rdfs:label xml:lang="en">acts as</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-drc-ma;NonDefaultingParty"/>
-		<rdfs:range rdf:resource="&fibo-der-drc-ma;EarlyTerminationDateDeterminingAgent"/>
-	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;automaticNettingApplicable">
 		<rdfs:label xml:lang="en">automatic netting applicable</rdfs:label>
@@ -519,6 +509,13 @@ Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
 		<rdfs:label xml:lang="en">has beneficiary</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-drc-ma;CreditSupportAgreement"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-ma;CreditSupportBeneficiary"/>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-drc-ma;hasEarlyTerminationDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-arr-arr;hasTerminationDate"/>
+		<rdfs:label xml:lang="en">has early termination date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
+		<skos:definition xml:lang="en">indicates a termination date that occurs prior to an explicit expiration date</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-drc-ma;inDefault">

--- a/DER/ExchangeTradedDerivatives/Futures.rdf
+++ b/DER/ExchangeTradedDerivatives/Futures.rdf
@@ -13,7 +13,6 @@
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
 	<!ENTITY fibo-sec-dbt-tstd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/">
@@ -38,7 +37,6 @@
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
 	xmlns:fibo-sec-dbt-tstd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"
@@ -68,7 +66,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
@@ -282,14 +279,14 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;firstDeliveryDate">
 		<rdfs:label xml:lang="en">first delivery date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The start date of the range of dates by which the underlying for a futures contract must be delivered in order for the terms of the contract to be fulfilled.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;firstNoticeDate">
 		<rdfs:label xml:lang="en">first notice date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The first date at which a delivery notice can be issued.</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -348,14 +345,14 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lastDeliveryDate">
 		<rdfs:label xml:lang="en">last delivery date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The last date in the range of dates by which the underlying for a futures contract must be delivered in order for the terms of the contract to be fulfilled.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lastNoticeDate">
 		<rdfs:label xml:lang="en">last notice date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;Date"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The last date at which a delivery notice can be issued.</skos:definition>
 	</owl:ObjectProperty>
 	

--- a/DER/RateDerivatives/IROptions.rdf
+++ b/DER/RateDerivatives/IROptions.rdf
@@ -6,7 +6,6 @@
 	<!ENTITY fibo-der-rat-iro "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IROptions/">
 	<!ENTITY fibo-fnd-arrxx-meth "https://spec.edmcouncil.org/fibo/ontology/FND/ArrangementsExt/MethodsAndRules/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-loan-ln-ln "https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/LoanCore/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -22,7 +21,6 @@
 	xmlns:fibo-der-rat-iro="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IROptions/"
 	xmlns:fibo-fnd-arrxx-meth="https://spec.edmcouncil.org/fibo/ontology/FND/ArrangementsExt/MethodsAndRules/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-loan-ln-ln="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/LoanCore/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -41,7 +39,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ArrangementsExt/MethodsAndRules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/LoanCore/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IROptions/"/>
@@ -144,7 +141,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;exerciseDateOffset">
 		<rdfs:label xml:lang="en">exercise date offset</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition xml:lang="en">The period in days between the Reset Date and the date on which the Option may be exercised.</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -164,14 +161,14 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;interestAccrualDateOffset">
 		<rdfs:label xml:lang="en">interest accrual date offset</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition xml:lang="en">The period in days between each Reset Date and the commencement of accrual of interest for the next period.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-rat-iro;settlementDateOffset">
 		<rdfs:label xml:lang="en">settlement date offset</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-rat-iro;OptionStripContract"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition xml:lang="en">The period in days between each Reset Date and the corresponding Settlement Date.</skos:definition>
 	</owl:ObjectProperty>
 

--- a/DER/RateDerivatives/InflationSwaps.rdf
+++ b/DER/RateDerivatives/InflationSwaps.rdf
@@ -6,9 +6,9 @@
 	<!ENTITY fibo-der-rtd-irswp "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/">
 	<!ENTITY fibo-der-rtd-isw "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/InflationSwaps/">
 	<!ENTITY fibo-der-rtd-rtd "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/">
+	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-math-math "https://spec.edmcouncil.org/fibo/ontology/FND/MathExt/Math/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
-	<!ENTITY fibo-fnd-tim-tim "https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -24,9 +24,9 @@
 	xmlns:fibo-der-rtd-irswp="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"
 	xmlns:fibo-der-rtd-isw="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/InflationSwaps/"
 	xmlns:fibo-der-rtd-rtd="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"
+	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-math-math="https://spec.edmcouncil.org/fibo/ontology/FND/MathExt/Math/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
-	xmlns:fibo-fnd-tim-tim="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -42,9 +42,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/MathExt/Math/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TimeExt/Time/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/InflationSwaps/"/>
@@ -121,7 +121,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-rtd-isw;lag">
 		<rdfs:label xml:lang="en">lag</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-rtd-isw;InflationIndexUnderlying"/>
-		<rdfs:range rdf:resource="&fibo-fnd-tim-tim;DurationDescriptionInCalendarTemporalUnit"/>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
 		<skos:definition xml:lang="en">Details needed. Inserted per telecon (Derivatives PoC) from Andrew Jacobs. Identify the corresponding term in FpML and use that here.</skos:definition>
 	</owl:ObjectProperty>
 	


### PR DESCRIPTION
…ose from the FinancialDates ontology, and cleaned up master agreement to define what early termination is rather referencing early termination date (which was not defined and used the TimeExt ontology for date determination agent)