### PR TITLE
FND-294 #comment - An additional datatype property is needed for local designations for states and provinces

### DIFF
--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -763,6 +763,12 @@
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-plc-adr;hasLocaleDesignation">
+		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
+		<rdfs:label>has locale designation</rdfs:label>
+		<skos:definition>location-specific appelation (name) for something</skos:definition>
+	</owl:DatatypeProperty>
+	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-plc-adr;hasMailRouting">
 		<rdfs:label>has mail routing</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>

--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -458,6 +458,18 @@
 		<fibo-fnd-plc-adr:requiresSecondaryUnitRange rdf:datatype="&xsd;boolean">false</fibo-fnd-plc-adr:requiresSecondaryUnitRange>
 	</owl:NamedIndividual>
 	
+	<owl:Class rdf:about="&fibo-fnd-plc-adr;RegionSpecificIdentifier">
+		<rdfs:subClassOf rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isUsedBy"/>
+				<owl:someValuesFrom rdf:resource="&lcc-cr;GeopoliticalEntity"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>region-specific identifier</rdfs:label>
+		<skos:definition>geographic region or subdivision identifier used internally by a country or other region</skos:definition>
+	</owl:Class>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-adr;Room">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitDesignator"/>
 		<rdfs:label xml:lang="en">room</rdfs:label>
@@ -762,12 +774,6 @@
 		<skos:definition>indicates the local or international postcode element of a delivery address as specified by the local postal service</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-fnd-plc-adr;hasLocaleDesignation">
-		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasName"/>
-		<rdfs:label>has locale designation</rdfs:label>
-		<skos:definition>location-specific appelation (name) for something</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-plc-adr;hasMailRouting">
 		<rdfs:label>has mail routing</rdfs:label>

--- a/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
@@ -62,6 +62,106 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AA">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>AA</rdfs:label>
+		<skos:definition>US-specific code for the state designation for Armed Forces Americas, excluding Canada</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
+		<lcc-lr:hasTag>AA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AB">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>AB</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Alberta</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AB</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;Alberta"/>
+		<lcc-lr:hasTag>AB</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;Alberta"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AE">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>AE</rdfs:label>
+		<skos:definition>US-specific code for the state designation for Armed Forces Europe, the Middle East, and Canada</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AE</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
+		<lcc-lr:hasTag>AE</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AK">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>AK</rdfs:label>
+		<skos:definition>US-specific code for the designation for Alaska</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AK</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Alaska"/>
+		<lcc-lr:hasTag>AK</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Alaska"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AL">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>AL</rdfs:label>
+		<skos:definition>US-specific code for the designation for Alabama</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AL</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Alabama"/>
+		<lcc-lr:hasTag>AL</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Alabama"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AP">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>AP</rdfs:label>
+		<skos:definition>US-specific code for the state designation for Armed Forces Pacific</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AP</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
+		<lcc-lr:hasTag>AP</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AR">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>AR</rdfs:label>
+		<skos:definition>US-specific code for the designation for Arkansas</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AR</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Arkansas"/>
+		<lcc-lr:hasTag>AR</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Arkansas"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AS">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>AS</rdfs:label>
+		<skos:definition>US-specific code for the designation for American Samoa</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AS</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;AmericanSamoa"/>
+		<lcc-lr:hasTag>AS</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;AmericanSamoa"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;AZ">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>AZ</rdfs:label>
+		<skos:definition>US-specific code for the designation for Arizona</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>AZ</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Arizona"/>
+		<lcc-lr:hasTag>AZ</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Arizona"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Alley">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>alley</rdfs:label>
@@ -132,6 +232,18 @@
 		<fibo-fnd-utl-av:commonDesignation>AVN</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:commonDesignation>AVNUE</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AVE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;BC">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>BC</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for British Columbia</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>BC</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;BritishColumbia"/>
+		<lcc-lr:hasTag>BC</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;BritishColumbia"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Bayou">
@@ -264,6 +376,39 @@
 		<fibo-fnd-utl-av:commonDesignation>BYPASS</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:commonDesignation>BYS</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>BYP</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;CA">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>CA</rdfs:label>
