### PR TITLE
FND-290 - Need to extend addresses to include the specifics for US addresses per the USPS Pub 28 standard

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -4,6 +4,8 @@
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="file:///AboutFIBO">
+  	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
+	<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
     <owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/MarketDataProviders/"/>
     <owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
     <owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/MarketsIndividuals/"/>

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -89,6 +89,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>

--- a/BE/AllBE-NorthAmerica.rdf
+++ b/BE/AllBE-NorthAmerica.rdf
@@ -108,7 +108,7 @@ The business scope of the BE ontologies covers a range of business and legal ent
  - Corporate structure, ownership and control, including primary executive roles for businesses,
  - Functional entities such as governments and government entities, non-governmental organizations, international organizations, not-for-profit organization, etc.
  - Concepts specific to corporations, partnerships, private limited companies, sole proprietorships, and trusts.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-02-24T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-03-27T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Business Entities (BE) Domain, North American Extension</dct:title>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
@@ -136,6 +136,7 @@ The business scope of the BE ontologies covers a range of business and legal ent
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/CAGovernmentEntitiesAndJurisdictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/GovernmentEntities/NorthAmericanJurisdiction/USGovernmentEntitiesAndJurisdictions/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND-NorthAmerica/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-AG/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-AS/"/>
@@ -172,7 +173,7 @@ The business scope of the BE ontologies covers a range of business and legal ent
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-VG/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-VI/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/UN-M49-RegionCodes/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200101/AllBE-NorthAmerica/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200301/AllBE-NorthAmerica/"/>
 		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for BE (North American Extension) is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports most of the Production (Released) ontologies that comprise the FIBO Business Entities (BE) domain, including all of FND but excluding individuals for European governments and jurisdictions, and the related LCC region-specific ontologies. Note that the U.N. M49 Codes do not distinguish North and South America, and thus this ontology defines North America as the landmass north of the Panama-Colombia border (Northern America and Central America from an M49 code perspective), and the islands of the Caribbean (also identified as the Caribbean in the M49 subregion codes).  North American government entities and jurisdictions are provided only for a fraction of these countries and regions in FIBO 2.0, with the anticipation that additional entities will be added over time.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/FND/AllFND-NorthAmerica.rdf
+++ b/FND/AllFND-NorthAmerica.rdf
@@ -61,7 +61,7 @@ The scope of the definitions provided in FND is limited to coverage of exactly t
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/AllBE-NorthAmerica/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/AllFND-NorthAmerica/"/>
 		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for Foundations (FND), North American Extension is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports the Production (Released) ontologies that comprise the FIBO Foundations (FND) domain, including extensions related to postal addressing in the US and Canada.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/FND/AllFND-NorthAmerica.rdf
+++ b/FND/AllFND-NorthAmerica.rdf
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-all "https://spec.edmcouncil.org/fibo/ontology/FND/AllFND/">
+	<!ENTITY fibo-fnd-plc-uspsa "https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/">
+	<!ENTITY fibo-fnd-plc-uspsai "https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-fndna-all "https://spec.edmcouncil.org/fibo/ontology/FND/AllFND-NorthAmerica/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND-NorthAmerica/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-all="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND/"
+	xmlns:fibo-fnd-plc-uspsa="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"
+	xmlns:fibo-fnd-plc-uspsai="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-fndna-all="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND-NorthAmerica/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND-NorthAmerica/">
+		<rdfs:label>Foundations Domain, North American Extension</rdfs:label>
+		<dct:abstract>The Foundations (FND) domain includes ontologies that define general purpose concepts required to support other FIBO domains. These include concepts and relationships about people, organizations, places, and most importantly, contracts that are essential to domains such as Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC). 
+
+The scope of the definitions provided in FND is limited to coverage of exactly those concepts needed by other FIBO specifications.  They may be useful for other domains, such as insurance, but are intentionally underspecified to avoid unintended consequences and thus do not provide exhaustive coverage for any concept contained herein.  However, Foundations is designed for growth over time.  The expectation is that as additional foundational knowledge is needed to define concepts in other FIBO domain areas, additional ontologies and/or concepts will be integrated into Foundations as required.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-03-22T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Foundations (FND) Domain, North American Extension</dct:title>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contributor>Adaptive, Inc.</sm:contributor>
+		<sm:contributor>Anthony B. Coates</sm:contributor>
+		<sm:contributor>John F. Gemski</sm:contributor>
+		<sm:contributor>Maxwell Gillmore</sm:contributor>
+		<sm:contributor>Nordea Bank AB</sm:contributor>
+		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
+		<sm:contributor>Pinnacle Bank (Morgan Hill, California)</sm:contributor>
+		<sm:contributor>State Street Bank and Trust</sm:contributor>
+		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
+		<sm:contributor>Thematix Partners LLC</sm:contributor>
+		<sm:contributor>Wells Fargo</sm:contributor>
+		<sm:contributor>Working Ontologist</sm:contributor>
+		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-fndna-all</sm:fileAbbreviation>
+		<sm:filename>AllFND-NorthAmerica.rdf</sm:filename>
+		<sm:keyword>foundational vocabulary</sm:keyword>
+		<sm:moduleAbbreviation>fibo-fnd</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/AllBE-NorthAmerica/"/>
+		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for Foundations (FND), North American Extension is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports the Production (Released) ontologies that comprise the FIBO Foundations (FND) domain, including extensions related to postal addressing in the US and Canada.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Ontology>
+
+</rdf:RDF>

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -80,7 +80,7 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDefinedIn"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;AddressingScheme"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -558,6 +558,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasPrimaryAddressNumber"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PrimaryAddressNumber"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasSecondaryUnit"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;SecondaryUnit"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -568,12 +575,6 @@
 				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasStreetSuffix"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasPrimaryAddressNumber"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-adr;PrimaryAddressNumber"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -114,9 +114,16 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Apartment">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
-		<rdfs:label>apartment</rdfs:label>
+		<rdfs:label xml:lang="en">apartment</rdfs:label>
 		<skos:definition>room or a group of related rooms, among similar sets in one building, designed for use as a dwelling</skos:definition>
 		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Basement">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">basement</rdfs:label>
+		<skos:definition>part of a building consisting of rooms that are partly or entirely below ground</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Building">
@@ -159,12 +166,26 @@
 		<fibo-fnd-utl-av:explanatoryNote>Other unconventional addresses may include rural and highway route addresses, general delivery addresses, post office box addresses, private mail center addresses, and so forth.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Department">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">department</rdfs:label>
+		<skos:definition>division of a large organization such as a government, university, business, or shop, dealing with a specific subject, commodity, or area of activity</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Floor">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
-		<rdfs:label>floor</rdfs:label>
+		<rdfs:label xml:lang="en">floor</rdfs:label>
 		<skos:definition>all of the rooms or areas on the same level of a building; a story</skos:definition>
 		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
 		<fibo-fnd-utl-av:explanatoryNote>Labeling systems for floors vary from country to country, and may be specific to the building, for example, whether or not a 13th floor is identified as such tends to be on a case-by-case basis.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Front">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">front</rdfs:label>
+		<skos:definition>side or part of a building that presents itself to view first, that faces the street; the most forward part of a building</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;GeographicDirectionalSymbol">
@@ -179,6 +200,55 @@
 		<skos:definition>code element that gives directional information for postal delivery</skos:definition>
 		<skos:example>In the United States, these include N, S, E, W, NE, NW, SE, SW.</skos:example>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Hangar">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">hanger</rdfs:label>
+		<skos:definition>shed or shelter; any relatively wide structure used for housing airplanes or airships</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Key">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">key</rdfs:label>
+		<skos:definition>usually metal instrument by which the bolt of a lock is turned</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Lobby">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">lobby</rdfs:label>
+		<skos:definition>entrance hall, corridor, or vestibule, as in a public building, often serving as an anteroom; foyer</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Lot">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">lot</rdfs:label>
+		<skos:definition>measured parcel of land having fixed boundaries and designated on a plot or survey</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Lower">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">lower</rdfs:label>
+		<skos:definition>floor of a building in a multistory structure that is closer to ground level</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Office">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">office</rdfs:label>
+		<skos:definition>place where a particular kind of business is transacted or a service is supplied</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Penthouse">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">penthouse</rdfs:label>
+		<skos:definition>structure or dwelling on the roof or top floor of a building</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;PhysicalAddress">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>
@@ -285,6 +355,13 @@
 		<skos:definition>scheme for specifying physical addresses according to a country specific standard</skos:definition>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Pier">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">pier</rdfs:label>
+		<skos:definition>structure extending into navigable water for use as a landing place or promenade</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;PostCodeArea">
 		<rdfs:subClassOf rdf:resource="&lcc-cr;GeographicRegion"/>
 		<rdfs:label xml:lang="en">post code area</rdfs:label>
@@ -320,7 +397,7 @@
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;PostOfficeBoxDesignator">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressDesignator"/>
-		<rdfs:label>post office box designator</rdfs:label>
+		<rdfs:label xml:lang="en">post office box designator</rdfs:label>
 		<skos:definition>designator used, together with an identifier, for a post office box</skos:definition>
 		<skos:example>In the U.S., the prefered designator is &apos;PO BOX&apos;.</skos:example>
 	</owl:Class>
