### PR TITLE
FBC-243 Property 'operates in municipality' defined as a data property and used as object property

### DIFF
--- a/FBC/FunctionalEntities/Markets.rdf
+++ b/FBC/FunctionalEntities/Markets.rdf
@@ -82,7 +82,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/Markets/ version of this ontology was modified to generalize certain unions where they were no longer required and to move international registration authorities individuals to a separate ontology for better modularity.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/FunctionalEntities/Markets/ version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/Markets/ version of this ontology was modified to integrated details from the redundant &apos;securities exchange&apos; concept with &apos;exchange&apos;.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191201/FunctionalEntities/Markets/ version of this ontology was modified to eliminate duplication of concepts in LCC, simplify addresses and merge countries with locations in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191201/FunctionalEntities/Markets/ version of this ontology was modified to eliminate duplication of concepts in LCC, simplify addresses, merge countries with locations in FND, and correct the declaration of the property &apos;operates in municipality&apos; to be an object property.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -393,10 +393,11 @@ OTFs are intended to be similar in scope to a swap execution facility (SEF), a t
 		<skos:definition>indicates the country in which the exchange is registered and operates</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-mkt;operatesInMunicipality">
+	<owl:ObjectProperty rdf:about="&fibo-fbc-fct-mkt;operatesInMunicipality">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-plc-loc;hasMunicipality"/>
 		<rdfs:label>operates in municipality</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
 		<skos:definition>indicates the municipality or business center in which the exchange is registered and operates</skos:definition>
-	</owl:DatatypeProperty>
+	</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This resolution corrects the typing on the property 'operates in municipality' and makes it a subproperty of hasMunicipality.

Fixes: #931 / FBC-243


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


