### PR TITLE
DER-68 - Orphaned property and considerable duplication in the Futures ontology

### DIFF
--- a/DER/AssetDerivatives/AssetDerivatives.rdf
+++ b/DER/AssetDerivatives/AssetDerivatives.rdf
@@ -182,7 +182,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-ass-ass;SecurityForwardDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 		<rdfs:label>security forward delivery</rdfs:label>
 		<skos:definition>Forward delivery of an Asset (Equity or Debt) either in the form of the asset itself (the observable) or the cash equivalent.</skos:definition>
 	</owl:Class>

--- a/DER/AssetDerivatives/EquityForwards.rdf
+++ b/DER/AssetDerivatives/EquityForwards.rdf
@@ -6,8 +6,10 @@
 	<!ENTITY fibo-der-ass-eqs "https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/EquitySwaps/">
 	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-gao-obj "https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -23,8 +25,10 @@
 	xmlns:fibo-der-ass-eqs="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/EquitySwaps/"
 	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-gao-obj="https://spec.edmcouncil.org/fibo/ontology/FND/GoalsAndObjectives/Objectives/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -75,7 +79,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-ass-eqf;EquityForwardCashSettlement">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 		<rdfs:label xml:lang="en">equity forward cash settlement</rdfs:label>
 	</owl:Class>
 	
@@ -108,12 +112,6 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardDeliveryCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardBuyer"/>
 			</owl:Restriction>
@@ -122,6 +120,12 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasSeller"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardSeller"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardDeliveryCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">equity forward contract</rdfs:label>
@@ -147,20 +151,20 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardCashSettlement"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-ass-ass;SecurityForwardDelivery"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-ass-eqf;EquityForwardContract"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">equity forward transaction</rdfs:label>

--- a/DER/CommoditiesDerivatives/CommodityForwards.rdf
+++ b/DER/CommoditiesDerivatives/CommodityForwards.rdf
@@ -5,6 +5,8 @@
 	<!ENTITY fibo-der-com-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommodityForwards/">
 	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -19,6 +21,8 @@
 	xmlns:fibo-der-com-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommodityForwards/"
 	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -34,6 +38,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommoditiesContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/CommoditiesDerivatives/CommodityForwards/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
@@ -75,7 +81,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-com-fwd;CommodityForwardDelivery">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 		<rdfs:label xml:lang="en">commodity forward delivery</rdfs:label>
 		<skos:definition xml:lang="en">The agreed forward delivery of a commodity or cash equivalent.</skos:definition>
 	</owl:Class>
@@ -84,14 +90,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardDelivery"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardDelivery"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-com-fwd;CommodityForwardContract"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">commodity forward transaction</rdfs:label>

--- a/DER/DerivativesContracts/Forwards.rdf
+++ b/DER/DerivativesContracts/Forwards.rdf
@@ -4,9 +4,14 @@
 	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
 	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-asmt "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-txn-ev "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionEvents/">
 	<!ENTITY fibo-fnd-txn-rea "https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
@@ -22,9 +27,14 @@
 	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
 	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-asmt="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-txn-ev="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/TransactionEvents/"
 	xmlns:fibo-fnd-txn-rea="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
@@ -42,9 +52,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
@@ -56,12 +68,13 @@
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-der-fwd;CalculationAgent">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;ThirdPartyAgent"/>
 		<rdfs:label xml:lang="en">calculation agent</rdfs:label>
 		<skos:definition xml:lang="en">The entity which carries out the valuation of an underlying asset, or from which the valuation of the underlying is to be taken.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-fwd;CashCloseout">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-fwd;closedOutBy"/>
@@ -85,66 +98,28 @@
 	
 	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;allowsForOptionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">forward cash conditional delivery commitment</rdfs:label>
 		<skos:definition xml:lang="en">Commitment to deliver agreed amountof cash in the event that the option is exercised.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashDelivery">
-		<rdfs:label xml:lang="en">forward cash delivery</rdfs:label>
-		<skos:definition xml:lang="en">&apos;This is the first of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashDeliveryCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;commitsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 		<rdfs:label xml:lang="en">forward cash delivery commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to deliver a cash amount at an agreed date in the future.</skos:definition>
+		<skos:definition xml:lang="en">commitment to deliver a cash amount at an agreed date in the future</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Not the earliest possible date as in a Spot. FpML exchangedCurrency1 referred to as a &quot;Currency Stream&quot; &apos;This is the first of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashSettlementCommitment">
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DerivativeTransactionTerms"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;SettlementTerms"/>
 		<rdfs:label xml:lang="en">forward cash settlement commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to settle a cash amount at an agreed date in the future.</skos:definition>
+		<skos:definition xml:lang="en">commitment to settle a cash amount at an agreed date in the future</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Note the earliest possible date as in a Spot. FpML exchangedCurrency2 referred to as a &quot;Currency Stream&quot; &apos;This is the second of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardCashSettlementTermsSet">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/SettlementTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">forward cash settlement terms set</rdfs:label>
-		<skos:definition xml:lang="en">&apos;This is the second of the two currency flows that define a single leg of a standard foreign exchange transaction.&apos;</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardContract">
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;OTCInstrument"/>
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/DerivativeInstrument"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DerivativeInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
@@ -165,14 +140,26 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;side.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">forward contract</rdfs:label>
@@ -195,12 +182,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardDeliveryCommitment">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;commitsTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-txn-ev;madeBy"/>
@@ -208,20 +190,14 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">forward delivery commitment</rdfs:label>
-		<skos:definition xml:lang="en">A commitment to deliver something at some time or under some terms in the future.</skos:definition>
+		<skos:definition xml:lang="en">commitment to deliver something in the future, at an agreed date or dates and under agreed terms</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">In an Option, there is still a commitment on one side to deliver in the event that the other side chooses to exercise the option.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardDeliveryTermsSet">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
-		<rdfs:label xml:lang="en">forward delivery terms</rdfs:label>
-		<skos:definition xml:lang="en">The delivery of something in the future, at an agreed date or dates and under agreed terms.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-der-fwd;ForwardTransaction">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;embodies"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -250,14 +226,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;specifies"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;valuationDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;Date"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-asmt;hasDateOfAssessment"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">forward valuation terms set</rdfs:label>
@@ -303,12 +279,6 @@
 		<rdfs:label xml:lang="en">x e t r a</rdfs:label>
 	</owl:Class>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;allowsForOptionOf">