+		<skos:definition>US-specific code for the designation for California</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>CA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;California"/>
+		<lcc-lr:hasTag>CA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;California"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;CO">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>CO</rdfs:label>
+		<skos:definition>US-specific code for the designation for Colorado</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>CO</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Colorado"/>
+		<lcc-lr:hasTag>CO</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Colorado"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;CT">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>CT</rdfs:label>
+		<skos:definition>US-specific code for the designation for Connecticut</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>CT</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Connecticut"/>
+		<lcc-lr:hasTag>CT</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Connecticut"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Camp">
@@ -489,6 +634,28 @@
 		<fibo-fnd-utl-av:preferredDesignation>CURV</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;DC">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>DC</rdfs:label>
+		<skos:definition>US-specific code for the designation for the District of Colombia</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>DC</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;DistrictOfColumbia"/>
+		<lcc-lr:hasTag>DC</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;DistrictOfColumbia"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;DE">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>DE</rdfs:label>
+		<skos:definition>US-specific code for the designation for Delaware</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>DE</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Delaware"/>
+		<lcc-lr:hasTag>DE</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Delaware"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Dale">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>dale</rdfs:label>
@@ -575,6 +742,17 @@
 		<rdfs:label>extensions</rdfs:label>
 		<fibo-fnd-utl-av:commonDesignation>EXTS</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>EXTS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;FL">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>FL</rdfs:label>
+		<skos:definition>US-specific code for the designation for Florida</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>FL</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Florida"/>
+		<lcc-lr:hasTag>FL</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Florida"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Fall">
@@ -709,6 +887,28 @@
 		<fibo-fnd-utl-av:preferredDesignation>FWY</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;GA">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>GA</rdfs:label>
+		<skos:definition>US-specific code for the designation for Georgia</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>GA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Georgia"/>
+		<lcc-lr:hasTag>GA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Georgia"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;GU">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>GU</rdfs:label>
+		<skos:definition>US-specific code for the designation for Guam</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>GU</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Guam"/>
+		<lcc-lr:hasTag>GU</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Guam"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Garden">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>garden</rdfs:label>
@@ -785,6 +985,17 @@
 		<fibo-fnd-utl-av:preferredDesignation>GRVS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;HI">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>HI</rdfs:label>
+		<skos:definition>US-specific code for the designation for Hawaii</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>HI</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Hawaii"/>
+		<lcc-lr:hasTag>HI</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Hawaii"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Harbor">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>harbor</rdfs:label>
@@ -858,6 +1069,50 @@
 		<fibo-fnd-utl-av:preferredDesignation>HOLW</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;IA">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>IA</rdfs:label>
+		<skos:definition>US-specific code for the designation for Iowa</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>IA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Iowa"/>
+		<lcc-lr:hasTag>IA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Iowa"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ID">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>ID</rdfs:label>
+		<skos:definition>US-specific code for the designation for Idaho</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>ID</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Idaho"/>
+		<lcc-lr:hasTag>ID</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Idaho"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;IL">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>IL</rdfs:label>
+		<skos:definition>US-specific code for the designation for Illinois</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>IL</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Illinois"/>
+		<lcc-lr:hasTag>IL</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Illinois"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;IN">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>IN</rdfs:label>
+		<skos:definition>US-specific code for the designation for Indiana</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>IN</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Indiana"/>
+		<lcc-lr:hasTag>IN</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Indiana"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Inlet">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>inlet</rdfs:label>
@@ -912,6 +1167,28 @@
 		<fibo-fnd-utl-av:preferredDesignation>JCTS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;KS">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>KS</rdfs:label>
+		<skos:definition>US-specific code for the designation for Kansas</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>KS</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Kansas"/>
+		<lcc-lr:hasTag>KS</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Kansas"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;KY">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>KY</rdfs:label>
+		<skos:definition>US-specific code for the designation for Kentucky</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>KY</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Kentucky"/>
+		<lcc-lr:hasTag>KY</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Kentucky"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Key">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>key</rdfs:label>
@@ -943,6 +1220,17 @@
 		<fibo-fnd-utl-av:commonDesignation>KNLS</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:commonDesignation>KNOLLS</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>KNLS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;LA">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>LA</rdfs:label>
+		<skos:definition>US-specific code for the designation for Louisiana</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>LA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Louisiana"/>
+		<lcc-lr:hasTag>LA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Louisiana"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Lake">
@@ -1040,6 +1328,117 @@
 		<fibo-fnd-utl-av:commonDesignation>LOOP</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:commonDesignation>LOOPS</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>LOOP</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MA">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>MA</rdfs:label>
