### PR TITLE
FND-293 - Correct subclass relation for MaturityLevel, subproperty hierarchy for adaptedFrom and logicalDefinition

### DIFF
--- a/FND/Arrangements/Lifecycles.rdf
+++ b/FND/Arrangements/Lifecycles.rdf
@@ -59,9 +59,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Lifecycles/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200501/Arrangements/Lifecycles/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Arrangements/Lifecycles.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Arrangements/Lifecycles.rdf version of this ontology was revised to define lifecycle status, normalize definitions per ISO 704 and eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Lifecycles.rdf version of this ontology was revised to add lifecycle stage as the superclass of maturity level.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -254,5 +255,9 @@
 		<owl:inverseOf rdf:resource="&fibo-fnd-arr-lif;hasStage"/>
 		<skos:definition>relates a stage in a product or trade lifecycle or process to the lifecycle or process that it is a stage of</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:Class rdf:about="&fibo-fnd-utl-av;MaturityLevel">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-lif;LifecycleStage"/>
+	</owl:Class>
 
 </rdf:RDF>

--- a/FND/Utilities/AnnotationVocabulary.rdf
+++ b/FND/Utilities/AnnotationVocabulary.rdf
@@ -43,6 +43,7 @@ Note that any of the original properties provided in Dublin Core and SKOS can be
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to add the symbol annotation.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to eliminate deprecated properties.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to add common and preferred designations as needed for postal addresses and other purposes, to correct named individuals to be properly declared, and to revise definitions to be ISO 704 compliant.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/AnnotationVocabulary.rdf version of this ontology was modified to eliminate skos:Concept as a superclass of MaturityLevel (replaced with LifecycleStage in the Lifecycles ontology), revise explanatory notes for maturity levels based on community feedback, and correct the subproperty inheritance for adaptedFrom and logicalDefinition.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -57,7 +58,6 @@ Note that any of the original properties provided in Dublin Core and SKOS can be
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-utl-av;MaturityLevel">
-		<rdfs:subClassOf rdf:resource="&skos;Concept"/>
 		<rdfs:label>maturity level</rdfs:label>
 		<skos:definition>classifier used to indicate state of an artifact with respect to its development lifecycle</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">FIBO currently has three maturity levels: Informative, Provisional, and Release.</fibo-fnd-utl-av:explanatoryNote>
@@ -67,7 +67,7 @@ Note that any of the original properties provided in Dublin Core and SKOS can be
 		<rdf:type rdf:resource="&fibo-fnd-utl-av;MaturityLevel"/>
 		<rdfs:label>provisional</rdfs:label>
 		<skos:definition xml:lang="en">entity that is considered to be under development</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Provisional content is subject to change, and may change substantially prior to release. FIBO users should be aware that it is not dependable, but could be used for informative reference and as the basis for further work.  Release notes with respect to provisional content are likely to be sketchy at best, and users should not expect official change notes to mention it.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Provisional content is subject to change, and may change substantially prior to release. FIBO users should be aware that it is not dependable, but could be used for reference and as the basis for further work.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-utl-av;Release">
@@ -85,7 +85,7 @@ Note that any of the original properties provided in Dublin Core and SKOS can be
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;adaptedFrom">
-		<rdfs:subPropertyOf rdf:resource="&sm;directSource"/>
+		<rdfs:subPropertyOf rdf:resource="&dct;source"/>
 		<rdfs:label>adapted from</rdfs:label>
 		<skos:definition>document or other source from which a given term (or its definition) was adapted; the range for this annotation can be a string, URI, or BibliographicCitation</skos:definition>
 	</owl:AnnotationProperty>
@@ -115,6 +115,7 @@ Note that any of the original properties provided in Dublin Core and SKOS can be
 	</owl:AnnotationProperty>
 	
 	<owl:AnnotationProperty rdf:about="&fibo-fnd-utl-av;logicalDefinition">
+		<rdfs:subPropertyOf rdf:resource="&skos;definition"/>
 		<rdfs:label>logical definition</rdfs:label>
 		<skos:definition>description of the OWL logic of a model element in natural language</skos:definition>
 	</owl:AnnotationProperty>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminates skos:Concept as the superclass of MaturityLevel and replaces it with LifecycleStage; addresses issues raised about explanatory notes against FND-290 / pull request #922; corrects property hierarchy for adaptedFrom and logicalDefinition.

Fixes: #1022 / FND-293 and #922 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


