### PR TITLE
META-993 - MetadataFIBO does not load all of the FIBO content

### DIFF
--- a/BP/MetadataBP.rdf
+++ b/BP/MetadataBP.rdf
@@ -25,39 +25,29 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/">
 		<rdfs:label>Metadata for the EDMC-FIBO Business Process (BP) Domain</rdfs:label>
-		<dct:abstract>The metadata for Business Process ontology describes the BP domain.</dct:abstract>
+		<dct:abstract>The Business Process (BP) domain includes ontologies that define financial process flows such as securities issuance and transaction workflows. In the case of securities issuance process models, these are provided in order to be able to represent reference data concepts that are dependent on the process by which a security was issued. Transaction process semantics provide the basis for the temporal dimension of securities and derivatives transactions.  These are process models represented using basic semantic primitive concepts of events, activities and control flows.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-bp-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataBP.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/Process/MetadataBPProcess/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MetadataBPSecuritiesIssuance/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/BP/MetadataBP/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/20200401/MetadataBP/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-bp-mod;BPDomain">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Business Process</rdfs:label>
-		<dct:abstract>The Business Process (BP) domain includes ontologies that define financial process flows such as securities issuance and transaction workflows. In the case of securities issuance process models, these are provided in order to be able to represent reference data concepts that are dependent on the process by which a security was issued. Transaction process semantics provide the basis for the temporal dimension of securities and derivatives transactions. 
-
-These are process models represented using basic semantic primitive concepts of events, activities and control flows.</dct:abstract>
-		<dct:creator rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/fct/Foundations</dct:creator>
+		<rdfs:label>Business Process Domain</rdfs:label>
+		<dct:abstract>The Business Process (BP) domain includes ontologies that define financial process flows such as securities issuance and transaction workflows. In the case of securities issuance process models, these are provided in order to be able to represent reference data concepts that are dependent on the process by which a security was issued. Transaction process semantics provide the basis for the temporal dimension of securities and derivatives transactions.  These are process models represented using basic semantic primitive concepts of events, activities and control flows.</dct:abstract>
 		<dct:hasPart rdf:resource="&fibo-bp-prc-mod;ProcessModule"/>
 		<dct:hasPart rdf:resource="&fibo-bp-iss-mod;SecuritiesIssuanceModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Business Process (BP) Domain</dct:title>
-		<sm:copyright>Copyright (c) 2013-2018 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/BEDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/FBCDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/FNDDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/LOANDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/MDDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/SECDomain"/>
-		<sm:keyword>foundational vocabulary</sm:keyword>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-bp</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/BP/Process/MetadataBPProcess.rdf
+++ b/BP/Process/MetadataBPProcess.rdf
@@ -21,24 +21,26 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/Process/MetadataBPProcess/">
 		<rdfs:label>Metadata for the EDMC-FIBO Business Process (BP) Process Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the BP Process Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of Process concepts including concepts common to a range of business processes, along with basic financial context concepts.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-bp-prc-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataBPProcess.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/BP/Process/MetadataBPProcess/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/20200401/Process/MetadataBPProcess/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-bp-prc-mod;ProcessModule">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Process</rdfs:label>
+		<rdfs:label>Process Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of Process concepts including concepts common to a range of business processes, along with basic financial context concepts.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/Process/FinancialContextAndProcess/"/>
-		<dct:title>FIBO Business Process - Core Process Terms Module</dct:title>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-bp-prc</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/BP/SecuritiesIssuance/MetadataBPSecuritiesIssuance.rdf
+++ b/BP/SecuritiesIssuance/MetadataBPSecuritiesIssuance.rdf
@@ -21,20 +21,20 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MetadataBPSecuritiesIssuance/">
 		<rdfs:label>Metadata for the EDMC-FIBO Business Process (BP) Securities Issuance Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the BP Securities Issuance Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of securities issuance process concepts, both for processes common to all securities issuance and variants for common types of equity and debt issuance such as auction and syndication.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-bp-iss-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataBPSecuritiesIssuance.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/BP/SecuritiesIssuance/MetadataBPSecuritiesIssuance/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/20200401/SecuritiesIssuance/MetadataBPSecuritiesIssuance/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-bp-iss-mod;SecuritiesIssuanceModule">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Securities Issuance</rdfs:label>
