### PR TITLE
SEC-73 - Augment the equities concepts with their CFI classification

### DIFF
--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -95,7 +95,7 @@
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
 		<rdfs:label>Alphabet Inc. class A common stock</rdfs:label>
 		<skos:definition>common share class that represents class A series shares in Alphabet Inc.</skos:definition>
-		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
+		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
@@ -115,7 +115,7 @@
 		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
 		<rdfs:label>Alphabet Inc. class C capital stock</rdfs:label>
 		<skos:definition>common share class that represents class C series shares in Alphabet Inc.</skos:definition>
-		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
+		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>

--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -92,7 +92,7 @@
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>Alphabet Inc. class A common stock</rdfs:label>
 		<skos:definition>common share class that represents class A series shares in Alphabet Inc.</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
@@ -112,7 +112,7 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>Alphabet Inc. class C capital stock</rdfs:label>
 		<skos:definition>common share class that represents class C series shares in Alphabet Inc.</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -133,6 +133,19 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en-GB">ordinary share</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;ConvertibleCommonShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;ConvertibleSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;EquityConversionTerms"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>convertible common share</rdfs:label>
+		<skos:definition>common share that is convertible into another security</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ConvertiblePreferredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;ConvertibleSecurity"/>
@@ -143,7 +156,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>convertible preferred share</rdfs:label>
-		<skos:definition>a preferred share that is convertible into another security</skos:definition>
+		<skos:definition>preferred share that is convertible into another security</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;CumulativePreferredShare">
@@ -217,6 +230,12 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-sch;ParametricSchedule"/>
 		<rdfs:label>dividend or share coupon schedule</rdfs:label>
 		<skos:definition>payment schedule indicating the dates on which dividends or share coupon payments are due to be paid</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;EnhancedVoting">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+		<rdfs:label>enhanced voting</rdfs:label>
+		<skos:definition>shareholder is entitled to more than one vote per share</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;EquityConversionTerms">
@@ -386,6 +405,18 @@
 		<skos:definition>preferred share that is not a participating preferred share</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;NonVoting">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+		<rdfs:label>non-voting</rdfs:label>
+		<owl:equivalentClass>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersNumberOfVotesPerShare"/>
+				<owl:hasValue rdf:datatype="&xsd;decimal">0</owl:hasValue>
+			</owl:Restriction>
+		</owl:equivalentClass>
+		<skos:definition>share has no voting rights</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;OrdinaryDividend">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Dividend"/>
 		<rdfs:label>ordinary dividend</rdfs:label>
@@ -510,10 +541,17 @@
 		<skos:definition>dividend that falls under capital gains tax rates that are lower than the income tax rates on unqualified, or ordinary, dividends</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;RestrictedVotingRight">
+	<owl:Class rdf:about="&fibo-sec-eq-eq;RestrictedShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+		<rdfs:label xml:lang="en">restricted share</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<skos:definition xml:lang="en">share whose ownership/transfer/sale is subject to special conditions including country-specific restrictions</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;RestrictedVoting">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
-		<rdfs:label>restricted voting right</rdfs:label>
-		<skos:definition>voting right that has certain limitations associated with it</skos:definition>
+		<rdfs:label>restricted voting</rdfs:label>
+		<skos:definition>shareholder is restricted to less than one vote per share</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;Share">
@@ -564,12 +602,31 @@
 		<fibo-fnd-utl-av:usageNote xml:lang="en">Special dividends may be included in a dividend schedule as an ad-hoc entry, since they still need to be tracked based on the date of issuance.</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;NegotiableSecurity"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
