### PR TITLE
SEC 73 - Augment the equities concepts with their CFI classification

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -24,7 +24,7 @@
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/">
   		<rdfs:label>About FIBO Development</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users.  It loads the very latest version of every FIBO ontology (released, provisional, and informative) based on the contents of GitHub, for use in particular while working on revisions.  Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-03-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-05-29T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
@@ -388,6 +388,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>
 		
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"/>
 		
@@ -402,7 +403,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 	 
-	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20200301/AboutFIBODev/"/>
+	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20200501/AboutFIBODev/"/>
   </owl:Ontology>
   
 </rdf:RDF>

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -24,7 +24,7 @@
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/">
   		<rdfs:label>About FIBO Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users.  It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release.  Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-03-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-05-29T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
@@ -224,6 +224,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/ExerciseConventions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/"/>
 		
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"/>
 		
@@ -238,7 +239,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20200301/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20200501/AboutFIBOProd/"/>
   </owl:Ontology>
 
 </rdf:RDF>

--- a/SEC/AllSEC-ReferenceIndividuals.rdf
+++ b/SEC/AllSEC-ReferenceIndividuals.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-sec-eq-10962 "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
 	<!ENTITY fibo-sec-sec-idind "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/">
 	<!ENTITY fibo-secri-all "https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
@@ -14,6 +15,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-sec-eq-10962="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
 	xmlns:fibo-sec-sec-idind="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"
 	xmlns:fibo-secri-all="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -26,7 +28,7 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ReferenceIndividuals/">
 		<rdfs:label>Securities Domain, Reference Individuals</rdfs:label>
 		<dct:abstract>The FIBO Securities (SEC) domain provides a model of concepts that are common to financial instruments that are also securities, including but not limited to exchange-traded securities. High-level concepts relevant to securities classification, identification, issuance, and registration of securities generally are covered, as well as additional detail for equities and debt instruments.  More details defining derivatives in particular are covered in a separate derivatives domain area.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-05-29T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Securities (SEC) Domain with Reference Individuals</dct:title>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
@@ -49,8 +51,8 @@
 		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
 		<sm:contributor>Wells Fargo</sm:contributor>
-		<sm:copyright>Copyright (c) 2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2018 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
@@ -66,8 +68,9 @@
 		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/AllIND-ReferenceRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/AllSEC-ReferenceIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/AllSEC-ReferenceIndividuals/"/>
 		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for SEC is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), and Securities (SEC) domains, including all individuals.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Ontology>
 

--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -12,12 +12,14 @@
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-sec-eq-10962 "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
 	<!ENTITY fibo-sec-eq-eqind "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/">
 	<!ENTITY fibo-sec-sec-id "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/">
 	<!ENTITY fibo-sec-sec-idind "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
 	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -39,12 +41,14 @@
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-sec-eq-10962="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
 	xmlns:fibo-sec-eq-eqind="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/"
 	xmlns:fibo-sec-sec-id="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"
 	xmlns:fibo-sec-sec-idind="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
 	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -64,7 +68,10 @@
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-sec-eq-eqind</sm:fileAbbreviation>
@@ -86,8 +93,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentificationIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquitiesExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquitiesExampleIndividuals/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was modified to add CFI codes to the example equity instruments.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -99,7 +108,7 @@
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
-		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AlphabetIncClassAFinancialInstrumentShortName">
@@ -150,6 +159,7 @@
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AppleIncEquityIssuer"/>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AppleIncCommonStockFinancialInstrumentShortName">
@@ -427,6 +437,7 @@
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;CitigroupIncEquityIssuer"/>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;CitigroupIncCommonStockFinancialInstrumentShortName">
@@ -536,6 +547,7 @@
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationEquityIssuer"/>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStockFinancialInstrumentShortName">
@@ -565,6 +577,7 @@
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoEquityIssuer"/>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStockFinancialInstrumentShortName">
@@ -602,6 +615,7 @@
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyEquityIssuer"/>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStockFinancialInstrumentShortName">
@@ -631,6 +645,7 @@
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncEquityIssuer"/>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStockFinancialInstrumentShortName">
@@ -660,6 +675,7 @@
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyEquityIssuer"/>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStockFinancialInstrumentShortName">
@@ -788,6 +804,7 @@
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-fbc-fct-usind;WellsFargoAndCompany"/>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
+		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;XLOMListedAppleIncCommonStock">

