### PR TITLE
BE-203 #comment - eliminated reasoning error which was caused by two …

### DIFF
--- a/BE/GovernmentEntities/GovernmentEntities.rdf
+++ b/BE/GovernmentEntities/GovernmentEntities.rdf
@@ -75,12 +75,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20190401/GovernmentEntities/GovernmentEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20190501/GovernmentEntities/GovernmentEntities/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was added to Business Entities, per the issue resolutions identified in the FIBO BE 1.1 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.2 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20170201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20180201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to to rationalize natural person and legally capable person in a new concept, competent natural person, simplify / merge the legal person and formal organization class hierarchies, and revise certain definitions, such as for supranational entity, to correspond to ISO definitions.</skos:changeNote>
-		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20181201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to reflect the move of hasObjective to FND to enable higher level reuse.</skos:changeNote>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20181201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to reflect the move of hasObjective to FND to enable higher level reuse and eliminate a reasoning error.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -259,39 +259,14 @@
 	<owl:Class rdf:about="&fibo-be-ge-ge;GovernmentMinister">
 		<rdfs:subClassOf rdf:resource="&fibo-be-ge-ge;GovernmentOfficial"/>
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;Executive"/>
-		<rdfs:subClassOf>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-						<owl:someValuesFrom>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-be-ge-ge;isElectedBy"/>
-								<owl:allValuesFrom rdf:resource="&fibo-be-ge-ge;Polity"/>
-							</owl:Restriction>
-						</owl:someValuesFrom>
-					</owl:Restriction>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
-						<owl:someValuesFrom>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isAppointedBy"/>
-								<owl:allValuesFrom rdf:resource="&fibo-be-ge-ge;ExecutiveBranch"/>
-							</owl:Restriction>
-						</owl:someValuesFrom>
-					</owl:Restriction>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:subClassOf>
 		<rdfs:label>government minister</rdfs:label>
-		<skos:definition>a person appointed or elected to a high office in the government</skos:definition>
+		<skos:definition>government official that is an executive, who is either appointed or elected to a high office in the government</skos:definition>
 		<skos:example>Minister of Finance, Secretary of State, Attorney General of California</skos:example>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.thefreedictionary.com/government+minister</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-ge-ge;GovernmentOfficial">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;ResponsibleParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;OrganizationMember"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -313,7 +313,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasTag">
-		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
 		<rdfs:label>has tag</rdfs:label>
 		<rdfs:range>
 			<rdfs:Datatype>


### PR DESCRIPTION
…separate but somewhat related issues: (1) an extra blank node in a reasoning loop for definining a government minister in unnecessary restrictions and (2) the fact that there were two ways to get to the same individual defining the legal entity for the government body, which is fine, but there were two tags on it as a result, and hasTag was incorrectly defined as being functional.  If you can get to an individual that has a tag in more than one way, it can't be functional.  And, anything that can be identified by more than one identifier could inadvertently also run into this problem.