+		<rdfs:label xml:lang="en">unrestricted share</rdfs:label>
+		<skos:definition xml:lang="en">share whose ownership/transfer/sale is not subject to special conditions including country-specific restrictions</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;Voting">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
+		<rdfs:label>voting</rdfs:label>
+		<owl:equivalentClass>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;confersNumberOfVotesPerShare"/>
+				<owl:hasValue rdf:datatype="&xsd;decimal">1</owl:hasValue>
+			</owl:Restriction>
+		</owl:equivalentClass>
+		<skos:definition>voting right that confers exactly one vote per share</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;VotingRight">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-lcap;ContractualRight"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasVotingRestriction"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -719,6 +776,7 @@
 		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition>specifies restrictions on voting rights, if any</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Such restrictions may apply regardless of the number of votes per share.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;indicatesNumberOfShares">

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -143,6 +143,34 @@
 		<fibo-fnd-utl-av:synonym xml:lang="en-GB">ordinary share</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:onClass rdf:resource="&fibo-sec-eq-eq;Voting"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+				<owl:onClass rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, voting, unrestricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly 1 vote per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ConvertibleCommonShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;ConvertibleSecurity"/>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -11,6 +11,8 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
+	<!ENTITY fibo-fnd-arr-lif "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/">
 	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
 	<!ENTITY fibo-fnd-law-lcap "https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/">
@@ -25,6 +27,7 @@
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
 	<!ENTITY fibo-sec-sec-rst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/">
 	<!ENTITY fibo-sec-sec-sch "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -45,6 +48,8 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
+	xmlns:fibo-fnd-arr-lif="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"
 	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
 	xmlns:fibo-fnd-law-lcap="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"
@@ -59,6 +64,7 @@
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
 	xmlns:fibo-sec-sec-rst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"
 	xmlns:fibo-sec-sec-sch="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -95,6 +101,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/LegalCapacity/"/>
@@ -108,11 +116,13 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -349,6 +359,12 @@
 		<skos:definition>right to vote at extraordinary meetings, as opposed to being able to vote strictly at annual general meetings</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;FullyPaidShareStatus">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
+		<rdfs:label>fully paid share status</rdfs:label>
+		<skos:definition>status indicating that no additional money is owed to the company by shareholders on the value of the shares</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;LimitedPartnershipUnit">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
 		<rdfs:subClassOf>
@@ -391,6 +407,15 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Listing requirements vary by exchange and include minimum stockholder&apos;s equity, a minimum share price and a minimum number of shareholders. Exchanges have listing requirements to ensure that only high quality securities are traded on them and to uphold the exchange&apos;s reputation among investors.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;NilPaidShareStatus">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
+		<rdfs:label>nil paid share status</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShareStatus"/>
+		<skos:definition>status indicating that none of the market value has been received by the company for the shares</skos:definition>
+		<skos:example>Unpaid shares may be issued, for example, for convenience by a start-up company.</skos:example>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;NonCumulativePreferredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
 		<rdfs:label>non-cumulative preferred share</rdfs:label>
@@ -429,6 +454,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
 		<rdfs:label>ordinary voting right</rdfs:label>
 		<skos:definition>voting right conferred on holders of common shares, as defined by the issuer</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;PartiallyPaidShareStatus">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
+		<rdfs:label>partially paid share status</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+		<skos:definition>status indicating that only a portion of the market value has been received by the company for the shares</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>In the case of partially paid shares, the shareholder is still required to pay the remaining amount to the company. Typically, partially paid shares are only issued to a shareholder if there are compelling business reasons to do so.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ParticipatingPreferredShare">
@@ -568,8 +601,27 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;ShareholdersEquity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">share</rdfs:label>
 		<skos:definition xml:lang="en">financial instrument that signifies a unit of equity ownership in a corporation, or a unit of ownership in a mutual fund, or interest in a general or limited partnership, or a unit of ownership in a structured product, such as a real estate investment trust</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;SharePaymentStatus">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStatus"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;Share"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>share payment status</rdfs:label>
