### PR TITLE
DER-66 #comment - eliminated the circular reference between Options a…

### DIFF
--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -5,7 +5,6 @@
 	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
 	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
-	<!ENTITY fibo-der-etd-eto "https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -36,7 +35,6 @@
 	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
 	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
-	xmlns:fibo-der-etd-eto="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -67,7 +65,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/AssetDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
@@ -450,7 +447,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Option"/>
 		<rdfs:label xml:lang="en">o t c option contract</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-der-etd-eto;ExchangeTradedOptionContract"/>
 		<skos:definition xml:lang="en">Exotic options traded on the over-the-counter market, where participants can choose the characteristics of the options traded.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The flexibility of these options is attractive to many. With OTC options, both hedgers and speculators can benefit from avoiding the restrictions that normal standardized exchanges place on options. The flexibility allows participants to achieve their desired position more precisely and cost effectively. Review note (13 Jan 2010 or earlier): optional delivery dates where there&apos;s a right to change e.g. extend or shorten the delivery period. Part of the terms. For instance time options.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>

--- a/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
+++ b/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
@@ -286,6 +286,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">exchange traded option contract</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-eto;ExchangeTradedOptionTransaction">
@@ -579,8 +580,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-etd-eto;TradedOptionPrincipal">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionWritingParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;NovatedOptionContractPrincipal"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;TradingParticipant"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionsExchangeParticipant"/>
 		<rdfs:label xml:lang="en">traded option principal</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-der-etd-eto;TradedOptionsCounterparty"/>
 		<skos:definition xml:lang="en">The principal to the Traded Option contract. THis is the party which gives the other party the right to take up the obligation, and which is obliged to honor that transaction if that option is taken up.</skos:definition>
@@ -588,13 +588,8 @@
 	
 	<owl:Class rdf:about="&fibo-der-etd-eto;TradedOptionsCounterparty">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OptionBuyer"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;TradingParticipant"/>
-		<rdfs:label xml:lang="en">traded options counterparty</rdfs:label>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-eto;TradingParticipant">
 		<rdfs:subClassOf rdf:resource="&fibo-der-etd-eto;OptionsExchangeParticipant"/>
-		<rdfs:label xml:lang="en">trading participant</rdfs:label>
+		<rdfs:label xml:lang="en">traded options counterparty</rdfs:label>
 	</owl:Class>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-etd-eto;contractSize">


### PR DESCRIPTION
…nd ExchangeTradedOptions, as well as the cycle within the ExchangeTradedOptions ontology

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This resolution cleans up two problems in the provisional DER content: (1) a circular reference between the Options and ExchangeTradedOptions ontologies, and (2) a circular dependency within the ExchangeTradedOptions ontology.

Fixes: #877 / DER-66


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).