-		<rdfs:label xml:lang="en">allows for option of</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashConditionalDeliveryCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;cashDelivery">
 		<rdfs:label xml:lang="en">cash delivery</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-fwd;CashCloseout"/>
@@ -317,7 +287,7 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;cashDelivery.1">
 		<rdfs:label xml:lang="en">cash delivery</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 	</owl:DatatypeProperty>
 	
@@ -327,60 +297,21 @@
 		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;commitsTo">
-		<rdfs:label xml:lang="en">commits to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
-	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;contractSize">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&xsd;integer"/>
-		<skos:definition xml:lang="en">The deliverable quantity of goods or commodities underlying futures, forward and option contracts.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;deliveryAmount">
 		<rdfs:label xml:lang="en">delivery amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;deliveryDate">
 		<rdfs:label xml:lang="en">delivery date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
 		<skos:definition xml:lang="en">FpML = valueDate Definition for &apos;valueDate&apos; in FpML &apos;The date on which both currencies traded will settle.&apos; Definition for &apos;currency1ValueDate&apos; in FpML &apos;The date on which the currency1 amount will be settled. To be used in a split value date scenario.&apos; Notes 20 Jan: single value date scenario adds nothing to the model. The &quot;split value date&quot; is when Payment Date and SettlementDate are different; otherwise they are the same. We don&apos;t need to model this.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;deliveryDate.1">
-		<rdfs:label xml:lang="en">delivery date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;embodies">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;transactionEmbodiesEconomicAgreement"/>
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;establishes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;establishes.1">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-txn-rea;establishesContractualEconomicCommitment"/>
-		<rdfs:label xml:lang="en">establishes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;forwardPrice">
 		<rdfs:label xml:lang="en">forward price</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">The forward price of the underlying.</skos:definition>
 	</owl:ObjectProperty>
@@ -391,6 +322,13 @@
 		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
 		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;hasContractSize">
+		<rdfs:label xml:lang="en">has contract size</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+		<rdfs:range rdf:resource="&xsd;integer"/>
+		<skos:definition xml:lang="en">indicates the deliverable quantity of goods, commodities, or shares underlying the futures contract. This is denominated as a multiple of the lot size in the case of a commodity future. For financial futures this is the number of units of the underlying security.</skos:definition>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;hasSeller">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasPrincipalParty"/>
@@ -432,46 +370,28 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;paymentFeeType">
 		<rdfs:label xml:lang="en">payment fee type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition xml:lang="en">The type of fee or additional payment, e.g. brokerage, upfront fee etc.</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;paymentType">
 		<rdfs:label xml:lang="en">payment type</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
 		<skos:definition xml:lang="en">&apos;A classification of the type of fee or additional payment, e.g. brokerage, upfront fee etc. FpML does not define domain values for this element.&apos;</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;settlementAmount">
 		<rdfs:label xml:lang="en">settlement amount</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-fwd;settlementDate">
 		<rdfs:label xml:lang="en">settlement date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 		<skos:definition xml:lang="en">FpML = valueDate Definition for &apos;valueDate&apos; in FpML &apos;The date on which both currencies traded will settle.&apos; Definition for &apos;currency2ValueDate&apos; in FpML &apos;The date on which the currency2 amount will be settled. To be used in a split value date scenario.&apos; Notes 20 Jan: This is the scenario where &quot;t&quot; for one leg is different to &quot;t&quot; for the other leg.</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;side">
-		<rdfs:label xml:lang="en">side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;side.1">
-		<rdfs:label xml:lang="en">side</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;specifies">
-		<rdfs:label xml:lang="en">specifies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;UnderlyingValuation"/>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;undertakenBy">
 		<rdfs:label xml:lang="en">undertaken by</rdfs:label>
@@ -479,11 +399,9 @@
 		<rdfs:range rdf:resource="&fibo-der-der-fwd;CalculationAgent"/>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-fwd;valuationDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDate"/>
-		<rdfs:label xml:lang="en">valuation date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-fwd;ForwardValuationTermsSet"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
-	</owl:ObjectProperty>
+	<owl:Class rdf:about="&fibo-fbc-fi-fi;Future">
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A futures contract obligates the buyer to purchase the underlying commodity, currency or financial instrument and the seller to sell it unless the contract is sold to another before settlement date which may happen if a trader waits to take a profit or cut a loss. Further notes: This contrasts with options trading in which the option buyer may choose whether or not to exercise the option by the exercise date. Unlike options, futures convey an obligation to buy. The risk to the holder is unlimited, and because the payoff pattern is symmetrical, the risk to the seller is unlimited as well. Dollars lost and gained by each party on a futures contract are equal and opposite. In other words, futures trading is a zero-sum game. Futures contracts are forward contracts, meaning they represent a pledge to make a certain transaction at a future date. The exchange of assets occurs on the date specified in the contract. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearinghouses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check. Definition origin: Barrons, adapted by EDMC SMER.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/OptionContractsOnFutures.rdf
+++ b/DER/DerivativesContracts/OptionContractsOnFutures.rdf
@@ -3,7 +3,8 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-der-cof "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/OptionContractsOnFutures/">
 	<!ENTITY fibo-der-der-opt "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/">