+		<rdfs:label>Securities Issuance Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of securities issuance process concepts, both for processes common to all securities issuance and variants for common types of equity and debt issuance such as auction and syndication.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/AgencyMBSIssuance/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/DebtIssuance/"/>
@@ -44,8 +44,10 @@
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MBSIssuance/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/MuniIssuance/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/SecuritiesIssuance/PrivateLabelMBSIssuance/"/>
-		<dct:title>FIBO Business Process - Securities Issuance Module</dct:title>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-bp-iss</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
+++ b/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
@@ -21,7 +21,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/">
 		<rdfs:label>Metadata for the EDMC-FIBO Corporate Actions and Events (CAE) Corporate Events Module</rdfs:label>
-		<dct:abstract>The Corporate Actions and Events (CAE) Corporate Events Module is the primary module for the CAE domain. It covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, to credit events that are relevant to investors and regulators alike.</dct:abstract>
+		<dct:abstract>This module contains ontologies of general corporate events and action-related concepts including events, messages, activities and, where applicable, responses required from security holders.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
@@ -35,11 +35,11 @@
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-mod;CorporateEventsModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Corporate Events Module</rdfs:label>
-		<dct:abstract>This module contains ontologies of general Corporate Events concepts including events, messages, activities and responses required from security holders.</dct:abstract>
+		<dct:abstract>This module contains ontologies of general corporate events and action-related concepts including events, messages, activities and, where applicable, responses required from security holders.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
-		<sm:moduleAbbreviation>FIBO-CAE-CE</sm:moduleAbbreviation>
+		<sm:moduleAbbreviation>fibo-cae-ce</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 

--- a/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
+++ b/CAE/CorporateEvents/MetadataCAECorporateEvents.rdf
@@ -20,25 +20,27 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/">
-		<rdfs:label>Metadata for the EDMC-FIBO Corporate Actions and Events (CAE) CorporateEvents Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the CAE Corporate Events Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<rdfs:label>Metadata for the EDMC-FIBO Corporate Actions and Events (CAE) Corporate Events Module</rdfs:label>
+		<dct:abstract>The Corporate Actions and Events (CAE) Corporate Events Module is the primary module for the CAE domain. It covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, to credit events that are relevant to investors and regulators alike.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-cae-ce-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataCAECorporateEvents.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/CAE/CorporateEvents/MetadataCAECorporateEvents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20200401/CorporateEvents/MetadataCAECorporateEvents/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-ce-mod;CorporateEventsModule">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Corporate Events</rdfs:label>
+		<rdfs:label>Corporate Events Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of general Corporate Events concepts including events, messages, activities and responses required from security holders.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"/>
-		<dct:title>FIBO Corporate Actions and Events - Corporate Events Module</dct:title>
-		<sm:moduleAbbreviation>fibo-cae-ce</sm:moduleAbbreviation>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
+		<sm:moduleAbbreviation>FIBO-CAE-CE</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/CAE/MetadataCAE.rdf
+++ b/CAE/MetadataCAE.rdf
@@ -22,37 +22,28 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CAE/MetadataCAE/">
-		<rdfs:label>Metadata for the EDMC-FIBO Corporate Actions and Events (CAE) Domain</rdfs:label>
-		<dct:abstract>The metadata for CAE ontology describes the CAE domain.</dct:abstract>
+		<rdfs:label>Metadata about the EDMC-FIBO Corporate Actions and Events (CAE) Domain</rdfs:label>
+		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, to credit events that are relevant to investors and regulators alike. Corporate actions include actions that require some action on the part of the holder, and in these and some other cases there are process descriptions for the flow of activities involved.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-cae-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataCAE.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/CorporateActionsEvents/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/CAE/MetadataCAE/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/CorporateEvents/MetadataCAECorporateEvents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CAE/20200401/MetadataCAE/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-cae-mod;CAEDomain">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Corporate Actions and Events</rdfs:label>
-		<dct:abstract>The Corporate Actions and Events (CAE) domain contain ontologies that define events and actions that may occur during the life of a security, and are typically those events which may cause some change in some part of the underlying reference information for that security. Corporate actions include actions that require some action on the part of the holder, and in these and some other cases there are process descriptions for the flow of activities involved.</dct:abstract>
-		<dct:creator rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/fct/Foundations</dct:creator>
+		<rdfs:label>Corporate Actions and Events Domain</rdfs:label>
+		<dct:abstract>The Corporate Actions and Events (CAE) domain covers events and actions that may occur during the life of a security, ranging from announcements regarding stock offerings, splits, dividends and so forth, to credit events that are relevant to investors and regulators alike. Corporate actions include actions that require some action on the part of the holder, and in these and some other cases there are process descriptions for the flow of activities involved.</dct:abstract>
 		<dct:hasPart rdf:resource="&fibo-cae-ce-mod;CorporateEventsModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Corporate Actions and Events (CAE) Domain</dct:title>