@@ -342,7 +419,7 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>postcode</rdfs:label>
+		<rdfs:label xml:lang="en">postcode</rdfs:label>
 		<skos:definition>sequence of characters used to assist in the sorting of mail</skos:definition>
 		<fibo-fnd-utl-av:synonym>postal code</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -373,6 +450,20 @@
 		<fibo-fnd-utl-av:explanatoryNote>Although traditionally called a &apos;number&apos;, the street number may consist of alphanumeric characters, for example, &apos;221B&apos;.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>street number</fibo-fnd-utl-av:synonym>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Rear">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">rear</rdfs:label>
+		<skos:definition>side or part of a building at the back, located opposite its front</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Room">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">room</rdfs:label>
+		<skos:definition>partitioned part of the inside of a building</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;SecondaryUnit">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;AddressComponent"/>
@@ -420,6 +511,34 @@
 		<rdfs:label>secondary unit indicator</rdfs:label>
 		<skos:definition>index to the specific unit within a secondary unit, such as a building or apartment, at a particular street address</skos:definition>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Side">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">side</rdfs:label>
+		<skos:definition>place, space, or direction with respect to a center or to a line of division</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Slip">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">slip</rdfs:label>
+		<skos:definition>sloping ramp extending out into the water to serve as a place for landing or repairing ships; ship&apos;s or boat&apos;s berth between two piers</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Space">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">space</rdfs:label>
+		<skos:definition>extent set apart or available, such as a parking or storage space</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Stop">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">stop</rdfs:label>
+		<skos:definition>stopping place, such as a bus or mail stop</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;StreetAddress">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;AddressComponent"/>
@@ -506,7 +625,7 @@
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Suite">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
-		<rdfs:label>suite</rdfs:label>
+		<rdfs:label xml:lang="en">suite</rdfs:label>
 		<skos:definition>group of rooms occupied as a unit</skos:definition>
 		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
 	</owl:NamedIndividual>
@@ -565,6 +684,27 @@
 		<rdfs:label>supplemental address indicator or unit</rdfs:label>
 		<skos:definition>address component that includes a specific route, box, apartment, condominium or other indicator or unit associated with a specific address</skos:definition>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Trailer">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">trailer</rdfs:label>
+		<skos:definition>vehicle designed to serve wherever parked as a temporary dwelling or place of business</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Unit">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">unit</rdfs:label>
+		<skos:definition>area in a facility, such as a medical facility or hospital that is specially staffed and equipped to provide a particular service or type of care</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">true</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Upper">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
+		<rdfs:label xml:lang="en">upper</rdfs:label>
+		<skos:definition>floor of a building in a multistory structure that is farther away from the ground level</skos:definition>
+		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;VirtualAddress">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -544,20 +544,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;AddressComponent"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasSecondaryUnit"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;SecondaryUnit"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasStreetSuffix"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasPostdirectionalSymbol"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PostdirectionalSymbol"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
@@ -572,16 +558,28 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasSecondaryUnit"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;SecondaryUnit"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasStreetSuffix"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasPrimaryAddressNumber"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PrimaryAddressNumber"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-adr;PrimaryAddressNumber"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasStreetName"/>
-				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;StreetName"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-adr;StreetName"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>street address</rdfs:label>

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -560,14 +560,14 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasPostdirectionalSymbol"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PostdirectionalSymbol"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasPredirectionalSymbol"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;PredirectionalSymbol"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">2</owl:maxQualifiedCardinality>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/FND/Places/MetadataFNDPlaces.rdf
+++ b/FND/Places/MetadataFNDPlaces.rdf
@@ -38,10 +38,12 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-mod;PlacesModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Places</rdfs:label>
-		<dct:abstract>This module includes ontologies defining concepts to do with real or virtual places and the addresses to such places.  Note that most of these terms are proxies for terms which exist or which are expected to be published in the future in formal ontologies for those concepts (e.g. geophysical, geopolitical, as well as the address components in physical standards like VCard).</dct:abstract>
+		<dct:abstract>This module includes ontologies defining concepts to do with real or virtual places and the addresses to such places.</dct:abstract>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>Financial Industry Business Ontology (FIBO) Foundations (FND) Places Module</dct:title>