--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -98,6 +98,7 @@
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 	</owl:NamedIndividual>
 	
@@ -118,6 +119,7 @@
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 	</owl:NamedIndividual>
 	
@@ -140,12 +142,13 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;AppleIncCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>Apple Inc. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in Apple Inc.</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AppleIncEquityIssuer"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 	</owl:NamedIndividual>
 	
@@ -416,12 +419,13 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;CitigroupIncCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>Citigroup Inc. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in Citigroup Inc.</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;CitigroupIncEquityIssuer"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
 	</owl:NamedIndividual>
 	
@@ -524,12 +528,13 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>International Business Machines Corporation common stock</rdfs:label>
 		<skos:definition>common share class representing shares in International Business Machines Corporation</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfNewYorkJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationEquityIssuer"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
 	</owl:NamedIndividual>
 	
@@ -552,12 +557,13 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in JPMorgan Chase &amp; Co.</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoEquityIssuer"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
 	</owl:NamedIndividual>
 	
@@ -588,12 +594,13 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>The Coca-Cola Company common stock</rdfs:label>
 		<skos:definition>common share class representing shares in The Coca-Cola Company</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyEquityIssuer"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
 	</owl:NamedIndividual>
 	
@@ -616,12 +623,13 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>The Home Depot, Inc. common stock</rdfs:label>
 		<skos:definition>common share class representing shares in The Home Depot, Inc.</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncEquityIssuer"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
 	</owl:NamedIndividual>
 	
@@ -644,12 +652,13 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>The Proctor &amp; Gamble Company common stock</rdfs:label>
 		<skos:definition>common share class representing shares in The Proctor &amp; Gamble Company</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfOhioJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyEquityIssuer"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNYS"/>
 	</owl:NamedIndividual>
 	
@@ -771,12 +780,13 @@
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-eqind;WellsFargoCommonStock">
-		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonShare"/>
+		<rdf:type rdf:resource="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare"/>
 		<rdfs:label>Wells Fargo common stock</rdfs:label>
 		<skos:definition>Wells Fargo &amp; Company common share</skos:definition>
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-fbc-fct-usind;WellsFargoAndCompany"/>
+		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
 	</owl:NamedIndividual>
 	

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -1,0 +1,602 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-sec-eq-10962 "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
+	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
+	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
+	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-sec-eq-10962="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
+	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
+	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
+	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
+		<rdfs:label>Equities CFI Classification Individuals Ontology</rdfs:label>
+		<dct:abstract>This ontology covers the ISO 10962, Fourth edition, 2019-10 classification codes for instruments that represent an ownership interest in an entity or pool of assets. It covers sections most of the codes included in section 6.2 of the standard, with the exception of structured instruments, section 6.2.8, which will be covered under derivatives.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contributor>Thematix Partners LLC</sm:contributor>
+		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-sec-eq-10962</sm:fileAbbreviation>
+		<sm:filename>EquityCFIClassificationIndividuals.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESETFR">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;EnhancedVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;EnhancedVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdfs:label>ESETFR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, enhanced voting, restricted transfer, fully-paid, registered share</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>ESETFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESEUFR">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;EnhancedVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;EnhancedVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdfs:label>ESEUFR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, enhanced voting, unrestricted transfer, fully-paid, registered share</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>ESEUFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNTFR">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;NonVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;NonVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdfs:label>ESNTFR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, non-voting, restricted transfer, fully-paid, registered share</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>ESNTFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNUFR">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+								<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonNonVotingUnrestrictedFullyPaidRegisteredShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+								<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdfs:label>ESNUFR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, non-voting, unrestricted transfer, fully-paid, registered share</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>ESNUFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRTFR">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;RestrictedVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;RestrictedVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdfs:label>ESRTFR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, restricted voting, restricted transfer, fully-paid, registered share</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>ESRTFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRUFR">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;RestrictedVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;UnrestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;RestrictedVoting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdfs:label>ESRUFR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, restricted voting, unrestricted transfer, fully-paid, registered share</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>ESRUFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVTFR">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;Voting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonShare">
+							</rdf:Description>
+							<owl:Class>
+								<owl:intersectionOf rdf:parseType="Collection">
+									<rdf:Description rdf:about="&fibo-sec-sec-lst;RegisteredSecurity">
+									</rdf:Description>
+									<owl:Restriction>
+										<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+										<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+									</owl:Restriction>
+								</owl:intersectionOf>
+							</owl:Class>
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;RestrictedShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasSharePaymentStatus"/>
+								<owl:hasValue rdf:resource="&fibo-sec-eq-eq;FullyPaidShareStatus"/>
+							</owl:Restriction>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
+								<owl:onClass rdf:resource="&fibo-sec-eq-eq;Voting"/>
+								<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdfs:label>ESVTFR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, voting, restricted transfer, fully-paid, registered share</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>ESVTFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVUFR">
+		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+								<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdf:type>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom>
+					<owl:Class>
+						<owl:intersectionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-sec-eq-eq;CommonVotingUnrestrictedFullyPaidRegisteredShare">
+							</rdf:Description>
+							<owl:Restriction>
+								<owl:onProperty rdf:resource="&fibo-sec-sec-iss;isIssuedInForm"/>
+								<owl:hasValue rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
+							</owl:Restriction>
+						</owl:intersectionOf>
+					</owl:Class>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdf:type>
+		<rdfs:label>ESVUFR CFI common/ordinary share classifier</rdfs:label>
+		<skos:definition>CFI code for a common, voting, unrestricted transfer, fully-paid, registered share</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>ESVUFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+	</owl:NamedIndividual>
+
+</rdf:RDF>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -6,6 +6,7 @@
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY fibo-sec-eq-10962 "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
 	<!ENTITY fibo-sec-eq-eq "https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/">