+		<skos:definition>US-specific code for the designation for Massachusetts</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>MA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Massachusetts"/>
+		<lcc-lr:hasTag>MA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Massachusetts"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MB">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>MB</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Manitoba</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>MB</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;Manitoba"/>
+		<lcc-lr:hasTag>MB</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;Manitoba"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MD">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>MD</rdfs:label>
+		<skos:definition>US-specific code for the designation for Maryland</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>MD</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Maryland"/>
+		<lcc-lr:hasTag>MD</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Maryland"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ME">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>ME</rdfs:label>
+		<skos:definition>US-specific code for the designation for Maine</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>ME</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Maine"/>
+		<lcc-lr:hasTag>ME</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Maine"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MI">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>MI</rdfs:label>
+		<skos:definition>US-specific code for the designation for Michigan</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>MI</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Michigan"/>
+		<lcc-lr:hasTag>MI</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Michigan"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MN">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>MN</rdfs:label>
+		<skos:definition>US-specific code for the designation for Minnesota</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>MN</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Minnesota"/>
+		<lcc-lr:hasTag>MN</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Minnesota"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MO">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>MO</rdfs:label>
+		<skos:definition>US-specific code for the designation for Missouri</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>MO</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Missouri"/>
+		<lcc-lr:hasTag>MO</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Missouri"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MP">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>MP</rdfs:label>
+		<skos:definition>US-specific code for the designation for the outlying area of Northern Mariana Islands</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>MP</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;NorthernMarianaIslands"/>
+		<lcc-lr:hasTag>MP</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;NorthernMarianaIslands"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MS">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>MS</rdfs:label>
+		<skos:definition>US-specific code for the designation for Mississippi</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>MS</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Mississippi"/>
+		<lcc-lr:hasTag>MS</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Mississippi"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;MT">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>MT</rdfs:label>
+		<skos:definition>US-specific code for the designation for Montana</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>MT</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Montana"/>
+		<lcc-lr:hasTag>MT</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Montana"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Mall">
@@ -1147,12 +1546,205 @@
 		<fibo-fnd-utl-av:preferredDesignation>MTNS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NB">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NB</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for New Brunswick</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NB</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;NewBrunswick"/>
+		<lcc-lr:hasTag>NB</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;NewBrunswick"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NC">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NC</rdfs:label>
+		<skos:definition>US-specific code for the designation for North Carolina</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NC</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
+		<lcc-lr:hasTag>NC</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;NorthCarolina"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ND">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>ND</rdfs:label>
+		<skos:definition>US-specific code for the designation for North Dakota</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>ND</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;NorthDakota"/>
+		<lcc-lr:hasTag>ND</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;NorthDakota"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NE">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NE</rdfs:label>
+		<skos:definition>US-specific code for the designation for Nebraska</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NE</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Nebraska"/>
+		<lcc-lr:hasTag>NE</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Nebraska"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NH">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NH</rdfs:label>
+		<skos:definition>US-specific code for the designation for New Hampshire</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NH</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;NewHampshire"/>
+		<lcc-lr:hasTag>NH</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;NewHampshire"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NJ">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NJ</rdfs:label>
+		<skos:definition>US-specific code for the designation for New Jersey</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NJ</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;NewJersey"/>
+		<lcc-lr:hasTag>NJ</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;NewJersey"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NL">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NL</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Newfoundland and Labrador</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NL</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;NewfoundlandAndLabrador"/>
+		<lcc-lr:hasTag>NL</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;NewfoundlandAndLabrador"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NM">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NM</rdfs:label>
+		<skos:definition>US-specific code for the designation for New Mexico</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NM</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;NewMexico"/>
+		<lcc-lr:hasTag>NM</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;NewMexico"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NS">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NS</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Nova Scotia</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NS</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;NovaScotia"/>
+		<lcc-lr:hasTag>NS</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;NovaScotia"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NT">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NT</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Northwest Territories</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NT</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;NorthwestTerritories"/>
+		<lcc-lr:hasTag>NT</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;NorthwestTerritories"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NU">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NU</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Nunavut</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NU</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;Nunavut"/>
+		<lcc-lr:hasTag>NU</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;Nunavut"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NV">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NV</rdfs:label>
+		<skos:definition>US-specific code for the designation for Nevada</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NV</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Nevada"/>
+		<lcc-lr:hasTag>NV</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Nevada"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;NY">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>NY</rdfs:label>
+		<skos:definition>US-specific code for the designation for New York</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>NY</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;NewYork"/>
+		<lcc-lr:hasTag>NY</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;NewYork"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Neck">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>neck</rdfs:label>
 		<fibo-fnd-utl-av:commonDesignation>NCK</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:commonDesignation>NECK</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NCK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;OH">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>OH</rdfs:label>