--- a/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
@@ -1,0 +1,615 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
+	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-plc-uspsa "https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
+	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-plc-uspsa="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/">
+		<rdfs:label>U.S. Postal Service Addresses Ontology</rdfs:label>
+		<dct:abstract>This ontology augments the Addresses ontology in FND with concepts that conform to the USPS Pub 28.  The USPS provides automated address verification services that use the concepts defined herein for that purpose, and which many financial services entities use for data quality purposes.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contributor>Thematix Partners LLC</sm:contributor>
+		<sm:copyright>Copyright (c) 2019-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2019-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-fnd-plc-uspsa</sm:fileAbbreviation>
+		<sm:filename>USPostalServiceAddresses.rdf</sm:filename>
+		<rdfs:seeAlso rdf:resource="https://about.usps.com/who/profile/"/>
+		<rdfs:seeAlso rdf:resource="https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/NorthAmerica/USPostalServiceAddresses/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Apartment">
+		<rdfs:label xml:lang="es">apartmento</rdfs:label>
+		<fibo-fnd-utl-av:preferredDesignation>APT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Basement">
+		<fibo-fnd-utl-av:preferredDesignation>BSMT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Building">
+		<fibo-fnd-utl-av:preferredDesignation>BLDG</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Department">
+		<rdfs:label xml:lang="es">departamento</rdfs:label>
+		<fibo-fnd-utl-av:preferredDesignation>DEPT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Floor">
+		<fibo-fnd-utl-av:preferredDesignation>FL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Front">
+		<fibo-fnd-utl-av:preferredDesignation>FRNT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-adr;GeographicDirectionalSymbol">
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;East">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;North">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;Northeast">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;Northwest">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;South">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;Southeast">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;Southwest">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;West">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Hangar">
+		<fibo-fnd-utl-av:preferredDesignation>HNGR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Key">
+		<fibo-fnd-utl-av:preferredDesignation>KEY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Lobby">
+		<fibo-fnd-utl-av:preferredDesignation>LBBY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Lot">
+		<fibo-fnd-utl-av:preferredDesignation>LOT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Lower">
+		<fibo-fnd-utl-av:preferredDesignation>LOWR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Office">
+		<fibo-fnd-utl-av:preferredDesignation>OFC</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Penthouse">
+		<fibo-fnd-utl-av:preferredDesignation>PH</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Pier">
+		<fibo-fnd-utl-av:preferredDesignation>PIER</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Rear">
+		<fibo-fnd-utl-av:preferredDesignation>REAR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Room">
+		<fibo-fnd-utl-av:preferredDesignation>RM</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Side">
+		<fibo-fnd-utl-av:preferredDesignation>SIDE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Slip">
+		<fibo-fnd-utl-av:preferredDesignation>SLP</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Space">
+		<fibo-fnd-utl-av:preferredDesignation>SPC</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Stop">
+		<fibo-fnd-utl-av:preferredDesignation>STOP</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Suite">
+		<fibo-fnd-utl-av:preferredDesignation>STE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Trailer">
+		<fibo-fnd-utl-av:preferredDesignation>TRLR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Unit">
+		<fibo-fnd-utl-av:preferredDesignation>UNIT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Upper">
+		<fibo-fnd-utl-av:preferredDesignation>UPPR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;CompleteAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-uspsa;StandardizedAddress"/>
+		<rdfs:label>complete address</rdfs:label>
+		<skos:definition>delivery address that has all the address elements necessary to allow an exact match with the current Postal Service ZIP+4 and City State files to obtain the finest level of ZIP+4 and delivery point codes for the delivery address</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A complete address may be required on mail at some automation rates.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;DeliveryAddressCodeSet">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeSet"/>
+		<rdfs:subClassOf rdf:resource="&lcc-lr;IdentificationScheme"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasMember"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-uspsa;USPostalServiceAddressIdentifier"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>delivery point code set</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf"/>
+		<skos:definition>system of numeric codes that substitute for specified delivery point details according to the U.S. Postal Service Publication 28</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;DeliveryPointCode">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isMemberOf"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;DeliveryPointCodeSet"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>delivery point code</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf"/>
+		<skos:definition>specific set of digits between 00 and 99 assigned to a delivery point</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>When combined with the ZIP + 4 code, the delivery point code provides a unique identifier for every deliverable address served by the USPS.  The delivery point digits are almost never printed on mail in human-readable form; instead they are encoded in the POSTNET delivery point barcode (DPBC) or as part of the newer Intelligent Mail Barcode (IMB).</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;DeliveryPointCodeSet">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeSet"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasMember"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-uspsa;DeliveryPointCode"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>delivery point code set</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf"/>
+		<skos:definition>system of numeric codes that substitute for specified delivery point details according to the U.S. Postal Service Publication 28</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;DepartmentOfStateAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasCityName"/>
+				<owl:hasValue>DPO</owl:hasValue>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;DepartmentOfStateUnitComponent"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;Mailbox"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>Department of State address</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<skos:definition>delivery address whose delivery address line uses &apos;UNIT&apos; followed by the unit identifier, followed by &apos;BOX&apos; followed by box number, in place of a street address, &apos;DPO&apos; as the literal value for the city, and the appropriate armed forces subdivision code in place of a subdivision (state) code</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;DepartmentOfStateUnitComponent">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressComponent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:hasValue rdf:resource="&fibo-fnd-plc-adr;Unit"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>Department of State unit component</rdfs:label>
+		<skos:definition>component of a Department of State address that includes &apos;UNIT&apos; followed by the unit identifier</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;East">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;GeographicDirectionalSymbol"/>
+		<rdfs:label xml:lang="en">East</rdfs:label>
+		<rdfs:label xml:lang="es">Este</rdfs:label>
+		<skos:definition>geographic directional symbol for East</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>E</fibo-fnd-rel-rel:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;GeneralDeliveryAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine1"/>
+				<owl:hasValue>GENERAL DELIVERY</owl:hasValue>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>general delivery address</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<skos:definition>delivery address that uses the words &apos;GENERAL DELIVERY&apos;, uppercase preferred, spelled out (no abbreviation), in place of a street address</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The value of the +4 component of a ZIP+4 code should be &apos;9999&apos;.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;HighwayContractRoute">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressComponent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:hasValue rdf:resource="&fibo-fnd-plc-uspsa;HighwayContractRouteDesignator"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>highway contract route</rdfs:label>
+		<skos:definition>highway contract route associated with an address</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;HighwayContractRouteAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;HighwayContractRoute"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;Mailbox"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>highway contract address</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<skos:definition>delivery address whose delivery address line uses the abbreviation &apos;HC&apos;, followed by the route identifier, followed by &apos;BOX&apos; followed by box number, in place of a street address</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;HighwayContractRouteDesignator">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressDesignator"/>
+		<rdfs:label>highway contract route designator</rdfs:label>
+		<skos:definition>designator for a route served by an independent contractor rather than directly by the U.S. Postal Service</skos:definition>
+		<fibo-fnd-plc-uspsa:preferredAbbreviation>HC</fibo-fnd-plc-uspsa:preferredAbbreviation>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;InternationalAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<rdfs:label>international address</rdfs:label>
+		<owl:equivalentClass>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasCountry"/>
+				<owl:onClass rdf:resource="&lcc-cr;Country"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</owl:equivalentClass>
+		<skos:definition>physical address that explicitly includes a country</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;Mailbox">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressComponent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:hasValue rdf:resource="&fibo-fnd-plc-uspsa;MailboxDesignator"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>mailbox</rdfs:label>
+		<skos:definition>mailbox, other than a U.S. Post Office box, associated with an address</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;MailboxDesignator">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressDesignator"/>
+		<rdfs:label>mailbox designator</rdfs:label>
+		<skos:definition>designator for a mail box other than a U.S. Post Office box</skos:definition>
+		<fibo-fnd-plc-uspsa:preferredAbbreviation>BOX</fibo-fnd-plc-uspsa:preferredAbbreviation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;North">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;GeographicDirectionalSymbol"/>
+		<rdfs:label xml:lang="es">Norte</rdfs:label>
+		<rdfs:label xml:lang="en">North</rdfs:label>
+		<skos:definition>geographic directional symbol for North</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>N</fibo-fnd-rel-rel:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Northeast">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;GeographicDirectionalSymbol"/>
+		<rdfs:label xml:lang="es">Noreste</rdfs:label>
+		<rdfs:label xml:lang="en">Northeast</rdfs:label>
+		<skos:definition>geographic directional symbol for Northeast</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>NE</fibo-fnd-rel-rel:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Northwest">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;GeographicDirectionalSymbol"/>
+		<rdfs:label xml:lang="es">Noroeste</rdfs:label>
+		<rdfs:label xml:lang="en">Northwest</rdfs:label>
+		<skos:definition>geographic directional symbol for Northwest</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>NO</fibo-fnd-rel-rel:hasTag>
+		<fibo-fnd-rel-rel:hasTag>NW</fibo-fnd-rel-rel:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;OverseasMilitaryAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasCityName"/>
+						<owl:hasValue>APO</owl:hasValue>
+					</owl:Restriction>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasCityName"/>
+						<owl:hasValue>FPO</owl:hasValue>
+					</owl:Restriction>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine1"/>
+						<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+						<owl:onDataRange rdf:resource="&rdfs;Literal"/>
+					</owl:Restriction>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine2"/>
+						<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+						<owl:onDataRange rdf:resource="&rdfs;Literal"/>
+					</owl:Restriction>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine3"/>
+						<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+						<owl:onDataRange rdf:resource="&rdfs;Literal"/>
+					</owl:Restriction>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label>overseas military address</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<skos:definition>delivery address whose delivery address line uses an abbreviation for the unit or command such as &apos;CMR&apos;, &apos;PSC&apos;, or &apos;UNIT&apos;, or  &apos;HC&apos;, followed by the unit identifier, followed by &apos;BOX&apos; followed by box number, in place of a street address, either &apos;APO&apos; or &apos;FPO&apos; as the literal value for the city and the appropriate armed forces subdivision code in place of a subdivision (state) code</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;PrivateMailBoxAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<rdfs:label>private mail box address</rdfs:label>
+		<skos:definition>delivery address provided by a commercial mail receiving company that includes a supplementary address line containing the abbreviation &apos;PMB&apos; or the pound &quot;#&quot; symbol followed by the mailbox number; alternatively, &apos;PMB&apos; or &apos;#&quot; and the mailbox number can be appended to the street address</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;PuertoRicoAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;Urbanization"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>Puerto Rico address</rdfs:label>
+		<skos:definition>delivery address for a delivery point in Puerto Rico that may include a supplementary address line containing the abbreviation &apos;URB&apos; followed by the name of the urbanization area that is appropriate for that address</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;RuralRoute">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressComponent"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:hasValue rdf:resource="&fibo-fnd-plc-uspsa;RuralRouteDesignator"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>highway contract route address</rdfs:label>
+		<skos:definition>mail route outside the city or township limits in a rural area associated with an address</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;RuralRouteAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;Mailbox"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;RuralRoute"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>rural route address</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-fnd-plc-adr;ConventionalStreetAddress"/>
+		<skos:definition>delivery address whose delivery address line uses the abbreviation &apos;RR&apos;, followed by the route identifier, followed by &apos;BOX&apos; followed by box number, in place of a street address</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;RuralRouteDesignator">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressDesignator"/>
+		<rdfs:label>rural route designator</rdfs:label>
+		<skos:definition>designator for a mail route outside the city or township limits in a rural area</skos:definition>
+		<fibo-fnd-plc-uspsa:preferredAbbreviation>RR</fibo-fnd-plc-uspsa:preferredAbbreviation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;South">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;GeographicDirectionalSymbol"/>
+		<rdfs:label xml:lang="en">South</rdfs:label>
+		<rdfs:label xml:lang="es">Sur</rdfs:label>
+		<skos:definition>geographic directional symbol for South</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>S</fibo-fnd-rel-rel:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Southeast">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;GeographicDirectionalSymbol"/>
+		<rdfs:label xml:lang="en">Southeast</rdfs:label>
+		<rdfs:label xml:lang="es">Sureste</rdfs:label>
+		<skos:definition>geographic directional symbol for Southeast</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>SE</fibo-fnd-rel-rel:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Southwest">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;GeographicDirectionalSymbol"/>
+		<rdfs:label xml:lang="en">Southwest</rdfs:label>
+		<rdfs:label xml:lang="es">Suroeste</rdfs:label>
+		<skos:definition>geographic directional symbol for Southwest</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>SO</fibo-fnd-rel-rel:hasTag>
+		<fibo-fnd-rel-rel:hasTag>SW</fibo-fnd-rel-rel:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;StandardizedAddress">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
+		<rdfs:label>standardized address</rdfs:label>
+		<skos:definition>delivery address that is fully spelled out, abbreviated by using the Postal Service standard abbreviations or as given in the current Postal Service ZIP+4 file</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;USPostOfficeBoxDesignator">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;PostOfficeBoxDesignator"/>
+		<rdfs:label>post office box designator</rdfs:label>
+		<skos:definition>designator for a U.S. Post Office box</skos:definition>
+		<fibo-fnd-plc-uspsa:preferredAbbreviation>PO BOX</fibo-fnd-plc-uspsa:preferredAbbreviation>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;USPostalServiceAddressIdentifier">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;PhysicalAddressIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;DeliveryPointCode"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-uspsa;ZIPPlus4Code"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<fibo-fnd-utl-av:explanatoryNote>When combined with the ZIP + 4 code, the delivery point code provides a unique identifier for every deliverable address served by the USPS.  The delivery point digits are almost never printed on mail in human-readable form; instead they are encoded in the POSTNET delivery point barcode (DPBC) or as part of the newer Intelligent Mail Barcode (IMB).</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;Urbanization">
+		<rdfs:subClassOf rdf:resource="&lcc-cr;CountrySubdivision"/>
+		<rdfs:label>urbanization</rdfs:label>
+		<skos:definition>an area, sector, or development within a larger geographic area</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>This URB descriptor, commonly used in urban areas of Puerto Rico, is an important part of the addressing format, as it describes the location of a given street.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;West">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;GeographicDirectionalSymbol"/>
+		<rdfs:label xml:lang="es">Oeste</rdfs:label>
+		<rdfs:label xml:lang="en">West</rdfs:label>
+		<skos:definition>geographic directional symbol for West</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>O</fibo-fnd-rel-rel:hasTag>
+		<fibo-fnd-rel-rel:hasTag>W</fibo-fnd-rel-rel:hasTag>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;ZIPCode">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Postcode"/>
+		<rdfs:label>Zip Code</rdfs:label>
+		<skos:definition>five-digit code code assigned to a delivery address indicating the state and post office or postal zone</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;ZIPPlus4Code">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Postcode"/>
+		<rdfs:label>ZIP+4 Code</rdfs:label>
+		<skos:definition>nine-digit number consisting of five digits, a hyphen, and four digits, which the USPS describes by its trademark ZIP+4</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The correct format for a numeric ZIP+4 code is five digits, a hyphen, and four digits. The first five digits represent the 5-digit ZIP Code; the sixth and seventh digits (the first two after the hyphen) identify an area known as a sector; the eighth and ninth digits identify a smaller area known as a segment. Together, the final four digits identify geographic units such as a side of a street between intersections, both sides of a street between intersections, a building, a floor or group of floors in a building, a firm within a building, a span of boxes on a rural route, or a group of Post Office boxes to which a single USPS employee makes delivery.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;ZipCodeScheme">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeSet"/>
+		<rdfs:subClassOf rdf:resource="&lcc-lr;IdentificationScheme"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasMember"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;ZIPCode">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fnd-plc-uspsa;ZIPPlus4Code">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>zip code scheme</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf"/>
+		<skos:definition>system used in the U.S. to facilitate the delivery of mail, consisting of a five- or nine-digit code Zone Improvement Plan (ZIP) printed directly after the address, the first five digits (initial code) indicating the state and post office or postal zone, the last four (expanded code) the box section or number, portion of a rural route, building, or other specific delivery location</skos:definition>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-plc-uspsa;hasUrbanization">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+		<rdfs:label>has urbanization</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-plc-uspsa;Urbanization"/>
+		<skos:definition>indicates  area, sector, or development within a geographic area relevant to a delivery address</skos:definition>
+	</owl:ObjectProperty>
+
+</rdf:RDF>