-	<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/">
+	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -16,7 +17,8 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-der-cof="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/OptionContractsOnFutures/"
 	xmlns:fibo-der-der-opt="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"
-	xmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/"
+	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -28,50 +30,28 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/OptionContractsOnFutures/">
 		<rdfs:label xml:lang="en">OptionContractsOnFutures</rdfs:label>
 		<dct:abstract>Over the counter option contracts giving the holder to purchase or sell a given futures contract at the allowed times.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
+		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-der-cof</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Options/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/OptionContractsOnFutures/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-der-der-cof;FuturesContractUnderlying">
-		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-cof;identity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures contract underlying</rdfs:label>
-		<skos:definition xml:lang="en">An underlying which is a futures contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">(not an underlying OF a future instrument)</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-der-cof;OTCContractOnFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-cof;hasUnderlying"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-cof;FuturesContractUnderlying"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Future"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">o t c contract on future</rdfs:label>
-		<skos:definition xml:lang="en">An option contract with an underlying futures contract.</skos:definition>
+		<rdfs:label xml:lang="en">over-the-counter contract on future</rdfs:label>
+		<skos:definition xml:lang="en">option contract with an underlying futures contract</skos:definition>
 	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-cof;hasUnderlying">
-		<rdfs:label xml:lang="en">has underlying</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-cof;OTCContractOnFuture"/>
-		<rdfs:range rdf:resource="&fibo-der-der-cof;FuturesContractUnderlying"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-der-cof;identity">
-		<rdfs:label xml:lang="en">identity</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-der-cof;FuturesContractUnderlying"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/OptionContractsOnFutures.rdf
+++ b/DER/DerivativesContracts/OptionContractsOnFutures.rdf
@@ -42,7 +42,7 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-der-der-cof;OTCContractOnFuture">
+	<owl:Class rdf:about="&fibo-der-der-cof;OptionContractOnFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-opt;OTCOptionContract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -50,8 +50,8 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Future"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">over-the-counter contract on future</rdfs:label>
-		<skos:definition xml:lang="en">option contract with an underlying futures contract</skos:definition>
+		<rdfs:label xml:lang="en">option contract on future</rdfs:label>
+		<skos:definition xml:lang="en">option that gives the holder the right, but not the obligation, to buy or sell a specific futures contract at a specified price on or before the option&apos;s expiration date</skos:definition>
 	</owl:Class>
 
 </rdf:RDF>

--- a/DER/DerivativesContracts/Options.rdf
+++ b/DER/DerivativesContracts/Options.rdf
@@ -574,7 +574,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;receives"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option call transaction</rdfs:label>
@@ -714,7 +714,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-der-opt;makes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -1196,7 +1196,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;makes.1">
 		<rdfs:label xml:lang="en">makes</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionPutTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-der-opt;numberOfOptions">
@@ -1230,7 +1230,7 @@ Further notes: REVIEW THIS - there appear to be two separate semantics in this l
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;receives">
 		<rdfs:label xml:lang="en">receives</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-der-opt;OptionCallTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryTermsSet"/>
+		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardDeliveryCommitment"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-der-opt;receives.1">

--- a/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
+++ b/DER/ExchangeTradedDerivatives/ExchangeTradedOptions.rdf
@@ -21,6 +21,7 @@
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-fnd-utl-val "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/">
+	<!ENTITY fibo-ind-fx-fx "https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/">
 	<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/">
 	<!ENTITY fibo-sec-dbt-ex "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
@@ -53,6 +54,7 @@
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-fnd-utl-val="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/"
+	xmlns:fibo-ind-fx-fx="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/"
 	xmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"
 	xmlns:fibo-sec-dbt-ex="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
@@ -67,6 +69,9 @@
 		<rdfs:label xml:lang="en">ExchangeTradedOptions</rdfs:label>
 		<dct:abstract>Option contracts offered on an options exchange. Includes a wide range of asset types (instruments, indices, foreign exchange, rates, commodities etc.) and the kinds of exchange traded option that are based on these.
 		Note that some of the contract types are named similarly to their OTC equivalents, such as bond option.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
+		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-etd-eto</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
@@ -323,7 +328,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-etd-eto;delivery"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Future"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">future options exercise terms</rdfs:label>
@@ -336,7 +341,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/ForeignExchange/ForeignExchange/CurrencySpotBuyRate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-ind-fx-fx;CurrencySpotBuyRate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fx option underlying</rdfs:label>
@@ -476,7 +481,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Future"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">option on futures underlying</rdfs:label>

--- a/DER/ExchangeTradedDerivatives/Futures.rdf
+++ b/DER/ExchangeTradedDerivatives/Futures.rdf
@@ -17,6 +17,7 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
+	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
 	<!ENTITY fibo-sec-dbt-tstd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -44,6 +45,7 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
+	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
 	xmlns:fibo-sec-dbt-tstd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -54,9 +56,12 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/">
-		<rdfs:label xml:lang="en">Futures</rdfs:label>
+		<rdfs:label xml:lang="en">Futures Ontology</rdfs:label>
 		<dct:abstract>Futures are functionally the same as forwards on the over the counter market, but are marketed via futures exchanges. Includes a wide range of asset types (instruments, indices, foreign exchange, rates, commodities etc.) and the kinds of futures that are based on these.
 		Note that some of the contract types are named similarly to their OTC equivalents, such as bond option.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