+		<skos:definition>US-specific code for the designation for Ohio</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>OH</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Ohio"/>
+		<lcc-lr:hasTag>OH</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Ohio"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;OK">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>OK</rdfs:label>
+		<skos:definition>US-specific code for the designation for Oklahoma</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>OK</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Oklahoma"/>
+		<lcc-lr:hasTag>OK</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Oklahoma"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;ON">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>ON</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Ontario</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>ON</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;Ontario"/>
+		<lcc-lr:hasTag>ON</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;Ontario"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;OR">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>OR</rdfs:label>
+		<skos:definition>US-specific code for the designation for Oregon</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>OR</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Oregon"/>
+		<lcc-lr:hasTag>OR</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Oregon"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Orchard">
@@ -1177,6 +1769,40 @@
 		<rdfs:label>overpass</rdfs:label>
 		<fibo-fnd-utl-av:commonDesignation>OVERPASS</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>OPAS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;PA">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>PA</rdfs:label>
+		<skos:definition>US-specific code for the designation for Pennsylvania</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>PA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
+		<lcc-lr:hasTag>PA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Pennsylvania"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;PE">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>PE</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Prince Edward Island</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>PE</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;PrinceEdwardIsland"/>
+		<lcc-lr:hasTag>PE</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;PrinceEdwardIsland"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;PR">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>PR</rdfs:label>
+		<skos:definition>US-specific code for the designation for Puerto Rico</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>PR</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;PuertoRico"/>
+		<lcc-lr:hasTag>PR</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;PuertoRico"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Park">
@@ -1331,6 +1957,29 @@
 		<fibo-fnd-utl-av:preferredDesignation>PR</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;QC">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>QC</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Quebec</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>QC</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;Quebec"/>
+		<lcc-lr:hasTag>QC</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;Quebec"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;RI">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>RI</rdfs:label>
+		<skos:definition>US-specific code for the designation for Rhode Island</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>RI</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;RhodeIsland"/>
+		<lcc-lr:hasTag>RI</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;RhodeIsland"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Radial">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>radial</rdfs:label>
@@ -1451,6 +2100,40 @@
 		<rdfs:label>run</rdfs:label>
 		<fibo-fnd-utl-av:commonDesignation>RUN</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>RUN</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;SC">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>SC</rdfs:label>
+		<skos:definition>US-specific code for the designation for South Carolina</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>SC</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;SouthCarolina"/>
+		<lcc-lr:hasTag>SC</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;SouthCarolina"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;SD">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>SD</rdfs:label>
+		<skos:definition>US-specific code for the designation for South Dakota</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>SD</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;SouthDakota"/>
+		<lcc-lr:hasTag>SD</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;SouthDakota"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;SK">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>SK</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Saskatchewan</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>SK</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;Saskatchewan"/>
+		<lcc-lr:hasTag>SK</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;Saskatchewan"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Shoal">
@@ -1606,6 +2289,28 @@
 		<fibo-fnd-utl-av:preferredDesignation>SMT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;TN">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>TN</rdfs:label>
+		<skos:definition>US-specific code for the designation for Tennessee</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>TN</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Tennessee"/>
+		<lcc-lr:hasTag>TN</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Tennessee"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;TX">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>TX</rdfs:label>
+		<skos:definition>US-specific code for the designation for Texas</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>TX</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Texas"/>
+		<lcc-lr:hasTag>TX</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Texas"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Terrace">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>terrace</rdfs:label>
@@ -1689,11 +2394,21 @@
 		<fibo-fnd-utl-av:preferredDesignation>TPKE</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;UM">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>UM</rdfs:label>