-		<sm:copyright>Copyright (c) 2013-2018 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/BEDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/BPDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/MetadataDER/DERDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/FBCDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/FNDDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/MDDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/SECDomain"/>
-		<sm:keyword>foundational vocabulary</sm:keyword>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-cae</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/CIV/Funds/MetadataCIVFunds.rdf
+++ b/CIV/Funds/MetadataCIVFunds.rdf
@@ -21,24 +21,26 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/MetadataCIVFunds/">
 		<rdfs:label>Metadata for the EDMC-FIBO Collective Investment Vehicles (CIV) Funds Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the CIV Funds Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of funds concepts covering fund structure, definition and involved parties, along with concepts for tradable fund units.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-civ-fnd-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataCIVFunds.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/CIV/Funds/MetadataCIVFunds/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CIV/20200401/Funds/MetadataCIVFunds/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-civ-fnd-mod;FundsModule">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Funds</rdfs:label>
+		<rdfs:label>Funds Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of funds concepts covering fund structure, definition and involved parties, along with concepts for tradable fund units.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/CIV/"/>
-		<dct:title>FIBO Collective Investment Vehicles - Funds Module</dct:title>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-civ-fnd</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 		<skos:editorialNote>This module currently contains all the FIBO model content relating to funds and is biased towards European traded funds.</skos:editorialNote>
 	</owl:NamedIndividual>
 

--- a/CIV/MetadataCIV.rdf
+++ b/CIV/MetadataCIV.rdf
@@ -23,33 +23,27 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/CIV/MetadataCIV/">
 		<rdfs:label>Metadata for the EDMC-FIBO Collective Investment Vehicles (CIV) Domain</rdfs:label>
-		<dct:abstract>The metadata for CIV ontology describes the CIV domain.</dct:abstract>
+		<dct:abstract>The Collective Investment Vehicles (CIV) domain contains ontologies that define terms for investment funds, covering the basic definition of a fund, the various fund related parties, portfolio characteristics and tradable units in those funds.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-06T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-civ-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataCIV.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CIV/Funds/MetadataCIVFunds/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/CIV/MetadataCIV/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/CIV/20200401/MetadataCIV/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-civ-mod;CIVDomain">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Collective Investment Vehicles</rdfs:label>
+		<rdfs:label>Collective Investment Vehicles Domain</rdfs:label>
 		<dct:abstract>The Collective Investment Vehicles (CIV) domain contains ontologies that define terms for investment funds, covering the basic definition of a fund, the various fund related parties, portfolio characteristics and tradable units in those funds.</dct:abstract>
-		<dct:creator rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/fct/Foundations</dct:creator>
 		<dct:hasPart rdf:resource="&fibo-civ-fnd-mod;FundsModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Collective Investment Vehicles (CIV) Domain</dct:title>
-		<sm:copyright>Copyright (c) 2013-2018 EDM Council, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/BEDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/MetadataFBC/FBCDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/MetadataFND/FNDDomain"/>
-		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/SECDomain"/>
-		<sm:keyword>foundational vocabulary</sm:keyword>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-civ</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 		<skos:editorialNote>This material is based largely on concepts from the European Funds and Asset Management Association (EFAMA) and will require future refactoring to accommodate other types of funds including hedge funds, funds arrangements in other jurisdictions and other variants. Part of that work would include subdividing this content into separate modules, particularly for concepts common to all or most funds.</skos:editorialNote>
 	</owl:NamedIndividual>
 

