### PR TITLE
SEC-116 - Properties lists and hasIssue seem redundant for class Listing

### DIFF
--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -785,7 +785,6 @@
 		<rdfs:label>XLOM-listed Apple Inc. common stock</rdfs:label>
 		<skos:definition>Apple Inc. common share listed in the London Stock Exchange</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;AppleIncCommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-mkti;Exchange-XLOM"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
@@ -795,7 +794,6 @@
 		<rdfs:label>XNAS-listed Alphabet Inc. class A common stock</rdfs:label>
 		<skos:definition>Alphabet Inc. class A common share listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
@@ -805,7 +803,6 @@
 		<rdfs:label>XNAS-listed Alphabet Inc. class C capital stock</rdfs:label>
 		<skos:definition>Alphabet Inc. class C capital stock listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
@@ -815,7 +812,6 @@
 		<rdfs:label>XNAS-listed Apple Inc. common stock</rdfs:label>
 		<skos:definition>Apple Inc. common share listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;AppleIncCommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
@@ -825,7 +821,6 @@
 		<rdfs:label>XNYS-listed Citigroup Inc. common stock</rdfs:label>
 		<skos:definition>Citigroup Inc. common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;CitigroupIncCommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
@@ -835,7 +830,6 @@
 		<rdfs:label>XNYS-listed IBM common stock</rdfs:label>
 		<skos:definition>IBM common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
@@ -845,7 +839,6 @@
 		<rdfs:label>XNYS-listed JPMorgan Chase &amp; Co. common stock</rdfs:label>
 		<skos:definition>JPMorgan Chase &amp; Co. common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
@@ -855,7 +848,6 @@
 		<rdfs:label>XNYS-listed The Coca-Cola Company common stock</rdfs:label>
 		<skos:definition>The Coca-Cola Company common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
@@ -865,7 +857,6 @@
 		<rdfs:label>XNYS-listed The Home Depot, Inc. common stock</rdfs:label>
 		<skos:definition>The Home Depot, Inc. common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
@@ -875,7 +866,6 @@
 		<rdfs:label>XNYS-listed The Proctor &amp; Gamble Company common stock</rdfs:label>
 		<skos:definition>The Proctor &amp; Gamble Company common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
@@ -885,7 +875,6 @@
 		<rdfs:label>XNYS-listed Wells Fargo common stock</rdfs:label>
 		<skos:definition>Wells Fargo &amp; Company common share listed in the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
-		<fibo-sec-sec-lst:hasIssue rdf:resource="&fibo-sec-eq-eqind;WellsFargoCommonStock"/>
 		<fibo-sec-sec-lst:isTradedOn rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 		<fibo-sec-sec-lst:lists rdf:resource="&fibo-sec-eq-eqind;WellsFargoCommonStock"/>
 	</owl:NamedIndividual>

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -75,12 +75,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesListings/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesListings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesListings.rdf version of this ontology was revised to reuse the composite date value datatype and add disjointness between registered security and exempt security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate an extraneous subclass axiom.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesListings.rdf version of this ontology was revised to rename isIssuedIn to isIssuedOn, which is more natural to most securities SMEs, generalized certain references to securities exchanges, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/SecuritiesListings.rdf version of this ontology was revised to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and to eliminate the redundancy between hasIssue and lists.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -178,13 +178,6 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;hasIssue"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Security"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;lists"/>
 				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Security"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
@@ -264,14 +257,6 @@
 		<fibo-fnd-utl-av:synonym>has primary trading market</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;hasIssue">
-		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
-		<rdfs:label>has issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;Listing"/>
-		<rdfs:range rdf:resource="&fibo-fbc-fi-fi;Security"/>
-		<skos:definition>links a given exchange-specific security to its issue</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;hasLastTradingDateTime">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDateTime"/>
 		<rdfs:label>has last trading date and time</rdfs:label>
@@ -325,7 +310,7 @@
 		<rdfs:label>lists</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-sec-lst;Listing"/>
 		<rdfs:range rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
-		<skos:definition>identifies a security that is listed by the listing service</skos:definition>
+		<skos:definition>relates a given exchange-specific security listing to its issue</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION
## Description

Eliminated the redundant hasIssue property and revised the definition of 'lists' to reflect its semantics better.

Fixes: #871 / SEC-116


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


