### PR TITLE
FND-287 #comment - revised the definition of OrganizationSubUnit so t…

### DIFF
--- a/BE/LegalEntities/FormalBusinessOrganizations.rdf
+++ b/BE/LegalEntities/FormalBusinessOrganizations.rdf
@@ -83,7 +83,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20181101/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was modified to reflect the move of hasObjective to FND to enable higher level reuse.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190401/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190701/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was revised to eliminate deprecated elements.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and simplify addresses.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/LegalEntities/FormalBusinessOrganizations.rdf version of this ontology was revised to eliminate duplication of concepts in LCC, simplify addresses, and correct the parent class of OrganizationSubUnit.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -200,7 +200,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-le-fbo;OrganizationalSubUnit">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-fm;FormalOrganization"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-org-org;Organization"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isPartOf"/>
@@ -208,7 +208,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>organizational sub-unit</rdfs:label>
-		<skos:definition>any department, service, or other entity within a larger formal organization that only has full recognition within the context of that formal organization, but requires identification for some purpose</skos:definition>
+		<skos:definition>any department, service, or other entity within a larger organization that only has full recognition within the context of that organization, but requires identification for some purpose</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/obp/ui/#iso:std:iso-iec:6523:-1:ed-1:v1:en</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>In other words, it is not a legal entity in its own right.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>organization part</fibo-fnd-utl-av:synonym>


### PR DESCRIPTION
…hat it is a subclass of Organization, rather than FormalOrganization and eliminated references to 'formal' in the textual definition

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Corrected class hierarchy for OrganizationSubUnit to make it a child of Organization rather than FormalOrganization

Fixes: #907 / FND-287


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


