### PR TITLE
datadictionary and fibopedia removed from the Jenkins pipeline

### DIFF
--- a/etc/process/Jenkinsfile
+++ b/etc/process/Jenkinsfile
@@ -9,7 +9,8 @@
 //
 //String[] derivedProducts = ['widoco', 'fibopedia', 'glossary', 'vocabulary', 'datadictionary', 'reference']
 //String[] derivedProducts = ['widoco', 'fibopedia', 'glossary', 'vocabulary', 'datadictionary']
-String[] derivedProducts = ['fibopedia', 'glossary', 'vocabulary', 'datadictionary','htmlpages']
+//String[] derivedProducts = ['fibopedia', 'glossary', 'vocabulary', 'datadictionary','htmlpages']
+String[] derivedProducts = ['glossary', 'vocabulary', 'htmlpages']
 // String[] derivedProducts = ['htmlpages']
 //String[] derivedProducts = ['fibopedia' ]
 //String[] derivedProducts = ['widoco']


### PR DESCRIPTION
Signed-off-by: Robert Trypuz <robert.trypuz@makolab.com>

## Description

FIBOPedia is deprecated. Data dictionary is now served in one file (Excel or CSV).

Fixes: https://github.com/edmcouncil/ontology-publisher/issues/13

## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).