### PR TITLE
LOAN-150 - The LoanCore ontology includes a bad annotation prefix

### DIFF
--- a/LOAN/LoanContracts/LoanCore.rdf
+++ b/LOAN/LoanContracts/LoanCore.rdf
@@ -701,7 +701,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>loan application</rdfs:label>
 		<skos:definition>request by a potential borrower to a potential lender to borrow money containing information used to decide whether to grant the loan</skos:definition>
-		<fibo-fnd-utl-av:scopeNote>The request typicaly includes most, if not all, of the information used to decide whether to grant the loan.</fibo-fnd-utl-av:scopeNote>
+		<skos:scopeNote>The request typicaly includes most, if not all, of the information used to decide whether to grant the loan.</skos:scopeNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-loan-ln-ln;LoanMarketCategory">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This resolution corrects an incorrect annotation prefix in LoanCore for skos:scopeNote.

Fixes: #984 / LOAN-150


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