+		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-der-etd-fut</sm:fileAbbreviation>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/AssetDerivatives/AssetDerivatives/"/>
@@ -75,6 +80,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/"/>
@@ -107,7 +113,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;CommodityFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-com-ctr;CommodityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:label xml:lang="en">commodity future</rdfs:label>
 		<skos:definition xml:lang="en">A futures contract tied to the movement of a particular commodity. This enables contract buyers to buy a specific amount of a commodity at a specific price on a particular date in the future.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The price of the contract is determined using the &quot;Open Outcry&quot; system on the floor of a commodity exchange such as the Chicago Board of Trade or the Commodity Exchange in New York. There are commodity futures contracts based on meats such as cattle and pork bellies; grains such as corn, oats, soybeans and wheat; metals such as gold, silver and platinum; and energy products such as heating oil, natural gas and crude oil.</fibo-fnd-utl-av:explanatoryNote>
@@ -128,7 +134,7 @@
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;EquityFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:label xml:lang="en">equity future</rdfs:label>
 		<skos:definition xml:lang="en">A Futures instrument which is based on an equity security or securities, specifically a publicly issued and traded share.</skos:definition>
 	</owl:Class>
@@ -146,64 +152,9 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;EquityFutureStandardizedTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFutureStandardizedTerms"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;StandardizedFuturesTerms"/>
 		<rdfs:label xml:lang="en">equity future standardized terms</rdfs:label>
 		<skos:definition xml:lang="en">A set of standard terms for equity futures contracts, as set out by the derivatives exchange. Equity Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FinancialFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
-		<rdfs:label xml:lang="en">financial future</rdfs:label>
-		<skos:definition xml:lang="en">A futures contract based on a financial instrument.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Typically a financial futures contract is based on an underlying debt instrument. Examples of instruments underlying financial futures contracts include Treasury bills, Treasury notes, Government National Mortgage Association (Ginnie Mae) pass-throughs, foreign currencies, and certificates of deposit. Such contracts usually move under the influence of interest rates. As rates rise, contracts fall in value; as rates fall, contracts gain in value. Trading in these contracts is governed in the U.S. by the federal Commodities Futures Trading Commission. Traders use these futures to speculate on the direction of interest rates. Financial institutions use them to hedge financial portfolios against adverse fluctuations in interest rates.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FinancialFutureStandardizedTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;StandardizedFuturesTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">financial future standardized terms</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for financial futures contracts, as set out by the derivatives exchange. Financial Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FutureInstrument">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;hasSettlementArrangement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;pricingDeterminedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FuturesTradingAccountProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/FuturesTemporal/hasAccountHolder"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/FuturesTemporal/FuturesTradingAccountHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">future instrument</rdfs:label>
-		<skos:definition xml:lang="en">Agreement to buy or sell a specific amount of a commodity, a currency or a financial instrument at a particular price on a stipulated future date. A futures contract obligates the buyer to purchase the underlying commodity, currency or financial instrument and the seller to sell it unless the contract is sold to another before settlement date which may happen if a trader waits to take a profit or cut a loss. Further notes: This contrasts with options trading in which the option buyer may choose whether or not to exercise the option by the exercise date. Unlike options, futures convey an obligation to buy. The risk to the holder is unlimited, and because the payoff pattern is symmetrical, the risk to the seller is unlimited as well. Dollars lost and gained by each party on a futures contract are equal and opposite. In other words, futures trading is a zero-sum game. Futures contracts are forward contracts, meaning they represent a pledge to make a certain transaction at a future date. The exchange of assets occurs on the date specified in the contract. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearinghouses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check. Definition origin: Barrons, adapted by EDMC SMER.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;FuturesCommodityUnderlying">
@@ -269,19 +220,19 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;IndexFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:label xml:lang="en">index future</rdfs:label>
 		<skos:definition xml:lang="en">A futures contract on a stock or financial index. For each index there may be a different multiple for determining the price of the futures contract.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;IndexFutureStandardizedTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFutureStandardizedTerms"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;StandardizedFuturesTerms"/>
 		<rdfs:label xml:lang="en">index future standardized terms</rdfs:label>
 		<skos:definition xml:lang="en">A set of standard terms for index futures contracts, as set out by the derivatives exchange. Index Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;InterestRateFuture">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFuture"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:label xml:lang="en">interest rate future</rdfs:label>
 		<skos:definition xml:lang="en">An Interest Rate Future is a futures contract with an interest-bearing instrument as the underlying asset.</skos:definition>
 	</owl:Class>
@@ -291,7 +242,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/TradableDebtInstrument"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">interest rate future debt underlying</rdfs:label>
@@ -299,7 +250,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;InterestRateFutureStandardizedTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;FinancialFutureStandardizedTerms"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;StandardizedFuturesTerms"/>
 		<rdfs:label xml:lang="en">interest rate future standardized terms</rdfs:label>
 		<skos:definition xml:lang="en">A set of standard terms for interest rate futures contracts, as set out by the derivatives exchange. Interest Rate Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
 	</owl:Class>
@@ -383,7 +334,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Future"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">standardized futures terms</rdfs:label>
@@ -396,7 +347,7 @@
 		<rdfs:domain>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-fut;FutureInstrument">
+					<rdf:Description rdf:about="&fibo-fbc-fi-fi;Future">
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-der-etd-fut;EquityFutureStandardizedTerms">
 					</rdf:Description>
@@ -409,7 +360,7 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;contractValue">
 		<rdfs:label xml:lang="en">contract value</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">The deliverable value of goods, instruments or commodities underlying the futures contract.</skos:definition>
 	</owl:ObjectProperty>