--- a/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
@@ -335,7 +335,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressDesignator"/>
 		<rdfs:label>highway contract route designator</rdfs:label>
 		<skos:definition>designator for a route served by an independent contractor rather than directly by the U.S. Postal Service</skos:definition>
-		<fibo-fnd-plc-uspsa:preferredAbbreviation>HC</fibo-fnd-plc-uspsa:preferredAbbreviation>
+		<fibo-fnd-utl-av:preferredDesignation>HC</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;InternationalAddress">
@@ -367,7 +367,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressDesignator"/>
 		<rdfs:label>mailbox designator</rdfs:label>
 		<skos:definition>designator for a mail box other than a U.S. Post Office box</skos:definition>
-		<fibo-fnd-plc-uspsa:preferredAbbreviation>BOX</fibo-fnd-plc-uspsa:preferredAbbreviation>
+		<fibo-fnd-utl-av:preferredDesignation>BOX</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;North">
@@ -493,7 +493,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressDesignator"/>
 		<rdfs:label>rural route designator</rdfs:label>
 		<skos:definition>designator for a mail route outside the city or township limits in a rural area</skos:definition>
-		<fibo-fnd-plc-uspsa:preferredAbbreviation>RR</fibo-fnd-plc-uspsa:preferredAbbreviation>
+		<fibo-fnd-utl-av:preferredDesignation>RR</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;South">
@@ -531,7 +531,7 @@
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;PostOfficeBoxDesignator"/>
 		<rdfs:label>post office box designator</rdfs:label>
 		<skos:definition>designator for a U.S. Post Office box</skos:definition>
-		<fibo-fnd-plc-uspsa:preferredAbbreviation>PO BOX</fibo-fnd-plc-uspsa:preferredAbbreviation>
+		<fibo-fnd-utl-av:preferredDesignation>PO BOX</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;USPostalServiceAddressIdentifier">
@@ -550,7 +550,9 @@
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:explanatoryNote>When combined with the ZIP + 4 code, the delivery point code provides a unique identifier for every deliverable address served by the USPS.  The delivery point digits are almost never printed on mail in human-readable form; instead they are encoded in the POSTNET delivery point barcode (DPBC) or as part of the newer Intelligent Mail Barcode (IMB).</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label>U.S. Postal Service address identifier</rdfs:label>
+		<skos:definition>combined with the ZIP + 4 code, the delivery point code provides a unique identifier for every deliverable address served by the USPS</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The delivery point digits are almost never printed on mail in human-readable form; instead they are encoded in the POSTNET delivery point barcode (DPBC) or as part of the newer Intelligent Mail Barcode (IMB).</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;Urbanization">

--- a/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
@@ -909,7 +909,7 @@
 		<fibo-fnd-utl-av:preferredDesignation>JCTS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Key-SFX">
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Key">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>key</rdfs:label>
 		<fibo-fnd-utl-av:commonDesignation>KEY</fibo-fnd-utl-av:commonDesignation>
@@ -1656,7 +1656,7 @@
 		<fibo-fnd-utl-av:preferredDesignation>TRL</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Trailer-SFX">
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Trailer">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>trailer</rdfs:label>
 		<fibo-fnd-utl-av:commonDesignation>TRAILER</fibo-fnd-utl-av:commonDesignation>