+		<skos:definition>classifier that specifies the overall payment status for shares issued</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>When a company issues shares upon incorporation or through an initial or secondary issuance, shareholders are required to pay a set amount for those shares. Once the company has received the full amount from shareholders, the shares become fully paid shares.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ShareYield">

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -138,15 +138,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
-				<owl:onClass rdf:resource="&fibo-sec-eq-eq;NonVoting"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+				<owl:hasValue rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-				<owl:onClass rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:onClass rdf:resource="&fibo-sec-eq-eq;NonVoting"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -182,15 +181,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
-				<owl:onClass rdf:resource="&fibo-sec-eq-eq;Voting"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+				<owl:hasValue rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-				<owl:onClass rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:onClass rdf:resource="&fibo-sec-eq-eq;Voting"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -138,15 +138,15 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-				<owl:hasValue rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:onClass rdf:resource="&fibo-sec-eq-eq;NonVoting"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
-				<owl:onClass rdf:resource="&fibo-sec-eq-eq;NonVoting"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted, fully-paid, registered share</rdfs:label>
@@ -181,15 +181,15 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-				<owl:hasValue rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:onClass rdf:resource="&fibo-sec-eq-eq;Voting"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
-				<owl:onClass rdf:resource="&fibo-sec-eq-eq;Voting"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en-US">common, voting, unrestricted, fully-paid, registered share</rdfs:label>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -132,9 +132,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -177,9 +176,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+				<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -416,11 +414,11 @@
 		<skos:definition>right to vote at extraordinary meetings, as opposed to being able to vote strictly at annual general meetings</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;FullyPaidShareStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eq;FullyPaidShareStatus">
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
 		<rdfs:label>fully paid share status</rdfs:label>
 		<skos:definition>status indicating that no additional money is owed to the company by shareholders on the value of the shares</skos:definition>
-	</owl:Class>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;LimitedPartnershipUnit">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
@@ -464,14 +462,14 @@
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Listing requirements vary by exchange and include minimum stockholder&apos;s equity, a minimum share price and a minimum number of shareholders. Exchanges have listing requirements to ensure that only high quality securities are traded on them and to uphold the exchange&apos;s reputation among investors.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;NilPaidShareStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eq;NilPaidShareStatus">
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
 		<rdfs:label>nil paid share status</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShareStatus"/>
+		<owl:differentFrom rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+		<owl:differentFrom rdf:resource="&fibo-sec-eq-eq;PartiallyPaidShareStatus"/>
 		<skos:definition>status indicating that none of the market value has been received by the company for the shares</skos:definition>
 		<skos:example>Unpaid shares may be issued, for example, for convenience by a start-up company.</skos:example>
-	</owl:Class>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;NonCumulativePreferredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
@@ -513,13 +511,13 @@
 		<skos:definition>voting right conferred on holders of common shares, as defined by the issuer</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-eq-eq;PartiallyPaidShareStatus">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eq;PartiallyPaidShareStatus">
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
 		<rdfs:label>partially paid share status</rdfs:label>
-		<owl:disjointWith rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+		<owl:differentFrom rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
 		<skos:definition>status indicating that only a portion of the market value has been received by the company for the shares</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In the case of partially paid shares, the shareholder is still required to pay the remaining amount to the company. Typically, partially paid shares are only issued to a shareholder if there are compelling business reasons to do so.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;ParticipatingPreferredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;PreferredShare"/>
@@ -660,7 +658,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -853,6 +851,14 @@
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.investor.gov/introduction-investing/investing-basics/glossary/ex-dividend-dates-when-are-you-entitled-stock-and</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Companies also use this date to determine who is sent proxy statements, financial reports, and other information.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>has date of record</fibo-fnd-utl-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasSharePaymentStatus">
+		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isClassifiedBy"/>
+		<rdfs:label xml:lang="en">has share payment status</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+		<rdfs:range rdf:resource="&fibo-sec-eq-eq;SharePaymentStatus"/>
+		<skos:definition xml:lang="en">indicates the payment status for shares issued</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasSharesIssued">

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -126,9 +126,37 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
+	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+				<owl:onClass rdf:resource="&fibo-sec-eq-eq;NonVoting"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+				<owl:onClass rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label xml:lang="en-US">common, non-voting, unrestricted, fully-paid, registered share</rdfs:label>
+		<skos:definition>common share that confers exactly 0 votes per share, is unrestricted from a sales perspective, is fully paid and is registered</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;Share"/>
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;pays"/>
@@ -146,6 +174,7 @@
 	<owl:Class rdf:about="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-eq-eq;UnrestrictedShare"/>
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;RegisteredSecurity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>