@@ -432,27 +383,27 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;firstDeliveryDate">
 		<rdfs:label xml:lang="en">first delivery date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The start date of the range of dates by which the underlying for a futures contract must be delivered in order for the terms of the contract to be fulfilled.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;firstNoticeDate">
 		<rdfs:label xml:lang="en">first notice date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The first date at which a delivery notice can be issued.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasListing">
 		<rdfs:label xml:lang="en">has listing</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:range rdf:resource="&fibo-der-etd-fut;FuturesListing"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasSettlementArrangement">
 		<rdfs:label xml:lang="en">has settlement arrangement</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:range rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
 		<skos:definition xml:lang="en">The action by which an underlying commodity, security, cash value, or delivery instrument covering a contract is tendered and received by the contract holder.</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">This determines what is delivered to the holder when the future is exercised.</fibo-fnd-utl-av:explanatoryNote>
@@ -460,14 +411,14 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lastDeliveryDate">
 		<rdfs:label xml:lang="en">last delivery date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The last date in the range of dates by which the underlying for a futures contract must be delivered in order for the terms of the contract to be fulfilled.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;lastNoticeDate">
 		<rdfs:label xml:lang="en">last notice date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The last date at which a delivery notice can be issued.</skos:definition>
 	</owl:ObjectProperty>
@@ -530,7 +481,7 @@
 		<rdfs:domain>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-fut;FutureInstrument">
+					<rdf:Description rdf:about="&fibo-fbc-fi-fi;Future">
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-der-etd-fut;StandardizedFuturesTerms">
 					</rdf:Description>
@@ -542,7 +493,7 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;securityDescription">
 		<rdfs:label xml:lang="en">security description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FutureInstrument"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition xml:lang="en">The name of the security that uniquely identifies it amongst all other securities.</skos:definition>
 	</owl:DatatypeProperty>
@@ -558,7 +509,7 @@
 		<rdfs:domain>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-fut;FutureInstrument">
+					<rdf:Description rdf:about="&fibo-fbc-fi-fi;Future">
 					</rdf:Description>
 					<rdf:Description rdf:about="&fibo-der-etd-fut;StandardizedFuturesTerms">
 					</rdf:Description>
@@ -581,9 +532,9 @@
 		<rdfs:domain>
 			<owl:Class>
 				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-fut;FinancialFuture">
+					<rdf:Description rdf:about="&fibo-fbc-fi-fi;Future">
 					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-fut;FinancialFutureStandardizedTerms">
+					<rdf:Description rdf:about="&fibo-der-etd-fut;StandardizedFuturesTerms">
 					</rdf:Description>
 				</owl:unionOf>
 			</owl:Class>
@@ -592,8 +543,28 @@
 		<skos:definition xml:lang="en">How many of the underlying securities can be sold.</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:Class rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/FuturesTemporal/FuturesTradingAccountHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
+	<owl:Class rdf:about="&fibo-fbc-fi-fi;Future">
+		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-etd-fut;pricingDeterminedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FuturesTradingAccountProvider"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<skos:editorialNote xml:lang="en">Note that the restriction that has been replaced isHeldBy was that a futures contract has an account holder that is a futures trading account holder - that restriction was inappropriate, but a restriction indicating that the holder of a futures instrument has an account with a derivatives exchange should be considered when this ontology is reviewed with SMEs.</skos:editorialNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A futures contract obligates the buyer to purchase the underlying commodity, currency or financial instrument and the seller to sell it unless the contract is sold to another before settlement date which may happen if a trader waits to take a profit or cut a loss. Further notes: This contrasts with options trading in which the option buyer may choose whether or not to exercise the option by the exercise date. Unlike options, futures convey an obligation to buy. The risk to the holder is unlimited, and because the payoff pattern is symmetrical, the risk to the seller is unlimited as well. Dollars lost and gained by each party on a futures contract are equal and opposite. In other words, futures trading is a zero-sum game. Futures contracts are forward contracts, meaning they represent a pledge to make a certain transaction at a future date. The exchange of assets occurs on the date specified in the contract. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearinghouses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check. Definition origin: Barrons, adapted by EDMC SMER.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/DER/ExchangeTradedDerivatives/Futures.rdf
+++ b/DER/ExchangeTradedDerivatives/Futures.rdf
@@ -8,6 +8,7 @@
 	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-etd-fut "https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/">
 	<!ENTITY fibo-der-etd-std "https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/">
+	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -38,6 +39,7 @@
 	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-etd-fut="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/"
 	xmlns:fibo-der-etd-std="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"
+	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -75,6 +77,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/DerivativesStandardizedTerms/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
@@ -230,7 +233,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;StandardizedFuturesListingTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;StandardizedTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-fct-pub;hasPublisher"/>
@@ -252,19 +255,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;StandardizedTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-fct-pub;hasPublisher"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesExchange"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;pricingDeterminedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;specifiesDeliveryMethod"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -299,13 +290,6 @@
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition xml:lang="en">The first date at which a delivery notice can be issued.</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;hasContractSize">
-		<rdfs:label xml:lang="en">has contract size</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
-		<rdfs:range rdf:resource="&xsd;integer"/>
-		<skos:definition xml:lang="en">indicates the deliverable quantity of goods, commodities, or shares underlying the futures contract. This is denominated as a multiple of the lot size in the case of a commodity future. For financial futures this is the number of units of the underlying security.</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;hasConversionFactor">
 		<rdfs:label xml:lang="en">has conversion factor</rdfs:label>
@@ -371,27 +355,6 @@
 		<skos:definition xml:lang="en">An amount necessary to cover the purchase of the underlying security since delivery is mandatory, be it physical or cash. Failing to provide a sufficient provision will result in a margin call.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;pricingDeterminedBy">
