### PR TITLE
slackinvite@edmcouncil.org -- > fibo@edmcouncil.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The FIBO development process follows rigorous and well-defined rules and princip
 ### Community Discussion
 
 Our preferred method for discussing topics unrelated to specific issues, pull requests, wiki pages or artifacts is [Slack](https://slack.com).
-Please join the *Slack workspace* [fibo-edmc.slack.com](https://fibo-edmc.slack.com) by sending an email with your information to slackinvite@edmcouncil.org, we will then send you a link (by email) that gets you in.
+Please join the *Slack workspace* [fibo-edmc.slack.com](https://fibo-edmc.slack.com) by sending an email with your information to fibo@edmcouncil.org, we will then send you a link (by email) that gets you in.
 
 A *Slack workspace* is a shared hub made up of channels where team members can communicate and work together. When you join a workspace, you need to create a Slack account using your email address.
 


### PR DESCRIPTION
Signed-off-by: trypuz <robert.trypuz@makolab.com>

## Description

E-mail address change in the README file

- slackinvite@edmcouncil.org -- > fibo@edmcouncil.org


Fixes: #852


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).