--- a/SEC/Securities/SecuritiesClassification.rdf
+++ b/SEC/Securities/SecuritiesClassification.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-sec-cls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -22,6 +23,7 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-sec-cls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -46,9 +48,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesClassification/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesClassification/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesClassification.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesClassification.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesClassification.rdf version of this ontology was modified to add an class representing the ISO 10962 CFI standard and an individual for the 2019 version of that standard.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -85,6 +89,43 @@
 		<fibo-fnd-utl-av:explanatoryNote>The three main asset classes are equities, or stocks; fixed income, or bonds; and cash equivalents, or money market instruments. Some investment professionals add real estate and commodities, and possibly other types of investments, to the asset class mix.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-sec-sec-cls;ClassificationOfFinancialInstrumentsCodeScheme">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationScheme"/>
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeSet"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;defines"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>classification of financial instruments code scheme</rdfs:label>
+		<rdfs:seeAlso rdf:resource="https://www.osha.gov/pls/imis/sic_manual.html/"/>
+		<skos:definition>classification scheme defining the Classification of Financial Instruments (CFI) Code</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The ISO 10962 Securities and related financial instruments - Classification of financial instruments (CFI) code was developed as a solution to a number of challenges. One is to establish a series of codes which clearly classify financial instruments having similar features. The other is to develop a glossary of terms and provide common definitions which allow market participants to easily understand terminology being used.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassifier"/>
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDefinedIn"/>
+				<owl:onClass rdf:resource="&fibo-sec-sec-cls;ClassificationOfFinancialInstrumentsCodeScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>financial instrument classification code</rdfs:label>
+		<skos:definition>code defined in the ISO 10962 Classification of Financial Instruments (CFI) Code Scheme</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>CFI code</fibo-fnd-utl-av:abbreviation>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-sec-sec-cls;FinancialInstrumentClassificationScheme">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;ClassificationScheme"/>
 		<rdfs:subClassOf>
@@ -116,5 +157,11 @@
 		<skos:definition>a standardized classifier for a financial instrument based on its type</skos:definition>
 		<skos:example>Examples include equity instrument, debt instrument, option, future, etc. per the the ISO 10962 CFI (Classification of Financial Instruments) standard, as cash instruments or derivative instruments per the Financial Accounting Standards Board (FASB) and International Accounting Standards Board (IASB) accounting standards, and so forth.</skos:example>
 	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme">
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;ClassificationOfFinancialInstrumentsCodeScheme"/>
+		<rdfs:label>ISO 10962 2019-10 code set</rdfs:label>
+		<skos:definition>Fourth Edition, 2019-10 version of the ISO 10962 Classification of Financial Instruments (CFI) Code scheme</skos:definition>
+	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/Securities/SecuritiesClassification.rdf
+++ b/SEC/Securities/SecuritiesClassification.rdf
@@ -101,6 +101,7 @@
 		<rdfs:label>classification of financial instruments code scheme</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://www.osha.gov/pls/imis/sic_manual.html/"/>
 		<skos:definition>classification scheme defining the Classification of Financial Instruments (CFI) Code</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>CFI code scheme</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:explanatoryNote>The ISO 10962 Securities and related financial instruments - Classification of financial instruments (CFI) code was developed as a solution to a number of challenges. One is to establish a series of codes which clearly classify financial instruments having similar features. The other is to develop a glossary of terms and provide common definitions which allow market participants to easily understand terminology being used.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	

--- a/SEC/Securities/SecuritiesIssuance.rdf
+++ b/SEC/Securities/SecuritiesIssuance.rdf
@@ -626,8 +626,8 @@
 		<skos:definition>indicates the form in which the security is issued, typically in registered form</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:DatatypeProperty rdf:about="&fibo-sec-sec-iss;isOverAlloted">