+		<skos:definition>US-specific code for the designation for the United States Minor Outlying Islands</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>UM</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;UnitedStatesMinorOutlyingIslands"/>
+		<lcc-lr:hasTag>UM</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;UnitedStatesMinorOutlyingIslands"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;US-AA">
 		<rdf:type rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
 		<rdfs:label>US-AA</rdfs:label>
 		<skos:definition>subdivision code for the state designation for Armed Forces Americas, excluding Canada</skos:definition>
-		<fibo-fnd-plc-adr:hasLocaleDesignation>AA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AA</fibo-fnd-utl-av:preferredDesignation>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
 		<lcc-lr:hasTag>US-AA</lcc-lr:hasTag>
@@ -1704,7 +2419,6 @@
 		<rdf:type rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
 		<rdfs:label>US-AE</rdfs:label>
 		<skos:definition>subdivision code for the state designation for Armed Forces Europe, the Middle East, and Canada</skos:definition>
-		<fibo-fnd-plc-adr:hasLocaleDesignation>AE</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AE</fibo-fnd-utl-av:preferredDesignation>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
 		<lcc-lr:hasTag>US-AE</lcc-lr:hasTag>
@@ -1715,11 +2429,21 @@
 		<rdf:type rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
 		<rdfs:label>US-AP</rdfs:label>
 		<skos:definition>subdivision code for the state designation for Armed Forces Pacific</skos:definition>
-		<fibo-fnd-plc-adr:hasLocaleDesignation>AP</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AP</fibo-fnd-utl-av:preferredDesignation>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
 		<lcc-lr:hasTag>US-AP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;UT">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>UT</rdfs:label>
+		<skos:definition>US-specific code for the designation for Utah</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>UT</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Utah"/>
+		<lcc-lr:hasTag>UT</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Utah"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Underpass">
@@ -1742,6 +2466,39 @@
 		<rdfs:label>unions</rdfs:label>
 		<fibo-fnd-utl-av:commonDesignation>UNIONS</fibo-fnd-utl-av:commonDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>UNS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;VA">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>VA</rdfs:label>
+		<skos:definition>US-specific code for the designation for Virginia</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>VA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Virginia"/>
+		<lcc-lr:hasTag>VA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Virginia"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;VI">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>VI</rdfs:label>
+		<skos:definition>US-specific code for the designation for the U.S. Virgin Islands</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>VI</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;VirginIslands"/>
+		<lcc-lr:hasTag>VI</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;VirginIslands"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;VT">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>VT</rdfs:label>
+		<skos:definition>US-specific code for the designation for Vermont</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>VT</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Vermont"/>
+		<lcc-lr:hasTag>VT</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Vermont"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Valley">
@@ -1827,6 +2584,50 @@
 		<fibo-fnd-utl-av:preferredDesignation>VIS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;WA">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>WA</rdfs:label>
+		<skos:definition>US-specific code for the designation for Washington</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>WA</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Washington"/>
+		<lcc-lr:hasTag>WA</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Washington"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;WI">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>WI</rdfs:label>
+		<skos:definition>US-specific code for the designation for Wisconsin</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>WI</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Wisconsin"/>
+		<lcc-lr:hasTag>WI</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Wisconsin"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;WV">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>WV</rdfs:label>
+		<skos:definition>US-specific code for the designation for West Virginia</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>WV</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;WestVirginia"/>
+		<lcc-lr:hasTag>WV</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;WestVirginia"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;WY">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>WY</rdfs:label>
+		<skos:definition>US-specific code for the designation for Wyoming</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>WY</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-us;Wyoming"/>
+		<lcc-lr:hasTag>WY</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-us;Wyoming"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;Walk">
 		<rdf:type rdf:resource="&fibo-fnd-plc-adr;StreetSuffix"/>
 		<rdfs:label>walk</rdfs:label>
@@ -1878,373 +2679,311 @@
 		<fibo-fnd-utl-av:preferredDesignation>WLS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsai;YT">
