### PR TITLE
SEC-124 - Redundant subclass relationships in Securities Identification should be eliminated

### DIFF
--- a/SEC/Securities/SecuritiesIdentification.rdf
+++ b/SEC/Securities/SecuritiesIdentification.rdf
@@ -75,8 +75,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesIdentification/"/>
-		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20180801/Securities/SecuritiesIdentification.rdf version of this ontology was modified to use the hasCoverageArea property rather than hasJurisdiction for coverage of national numbering agencies.</skos:changeNote>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesIdentification/"/>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20180801/Securities/SecuritiesIdentification.rdf version of this ontology was modified to use the hasCoverageArea property rather than hasJurisdiction for coverage of national numbering agencies, and eliminate redundant subclass relationships for two of the schemes defined herein.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20181101/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was modified to add the concept of a ticker symbol and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesIdentification/ version of this ontology was modified to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
@@ -130,7 +130,6 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumberingScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;RegistrationScheme"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;SecurityIdentificationScheme"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -281,7 +280,6 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-id;NationalSecurityIdentificationScheme">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;RegistrationScheme"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-id;SecurityIdentificationScheme"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminates redundant registration scheme subclass relationships on two identification schemes

Fixes: #1001 / SEC-124


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