-		<rdfs:label xml:lang="en">pricing determined by</rdfs:label>
-		<rdfs:domain>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fbc-fi-fi;Future">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-fut;StandardizedFuturesTerms">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:domain>
-		<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;specifiesDeliveryMethod">
-		<rdfs:label xml:lang="en">specifies delivery method</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-der-drc-bsc;DeliveryTerms"/>
-		<skos:definition xml:lang="en">Type of delivery for contracts. This determines what is delivered to the holder when the future is exercised.</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;tickValue">
 		<rdfs:label xml:lang="en">tick value</rdfs:label>
 		<rdfs:domain>
@@ -423,29 +386,5 @@
 		<rdfs:range rdf:resource="&xsd;integer"/>
 		<skos:definition xml:lang="en">How many of the underlying securities can be sold.</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:Class rdf:about="&fibo-fbc-fi-fi;Future">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContract"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-etd-fut;pricingDeterminedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;FuturesTradingAccountProvider"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<skos:editorialNote xml:lang="en">Note that the restriction that has been replaced isHeldBy was that a futures contract has an account holder that is a futures trading account holder - that restriction was inappropriate, but a restriction indicating that the holder of a futures instrument has an account with a derivatives exchange should be considered when this ontology is reviewed with SMEs.</skos:editorialNote>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">A futures contract obligates the buyer to purchase the underlying commodity, currency or financial instrument and the seller to sell it unless the contract is sold to another before settlement date which may happen if a trader waits to take a profit or cut a loss. Further notes: This contrasts with options trading in which the option buyer may choose whether or not to exercise the option by the exercise date. Unlike options, futures convey an obligation to buy. The risk to the holder is unlimited, and because the payoff pattern is symmetrical, the risk to the seller is unlimited as well. Dollars lost and gained by each party on a futures contract are equal and opposite. In other words, futures trading is a zero-sum game. Futures contracts are forward contracts, meaning they represent a pledge to make a certain transaction at a future date. The exchange of assets occurs on the date specified in the contract. Futures are distinguished from generic forward contracts in that they contain standardized terms, trade on a formal exchange, are regulated by overseeing agencies, and are guaranteed by clearinghouses. Also, in order to insure that payment will occur, futures have a margin requirement that must be settled daily. Finally, by making an offsetting trade, taking delivery of goods, or arranging for an exchange of goods, futures contracts can be closed. Hedgers often trade futures for the purpose of keeping price risk in check. Definition origin: Barrons, adapted by EDMC SMER.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
 
 </rdf:RDF>

--- a/DER/ExchangeTradedDerivatives/Futures.rdf
+++ b/DER/ExchangeTradedDerivatives/Futures.rdf
@@ -12,14 +12,16 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
-	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
+	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-ind-ei-ei "https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/">
+	<!ENTITY fibo-ind-mkt-bas "https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/">
 	<!ENTITY fibo-sec-dbt-bnd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/">
 	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
 	<!ENTITY fibo-sec-dbt-tstd "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
+	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -40,14 +42,16 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
-	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
+	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-ind-ei-ei="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"
+	xmlns:fibo-ind-mkt-bas="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"
 	xmlns:fibo-sec-dbt-bnd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"
 	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
 	xmlns:fibo-sec-dbt-tstd="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
+	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -75,40 +79,30 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/Bonds/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/ExchangeTradedDerivatives/Futures/"/>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;BondFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFuture"/>
-		<rdfs:label xml:lang="en">bond future</rdfs:label>
-		<skos:definition xml:lang="en">A future instrument where the underlying is a bond.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;BondFutureStandardizedTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFutureStandardizedTerms"/>
-		<rdfs:label xml:lang="en">bond future standardized terms</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for bond futures contracts, as set out by the derivatives exchange. Bond Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;BondFutureUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-bnd;Bond"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">bond future underlying</rdfs:label>
-		<skos:definition xml:lang="en">The Bond which is the underlying instrument of a Bond Future contract.</skos:definition>
+		<rdfs:label xml:lang="en">bond future</rdfs:label>
+		<skos:definition xml:lang="en">A future instrument where the underlying is a bond.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;CommodityFuture">
@@ -135,54 +129,25 @@
 	<owl:Class rdf:about="&fibo-der-etd-fut;EquityFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-ass-ass;EquityDerivativeContract"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Future"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">equity future</rdfs:label>
 		<skos:definition xml:lang="en">A Futures instrument which is based on an equity security or securities, specifically a publicly issued and traded share.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-etd-fut;EquityFutureShareUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;ListedShare"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">equity future share underlying</rdfs:label>
-		<skos:definition xml:lang="en">A share which is the underlying of an Equities Future contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;EquityFutureStandardizedTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;StandardizedFuturesTerms"/>
-		<rdfs:label xml:lang="en">equity future standardized terms</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for equity futures contracts, as set out by the derivatives exchange. Equity Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FuturesCommodityUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;NegotiableCommodity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures commodity underlying</rdfs:label>
-		<skos:definition xml:lang="en">A negotiable commodity as the underlying of a Futures contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;FuturesIndexUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">futures index underlying</rdfs:label>
-		<skos:definition xml:lang="en">An economic rate which is the underlying of a Futures contract.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-etd-fut;FuturesListing">
 		<rdfs:subClassOf rdf:resource="&fibo-der-etd-std;DerivativesListing"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-lst;lists"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fi-fi;Future"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-etd-fut;marginCall"/>
