### PR TITLE
FND-226 incorporating the remaining actions in the resolution of FND-…

### DIFF
--- a/FND/Agreements/Agreements.rdf
+++ b/FND/Agreements/Agreements.rdf
@@ -73,11 +73,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">agreement</rdfs:label>
-		<skos:definition>a negotiated and usually legally enforceable understanding between two or more legally competent parties</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/agreement.html</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>Although a binding contract can (and often does) result from an agreement, an agreement typically documents the give-and-take of a negotiated settlement and a contract specifies the minimum acceptable standard of performance.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>An agreement may be formalized in the form of a Contract or other formal instrument, or it may not.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>In the sense intended here, negotiated refers to something with some offer and acceptance, with or without further to and fro discussions between these two end points.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>a negotiated understanding between two or more parties, reflecting the offer and acceptance of commitments on the part of either party</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-agr-agr;Beneficiary">

--- a/FND/Agreements/Contracts.rdf
+++ b/FND/Agreements/Contracts.rdf
@@ -115,6 +115,7 @@
 		<rdfs:label>contract</rdfs:label>
 		<skos:definition>a voluntary, deliberate agreement between two or more competent parties to which those parties agree to be legally bound, and to which the parties must have provided valuable consideration</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/contract.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>A contractual relationship is evidenced by (1) an offer, (2) acceptance of the offer, and a (3) valid (legal and valuable) consideration. A contract is a kind of agreement, and as such it embodies the assertion that it has been negotiated, such negotiation having included the presence of some offer and the acceptance of that offer on the part of either or both of the parties.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Contracts are usually written but may be spoken or implied, and generally have to do with employment, sale or lease, or tenancy.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	


### PR DESCRIPTION
…224 (Contracts). In FND/Agreements/Agreements.rdf changed the definition to reflect the model semantics, removed the explanatory notes that qualified the previous, inapplicable definition and removed the definition origin as this no longer applies. In FND/Agreements/Contracts, added an explanatory note describing the nature of a contractual relationship and asserting how parts of those requirement are met by inheritance from Agreements now that the concept is as defined in this issue resolution.