--- a/LOAN/LoanContracts/MetadataLOANLoanContracts.rdf
+++ b/LOAN/LoanContracts/MetadataLOANLoanContracts.rdf
@@ -21,25 +21,28 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/MetadataLOANLoanContracts/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) LoanContracts Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the LOAN Loan Contracts Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of general loans related concepts with a focus on concepts needed to support mortgage lending.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-loan-ln-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataLOANLoanContracts.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/LOAN/LoanContracts/MetadataLOANLoanContracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20200401/LoanContracts/MetadataLOANLoanContracts/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-ln-mod;LoanContractsModule">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Loan Contracts</rdfs:label>
+		<rdfs:label>Loan Contracts Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of general loans related concepts with a focus on concepts needed to support mortgage lending.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/LoanCore/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/LoanHMDA/"/>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO Loans - Loan Contracts Module</dct:title>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-loan-ln</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/LoanTypes/MetadataLOANLoanTypes.rdf
+++ b/LOAN/LoanTypes/MetadataLOANLoanTypes.rdf
@@ -21,20 +21,20 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/MetadataLOANLoanTypes/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) LoanTypes Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the LOAN Loan Types Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of concepts descriptive of a range of types of loans, including secured and unsecured, corporate and personal, loans differentiated by purpose and their differentiating characteristics.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-loan-typ-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataLOANLoanTypes.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/LOAN/LoanTypes/MetadataLOANLoanTypes/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20200401/LoanTypes/MetadataLOANLoanTypes/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-typ-mod;LoanTypesModule">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Loan Types</rdfs:label>
+		<rdfs:label>Loan Types Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of concepts descriptive of a range of types of loans, including secured and unsecured, corporate and personal, loans differentiated by purpose and their differentiating characteristics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/CommercialLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/ConstructionLoans/"/>
@@ -46,8 +46,11 @@
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/SecuredLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/StudentLoans/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/UnsecuredLoans/"/>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO Loans - Loan Types Module</dct:title>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-loan-typ</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/Loans/MetadataLOANLoans.rdf
+++ b/LOAN/Loans/MetadataLOANLoans.rdf
@@ -21,25 +21,29 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/MetadataLOANLoans/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) Loans Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the LOAN Loans Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of concepts common to all loan types along with foundational concepts for credit facilities and loan products.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-loan-loan-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataLOANLoans.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/MetadataLOANLoans/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20200401/Loans/MetadataLOANLoans/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-loan-mod;LoansModule">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Loans</rdfs:label>
+		<rdfs:label>Loans Module</rdfs:label>
 		<dct:abstract>This module contains ontologies of concepts common to all loan types along with foundational concepts for credit facilities and loan products.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/LoanBasicTerms/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/LoansRegulatory/"/>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO Loans - Foundational Loans Module</dct:title>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-loan-loan</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<skos:editorialNote>Note that the ontologies in this module will at some point be combined with / migrated to the Loan Contracts module, so that the most general loans ontologies are together.</skos:editorialNote>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/LoansTemporal/MetadataLOANLoansTemporal.rdf
+++ b/LOAN/LoansTemporal/MetadataLOANLoansTemporal.rdf
@@ -21,15 +21,15 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansTemporal/MetadataLOANLoansTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) LoansTemporal Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the LOAN Loans Temporal Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of temporal concepts related to all loan types. These are terms that explicitly vary over time such as loan to value ratios.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-loan-tem-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataLOANLoansTemporal.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/LOAN/LoansTemporal/MetadataLOANLoansTemporal/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20200401/LoansTemporal/MetadataLOANLoansTemporal/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-tem-mod;LoansTemporalModule">
@@ -44,6 +44,8 @@
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansTemporal/LoansTemporal/"/>
 		<dct:title>FIBO Loans - Loans Temporal Terms Module</dct:title>
 		<sm:moduleAbbreviation>fibo-loan-tem</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
+		<skos:editorialNote>Note that the ontologies in this module will at some point be combined with / migrated to the Loan Contracts or Loan Types module, so that the most general loans ontologies are together, and content specific to a product such as construction loans are also merged.</skos:editorialNote>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/LOAN/MetadataLOAN.rdf
+++ b/LOAN/MetadataLOAN.rdf
@@ -35,19 +35,18 @@
 		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-loan-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataLOAN.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanContracts/MetadataLOANLoanContracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoanTypes/MetadataLOANLoanTypes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/Loans/MetadataLOANLoans/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/LoansTemporal/MetadataLOANLoansTemporal/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20200201/LOAN/MetadataLOAN/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/20200401/MetadataLOAN/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-loan-mod;LOANDomain">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Loans</rdfs:label>
 		<dct:abstract>The FIBO Loan domain provides a model of concepts that are common to loan contracts in various market categories including but not limited to commercial, small business, automobile, education and mortgage. High-level concepts relevant to loan contracts include the obligations of parties playing different roles, credit and risk, security agreements as well as additional detail for HMDA-specific loans.  Details defining debt instruments in general are covered in a separate debt module in the Securities domain.</dct:abstract>
