### PR TITLE
FND-283 #comment - eliminated hasDispositionDate, whose semantics wer…

### DIFF
--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -43,7 +43,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Relations/Relations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20170201/Relations/Relations.rdf version of this ontology was modified per the FIBO 2.0 RFC to include additional properties and the linkage to LCC.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Relations/Relations.owl version of the ontology submitted with 
 the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
@@ -62,7 +62,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190301/Relations/Relations.rdf version of this ontology was modified to loosen constraints on properties using xsd:dateTime in their range to allow for more flexible representation, and to add properties including produces, isProducedBy.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Relations/Relations.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Relations/Relations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and remove the unused hasDispositionDate property, whose semantics were unclear at best.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -211,24 +211,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
 		<skos:definition>relates an individual or organization to a position, role, or other designation</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasDispositionDate">
-		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
-		<rdfs:label>has disposition date</rdfs:label>
-		<rdfs:range>
-			<rdfs:Datatype>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&xsd;string">
-					</rdf:Description>
-					<rdf:Description rdf:about="&xsd;dateTime">
-					</rdf:Description>
-					<rdf:Description rdf:about="&xsd;dateTimeStamp">
-					</rdf:Description>
-				</owl:unionOf>
-			</rdfs:Datatype>
-		</rdfs:range>
-		<skos:definition>links something, such as an asset or its owner/controller/controllee to the date or date and time something was sold, transferred, destroyed, etc.</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasFormalName">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>


### PR DESCRIPTION
…e unclear at best

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This resolution eliminates the property hasDispositionDate, as it's semantics were not clear and it was unused across FIBO.

Fixes: #904 / FND-283


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


