### PR TITLE
FND-229 Modified definition of the class CurrencyIdentifier in FND/Ac…

### DIFF
--- a/FND/Accounting/CurrencyAmount.rdf
+++ b/FND/Accounting/CurrencyAmount.rdf
@@ -178,7 +178,7 @@ The definition of currency provided herein is compliant with the definitions giv
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>currency identifier</rdfs:label>
-		<skos:definition>a set of textual elements representing some currency</skos:definition>
+		<skos:definition>a sequence of characters representing some currency</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In the case of the ISO 3166 3-letter currency code, the first (left-most) two characters of the currency identifier provide a code unique to the currency authority to which it is assigned. Wherever practicable, it is derived from the geographical location of the currency authority, as described in ISO 3166.
 
 The third (right-most) character of the identifier (alphabetic code) is an indicator, preferably mnemonic, derived from the name of the major currency unit or fund.


### PR DESCRIPTION
…counting/CurrencyAmount.rdf to remove the word trigraph. Also made the definition more generic, to reflect the class as framed by the DL assertions, and changed from the definite to the indefinite article. Modified the explanatoryNote to indicate that this is specific to the kind of CurrencyIdentifier which is an ISO 3166 Currency Identifier.