### PR TITLE
ElisaKendall/SEC-82

### DIFF
--- a/SEC/Debt/Bonds.rdf
+++ b/SEC/Debt/Bonds.rdf
@@ -379,7 +379,7 @@
 		<rdfs:label>controlled amortization bond</rdfs:label>
 		<skos:definition>bond that is securitized using a controlled amortization structure</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>http://www.investinginbonds.com/learnmore.asp?catid=11&amp;subcatid=57&amp;id=15</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Revolving debt (primarily credit card receivables, but also HELOCs, trade receivables, dealer floor-plan loans and some leases) may be securitized using a controlled amortization structure. This is a method of providing investors with a relatively predictable repayment schedule, even though the underlying assets are nonamortizing. Controlled-amortization ABS resemble corporate bonds with a sinking fund. After a predetermined “revolving” period during which only interest payments are made, these securities attempt to return principal to investors in a series of defined periodic payments that usually occur over less than a year. A risk inherent in this kind of ABS is an early amortization event. (See “Early-Amortization Risk,” on page 20.)</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Revolving debt (primarily credit card receivables, but also HELOCs, trade receivables, dealer floor-plan loans and some leases) may be securitized using a controlled amortization structure. This is a method of providing investors with a relatively predictable repayment schedule, even though the underlying assets are nonamortizing. Controlled-amortization ABS resemble corporate bonds with a sinking fund. After a predetermined &apos;revolving&apos; period during which only interest payments are made, these securities attempt to return principal to investors in a series of defined periodic payments that usually occur over less than a year. A risk inherent in this kind of ABS is an early amortization event. (See &apos;Early-Amortization Risk&apos;, on page 20.)</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;ControlledAmortizationStructure">
@@ -1231,7 +1231,7 @@ Further Notes:Additional review with OTPP May 05 2010 indicates that this is par
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>step up bond</rdfs:label>
-		<skos:definition>bond with a coupon that increases (steps up), usually at regular intervals, while the bond is outstanding</skos:definition>
+		<skos:definition>bond with a coupon that increases (steps up), usually at regular intervals, while the bond is outstanding</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SteppedCouponTerms">
@@ -1739,7 +1739,7 @@ Further Notes:Additional review with OTPP May 05 2010 indicates that this is par
 		<rdfs:label>is bank qualified</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition>Designation given to a public purpose bond offering by the issuer if it reasonably expects to issue in the calendar year of such offering no more than $10 million ($30 million for bonds issued in 2009-2010) of bonds of the type required to be included in making such calculation under section 265(b)(3) of the IRS tax code. When purchased by a commercial bank for its portfolio, the bank may deduct a portion of the interest cost of carry for the position. A bond that is bank qualified is also known as a “qualified tax-exempt obligation.</skos:definition>
+		<skos:definition>Designation given to a public purpose bond offering by the issuer if it reasonably expects to issue in the calendar year of such offering no more than $10 million ($30 million for bonds issued in 2009-2010) of bonds of the type required to be included in making such calculation under section 265(b)(3) of the IRS tax code. When purchased by a commercial bank for its portfolio, the bank may deduct a portion of the interest cost of carry for the position. A bond that is bank qualified is also known as a qualified tax-exempt obligation.</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;isBasedOn">
@@ -1848,7 +1848,7 @@ Further Notes:Additional review with OTPP May 05 2010 indicates that this is par
 		<rdfs:label>super sinker</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;MandatorySinkingFundTerms"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition>A colloquial term for a term maturity, usually from a single family mortgage revenue issue with several term maturities, that will be the first to be called from a sinking fund into which all proceeds from prepayments of mortgages financed by the issue are deposited.  The maturity&apos;s priority status under the call provisions means that it is likely to be redeemed in its entirety well before the stated maturity date.</skos:definition>
+		<skos:definition>A colloquial term for a term maturity, usually from a single family mortgage revenue issue with several term maturities, that will be the first to be called from a sinking fund into which all proceeds from prepayments of mortgages financed by the issue are deposited. The maturity&apos;s priority status under the call provisions means that it is likely to be redeemed in its entirety well before the stated maturity date.</skos:definition>
 	</owl:DatatypeProperty>
 
 </rdf:RDF>


### PR DESCRIPTION
Simplified provisional bonds ontology substantively, including normalization of definitions, elimination of references to provisional ontologies, elimination of redundant properties, and better integration with the existing FIBO FBC/DebtAndEquitites/Debt and SEC/Debt/DebtInstruments ontologies, in preparation for further work by the SEC FCT