-		<dct:creator rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/fct/Loans</dct:creator>
 		<dct:hasPart rdf:resource="&fibo-loan-ln-mod;LoanContractsModule"/>
 		<dct:hasPart rdf:resource="&fibo-loan-typ-mod;LoanTypesModule"/>
 		<dct:hasPart rdf:resource="&fibo-loan-loan-mod;LoansModule"/>

--- a/LOAN/MetadataLOAN.rdf
+++ b/LOAN/MetadataLOAN.rdf
@@ -29,7 +29,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/">
 		<rdfs:label>Metadata for the EDMC-FIBO Loans (LOAN) Domain</rdfs:label>
-		<dct:abstract>The metadata for Loans ontology describes the LOAN domain.</dct:abstract>
+		<dct:abstract>The FIBO Loan domain provides a model of concepts that are common to loan contracts in various market categories including but not limited to commercial, small business, automobile, education and mortgage. High-level concepts relevant to loan contracts include the obligations of parties playing different roles, credit and risk, security agreements as well as additional detail for HMDA-specific loans.  Details defining debt instruments in general are covered in a separate debt module in the Securities domain.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>

--- a/MD/CIVTemporal/MetadataMDCIVTemporal.rdf
+++ b/MD/CIVTemporal/MetadataMDCIVTemporal.rdf
@@ -21,15 +21,15 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) CIVTemporal Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the MD CIV Temporal Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of temporally variable concepts relating to funds and other collective investment vehicles. These are concepts for variables that have past, presented and projected future values.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-md-civx-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataMDCIVTemporal.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/MD/CIVTemporal/MetadataMDCIVTemporal/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20200401/CIVTemporal/MetadataMDCIVTemporal/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-civx-mod;CIVTemporalModule">
@@ -37,8 +37,11 @@
 		<rdfs:label>CIV Temporal</rdfs:label>
 		<dct:abstract>This module contains ontologies of temporally variable concepts relating to funds and other collective investment vehicles. These are concepts for variables that have past, presented and projected future values.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/"/>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO Market Data - Collective Investment Vehicles Temporal Terms Module</dct:title>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-md-civx</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/CIVTemporal/MetadataMDCIVTemporal.rdf
+++ b/MD/CIVTemporal/MetadataMDCIVTemporal.rdf
@@ -21,7 +21,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) CIVTemporal Module</rdfs:label>
-		<dct:abstract>This module contains ontologies of temporally variable concepts relating to funds and other collective investment vehicles. These are concepts for variables that have past, presented and projected future values.</dct:abstract>
+		<dct:abstract>This module provides time-dependent concepts specific to funds and other collective investment vehicles.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
@@ -35,7 +35,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-md-civx-mod;CIVTemporalModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>CIV Temporal</rdfs:label>
-		<dct:abstract>This module contains ontologies of temporally variable concepts relating to funds and other collective investment vehicles. These are concepts for variables that have past, presented and projected future values.</dct:abstract>
+		<dct:abstract>This module provides time-dependent concepts specific to funds and other collective investment vehicles.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/FundsTemporal/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO Market Data - Collective Investment Vehicles Temporal Terms Module</dct:title>

--- a/MD/DebtTemporal/MetadataMDDebtTemporal.rdf
+++ b/MD/DebtTemporal/MetadataMDDebtTemporal.rdf
@@ -21,15 +21,15 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) DebtTemporal Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the MD Debt Temporal Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of temporally variable concepts relating to debt instruments. These are concepts for variables that have past, presented and projected future values, such as pricing, yields and analytics.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-md-dbtx-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataMDDebtTemporal.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/MD/DebtTemporal/MetadataMDDebtTemporal/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20200401/DebtTemporal/MetadataMDDebtTemporal/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-dbtx-mod;DebtTemporalModule">
@@ -38,8 +38,11 @@
 		<dct:abstract>This module contains ontologies of temporally variable concepts relating to debt instruments. These are concepts for variables that have past, presented and projected future values, such as pricing, yields and analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtPricingYields/"/>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO Market Data - Debt Temporal Terms Module</dct:title>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-md-dbtx</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/DebtTemporal/MetadataMDDebtTemporal.rdf