@@ -221,75 +186,47 @@
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;IndexFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Future"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-ind-ei-ei;EconomicIndicator">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-ind-mkt-bas;ReferenceIndex">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">index future</rdfs:label>
 		<skos:definition xml:lang="en">A futures contract on a stock or financial index. For each index there may be a different multiple for determining the price of the futures contract.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-etd-fut;IndexFutureStandardizedTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;StandardizedFuturesTerms"/>
-		<rdfs:label xml:lang="en">index future standardized terms</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for index futures contracts, as set out by the derivatives exchange. Index Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-etd-fut;InterestRateFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Future"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">interest rate future</rdfs:label>
 		<skos:definition xml:lang="en">An Interest Rate Future is a futures contract with an interest-bearing instrument as the underlying asset.</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;Underlier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">interest rate future debt underlying</rdfs:label>
-		<skos:definition xml:lang="en">The debt instrument which is the underlying of an Interest Rate Future contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;InterestRateFutureStandardizedTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;StandardizedFuturesTerms"/>
-		<rdfs:label xml:lang="en">interest rate future standardized terms</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for interest rate futures contracts, as set out by the derivatives exchange. Interest Rate Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-etd-fut;MoneyMarketFuture">
 		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFuture"/>
-		<rdfs:label xml:lang="en">money market future</rdfs:label>
-		<skos:definition xml:lang="en">A future instrument where the underlying is a money market instrument.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;MoneyMarketFutureStandardizedTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFutureStandardizedTerms"/>
-		<rdfs:label xml:lang="en">money market future standardized terms</rdfs:label>
-		<skos:definition xml:lang="en">A set of standard terms for money market futures contracts, as set out by the derivatives exchange. Money Market Futures contracts issued by and traded on that exchange will take on these terms or override them.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;MoneyMarketFutureUnderlying">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;InterestRateFutureDebtUnderlying"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasIdentity"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-dbt-tstd;MoneyMarketInstrument"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">money market future underlying</rdfs:label>
-		<skos:definition xml:lang="en">The money market instrument which is the underlying of a Money Market Futures contract.</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-etd-fut;StandardizedCommodityFutureTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-der-etd-fut;StandardizedFuturesTerms"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-etd-fut;CommodityFuture"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">standardized commodity future terms</rdfs:label>
-		<skos:definition xml:lang="en">Standard terms for a commodity futures contract, determined in advance by the exchange. These will become terms of an individual futures contract.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">These may be varied or overridden for individual contracts.</fibo-fnd-utl-av:explanatoryNote>
+		<rdfs:label xml:lang="en">money market future</rdfs:label>
+		<skos:definition xml:lang="en">A future instrument where the underlying is a money market instrument.</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-etd-fut;StandardizedFuturesListingTerms">
@@ -342,44 +279,12 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Standard symbology for the commodities are standardized by the exchanges as part of their standard contracts, for example trading in standard bushels, commonly defined kinds of oil and so on. These give the units in which lot sizes are described and defined.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;contractSize">
-		<rdfs:label xml:lang="en">contract size</rdfs:label>
-		<rdfs:domain>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-fbc-fi-fi;Future">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-fut;EquityFutureStandardizedTerms">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:domain>
-		<rdfs:range rdf:resource="&xsd;integer"/>
-		<skos:definition xml:lang="en">The deliverable quantity of goods, commodities, or shares underlying the futures contract. This is denominated as a multiple of the lot size in the case of a commodity future. For financial futures this is the number of units of the underlying security.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;contractValue">
 		<rdfs:label xml:lang="en">contract value</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">The deliverable value of goods, instruments or commodities underlying the futures contract.</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;conversionFactor">
-		<rdfs:label xml:lang="en">conversion factor</rdfs:label>
-		<rdfs:domain>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-fut;BondFuture">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-fut;BondFutureStandardizedTerms">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:domain>
-		<rdfs:range rdf:resource="&xsd;decimal"/>
-		<skos:definition xml:lang="en">The conversion factor is the price of the delivered bond/note ($1 par value) to yield a fixed rate. The conversion factor is used to calculate a final delivery price.</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;firstDeliveryDate">
 		<rdfs:label xml:lang="en">first delivery date</rdfs:label>
@@ -395,11 +300,33 @@
 		<skos:definition xml:lang="en">The first date at which a delivery notice can be issued.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasListing">
-		<rdfs:label xml:lang="en">has listing</rdfs:label>
+	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;hasContractSize">
+		<rdfs:label xml:lang="en">has contract size</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
-		<rdfs:range rdf:resource="&fibo-der-etd-fut;FuturesListing"/>
+		<rdfs:range rdf:resource="&xsd;integer"/>
+		<skos:definition xml:lang="en">indicates the deliverable quantity of goods, commodities, or shares underlying the futures contract. This is denominated as a multiple of the lot size in the case of a commodity future. For financial futures this is the number of units of the underlying security.</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;hasConversionFactor">
+		<rdfs:label xml:lang="en">has conversion factor</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-etd-fut;BondFuture"/>
+		<rdfs:range rdf:resource="&xsd;decimal"/>
+		<skos:definition xml:lang="en">indicates the price of the delivered bond/note ($1 par value) to yield a fixed rate. The conversion factor is used to calculate a final delivery price.</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasLotSize">
+		<rdfs:label xml:lang="en">lot size</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-etd-fut;CommodityFuture"/>
+		<rdfs:range rdf:resource="&fibo-fnd-qt-qtu;QuantityValue"/>
+		<skos:definition xml:lang="en">How many of the underlying commodity can be sold. The groupings of certain units of measure in the underlying commodity.</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;hasMultiple">
+		<rdfs:label xml:lang="en">has multiple</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-der-etd-fut;IndexFuture"/>
+		<rdfs:range rdf:resource="&xsd;decimal"/>
+		<skos:definition xml:lang="en">indicates the multiple for determining the price of the futures contract in relation to the underlying index rate</skos:definition>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;hasSettlementArrangement">
 		<rdfs:label xml:lang="en">has settlement arrangement</rdfs:label>