--- a/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
@@ -1,0 +1,2119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-plc-adr "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/">
+	<!ENTITY fibo-fnd-plc-uspsa "https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/">
+	<!ENTITY fibo-fnd-plc-uspsai "https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
+	<!ENTITY lcc-3166-2-us "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-plc-adr="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"
+	xmlns:fibo-fnd-plc-uspsa="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"
+	xmlns:fibo-fnd-plc-uspsai="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
+	xmlns:lcc-3166-2-us="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/">
+		<rdfs:label>U.S. Postal Service Addresses Individuals Ontology</rdfs:label>
+		<dct:abstract>This ontology augments the U.S. Postal Service Address ontology with individuals for various street suffixes, military and U.S. Department of State specific individuals, and preferred designations for state and territory codes.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contributor>Thematix Partners LLC</sm:contributor>
+		<sm:copyright>Copyright (c) 2019-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2019-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-fnd-plc-uspsai</sm:fileAbbreviation>
+		<sm:filename>USPostalServiceAddressIndividuals.rdf</sm:filename>
+		<rdfs:seeAlso rdf:resource="https://about.usps.com/who/profile/"/>
+		<rdfs:seeAlso rdf:resource="https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Addresses/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Alley">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>alley</rdfs:label>
+		<skos:definition>narrow passageway between or behind buildings</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>ALLEE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ALLEY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ALLY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ALY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ALY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Annex">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>annex</rdfs:label>
+		<skos:definition>addition appended to something else, such as another street</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>ANEX</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ANNEX</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ANNX</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ANX</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ANX</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Arcade">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>arcade</rdfs:label>
+		<skos:definition>arched or covered passageway, usually with shops on each side</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>ARC</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ARCADE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ARC</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ArmedForcesAmericas">
+		<rdf:type rdf:resource="&lcc-cr;CountrySubdivision"/>
+		<rdfs:label>Armed Forces Americas</rdfs:label>
+		<skos:definition>state designation for Armed Forces Americas, excluding Canada</skos:definition>
+		<lcc-cr:hasEnglishShortName xml:lang="en">Armed Forces Americas</lcc-cr:hasEnglishShortName>
+		<lcc-cr:isClassifiedBy rdf:resource="&lcc-3166-2-us;State"/>
+		<lcc-cr:isSubregionOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ArmedForcesEurope">
+		<rdf:type rdf:resource="&lcc-cr;CountrySubdivision"/>
+		<rdfs:label>Armed Forces Europe</rdfs:label>
+		<skos:definition>state designation for Armed Forces Europe, the Middle East, and Canada</skos:definition>
+		<lcc-cr:hasEnglishShortName xml:lang="en">Armed Forces Europe, the Middle East, and Canada</lcc-cr:hasEnglishShortName>
+		<lcc-cr:isClassifiedBy rdf:resource="&lcc-3166-2-us;State"/>
+		<lcc-cr:isSubregionOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ArmedForcesPacific">
+		<rdf:type rdf:resource="&lcc-cr;CountrySubdivision"/>
+		<rdfs:label>Armed Forces Pacific</rdfs:label>
+		<skos:definition>state designation for Armed Forces Pacific</skos:definition>
+		<lcc-cr:hasEnglishShortName xml:lang="en">Armed Forces Pacific</lcc-cr:hasEnglishShortName>
+		<lcc-cr:isClassifiedBy rdf:resource="&lcc-3166-2-us;State"/>
+		<lcc-cr:isSubregionOf rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Avenue">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>avenue</rdfs:label>
+		<skos:definition>broad road in a town or city, typically having trees at regular intervals along its sides</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>AV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>AVE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>AVEN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>AVENU</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>AVENUE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>AVN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>AVNUE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>AVE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Bayou">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>bayou</rdfs:label>
+		<skos:definition>creek, secondary watercourse, or minor river that is tributary to another body of water</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BAYOO</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BAYOU</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BYU</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Beach">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>beach</rdfs:label>
+		<skos:definition>shore of a body of water covered by sand, gravel, or larger rock fragments</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BCH</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BEACH</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BCH</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Bend">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>bend</rdfs:label>
+		<skos:definition>curve, especially a sharp one, in a road, river, racecourse, or path</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BEND</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BND</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BND</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Bluff">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>bluff</rdfs:label>
+		<skos:definition>broad, rounded cliff</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BLF</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BLUF</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BLUFF</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BLF</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Bluffs">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>bluffs</rdfs:label>
+		<skos:definition>multiple broad, rounded cliffs</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BLUFFS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BLFS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Bottom">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>bottom</rdfs:label>
+		<skos:definition>deepest or lowest part of something, such as the bottom of a hill</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BOT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BOTTM</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BOTTOM</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BTM</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BTM</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Boulevard">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>boulevard</rdfs:label>
+		<skos:definition>broad thoroughfare in a city, usually having areas at the sides or center for trees, grass, or flowers</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BLVD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BOUL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BOULEVARD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BOULV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BLVD</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Branch">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>branch</rdfs:label>
+		<skos:definition>division of a road or path</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BRANCH</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BRNCH</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Bridge">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>bridge</rdfs:label>
+		<skos:definition>structure carrying a road, path, railroad, or canal across a river, ravine, road, railroad, or other obstacle</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BRDGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BRG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BRIDGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BRG</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Brook">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>brook</rdfs:label>
+		<skos:definition>small, natural freshwater stream</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BRK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BROOK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BRK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Brooks">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>brooks</rdfs:label>
+		<skos:definition>multiple small, natural freshwater streams</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BROOKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BRKS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Burg">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>burg</rdfs:label>
+		<skos:definition>city or town (informal)</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BURG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BG</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Burgs">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>burgs</rdfs:label>
+		<skos:definition>multiple cities or towns (informal)</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BURGS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BGS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Bypass">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>bypass</rdfs:label>
+		<skos:definition>road passing around a town or its center to provide an alternative route for through traffic</skos:definition>
+		<fibo-fnd-utl-av:commonDesignation>BYP</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BYPA</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BYPAS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BYPASS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>BYS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BYP</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Camp">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>camp</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CAMP</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CMP</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CP</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CP</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Canyon">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>canyon</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CANYN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CANYON</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CNYN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CYN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Cape">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>cape</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CAPE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CPE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CPE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Causeway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>causeway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CAUSEWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CAUSWA</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CSWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CSWY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Center">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>center</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CEN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CENT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CENTER</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CENTR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CENTRE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CNTER</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CNTR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CTR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CTR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Centers">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>centers</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CENTERS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CTRS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Circle">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>circle</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CIR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CIRC</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CIRCL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CIRCLE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CRCL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CRCLE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CIR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Circles">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>circles</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CIRCLES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CIRS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Cliff">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>cliff</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CLF</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CLIFF</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CLF</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Cliffs">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>cliffs</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CLFS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CLIFFS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CLFS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Club">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>club</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CLB</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CLUB</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CLB</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Common">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>common</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>COMMON</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CMN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Commons">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>commons</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>COMMONS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CMNS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Corner">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>corner</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>COR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CORNER</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>COR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Corners">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>corners</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CORNERS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CORS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CORS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Course">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>course</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>COURSE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CRSE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CRSE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Court">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>court</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>COURT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Courts">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>courts</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>COURTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Cove">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>cove</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>COVE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CV</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Coves">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>coves</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>COVES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CVS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Creek">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>creek</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CREEK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CRK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CRK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Crescent">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>crescent</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CRES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CRESCENT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CRSENT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CRSNT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CRES</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Crest">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>crest</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CREST</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CRST</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Crossing">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>crossing</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CROSSING</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>CRSSNG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>XING</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>XING</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Crossroad">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>crossroad</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CROSSROAD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>XRD</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Crossroads">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>crossroads</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CROSSROADS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>XRDS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Curve">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>curve</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>CURVE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>CURV</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Dale">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>dale</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>DALE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>DL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>DL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Dam">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>dam</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>DAM</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>DM</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>DM</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Divide">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>divide</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>DIV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>DIVIDE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>DV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>DVD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>DV</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Drive">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>drive</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>DR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>DRIV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>DRIVE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>DRV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>DR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Drives">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>drives</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>DRIVES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>DRS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Estate">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>estate</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>EST</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ESTATE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>EST</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Estates">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>estates</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>ESTATES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ESTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ESTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Expressway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>expressway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>EXP</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>EXPR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>EXPRESS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>EXPRESSWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>EXPW</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>EXPY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>EXPY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Extension">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>extension</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>EXT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>EXTENSION</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>EXTN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>EXTNSN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>EXT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Extensions">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>extensions</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>EXTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>EXTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Fall">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>fall</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FALL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FALL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Falls">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>falls</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FALLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FLS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Ferry">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>ferry</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FERRY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRRY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FRY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Field">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>field</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FIELD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FLD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FLD</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Fields">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>fields</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FIELDS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FLDS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FLDS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Flat">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>flat</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FLAT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FLT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FLT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Flats">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>flats</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FLATS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FLTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FLTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Ford">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>ford</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FORD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FRD</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Fords">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>fords</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FORDS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FRDS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Forest">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>forest</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FOREST</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FORESTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRST</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FRST</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Forge">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>forge</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FORG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FORGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FRG</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Forges">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>forges</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FORGES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FRGS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Fork">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>fork</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FORK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FRK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Forks">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>forks</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FORKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FRKS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Fort">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>fort</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FORT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Freeway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>freeway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>FREEWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FREEWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FRWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>FWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>FWY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Garden">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>garden</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>GARDEN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GARDN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GRDEN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GRDN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>GDN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Gardens">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>gardens</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>GARDENS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GDNS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GRDNS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>GDNS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Gateway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>gateway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>GATEWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GATEWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GATWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GTWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GTWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>GTWY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Glen">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>glen</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>GLEN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GLN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>GLN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Glens">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>glens</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>GLENS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>GLNS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Green">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>green</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>GREEN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GRN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>GRN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Greens">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>greens</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>GREENS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>GRNS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Grove">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>grove</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>GROV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GROVE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>GRV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>GRV</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Groves">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>groves</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>GROVES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>GRVS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Harbor">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>harbor</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>HARB</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HARBOR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HARBR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HBR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HRBOR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>HBR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Harbors">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>harbors</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>HARBORS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>HBRS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Haven">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>haven</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>HAVEN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HVN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>HVN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Heights">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>heights</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>HT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>HTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Highway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>highway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>HIGHWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HIGHWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HIWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HIWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>HWY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Hill">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>hill</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>HILL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>HL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Hills">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>hills</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>HILLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>HLS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Hollow">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>hollow</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>HLLW</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HOLLOW</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HOLLOWS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HOLW</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>HOLWS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>HOLW</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Inlet">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>inlet</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>INLT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>INLT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Island">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>island</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>IS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ISLAND</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ISLND</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>IS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Islands">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>islands</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>ISLANDS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ISLNDS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ISS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ISS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Isle">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>isle</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>ISLE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ISLES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ISLE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Junction">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>junction</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>JCT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>JCTION</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>JCTN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>JUNCTION</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>JUNCTN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>JUNCTON</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>JCT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Junctions">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>junctions</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>JCTNS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>JCTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>JUNCTIONS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>JCTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Key-SFX">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>key</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>KEY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>KY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>KY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Keys">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>keys</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>KEYS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>KYS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>KYS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Knoll">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>knoll</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>KNL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>KNOL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>KNOLL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>KNL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Knolls">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>knolls</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>KNLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>KNOLLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>KNLS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Lake">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>lake</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LAKE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Lakes">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>lakes</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LAKES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LKS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Land">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>land</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LAND</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LAND</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Landing">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>landing</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LANDING</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LNDG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LNDNG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LNDG</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Lane">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>lane</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LANE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Light">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>light</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LGT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LIGHT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LGT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Lights">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>lights</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LIGHTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LGTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Loaf">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>loaf</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LF</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LOAF</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LF</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Lock">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>lock</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LCK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LOCK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LCK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Locks">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>locks</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LCKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LOCKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LCKS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Lodge">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>lodge</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LDG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LDGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LODG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LODGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LDG</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Loop">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>loop</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>LOOP</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>LOOPS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>LOOP</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mall">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>mall</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MALL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MALL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Manor">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>manor</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MANOR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MNR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MNR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Manors">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>manors</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MANORS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MNRS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MNRS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Meadow">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>meadow</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MEADOW</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MDW</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Meadows">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>meadows</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MDW</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MDWS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MEADOWS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MEDOWS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MDWS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mews">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>mews</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MEWS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MEWS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mill">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>mill</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MILL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ML</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mills">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>mills</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MILLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MLS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mission">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>mission</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MISSN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MSSN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MSN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Motorway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>motorway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MOTORWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MTWY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mount">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>mount</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MNT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MOUNT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mountain">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>mountain</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MNTAIN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MNTN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MOUNTAIN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MOUNTIN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MTIN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MTN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MTN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mountains">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>mountains</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>MNTNS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>MOUNTAINS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MTNS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Neck">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>neck</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>NCK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>NECK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>NCK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Orchard">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>orchard</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>ORCH</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ORCHARD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ORCHRD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ORCH</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Oval">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>oval</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>OVAL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>OVL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>OVAL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Overpass">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>overpass</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>OVERPASS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>OPAS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Park">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>park</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PARK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PRK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PARK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Parks">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>parks</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PARKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PARK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Parkway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>parkway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PARKWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PARKWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PKWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PKWY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PKY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PKWY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Parkways">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>parkways</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PARKWAYS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PKWYS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PKWY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Pass">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>pass</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PASS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PASS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Passage">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>passage</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PASSAGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PSGE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Path">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>path</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PATH</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PATHS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PATH</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Pike">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>pike</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PIKE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PIKES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PIKE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Pine">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>pine</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PINE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PNE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Pines">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>pines</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PINES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PNES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PNES</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Place">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>place</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Plain">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>plain</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PLAIN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PLN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PLN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Plains">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>plains</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PLAINS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PLNS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PLNS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Plaza">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>plaza</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PLAZA</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PLZ</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PLZA</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PLZ</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Point">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>point</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>POINT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Points">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>points</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>POINTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Port">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>port</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PORT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PRT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PRT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Ports">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>ports</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PORTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PRTS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PRTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Prairie">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>prairie</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>PR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PRAIRIE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>PRR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Radial">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>radial</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RAD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RADIAL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RADIEL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RADL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RADL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Ramp">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>ramp</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RAMP</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RAMP</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Ranch">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>ranch</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RANCH</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RANCHES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RNCH</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RNCHS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RNCH</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Rapid">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>rapid</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RAPID</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RPD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RPD</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Rapids">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>rapids</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RAPIDS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RPDS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RPDS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Rest">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>rest</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>REST</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RST</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RST</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Ridge">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>ridge</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RDG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RDGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RIDGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RDG</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Ridges">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>ridges</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RDGS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RIDGES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RDGS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;River">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>river</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RIV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RIVER</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RIVR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>RVR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RIV</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Road">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>road</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ROAD</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RD</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Roads">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>roads</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RDS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>ROADS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RDS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Route">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>route</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>ROUTE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RTE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Row">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>row</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>ROW</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ROW</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Rue">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>rue</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RUE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RUE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Run">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>run</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>RUN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>RUN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Shoal">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>shoal</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SHL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SHOAL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SHL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Shoals">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>shoals</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SHLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SHOALS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SHLS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Shore">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>shore</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SHOAR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SHORE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SHR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SHR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Shores">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>shores</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SHOARS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SHORES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SHRS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SHRS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Skyway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>skyway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SKYWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SKWY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Spring">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>spring</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SPG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SPNG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SPRING</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SPRNG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SPG</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Springs">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>springs</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SPGS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SPNGS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SPRINGS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SPRNGS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SPGS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Spur">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>spur</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SPUR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SPUR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Spurs">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>spurs</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SPURS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SPUR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Square">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>square</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SQ</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SQR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SQRE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SQU</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SQUARE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SQ</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Squares">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>squares</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SQRS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SQUARES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SQS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Station">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>station</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>STA</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STATION</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STATN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>STA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Stravenue">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>stravenue</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>STRA</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STRAV</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STRAVEN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STRAVENUE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STRAVN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STRVN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STRVNUE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>STRA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Stream">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>stream</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>STREAM</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STREME</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STRM</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>STRM</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Street">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>street</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>ST</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STREET</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>STRT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ST</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Streets">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>streets</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>STREETS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>STS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Summit">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>summit</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>SMT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SUMIT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SUMITT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>SUMMIT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SMT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Terrace">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>terrace</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>TER</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TERR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TERRACE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>TER</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Throughway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>throughway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>THROUGHWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>TRWY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Trace">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>trace</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>TRACE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRACES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRCE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>TRCE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Track">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>track</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>TRACK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRACKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRAK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>TRAK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Trafficway">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>trafficway</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>TRAFFICWAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>TRFY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Trail">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>trail</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>TRAIL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRAILS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>TRL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Trailer-SFX">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>trailer</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>TRAILER</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRLR</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TRLRS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>TRLR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Tunnel">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>tunnel</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>TUNEL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TUNL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TUNLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TUNNEL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TUNNELS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TUNNL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>TUNL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Turnpike">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>turnpike</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>TRNPK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TURNPIKE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>TURNPK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>TPKE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;US-AA">
+		<rdf:type rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
+		<rdfs:label>US-AA</rdfs:label>
+		<skos:definition>subdivision code for the state designation for Armed Forces Americas, excluding Canada</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
+		<lcc-lr:hasTag>US-AA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;US-AE">
+		<rdf:type rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
+		<rdfs:label>US-AE</rdfs:label>
+		<skos:definition>subdivision code for the state designation for Armed Forces Europe, the Middle East, and Canada</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AE</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
+		<lcc-lr:hasTag>US-AE</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;US-AP">
+		<rdf:type rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
+		<rdfs:label>US-AP</rdfs:label>
+		<skos:definition>subdivision code for the state designation for Armed Forces Pacific</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AP</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
+		<lcc-lr:hasTag>US-AP</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Underpass">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>underpass</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>UNDERPASS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>UPAS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Union">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>union</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>UN</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>UNION</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>UN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Unions">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>unions</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>UNIONS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>UNS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Valley">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>valley</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>VALLEY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VALLY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VLLY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VLY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>VLY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Valleys">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>valleys</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>VALLEYS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VLYS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>VLYS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Viaduct">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>viaduct</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>VDCT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VIA</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VIADCT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VIADUCT</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>VIA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;View">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>view</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>VIEW</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VW</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>VW</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Views">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>views</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>VIEWS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VWS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>VWS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Village">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>village</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>VILL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VILLAG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VILLAGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VILLG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VILLIAGE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VLG</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>VLG</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Villages">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>villages</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>VILLAGES</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VLGS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>VLGS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Ville">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>ville</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>VILLE</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>VL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Vista">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>vista</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>VIS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VIST</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VISTA</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VST</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>VSTA</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>VIS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Walk">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>walk</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>WALK</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>WALK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Walks">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>walks</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>WALKS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>WALK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Wall">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>wall</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>WALL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>WALL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Way">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>way</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>WAY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>WY</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>WAY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Ways">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>ways</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>WAYS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>WAYS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Well">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>well</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>WELL</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>WL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Wells">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
+		<rdfs:label>wells</rdfs:label>
+		<fibo-fnd-utl-av:commonDesignation>WELLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:commonDesignation>WLS</fibo-fnd-utl-av:commonDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>WLS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-1;FM">
+		<fibo-fnd-utl-av:preferredDesignation>FM</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-1;GU">
+		<fibo-fnd-utl-av:preferredDesignation>GU</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-1;MH">
+		<fibo-fnd-utl-av:preferredDesignation>MH</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-1;PW">
+		<fibo-fnd-utl-av:preferredDesignation>PW</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AK">
+		<fibo-fnd-utl-av:preferredDesignation>AK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AL">
+		<fibo-fnd-utl-av:preferredDesignation>AL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AR">
+		<fibo-fnd-utl-av:preferredDesignation>AR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AS">
+		<fibo-fnd-utl-av:preferredDesignation>AS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AZ">
+		<fibo-fnd-utl-av:preferredDesignation>AZ</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-CA">
+		<fibo-fnd-utl-av:preferredDesignation>CA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-CO">
+		<fibo-fnd-utl-av:preferredDesignation>CO</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-CT">
+		<fibo-fnd-utl-av:preferredDesignation>CT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-DC">
+		<fibo-fnd-utl-av:preferredDesignation>DC</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-DE">
+		<fibo-fnd-utl-av:preferredDesignation>DE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-FL">
+		<fibo-fnd-utl-av:preferredDesignation>FL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-GA">
+		<fibo-fnd-utl-av:preferredDesignation>GA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-GU">
+		<fibo-fnd-utl-av:preferredDesignation>GU</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-HI">
+		<fibo-fnd-utl-av:preferredDesignation>HI</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-IA">
+		<fibo-fnd-utl-av:preferredDesignation>IA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-ID">
+		<fibo-fnd-utl-av:preferredDesignation>ID</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-IL">
+		<fibo-fnd-utl-av:preferredDesignation>IL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-IN">
+		<fibo-fnd-utl-av:preferredDesignation>IN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-KS">
+		<fibo-fnd-utl-av:preferredDesignation>KS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-KY">
+		<fibo-fnd-utl-av:preferredDesignation>KY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-LA">
+		<fibo-fnd-utl-av:preferredDesignation>LA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MA">
+		<fibo-fnd-utl-av:preferredDesignation>MA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MD">
+		<fibo-fnd-utl-av:preferredDesignation>MD</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-ME">
+		<fibo-fnd-utl-av:preferredDesignation>ME</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MI">
+		<fibo-fnd-utl-av:preferredDesignation>MI</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MN">
+		<fibo-fnd-utl-av:preferredDesignation>MN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MO">
+		<fibo-fnd-utl-av:preferredDesignation>MO</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MP">
+		<fibo-fnd-utl-av:preferredDesignation>MP</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MS">
+		<fibo-fnd-utl-av:preferredDesignation>MS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MT">
+		<fibo-fnd-utl-av:preferredDesignation>MT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NC">
+		<fibo-fnd-utl-av:preferredDesignation>NC</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-ND">
+		<fibo-fnd-utl-av:preferredDesignation>ND</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NE">
+		<fibo-fnd-utl-av:preferredDesignation>NE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NH">
+		<fibo-fnd-utl-av:preferredDesignation>NH</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NJ">
+		<fibo-fnd-utl-av:preferredDesignation>NJ</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NM">
+		<fibo-fnd-utl-av:preferredDesignation>NM</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NV">
+		<fibo-fnd-utl-av:preferredDesignation>NV</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NY">
+		<fibo-fnd-utl-av:preferredDesignation>NY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-OH">
+		<fibo-fnd-utl-av:preferredDesignation>OH</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-OK">
+		<fibo-fnd-utl-av:preferredDesignation>OK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-OR">
+		<fibo-fnd-utl-av:preferredDesignation>OR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-PA">
+		<fibo-fnd-utl-av:preferredDesignation>PA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-PR">
+		<fibo-fnd-utl-av:preferredDesignation>PR</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-RI">
+		<fibo-fnd-utl-av:preferredDesignation>RI</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-SC">
+		<fibo-fnd-utl-av:preferredDesignation>SC</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-SD">
+		<fibo-fnd-utl-av:preferredDesignation>SD</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-TN">
+		<fibo-fnd-utl-av:preferredDesignation>TN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-TX">
+		<fibo-fnd-utl-av:preferredDesignation>TX</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-UM">
+		<fibo-fnd-utl-av:preferredDesignation>UM</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-UT">
+		<fibo-fnd-utl-av:preferredDesignation>UT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-VA">
+		<fibo-fnd-utl-av:preferredDesignation>VA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-VI">
+		<fibo-fnd-utl-av:preferredDesignation>VI</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-VT">
+		<fibo-fnd-utl-av:preferredDesignation>VT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WA">
+		<fibo-fnd-utl-av:preferredDesignation>WA</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WI">
+		<fibo-fnd-utl-av:preferredDesignation>WI</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WV">
+		<fibo-fnd-utl-av:preferredDesignation>WV</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WY">
+		<fibo-fnd-utl-av:preferredDesignation>WY</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+
+</rdf:RDF>

