### PR TITLE
FBC-238 #comment - adds several of the most commonly used day count c…

### DIFF
--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -58,8 +58,8 @@
 		<dct:abstract>This ontology defines concepts that are common to all debt instruments, such as debt, borrower, lender, debtor, creditor, interest, principal, and the like. It is designed to be used by various other FIBO specifications, including but not limited to SEC/Debt and LOAN.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2016-2019 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2019 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -83,9 +83,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200101/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -276,6 +277,37 @@
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/terms/d/daycount.asp</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Day-count conventions apply to swaps, mortgages and forward rate agreements as well as bonds, each of which has its own day-count convention, which varies depending on the type of instrument, whether the interest rate is fixed or floating, and the country of issuance. Among the most common conventions are 30/360 or 365, actual/360 or 365, and actual/actual. A 30/360 convention assumes 30 days in a month and 360 days in a year. An actual/360 convention assumes the actual number of days in the given month and 360 days in the year. An actual/ actual convention uses the actual number of days in the given interest period and year.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30360">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+		<rdfs:label>day-count convention 30/360</rdfs:label>
+		<skos:definition>day-count convention indicating that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30365">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+		<rdfs:label>day-count convention 30/365</rdfs:label>
+		<skos:definition>day-count convention indicating that uses 30 days in a month and 365 days in a year for calculating interest payments</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-Actual360">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+		<rdfs:label>day-count convention actual/360</rdfs:label>
+		<skos:definition>day-count convention indicating that uses the actual number of days in a month and 360 days in a year for calculating interest payments</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-Actual365">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+		<owl:sameAs rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention-ActualActual"/>
+		<rdfs:label>day-count convention actual/365</rdfs:label>
+		<skos:definition>day-count convention indicating that uses the actual number of days in a month and 365 days in a year for calculating interest payments</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-ActualActual">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+		<rdfs:label>day-count convention actual/actual</rdfs:label>
+		<skos:definition>day-count convention indicating that uses the actual number of days in a month and actual number of days in a year for calculating interest payments</skos:definition>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Debt">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-agr;Commitment"/>

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -278,35 +278,94 @@
 		<fibo-fnd-utl-av:explanatoryNote>Day-count conventions apply to swaps, mortgages and forward rate agreements as well as bonds, each of which has its own day-count convention, which varies depending on the type of instrument, whether the interest rate is fixed or floating, and the country of issuance. Among the most common conventions are 30/360 or 365, actual/360 or 365, and actual/actual. A 30/360 convention assumes 30 days in a month and 360 days in a year. An actual/360 convention assumes the actual number of days in the given month and 360 days in the year. An actual/ actual convention uses the actual number of days in the given interest period and year.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30360">
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30360BondBasis">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
-		<rdfs:label>day-count convention 30/360</rdfs:label>
-		<skos:definition>day-count convention indicating that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
+		<rdfs:label>day-count convention 30/360 bond basis</rdfs:label>
+		<skos:definition>day-count convention that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(f), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>30A/360</fibo-fnd-utl-av:synonym>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30360US">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+		<rdfs:label>day-count convention 30/360 US</rdfs:label>
+		<skos:definition>day-count convention that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(f), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>This convention is used for US corporate bonds and many US agency issues. It is most commonly referred to as &apos;30/360&apos;, but the term &apos;30/360&apos; may also refer to any of the other conventions of this class, depending on the context. See ISDA 2006 Section 4.16(f), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>30/360</fibo-fnd-utl-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30365">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention 30/365</rdfs:label>
-		<skos:definition>day-count convention indicating that uses 30 days in a month and 365 days in a year for calculating interest payments</skos:definition>
+		<skos:definition>day-count convention that uses 30 days in a month and 365 days in a year for calculating interest payments</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30E360">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+		<rdfs:label>day-count convention 30E/360</rdfs:label>
+		<skos:definition>day-count convention that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>See ICMA Rule 251.1(ii), 251.2, and ISDA 2006 Section 4.16(g), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>30/360 ICMA</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>30S/360</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>Eurobond basis (ISDA 2006)</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>Special German</fibo-fnd-utl-av:synonym>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-30E360ISDA">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+		<rdfs:label>day-count convention 30E/360 ISDA</rdfs:label>
+		<skos:definition>day-count convention that uses 30 days in a month and 360 days in a year for calculating interest payments</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(h), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>30/360 ICMA</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>Eurobond basis (ISDA 2006)</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>German</fibo-fnd-utl-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-Actual360">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
 		<rdfs:label>day-count convention actual/360</rdfs:label>
-		<skos:definition>day-count convention indicating that uses the actual number of days in a month and 360 days in a year for calculating interest payments</skos:definition>
+		<skos:definition>day-count convention that uses the actual number of days in each month and 360 days in a year for calculating interest payments</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>See ICMA Rule 251.1(i) (not sterling), ISDA 2006 Section 4.16(e), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>This convention is used in money markets for short-term lending of currencies, including the US dollar and Euro, and is applied in ESCB monetary policy operations. It is the convention used with repurchase agreements.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>French</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>a/360</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>act/360</fibo-fnd-utl-av:synonym>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-Actual365">
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-Actual365Fixed">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
-		<owl:sameAs rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention-ActualActual"/>
-		<rdfs:label>day-count convention actual/365</rdfs:label>
-		<skos:definition>day-count convention indicating that uses the actual number of days in a month and 365 days in a year for calculating interest payments</skos:definition>
+		<rdfs:label>day-count convention actual/365 fixed</rdfs:label>
+		<skos:definition>day-count convention that uses the actual number of days in each month and 365 days in a year for calculating interest payments</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(d), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>English</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>a/365 fixed</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>a/365f</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>act/365 fixed</fibo-fnd-utl-av:synonym>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-ActualActual">
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-ActualActualICMA">
 		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
-		<rdfs:label>day-count convention actual/actual</rdfs:label>
-		<skos:definition>day-count convention indicating that uses the actual number of days in a month and actual number of days in a year for calculating interest payments</skos:definition>
+		<rdfs:label>day-count convention actual/actual ICMA</rdfs:label>
+		<skos:definition>day-count convention that uses the actual number of days in each month and actual number of days in that year for calculating interest payments</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>See ICMA Rule 251.1(iii), ISDA 2006 Section 4.16(c), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>This method ensures that all coupon payments are always for the same amount. It also ensures that all days in a coupon period are valued equally. This is the convention used for US Treasury bonds and notes, among other securities.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>ISMA-99</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>act/act ICMA</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>act/act ISMA</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>actual/actual</fibo-fnd-utl-av:synonym>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-dae-dbt;DayCountConvention-ActualActualISDA">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+		<rdfs:label>day-count convention actual/actual ISDA</rdfs:label>
+		<skos:definition>day-count convention that uses the actual number of days in each month and actual number of days in that year for calculating interest payments</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>See ISDA 2006 Section 4.16(b), https://web.archive.org/web/20140913145444/http://www.hsbcnet.com/gbm/attachments/standalone/2006-isda-definitions.pdf for more details on the calculation.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>This convention accounts for days in the period based on the portion in a leap year and the portion in a non-leap year.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>act/365</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>act/act</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>actual/365</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>actual/actual</fibo-fnd-utl-av:synonym>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;Debt">


### PR DESCRIPTION
…onventions as individuals to support several FIBO use cases for bonds and derivatives

## Description

Adds several of the most commonly used day count conventions as individuals to support several FIBO use cases for bonds and derivatives

Fixes: #848 / FBC-238


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).