@@ -423,22 +350,6 @@
 		<skos:definition xml:lang="en">The last date at which a delivery notice can be issued.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;lotSize">
-		<rdfs:label xml:lang="en">lot size</rdfs:label>
-		<rdfs:domain>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-fut;CommodityFuture">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-fut;StandardizedCommodityFutureTerms">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:domain>
-		<rdfs:range rdf:resource="&xsd;decimal"/>
-		<skos:definition xml:lang="en">How many of the underlying commodity can be sold. The groupings of certain units of measure in the underlying commodity.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;marginCall">
 		<rdfs:label xml:lang="en">has margin call</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-etd-fut;FuturesListing"/>
@@ -460,22 +371,6 @@
 		<skos:definition xml:lang="en">An amount necessary to cover the purchase of the underlying security since delivery is mandatory, be it physical or cash. Failing to provide a sufficient provision will result in a margin call.</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;multiple">
-		<rdfs:label xml:lang="en">multiple</rdfs:label>
-		<rdfs:domain>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&fibo-der-etd-fut;IndexFuture">
-					</rdf:Description>
-					<rdf:Description rdf:about="&fibo-der-etd-fut;IndexFutureStandardizedTerms">
-					</rdf:Description>
-				</owl:unionOf>
-			</owl:Class>
-		</rdfs:domain>
-		<rdfs:range rdf:resource="&xsd;decimal"/>
-		<skos:definition xml:lang="en">The multiple for determining the price of the futures contract in relation to the underlying index rate.</skos:definition>
-	</owl:DatatypeProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;pricingDeterminedBy">
 		<rdfs:label xml:lang="en">pricing determined by</rdfs:label>
 		<rdfs:domain>
@@ -490,13 +385,6 @@
 		</rdfs:domain>
 		<rdfs:range rdf:resource="&fibo-der-etd-std;DerivativesPriceDeterminationMethod"/>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;securityDescription">
-		<rdfs:label xml:lang="en">security description</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Future"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">The name of the security that uniquely identifies it amongst all other securities.</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-etd-fut;specifiesDeliveryMethod">
 		<rdfs:label xml:lang="en">specifies delivery method</rdfs:label>
@@ -519,13 +407,6 @@
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
 		<skos:definition xml:lang="en">The minimum value of the upward or downward movement of the contract. This is the contract size multiplied by the tick size.</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;unitOfMeasure">
-		<rdfs:label xml:lang="en">unit of measure</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-etd-fut;StandardizedCommodityFutureTerms"/>
-		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition xml:lang="en">The unit in which the underlying commodity is to be measured.</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-etd-fut;unitOfTrading">
 		<rdfs:label xml:lang="en">unit of trading</rdfs:label>

--- a/DER/FxDerivatives/FxForwards.rdf
+++ b/DER/FxDerivatives/FxForwards.rdf
@@ -8,6 +8,7 @@
 	<!ENTITY fibo-der-fx-sp "https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSpots/">
 	<!ENTITY fibo-der-fx-sw "https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSwaps/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-fnd-utl-val "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -26,6 +27,7 @@
 	xmlns:fibo-der-fx-sp="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSpots/"
 	xmlns:fibo-der-fx-sw="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSwaps/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-fnd-utl-val="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -45,6 +47,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSpots/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/FxDerivatives/FxSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/TransactionsExt/REATransactions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Values/"/>
@@ -65,14 +68,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-fx-ctr;ForeignExchangeDerivativeContract"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;establishes.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fx forward contract</rdfs:label>
@@ -100,31 +103,25 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardTransaction"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-fx-fwd;embodies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-fx-fwd;side"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-fx-fwd;side.1"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;embodies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">fx forward transaction</rdfs:label>
 		<skos:definition xml:lang="en">A transaction in which cash is exchanged in two currencies at an agreed rate at an agreed date in the future.</skos:definition>
 	</owl:Class>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;embodies">
-		<rdfs:label xml:lang="en">embodies</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-fx-fwd;FxForwardContract"/>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;exchangedCurrencyOne">
 		<rdfs:label xml:lang="en">exchanged currency one</rdfs:label>
@@ -168,13 +165,13 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;side">
 		<rdfs:label xml:lang="en">side</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDelivery"/>
+		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashDeliveryCommitment"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-fx-fwd;side.1">
 		<rdfs:label xml:lang="en">side</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-fx-fwd;FxForwardTransaction"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/DER/FxDerivatives/FxOptions.rdf
+++ b/DER/FxDerivatives/FxOptions.rdf
@@ -56,7 +56,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-fx-opt;allowsForOptionOf"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">cash call option</rdfs:label>
@@ -183,7 +183,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;allowsForOptionOf">
 		<rdfs:label xml:lang="en">allows for option of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-der-fx-opt;CashCallOption"/>
-		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementTermsSet"/>
+		<rdfs:range rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-fx-opt;buyer">


### PR DESCRIPTION
## Description

This resolution eliminates the bad reference to the MD property that was likely deleted in a prior clean-up pass, eliminates references that use long URIs rather than abbreviated IRIs in Futures (which caused this reference to be missed), ExchangeTradedOptions and OptionContractOnFuture, and eliminates a significant amount of technical debt (redundancy, indirection, etc.) in the Futures and OptionContractOnFuture ontology.  Note that the latter should be merged with another derivatives ontology in a follow-up pass.

Fixes: #989 / DER-68


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