--- a/FND/Utilities/AnnotationVocabulary.rdf
+++ b/FND/Utilities/AnnotationVocabulary.rdf
@@ -26,13 +26,13 @@
 Note that any of the original properties provided in Dublin Core and SKOS can be used in addition to the terms provided herein.  However, any Dublin Core terms that are not explicitly defined as OWL annotation properties in this ontology or in any of its imports must be so declared in the ontologies that use them.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2019 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2019 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-fnd-utl-av</sm:fileAbbreviation>
 		<sm:filename>AnnotationVocabulary.rdf</sm:filename>
 		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/AnnotationVocabulary/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20130801/Utilities/AnnotationVocabulary.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://www.omg.org/spec/EDMC-FIBO/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Utilities/AnnotationVocabulary.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
@@ -42,53 +42,71 @@ Note that any of the original properties provided in Dublin Core and SKOS can be
    (5) to incorporate changes to the specification metadata to support documentation at the family, specification, module, and ontology level, similar to the abbreviations</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to add the symbol annotation.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to eliminate deprecated properties.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to add common and preferred designations as needed for postal addresses and other purposes, to correct named individuals to be properly declared, and to revise definitions to be ISO 704 compliant.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
-	<fibo-fnd-utl-av:MaturityLevel rdf:about="&fibo-fnd-utl-av;Informative">
+	<owl:AnnotationProperty rdf:about="&dct;modified">
+	</owl:AnnotationProperty>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-utl-av;Informative">
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;MaturityLevel"/>
 		<rdfs:label>informative</rdfs:label>