+++ b/MD/DebtTemporal/MetadataMDDebtTemporal.rdf
@@ -21,7 +21,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) DebtTemporal Module</rdfs:label>
-		<dct:abstract>This module contains ontologies of temporally variable concepts relating to debt instruments. These are concepts for variables that have past, presented and projected future values, such as pricing, yields and analytics.</dct:abstract>
+		<dct:abstract>This module covers time-dependent concepts related to debt instruments, such as pricing, yields and analytics.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
@@ -35,7 +35,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-md-dbtx-mod;DebtTemporalModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Debt Temporal</rdfs:label>
-		<dct:abstract>This module contains ontologies of temporally variable concepts relating to debt instruments. These are concepts for variables that have past, presented and projected future values, such as pricing, yields and analytics.</dct:abstract>
+		<dct:abstract>This module covers time-dependent concepts related to debt instruments, such as pricing, yields and analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtAnalytics/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/DebtPricingYields/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>

--- a/MD/DerivativesTemporal/MetadataMDDerivativesTemporal.rdf
+++ b/MD/DerivativesTemporal/MetadataMDDerivativesTemporal.rdf
@@ -21,15 +21,15 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) DerivativesTemporal Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the MD Derivatives Temporal Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:abstract>This module contains ontologies of temporally variable concepts relating to derivatives instruments. These are concepts for variables that have past, presented and projected future values, such as the various derivatives related greeks and other analytics.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-md-derx-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataMDDerivativesTemporal.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20200401/DerivativesTemporal/MetadataMDDerivativesTemporal/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-derx-mod;DerivativesTemporalModule">
@@ -38,8 +38,11 @@
 		<dct:abstract>This module contains ontologies of temporally variable concepts relating to derivatives instruments. These are concepts for variables that have past, presented and projected future values, such as the various derivatives related greeks and other analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/ETOptionsTemporal/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/FuturesTemporal/"/>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO Market Data - Derivatives Temporal Terms Module</dct:title>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-md-derx</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/DerivativesTemporal/MetadataMDDerivativesTemporal.rdf
+++ b/MD/DerivativesTemporal/MetadataMDDerivativesTemporal.rdf
@@ -21,7 +21,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) DerivativesTemporal Module</rdfs:label>
-		<dct:abstract>This module contains ontologies of temporally variable concepts relating to derivatives instruments. These are concepts for variables that have past, presented and projected future values, such as the various derivatives related greeks and other analytics.</dct:abstract>
+		<dct:abstract>This module covers time-dependent concepts related to derivative instruments, such as the various derivatives-related greeks and other analytics.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
@@ -35,7 +35,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-md-derx-mod;DerivativesTemporalModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Derivatives Temporal</rdfs:label>
-		<dct:abstract>This module contains ontologies of temporally variable concepts relating to derivatives instruments. These are concepts for variables that have past, presented and projected future values, such as the various derivatives related greeks and other analytics.</dct:abstract>
+		<dct:abstract>This module covers time-dependent concepts related to derivative instruments, such as the various derivatives-related greeks and other analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/ETOptionsTemporal/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/FuturesTemporal/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>

--- a/MD/MetadataMD.rdf
+++ b/MD/MetadataMD.rdf
@@ -29,32 +29,31 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/MetadataMD/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) Domain</rdfs:label>
-		<dct:abstract>The metadata for Market Data ontology describes the MD domain.</dct:abstract>
+		<dct:abstract>The Market Data (MD) domain contains ontologies that represent temporally variant concepts for financial instruments, loans and funds. As such this domain covers the concepts represented in market data, such as prices, yields and analytics for debt and for pools of assets.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-md-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataMD.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/CIVTemporal/MetadataMDCIVTemporal/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DebtTemporal/MetadataMDDebtTemporal/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/DerivativesTemporal/MetadataMDDerivativesTemporal/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/MD/MetadataMD/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20200401/MetadataMD/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-mod;MDDomain">
 		<rdf:type rdf:resource="&sm;Module"/>
