### PR TITLE
FND-296 - Extra blank skos:definition on fibo-fnd-plc-adr:PhysicalAddressIdentifier

### DIFF
--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -327,7 +327,6 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>physical address identifier</rdfs:label>
-		<skos:definition></skos:definition>
 		<skos:definition>unique identifier for a physical address</skos:definition>
 		<skos:example>Physical address identifiers may include bar codes, QCR codes, and +codes in a number of countries.</skos:example>
 	</owl:Class>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Removed an empty skos:definition annotation from physical address identifier


Fixes: #970 / FND-296


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