-		<skos:definition xml:lang="en">This entity has been excluded from publication, but appears here for informational purposes only.  Typically, there is one or more provisional entity that refers to it.</skos:definition>
-	</fibo-fnd-utl-av:MaturityLevel>
+		<skos:definition xml:lang="en">entity that is considered deprecated but included for informational purposes because it is referenced by some provisional concept</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Informative content will be removed as soon as all dependencies have been eliminated, thus FIBO users should not depend on it going forward.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-utl-av;MaturityLevel">
 		<rdfs:subClassOf rdf:resource="&skos;Concept"/>
 		<rdfs:label>maturity level</rdfs:label>
-		<skos:definition>Level of development in some lifecycle that an artifact has reached</skos:definition>
+		<skos:definition>classifier used to indicate state of an artifact with respect to its development lifecycle</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FIBO currently has three maturity levels: Informative, Provisional, and Release.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<fibo-fnd-utl-av:MaturityLevel rdf:about="&fibo-fnd-utl-av;Provisional">
+	<owl:NamedIndividual rdf:about="&fibo-fnd-utl-av;Provisional">
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;MaturityLevel"/>
 		<rdfs:label>provisional</rdfs:label>
-		<skos:definition xml:lang="en">Developmental maturity;  someone has proposed this, but it hasn&apos;t been approved for release</skos:definition>
-	</fibo-fnd-utl-av:MaturityLevel>
+		<skos:definition xml:lang="en">entity that is considered to be under development</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Provisional content is subject to change, and may change substantially prior to release. FIBO users should be aware that it is not dependable, but could be used for informative reference and as the basis for further work.  Release notes with respect to provisional content are likely to be sketchy at best, and users should not expect official change notes to mention it.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
 	
-	<fibo-fnd-utl-av:MaturityLevel rdf:about="&fibo-fnd-utl-av;Release">
+	<owl:NamedIndividual rdf:about="&fibo-fnd-utl-av;Release">
+		<rdf:type rdf:resource="&fibo-fnd-utl-av;MaturityLevel"/>
 		<rdfs:label>release</rdfs:label>
-		<skos:definition xml:lang="en">The most mature level of maturity. Approved for release to the general public</skos:definition>
-	</fibo-fnd-utl-av:MaturityLevel>
+		<skos:definition xml:lang="en">entity that is considered to be stable and mature from a development perspective</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Release notes will be provided for any changes with respect to released content, and any revisions will be backwards compatible with the prior version to the degree possible.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;abbreviation">
 		<rdfs:subPropertyOf rdf:resource="&skos;altLabel"/>
 		<rdfs:label>abbreviation</rdfs:label>
-		<skos:definition>An abbreviation is short form for a particular designation that can be substituted for the primary representation.</skos:definition>
+		<skos:definition>short form designation for an entity that can be substituted for its primary representation</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 1087-1 Terminology work - Vocabulary</fibo-fnd-utl-av:adaptedFrom>
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;adaptedFrom">
 		<rdfs:subPropertyOf rdf:resource="&sm;directSource"/>
 		<rdfs:label>adapted from</rdfs:label>
-		<skos:definition>the document from which a given term (or its definition) was adapted; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
+		<skos:definition>document or other source from which a given term (or its definition) was adapted; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;commonDesignation">
+		<rdfs:subPropertyOf rdf:resource="&skos;altLabel"/>
+		<rdfs:label>common designation</rdfs:label>
+		<skos:definition>frequently used designation for an entity</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf</fibo-fnd-utl-av:adaptedFrom>
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;definitionOrigin">
 		<rdfs:subPropertyOf rdf:resource="&sm;directSource"/>
 		<rdfs:label>definition origin</rdfs:label>
-		<skos:definition>Document from which a given definition was taken directly; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
+		<skos:definition>document or other source from which a given definition was taken directly; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;explanatoryNote">
 		<rdfs:subPropertyOf rdf:resource="&skos;note"/>
 		<rdfs:label>explanatory note</rdfs:label>
-		<skos:definition>a note that provides additional explanatory information about a given concept</skos:definition>
+		<skos:definition>note that provides additional explanatory information about a given concept</skos:definition>
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;hasMaturityLevel">
@@ -98,19 +116,26 @@ Note that any of the original properties provided in Dublin Core and SKOS can be
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;logicalDefinition">
 		<rdfs:label>logical definition</rdfs:label>
-		<skos:definition>describes the OWL logic of a class in natural language</skos:definition>
+		<skos:definition>description of the OWL logic of a model element in natural language</skos:definition>
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;modifiedBy">
 		<rdfs:subPropertyOf rdf:resource="&sm;contributor"/>
 		<rdfs:label>modified by</rdfs:label>
-		<skos:definition>identifies the organization or person responsible for making a change to a model element in the body of an ontology</skos:definition>
+		<skos:definition>organization or person responsible for making a change to a model element</skos:definition>
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;modifiedOn">
 		<rdfs:subPropertyOf rdf:resource="&dct;modified"/>
 		<rdfs:label>modified on</rdfs:label>
-		<skos:definition>identifies the date a model element in the body of an ontology was changed</skos:definition>
+		<skos:definition>date a model element was changed</skos:definition>
+	</owl:AnnotationProperty>
+	
+	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;preferredDesignation">
+		<rdfs:subPropertyOf rdf:resource="&skos;altLabel"/>
+		<rdfs:label>preferred designation</rdfs:label>
+		<skos:definition>recommended designation for an entity in some context</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf</fibo-fnd-utl-av:adaptedFrom>
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;symbol">
@@ -124,20 +149,20 @@ Note that any of the original properties provided in Dublin Core and SKOS can be
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;synonym">
 		<rdfs:subPropertyOf rdf:resource="&skos;altLabel"/>
 		<rdfs:label>synonym</rdfs:label>
-		<skos:definition>A synonym is another designation that can be substituted for the primary representation. It is a designation for the same concept.</skos:definition>
+		<skos:definition>designation that can be substituted for the primary representation of something</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 1087-1 Terminology work - Vocabulary</fibo-fnd-utl-av:adaptedFrom>
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;termOrigin">
 		<rdfs:subPropertyOf rdf:resource="&sm;directSource"/>
 		<rdfs:label>term origin</rdfs:label>
-		<skos:definition>Document from which a given term was taken directly; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
+		<skos:definition>document or other source from which a given term was taken directly; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;usageNote">
 		<rdfs:subPropertyOf rdf:resource="&skos;note"/>
 		<rdfs:label>usage note</rdfs:label>
-		<skos:definition>a note that provides information about how a given concept is used in the FIBO context</skos:definition>
+		<skos:definition>note that provides information about how a given concept should be used or extended</skos:definition>
 	</owl:AnnotationProperty>
 
 </rdf:RDF>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USPostalServiceAndAddressingIndividuals/" uri="./FBC/FunctionalEntities/NorthAmericanEntities/USPostalServiceAndAddressingIndividuals.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USPostalServiceAndAddressing/" uri="./FBC/FunctionalEntities/NorthAmericanEntities/USPostalServiceAndAddressing.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/" uri="./AboutFIBODev.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/" uri="./AboutFIBOProd.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE/" uri="./BE/AllBE.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-Europe/" uri="./BE/AllBE-Europe.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/BE/AllBE-EuropeAndNorthAmerica/" uri="./BE/AllBE-EuropeAndNorthAmerica.rdf"/>