-		<rdfs:label>Market Data</rdfs:label>
-		<dct:abstract>The Market Data (MD) domain contains ontologies that represent temporally variant concepts for the whole range of financial instruments, loans and funds. While all concepts can be regarded as having some relationship to time, the ones in this domain are those concepts which explicitly have a set of past values a present value and projected future values. As such this domain covers the concepts represented in market data, such as prices, yields and analytics for debt and for pools of assets.</dct:abstract>
-		<dct:creator rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/fct/Foundations</dct:creator>
+		<rdfs:label>Market Data Domain</rdfs:label>
+		<dct:abstract>The Market Data (MD) domain contains ontologies that represent temporally variant concepts for financial instruments, loans and funds. As such this domain covers the concepts represented in market data, such as prices, yields and analytics for debt and for pools of assets.</dct:abstract>
 		<dct:hasPart rdf:resource="&fibo-md-civx-mod;CIVTemporalModule"/>
 		<dct:hasPart rdf:resource="&fibo-md-dbtx-mod;DebtTemporalModule"/>
 		<dct:hasPart rdf:resource="&fibo-md-derx-mod;DerivativesTemporalModule"/>
 		<dct:hasPart rdf:resource="&fibo-md-temx-mod;TemporalCoreModule"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Market Data (MD) Domain</dct:title>
-		<sm:copyright>Copyright (c) 2013-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/MetadataBE/BEDomain"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BP/MetadataBP/BPDomain"/>
@@ -65,7 +64,6 @@
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/MetadataIND/INDDomain"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/LOAN/MetadataLOAN/LOANDomain"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/MetadataSEC/SECDomain"/>
-		<sm:keyword>foundational vocabulary</sm:keyword>
 		<sm:moduleAbbreviation>fibo-md</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/</rdfs:seeAlso>
 	</owl:NamedIndividual>

--- a/MD/TemporalCore/MetadataMDTemporalCore.rdf
+++ b/MD/TemporalCore/MetadataMDTemporalCore.rdf
@@ -22,14 +22,14 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) TemporalCore Module</rdfs:label>
 		<dct:abstract>This is the metadata ontology used to describe the MD Temporal Core Module.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-06-30T18:00:00</dct:issued>
-		<dct:license rdf:resource="&sm;MITLicense"/>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2014-2018 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-md-temx-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataMDTemporalCore.rdf</sm:filename>
-		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/master/2018Q2/MD/TemporalCore/MetadataMDTemporalCore/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/20200401/TemporalCore/MetadataMDTemporalCore/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-md-temx-mod;TemporalCoreModule">
@@ -38,8 +38,11 @@
 		<dct:abstract>This module contains ontologies of temporally variable concepts common to all instruments, funds and loans. These are concepts for variables that have past, presented and projected future values, such as pricing, yields and analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityCreditStatuses/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"/>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>FIBO Market Data - Core Temporal Terms Module</dct:title>
+		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>fibo-md-temx</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/MD/TemporalCore/MetadataMDTemporalCore.rdf
+++ b/MD/TemporalCore/MetadataMDTemporalCore.rdf
@@ -21,7 +21,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/MetadataMDTemporalCore/">
 		<rdfs:label>Metadata for the EDMC-FIBO Market Data (MD) TemporalCore Module</rdfs:label>
-		<dct:abstract>This is the metadata ontology used to describe the MD Temporal Core Module.</dct:abstract>
+		<dct:abstract>This module covers time-dependent concepts common to all instruments, funds and loans, such as pricing, yields and analytics.</dct:abstract>
 		<dct:issued rdf:datatype="&xsd;dateTime">2020-04-07T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
@@ -35,7 +35,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-md-temx-mod;TemporalCoreModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>Temporal Core</rdfs:label>
-		<dct:abstract>This module contains ontologies of temporally variable concepts common to all instruments, funds and loans. These are concepts for variables that have past, presented and projected future values, such as pricing, yields and analytics.</dct:abstract>
+		<dct:abstract>This module covers time-dependent concepts common to all instruments, funds and loans, such as pricing, yields and analytics.</dct:abstract>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityCreditStatuses/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/MD/TemporalCore/SecurityTradingStatuses/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -170,6 +170,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/" uri="./FND/Arrangements/Arrangements.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Assessments/" uri="./FND/Arrangements/Assessments.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/" uri="./FND/Arrangements/ClassificationSchemes.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Communications/" uri="./FND/Arrangements/Communications.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/" uri="./FND/Arrangements/Documents.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/" uri="./FND/Arrangements/IdentifiersAndIndices.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/" uri="./FND/Arrangements/Lifecycles.rdf"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall ekendall@thematix.com

## Description

Revised metadata files so that the provisional ones were consistent with what we have in release, and to ensure that none are missing if one imports MetadataFIBO.  MetadataFIBO can be used together with AboutFIBODev to drive the FIBO viewer as a consequence.

Fixes: #993 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