+		<rdf:type rdf:resource="&fibo-fnd-plc-adr;RegionSpecificIdentifier"/>
+		<rdfs:label>YT</rdfs:label>
+		<skos:definition>Canadian and US-specific code for the designation for Yukon</skos:definition>
+		<fibo-fnd-utl-av:preferredDesignation>YT</fibo-fnd-utl-av:preferredDesignation>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
+		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedStatesOfAmerica"/>
+		<lcc-lr:denotes rdf:resource="&lcc-3166-2-ca;Yukon"/>
+		<lcc-lr:hasTag>YT</lcc-lr:hasTag>
+		<lcc-lr:identifies rdf:resource="&lcc-3166-2-ca;Yukon"/>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&lcc-3166-1;FM">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>FM</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>FM</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-1;GU">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>GU</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>GU</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-1;MH">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MH</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MH</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-1;PW">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>PW</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>PW</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-AB">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>AB</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AB</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-BC">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>BC</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>BC</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-MB">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MB</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MB</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NB">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NB</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NB</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NL">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NL</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NL</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NS">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NS</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NT">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NU">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NU</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NU</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-ON">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>ON</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>ON</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-PE">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>PE</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>PE</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-QC">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>QC</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>QC</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-SK">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>SK</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>SK</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-YT">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>YT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>YT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AK">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>AK</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AK</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AL">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>AL</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AL</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AR">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>AR</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AR</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AS">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>AS</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AZ">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>AZ</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AZ</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-CA">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>CA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>CA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-CO">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>CO</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>CO</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-CT">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>CT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>CT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-DC">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>DC</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>DC</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-DE">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>DE</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>DE</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-FL">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>FL</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>FL</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-GA">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>GA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>GA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-GU">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>GU</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>GU</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-HI">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>HI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>HI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-IA">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>IA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>IA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-ID">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>ID</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>ID</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-IL">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>IL</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>IL</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-IN">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>IN</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>IN</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-KS">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>KS</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>KS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-KY">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>KY</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>KY</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-LA">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>LA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>LA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MA">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MD">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MD</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MD</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-ME">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>ME</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>ME</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MI">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MN">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MN</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MN</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MO">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MO</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MO</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MP">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MP</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MP</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MS">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MS</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MT">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>MT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NC">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NC</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NC</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-ND">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>ND</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>ND</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NE">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NE</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NE</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NH">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NH</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NH</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NJ">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NJ</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NJ</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NM">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NM</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NM</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NV">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NV</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NV</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NY">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>NY</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NY</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-OH">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>OH</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>OH</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-OK">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>OK</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>OK</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-OR">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>OR</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>OR</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-PA">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>PA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>PA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-PR">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>PR</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>PR</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-RI">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>RI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>RI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-SC">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>SC</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>SC</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-SD">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>SD</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>SD</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-TN">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>TN</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>TN</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-TX">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>TX</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>TX</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-UM">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>UM</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>UM</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-UT">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>UT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>UT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-VA">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>VA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>VA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-VI">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>VI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>VI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-VT">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>VT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>VT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WA">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>WA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>WA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WI">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>WI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>WI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WV">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>WV</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>WV</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WY">
-		<fibo-fnd-plc-adr:hasLocaleDesignation>WY</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>WY</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 

--- a/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY fibo-fnd-plc-uspsai "https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
+	<!ENTITY lcc-3166-2-ca "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/">
 	<!ENTITY lcc-3166-2-us "https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
@@ -23,6 +24,7 @@
 	xmlns:fibo-fnd-plc-uspsai="https://spec.edmcouncil.org/fibo/ontology/FND/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
+	xmlns:lcc-3166-2-ca="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"
 	xmlns:lcc-3166-2-us="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
@@ -53,6 +55,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/NorthAmerica/USPostalServiceAddressesIndividuals/"/>
@@ -1690,6 +1693,7 @@
 		<rdf:type rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
 		<rdfs:label>US-AA</rdfs:label>
 		<skos:definition>subdivision code for the state designation for Armed Forces Americas, excluding Canada</skos:definition>
+		<fibo-fnd-plc-adr:hasLocaleDesignation>AA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AA</fibo-fnd-utl-av:preferredDesignation>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesAmericas"/>
 		<lcc-lr:hasTag>US-AA</lcc-lr:hasTag>
@@ -1700,6 +1704,7 @@
 		<rdf:type rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
 		<rdfs:label>US-AE</rdfs:label>
 		<skos:definition>subdivision code for the state designation for Armed Forces Europe, the Middle East, and Canada</skos:definition>