@@ -62,62 +58,59 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/CIV/" uri="./CIV/Funds/CIV.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/MetadataCIVFunds/" uri="./CIV/Funds/MetadataCIVFunds.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/CIV/MetadataCIV/" uri="./CIV/MetadataCIV.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ReferenceIndividuals/" uri="./DER/AllDER-ReferenceIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER/" uri="./DER/AllDER.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ExampleIndividuals/" uri="./DER/AllDER-ExampleIndividuals.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ReferenceIndividuals/" uri="./DER/AllDER-ReferenceIndividuals.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/MetadataDERCreditDerivatives/" uri="./DER/CreditDerivatives/MetadataDERCreditDerivatives.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/" uri="./DER/CreditDerivatives/CreditDefaultSwaps.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/MetadataDERExchangeTradedDerivatives/" uri="./DER/ExchangeTradedDerivatives/MetadataDERExchangeTradedDerivatives.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/" uri="./DER/ExchangeTradedDerivatives/Futures.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/" uri="./DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/" uri="./DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/" uri="./DER/MetadataDER.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxForwards/" uri="./DER/FxDerivatives/FxForwards.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxOptions/" uri="./DER/FxDerivatives/FxOptions.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/MetadataDERFxDerivatives/" uri="./DER/FxDerivatives/MetadataDERFxDerivatives.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSwaps/" uri="./DER/FxDerivatives/FxSwaps.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxContracts/" uri="./DER/FxDerivatives/FxContracts.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSpots/" uri="./DER/FxDerivatives/FxSpots.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/EquityForwards/" uri="./DER/AssetDerivatives/EquityForwards.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/MetadataDERAssetDerivatives/" uri="./DER/AssetDerivatives/MetadataDERAssetDerivatives.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/EquityOptions/" uri="./DER/AssetDerivatives/EquityOptions.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/EquitySwaps/" uri="./DER/AssetDerivatives/EquitySwaps.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/AssetBaskets/" uri="./DER/AssetDerivatives/AssetBaskets.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/AssetDerivatives/" uri="./DER/AssetDerivatives/AssetDerivatives.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/BondOptions/" uri="./DER/AssetDerivatives/BondOptions.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/BondReturnSwaps/" uri="./DER/AssetDerivatives/BondReturnSwaps.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/EquityForwards/" uri="./DER/AssetDerivatives/EquityForwards.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/EquityOptions/" uri="./DER/AssetDerivatives/EquityOptions.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/EquitySwaps/" uri="./DER/AssetDerivatives/EquitySwaps.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/MetadataDERAssetDerivatives/" uri="./DER/AssetDerivatives/MetadataDERAssetDerivatives.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/Commodities/" uri="./DER/CommoditiesDerivatives/Commodities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/" uri="./DER/CommoditiesDerivatives/CommoditiesContracts.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesDelivery/" uri="./DER/CommoditiesDerivatives/CommoditiesDelivery.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommodityForwards/" uri="./DER/CommoditiesDerivatives/CommodityForwards.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/Commodities/" uri="./DER/CommoditiesDerivatives/Commodities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommodityOptions/" uri="./DER/CommoditiesDerivatives/CommodityOptions.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditySpots/" uri="./DER/CommoditiesDerivatives/CommoditySpots.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditySwaps/" uri="./DER/CommoditiesDerivatives/CommoditySwaps.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommodityForwards/" uri="./DER/CommoditiesDerivatives/CommodityForwards.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditySpots/" uri="./DER/CommoditiesDerivatives/CommoditySpots.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/MetadataDERCommoditiesDerivatives/" uri="./DER/CommoditiesDerivatives/MetadataDERCommoditiesDerivatives.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/CreditDefaultSwaps/" uri="./DER/CreditDerivatives/CreditDefaultSwaps.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/CreditDerivatives/MetadataDERCreditDerivatives/" uri="./DER/CreditDerivatives/MetadataDERCreditDerivatives.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ContractsForDifference/" uri="./DER/DerivativesContracts/ContractsForDifference.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/" uri="./DER/DerivativesContracts/DerivativesBasics.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ReturnSwaps/" uri="./DER/DerivativesContracts/ReturnSwaps.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/SwapsIndividuals/" uri="./DER/DerivativesContracts/SwapsIndividuals.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/" uri="./DER/DerivativesContracts/RightsAndWarrants.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/OptionContractsOnFutures/" uri="./DER/DerivativesContracts/OptionContractsOnFutures.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesMasterAgreements/" uri="./DER/DerivativesContracts/DerivativesMasterAgreements.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/" uri="./DER/DerivativesContracts/Forwards.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ContractsForDifference/" uri="./DER/DerivativesContracts/ContractsForDifference.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/MetadataDERDerivativesContracts/" uri="./DER/DerivativesContracts/MetadataDERDerivativesContracts.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/OptionContractsOnFutures/" uri="./DER/DerivativesContracts/OptionContractsOnFutures.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/" uri="./DER/DerivativesContracts/Options.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ParticipationNotes/" uri="./DER/DerivativesContracts/ParticipationNotes.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ReturnSwaps/" uri="./DER/DerivativesContracts/ReturnSwaps.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/RightsAndWarrants/" uri="./DER/DerivativesContracts/RightsAndWarrants.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Spots/" uri="./DER/DerivativesContracts/Spots.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/" uri="./DER/DerivativesContracts/Swaps.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/SwapsIndividuals/" uri="./DER/DerivativesContracts/SwapsIndividuals.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/ParticipationNotes/" uri="./DER/DerivativesContracts/ParticipationNotes.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/" uri="./DER/DerivativesContracts/DerivativesBasics.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaptions/" uri="./DER/DerivativesContracts/Swaptions.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/" uri="./DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/ExchangeTradedOptions/" uri="./DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/" uri="./DER/ExchangeTradedDerivatives/Futures.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/FuturesExchanges/" uri="./DER/ExchangeTradedDerivatives/FuturesExchanges.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/FuturesStandardizedTerms/" uri="./DER/ExchangeTradedDerivatives/FuturesStandardizedTerms.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/MetadataDERExchangeTradedDerivatives/" uri="./DER/ExchangeTradedDerivatives/MetadataDERExchangeTradedDerivatives.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/OptionsExchanges/" uri="./DER/ExchangeTradedDerivatives/OptionsExchanges.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/OptionsStandardizedTerms/" uri="./DER/ExchangeTradedDerivatives/OptionsStandardizedTerms.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxContracts/" uri="./DER/FxDerivatives/FxContracts.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxForwards/" uri="./DER/FxDerivatives/FxForwards.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxOptions/" uri="./DER/FxDerivatives/FxOptions.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSpots/" uri="./DER/FxDerivatives/FxSpots.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSwaps/" uri="./DER/FxDerivatives/FxSwaps.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/MetadataDERFxDerivatives/" uri="./DER/FxDerivatives/MetadataDERFxDerivatives.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/" uri="./DER/MetadataDER.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/" uri="./DER/DerivativesContracts/Swaps.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Spots/" uri="./DER/DerivativesContracts/Spots.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/" uri="./DER/RateDerivatives/RateDerivatives.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/ForwardRateAgreements/" uri="./DER/RateDerivatives/ForwardRateAgreements.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/InflationSwaps/" uri="./DER/RateDerivatives/InflationSwaps.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IROptions/" uri="./DER/RateDerivatives/IROptions.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/" uri="./DER/RateDerivatives/IRSwaps.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/" uri="./DER/RateDerivatives/IRSwapExampleIndividuals.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/InflationSwaps/" uri="./DER/RateDerivatives/InflationSwaps.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/MetadataDERRateDerivatives/" uri="./DER/RateDerivatives/MetadataDERRateDerivatives.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/OTCIndexOptions/" uri="./DER/RateDerivatives/OTCIndexOptions.rdf"/>
-    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/" uri="./DER/RateDerivatives/RateDerivatives.rdf"/>
+    <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IROptions/" uri="./DER/RateDerivatives/IROptions.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC/" uri="./FBC/AllFBC.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-Europe/" uri="./FBC/AllFBC-Europe.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/AllFBC-EuropeAndNorthAmerica/" uri="./FBC/AllFBC-EuropeAndNorthAmerica.rdf"/>
@@ -159,6 +152,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/" uri="./FBC/ProductsAndServices/FinancialProductsAndServices.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/" uri="./FBC/ProductsAndServices/MetadataFBCProductsAndServices.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND/" uri="./FND/AllFND.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/AllFND-NorthAmerica/" uri="./FND/AllFND-NorthAmerica.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/" uri="./FND/MetadataFND.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/" uri="./FND/Accounting/AccountingEquity.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/" uri="./FND/Accounting/CurrencyAmount.rdf"/>
@@ -206,6 +200,8 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Facilities/" uri="./FND/Places/Facilities.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/" uri="./FND/Places/Locations.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/MetadataFNDPlaces/" uri="./FND/Places/MetadataFNDPlaces.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddresses/" uri="./FND/Places/NorthAmerica/USPostalServiceAddresses.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/" uri="./FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/" uri="./FND/Places/VirtualPlaces.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/MetadataFNDProductsAndServices/" uri="./FND/ProductsAndServices/MetadataFNDProductsAndServices.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/PaymentsAndSchedules/" uri="./FND/ProductsAndServices/PaymentsAndSchedules.rdf"/>


### PR DESCRIPTION
## Description

These extensions are needed for LOAN, where for some use cases it is important to know whether or not an address is a military address. Privacy restrictions on customer data in the US require that military addresses are treated with additional care, for example, and members of the service that are stationed overseas are given consideration with respect to delinquency. The extensions include a number of unconventional addresses, in addition to US military addresses, such as rural route addresses, highway contract addresses, private mailboxes, and general delivery addresses.

Fixes: #921 / FND-290 and FBC-226


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