-		<rdfs:label>is over-alloted</rdfs:label>
+	<owl:DatatypeProperty rdf:about="&fibo-sec-sec-iss;isOverAllotted">
+		<rdfs:label>is over-allotted</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether or not the subscription is over-subscribed</skos:definition>
 	</owl:DatatypeProperty>

--- a/SEC/Securities/SecuritiesIssuance.rdf
+++ b/SEC/Securities/SecuritiesIssuance.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
@@ -35,6 +36,7 @@
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
@@ -77,6 +79,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
@@ -444,7 +447,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractDocument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidenceFor"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -616,7 +619,7 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-iss;isIssuedInForm">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isEvidencedBy"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
 		<rdfs:label>is issued in form</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Security"/>
 		<rdfs:range rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>

--- a/SEC/Securities/SecuritiesIssuance.rdf
+++ b/SEC/Securities/SecuritiesIssuance.rdf
@@ -7,6 +7,7 @@
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
+	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-agr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
@@ -35,6 +36,7 @@
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
+	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-agr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
@@ -76,6 +78,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Agreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
@@ -90,9 +93,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesIssuance/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesIssuance/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIssuance/ version of this ontology was modified to refine the concept of a securities underwriter.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20181201/Securities/SecuritiesIssuance/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesIssuance/ version of this ontology was modified to add the concept of the form the security is issued in, namely bearer or registered.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -115,6 +119,38 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-fi-fi;Security">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isRegisteredWith"/>
+				<owl:onClass rdf:resource="&fibo-fbc-fct-ra;RegistrationAuthority"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+				<owl:onClass rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;BearerAndRegisteredForm">
+		<rdf:type rdf:resource="&fibo-fnd-arr-doc;Certificate"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+		<rdfs:label>bearer and registered form</rdfs:label>
+		<skos:definition>form of a security that may be issued in both bearer and registered form but with the same identification number</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;BearerForm">
+		<rdf:type rdf:resource="&fibo-fnd-arr-doc;Certificate"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+		<rdfs:label>bearer form</rdfs:label>
+		<skos:definition>form of a security that is not registered in the books of the issuer or of the registrar and is payable to the person possessing the stock or bond certificate</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Unlike normal registered instruments, no record is kept of who owns bearer instruments or of transactions involving the transfer of ownership.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;BestEffortsOffering">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecuritiesOffering"/>
@@ -219,6 +255,12 @@
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;MiscellaneousForm">
+		<rdf:type rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+		<rdfs:label>miscellaneous form</rdfs:label>
+		<skos:definition>form of a security that is not identified as registered or bearer</skos:definition>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;OfferingDocument">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-pub;Publication"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;LegalDocument"/>
@@ -314,6 +356,13 @@
 		<fibo-fnd-utl-av:explanatoryNote>In the US, public offerings generally require approval of the Securities Exchange Commission and/or relevant state regulators, unless the issuer is an exempt issuer, and are usually conducted by an investment banker or a syndicate made up of several investment bankers, at a price agreed upon between the issuer and the investment bankers.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&fibo-sec-sec-iss;RegisteredForm">
+		<rdf:type rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+		<rdfs:label>registered form</rdfs:label>
+		<skos:definition>form of a security whereby ownership is recorded in the name of the owner on the books of the issuer or the issuer&apos;s registrar and can only be transferred to another owner when endorsed by the registered owner</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>With registered securities, a ledger is kept by the issuing company or agent which records the owners of all the securities. Transfer of ownership can only occur when names are changed in the ledger.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;SecuritiesContractTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:subClassOf>
@@ -389,6 +438,25 @@
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Finance and Investment Terms, Ninth Edition, 2014.</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.investopedia.com/</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>If the offering is public, then it can only be made after regulatory registration requirements have been met. The securities may be new or a secondary offering of a previously issued security, and may include stock, multiple classes of equity shares, municipal or other government bonds, and so forth. Offerings, especially to the investment public, are typically made by an investment banker, or syndicate of investment bankers.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-sec-iss;SecurityForm">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractDocument"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isEvidenceFor"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>security form</rdfs:label>
+		<skos:definition>contract document and certificate that is evidence for ownership of a security and that may be digital or physical</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Securities are typically issued in one of two forms, registered or bearer. Most securities issued today are in registered form, which enables the issuing firm or registrar to keep records of a security&apos;s owner and mail them any dividend, coupon, or other payments.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<rdfs:Datatype rdf:about="&fibo-sec-sec-iss;SecurityOfferingDistributionType">
@@ -545,6 +613,14 @@
 		<rdfs:label>has subscription period</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;DatePeriod"/>
 		<skos:definition>indicates a period of time in which investors can commit to purchase shares (or units) to be issued</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-sec-sec-iss;isIssuedInForm">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;isEvidencedBy"/>
