### PR TITLE
FBC-246  - Misspelled annotation in RegistrationAuthorities

### DIFF
--- a/FBC/FunctionalEntities/RegistrationAuthorities.rdf
+++ b/FBC/FunctionalEntities/RegistrationAuthorities.rdf
@@ -78,7 +78,7 @@
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/RegistrationAuthorities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified as a part of organizational hierarchy simplification, to loosen the definition of registrar, and to leverage the composite date value datatype.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190201/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, make Registry a subclass of Record and StructuredCollection, and make RegistryEntry a child of CollectionConstituent.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190201/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, make Registry a subclass of Record and StructuredCollection, make RegistryEntry a child of CollectionConstituent and correct a misspelled annotation.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -224,7 +224,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>registry</rdfs:label>
 		<skos:definition>authoritative record or collection of records relating to something</skos:definition>
-		<fibo-fnd-utl-av:explantoryNote>Electronic registries typically contain a unique identifier for each entry, so that individual records can be referenced from other documents and registries.</fibo-fnd-utl-av:explantoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Electronic registries typically contain a unique identifier for each entry, so that individual records can be referenced from other documents and registries.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>register</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	


### PR DESCRIPTION
## Description

This resolution fixes the misspelling, likely overlooked for a long time.

Fixes: #944  / FBC-246


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