+		<fibo-fnd-plc-adr:hasLocaleDesignation>AE</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AE</fibo-fnd-utl-av:preferredDesignation>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesEurope"/>
 		<lcc-lr:hasTag>US-AE</lcc-lr:hasTag>
@@ -1710,6 +1715,7 @@
 		<rdf:type rdf:resource="&lcc-cr;GeographicRegionIdentifier"/>
 		<rdfs:label>US-AP</rdfs:label>
 		<skos:definition>subdivision code for the state designation for Armed Forces Pacific</skos:definition>
+		<fibo-fnd-plc-adr:hasLocaleDesignation>AP</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AP</fibo-fnd-utl-av:preferredDesignation>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-plc-uspsai;ArmedForcesPacific"/>
 		<lcc-lr:hasTag>US-AP</lcc-lr:hasTag>
@@ -1873,246 +1879,372 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-1;FM">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>FM</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>FM</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-1;GU">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>GU</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>GU</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-1;MH">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MH</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MH</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-1;PW">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>PW</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>PW</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-AB">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>AB</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>AB</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-BC">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>BC</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>BC</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-MB">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MB</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>MB</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NB">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NB</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>NB</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NL">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NL</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>NL</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NS">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NS</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>NS</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NT">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NT</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>NT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-NU">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NU</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>NU</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-ON">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>ON</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>ON</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-PE">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>PE</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>PE</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-QC">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>QC</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>QC</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-SK">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>SK</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>SK</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&lcc-3166-2-ca;CA-YT">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>YT</fibo-fnd-plc-adr:hasLocaleDesignation>
+		<fibo-fnd-utl-av:preferredDesignation>YT</fibo-fnd-utl-av:preferredDesignation>
+	</owl:NamedIndividual>
+	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AK">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>AK</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AK</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AL">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>AL</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AL</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AR">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>AR</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AR</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AS">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>AS</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-AZ">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>AZ</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>AZ</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-CA">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>CA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>CA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-CO">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>CO</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>CO</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-CT">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>CT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>CT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-DC">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>DC</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>DC</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-DE">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>DE</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>DE</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-FL">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>FL</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>FL</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-GA">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>GA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>GA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-GU">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>GU</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>GU</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-HI">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>HI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>HI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-IA">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>IA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>IA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-ID">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>ID</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>ID</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-IL">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>IL</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>IL</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-IN">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>IN</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>IN</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-KS">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>KS</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>KS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-KY">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>KY</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>KY</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-LA">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>LA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>LA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MA">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MD">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MD</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MD</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-ME">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>ME</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>ME</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MI">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MN">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MN</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MN</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MO">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MO</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MO</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MP">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MP</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MP</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MS">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MS</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MS</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-MT">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>MT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>MT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NC">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NC</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NC</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-ND">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>ND</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>ND</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NE">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NE</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NE</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NH">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NH</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NH</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NJ">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NJ</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NJ</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NM">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NM</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NM</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NV">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NV</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NV</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-NY">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>NY</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>NY</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-OH">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>OH</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>OH</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-OK">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>OK</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>OK</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-OR">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>OR</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>OR</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-PA">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>PA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>PA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-PR">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>PR</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>PR</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-RI">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>RI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>RI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-SC">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>SC</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>SC</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-SD">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>SD</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>SD</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-TN">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>TN</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>TN</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-TX">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>TX</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>TX</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-UM">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>UM</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>UM</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-UT">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>UT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>UT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-VA">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>VA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>VA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-VI">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>VI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>VI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-VT">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>VT</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>VT</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WA">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>WA</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>WA</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WI">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>WI</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>WI</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WV">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>WV</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>WV</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&lcc-3166-2-us;US-WY">
+		<fibo-fnd-plc-adr:hasLocaleDesignation>WY</fibo-fnd-plc-adr:hasLocaleDesignation>
 		<fibo-fnd-utl-av:preferredDesignation>WY</fibo-fnd-utl-av:preferredDesignation>
 	</owl:NamedIndividual>
 


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

Added property hasLocaleDesignation to Addresses; added the locale designation to US state and territory codes as well as to Canadian province codes, which are specified in USPS Pub  28, although created and managed by the Canadian government in Ottawa.

Fixes: #947 / FND-294


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