+	<!ENTITY fibo-sec-sec-cls "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/">
 	<!ENTITY fibo-sec-sec-iss "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/">
 	<!ENTITY fibo-sec-sec-lst "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
@@ -24,6 +25,7 @@
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:fibo-sec-eq-10962="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"
 	xmlns:fibo-sec-eq-eq="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/"
+	xmlns:fibo-sec-sec-cls="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/"
 	xmlns:fibo-sec-sec-iss="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"
 	xmlns:fibo-sec-sec-lst="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
@@ -42,6 +44,7 @@
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
 		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
@@ -60,7 +63,7 @@
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESETFR">
-		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
@@ -132,11 +135,11 @@
 		<rdfs:label>ESETFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, restricted transfer, fully-paid, registered share</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ESETFR</fibo-fnd-rel-rel:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESEUFR">
-		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
@@ -208,11 +211,11 @@
 		<rdfs:label>ESEUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, unrestricted transfer, fully-paid, registered share</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ESEUFR</fibo-fnd-rel-rel:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNTFR">
-		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
@@ -284,11 +287,11 @@
 		<rdfs:label>ESNTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, restricted transfer, fully-paid, registered share</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ESNTFR</fibo-fnd-rel-rel:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESNUFR">
-		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
@@ -326,11 +329,11 @@
 		<rdfs:label>ESNUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, unrestricted transfer, fully-paid, registered share</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ESNUFR</fibo-fnd-rel-rel:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRTFR">
-		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
@@ -402,11 +405,11 @@
 		<rdfs:label>ESRTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, restricted transfer, fully-paid, registered share</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ESRTFR</fibo-fnd-rel-rel:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESRUFR">
-		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
@@ -478,11 +481,11 @@
 		<rdfs:label>ESRUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, unrestricted transfer, fully-paid, registered share</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ESRUFR</fibo-fnd-rel-rel:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVTFR">
-		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
@@ -554,11 +557,11 @@
 		<rdfs:label>ESVTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, restricted transfer, fully-paid, registered share</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ESVTFR</fibo-fnd-rel-rel:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESVUFR">
-		<rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/FinancialInstrumentClassificationCode"/>
+		<rdf:type rdf:resource="&fibo-sec-sec-cls;FinancialInstrumentClassificationCode"/>
 		<rdf:type>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
@@ -596,7 +599,7 @@
 		<rdfs:label>ESVUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, unrestricted transfer, fully-paid, registered share</skos:definition>
 		<fibo-fnd-rel-rel:hasTag>ESVUFR</fibo-fnd-rel-rel:hasTag>
-		<lcc-lr:isMemberOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesClassification/ISO10962-201910-CodeScheme"/>
+		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 
 </rdf:RDF>

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -39,7 +39,7 @@
 	
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/">
 		<rdfs:label>Equities CFI Classification Individuals Ontology</rdfs:label>