+		<rdfs:label>is issued in form</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;Security"/>
+		<rdfs:range rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+		<skos:definition>indicates the form in which the security is issued, typically in registered form</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-sec-iss;isOverAlloted">

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -235,16 +235,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:oneOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurityForm">
-							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-iss;BearerAndRegisteredForm">
-							</rdf:Description>
-						</owl:oneOf>
-					</owl:Class>
-				</owl:someValuesFrom>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -14,6 +14,7 @@
 	<!ENTITY fibo-fnd-plc-vrt "https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
 	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -38,6 +39,7 @@
 	xmlns:fibo-fnd-plc-vrt="https://spec.edmcouncil.org/fibo/ontology/FND/Places/VirtualPlaces/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
 	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -74,13 +76,15 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesListings/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesListings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesListings.rdf version of this ontology was revised to reuse the composite date value datatype and add disjointness between registered security and exempt security.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190401/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate an extraneous subclass axiom.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesListings.rdf version of this ontology was revised to rename isIssuedIn to isIssuedOn, which is more natural to most securities SMEs, generalized certain references to securities exchanges, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/SecuritiesListings.rdf version of this ontology was revised to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesListings.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and to eliminate the redundancy between hasIssue and lists.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesListings.rdf version of this ontology was revised to incorporate the form of registration and loosen the restriction on the number of possible registration authorities for a registered security.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -218,13 +222,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;Security"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;isRegisteredBy"/>
-				<owl:onClass rdf:resource="&fibo-fbc-fct-ra;RegistrationAuthority"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;mayBeTradedIn"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-mkt;Exchange"/>
 			</owl:Restriction>
@@ -235,9 +232,37 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;CombinedDateTime"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isRegisteredWith"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-ra;RegistrationAuthority"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>registered security</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-fi-fi;ExemptSecurity"/>
 		<skos:definition>security that is registered with some registration authority and that may be traded in some trading venue (market) or over the counter</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-sec-sec-lst;RegisteredSecurityForm">
+		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecurityForm"/>
+		<rdfs:label>registered security form</rdfs:label>
+		<owl:equivalentClass>
+			<owl:Class>
+				<owl:oneOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-sec-sec-iss;BearerAndRegisteredForm">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-sec-sec-iss;RegisteredForm">
+					</rdf:Description>
+				</owl:oneOf>
+			</owl:Class>
+		</owl:equivalentClass>
+		<skos:definition>form that a registered security can take</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-sec-lst;hasDelistingDate">

--- a/SEC/Securities/SecuritiesListings.rdf
+++ b/SEC/Securities/SecuritiesListings.rdf
@@ -235,7 +235,16 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-lst;RegisteredSecurityForm"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:oneOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurityForm">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-sec-sec-iss;BearerAndRegisteredForm">
+							</rdf:Description>
+						</owl:oneOf>
+					</owl:Class>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

This initial PR reflects work-in-progress by the Securities FCT to augment the securities and equities ontologies to facilitate incorporation of the CFI codes for equities.  They represent a small subset of the CFI standard, but are important for several organizations participating in the FCT.

This initial pull request includes the additional concepts identified by the FCT to enable representation of the codes.  A subsequent pull request will include examples of the codes themselves classifying specific example instruments, to show FIBO users how to encode them for various applications.

Fixes: #1015  / SEC-73


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