-		<dct:abstract>This ontology covers the ISO 10962, Fourth edition, 2019-10 classification codes for instruments that represent an ownership interest in an entity or pool of assets. It covers sections most of the codes included in section 6.2 of the standard, with the exception of structured instruments, section 6.2.8, which will be covered under derivatives.</dct:abstract>
+		<dct:abstract>This ontology covers the ISO 10962, Fourth edition, 2019-10 classification codes for instruments that represent an ownership interest in an entity or pool of assets. It is intended to cover sections most of the codes included in section 6.2 of the standard, with the exception of structured instruments, section 6.2.8, which will be covered under derivatives.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:contributor>Thematix Partners LLC</sm:contributor>
@@ -58,8 +58,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/"/>
-		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-eq-10962;ESETFR">

--- a/SEC/Securities/SecuritiesClassification.rdf
+++ b/SEC/Securities/SecuritiesClassification.rdf
@@ -49,7 +49,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesClassification/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Securities/SecuritiesClassification/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesClassification.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesClassification.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesClassification.rdf version of this ontology was modified to add an class representing the ISO 10962 CFI standard and an individual for the 2019 version of that standard.</skos:changeNote>
@@ -99,9 +99,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>classification of financial instruments code scheme</rdfs:label>
-		<rdfs:seeAlso rdf:resource="https://www.osha.gov/pls/imis/sic_manual.html/"/>
-		<skos:definition>classification scheme defining the Classification of Financial Instruments (CFI) Code</skos:definition>
+		<skos:definition>classification scheme for set of codes for financial instruments that can be used globally for straight-through processing by all involved participants in an electronic data processing environment</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CFI code scheme</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/73564.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>The ISO 10962 Securities and related financial instruments - Classification of financial instruments (CFI) code was developed as a solution to a number of challenges. One is to establish a series of codes which clearly classify financial instruments having similar features. The other is to develop a glossary of terms and provide common definitions which allow market participants to easily understand terminology being used.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -123,8 +123,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>financial instrument classification code</rdfs:label>
-		<skos:definition>code defined in the ISO 10962 Classification of Financial Instruments (CFI) Code Scheme</skos:definition>
+		<skos:definition>classifier and code for a financial instrument defined in the ISO 10962 Classification of Financial Instruments (CFI) Code Scheme</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>CFI code</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.iso.org/standard/73564.html</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-cls;FinancialInstrumentClassificationScheme">
@@ -136,7 +137,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>financial instrument classification scheme</rdfs:label>
-		<skos:definition>a classification scheme defining a particular classifier for a security, such as the ISO 10962 CFI classification scheme</skos:definition>
+		<skos:definition>classification scheme defining a set of classifiers for financial instruments</skos:definition>
+		<skos:example>the ISO 10962 Classification of Financial Instruments (CFI) classification scheme</skos:example>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-cls;FinancialInstrumentClassifier">
@@ -155,7 +157,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>financial instrument classifier</rdfs:label>
-		<skos:definition>a standardized classifier for a financial instrument based on its type</skos:definition>
+		<skos:definition>classifier for a financial instrument based on its type and features</skos:definition>
 		<skos:example>Examples include equity instrument, debt instrument, option, future, etc. per the the ISO 10962 CFI (Classification of Financial Instruments) standard, as cash instruments or derivative instruments per the Financial Accounting Standards Board (FASB) and International Accounting Standards Board (IASB) accounting standards, and so forth.</skos:example>
 	</owl:Class>
 	

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -306,6 +306,7 @@
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/MetadataSECDebt/" uri="./SEC/Debt/MetadataSECDebt.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/TradedShortTermDebt/" uri="./SEC/Debt/TradedShortTermDebt.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/DepositaryReceipts/" uri="./SEC/Equities/DepositaryReceipts.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityCFIClassificationIndividuals/" uri="./SEC/Equities/EquityCFIClassificationIndividuals.rdf"/>
 	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquitiesExampleIndividuals/" uri="./SEC/Equities/EquitiesExampleIndividuals.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/" uri="./SEC/Equities/EquityInstruments.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/MetadataSECEquities/" uri="./SEC/Equities/MetadataSECEquities.rdf"/>


### PR DESCRIPTION
## Description

Revises the equities module to add the actual CFI classification codes for an initial set of codes representing common shares and demonstrates their use in the example equities.

Fixes: #1015 / SEC-73


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


