### PR TITLE
BE-211 - The domain of hasMajorityControllingInterestParty is StockCorporation, which is too narrow

### DIFF
--- a/BE/OwnershipAndControl/CorporateControl.rdf
+++ b/BE/OwnershipAndControl/CorporateControl.rdf
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
-	<!ENTITY fibo-be-corp-corp "https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/">
-	<!ENTITY fibo-be-le-cb "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/">
-	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-cctl "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/">
 	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
@@ -23,9 +20,6 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"
 	xmlns:dct="http://purl.org/dc/terms/"
-	xmlns:fibo-be-corp-corp="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"
-	xmlns:fibo-be-le-cb="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"
-	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-cctl="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"
 	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
@@ -48,11 +42,8 @@
 		<dct:abstract>This ontology defines concepts relating to corporation-specific control. These concepts are based on the general types of control (both de facto control and controlling interests), as defined in the ControlParties ontology, and are the specific examples of these concepts as they apply to companies incorporated by the issuance of shares.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2013-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2013-2018 Object Management Group, Inc.</sm:copyright>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/</sm:dependsOn>
+		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/</sm:dependsOn>
@@ -60,9 +51,6 @@
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-be-oac-cctl</sm:fileAbbreviation>
 		<sm:filename>CorporateControl.rdf</sm:filename>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/Corporations/Corporations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/CorporateBodies/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
@@ -72,14 +60,15 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20190101/OwnershipAndControl/CorporateControl/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200501/OwnershipAndControl/CorporateControl/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified per the FIBO 2.0 RFC to add missing definitions and labels, eliminate references to BusinessFacingTypes, replace min 1 QCRs with someValuesFrom, address other hygiene issues, and limit the burden of certain restrictions, such as those on stock corporation, for typical applications.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to correct reasoning anomalies.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190101/OwnershipAndControl/CorporateControl.rdf version of this ontology was revised to allow any legal entity to participate in control relations rather than limiting control to a stock corporation.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-be-le-cb;StockCorporation">
+	<owl:Class rdf:about="&fibo-be-le-lp;LegalEntity">
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-oac-cctl;hasMajorityControllingInterestParty"/>
@@ -264,7 +253,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasMajorityControllingInterestParty">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasSignificantControllingInterestParty"/>
 		<rdfs:label>has majority controlling interest party</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestCompany"/>
 		<skos:definition>relates a company to an organization that has a majority ownership and control over it, i.e., its parent organization, if there is one</skos:definition>
 		<skos:editorialNote>This is defined as company or other Formal Organization which owns a controlling stake of greater than 50 percent (50 percent plus one voting share or above) in this company.</skos:editorialNote>
@@ -273,14 +262,14 @@
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasMajorityOwnedSubsidiary">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasSubsidiary"/>
 		<rdfs:label>has majority owned subsidiary</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cctl;WhollyOwnedSubsidiary"/>
 		<skos:definition>relates a company to one of its majority-owned subsidiaries, i.e., a subsidiary of which it owns more than 50 percent (50 percent plus one share) of the outstanding shares</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasSubsidiary">
 		<rdfs:label>has subsidiary</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cctl;Subsidiary"/>
 		<skos:definition>relates a company to one of its subsidiaries, that is an affiliae controlled by the company directly, or indirectly through one or more intermediaries</skos:definition>
 	</owl:ObjectProperty>
@@ -310,7 +299,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;isWhollyOwnedBy">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasMajorityControllingInterestParty"/>
 		<rdfs:label>is wholly owned by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-cb;StockCorporation"/>
+		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
 		<skos:definition>relates a company to an organization that has 100 percent ownership and control over it</skos:definition>
 	</owl:ObjectProperty>

--- a/BE/OwnershipAndControl/CorporateControl.rdf
+++ b/BE/OwnershipAndControl/CorporateControl.rdf
@@ -274,14 +274,6 @@
 		<skos:definition>relates a legal entity to a party that owns a controlling stake of greater than 50 percent (50 percent plus one voting share or above)</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasMajorityOwnedSubsidiary">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasSubsidiary"/>
-		<rdfs:label>has majority owned subsidiary</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-cctl;WhollyOwnedSubsidiary"/>
-		<skos:definition>relates a company to one of its majority-owned subsidiaries, i.e., a subsidiary of which it owns more than 50 percent (50 percent plus one share) of the outstanding shares</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasSubsidiary">
 		<rdfs:label>has subsidiary</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
@@ -293,14 +285,14 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsSignificantControllingVotingRightsIn"/>
 		<rdfs:label>holds majority controlling voting rights in</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<skos:definition>relates a party to a legal entity in which it holds fifty percent or more of the controlling voting rights</skos:definition>
+		<skos:definition>relates a party to a legal entity in which it holds fifty percent or more voting rights</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsSignificantControllingVotingRightsIn">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsSomeControllingVotingRightsIn"/>
 		<rdfs:label>holds significant controlling voting rights in</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<skos:definition>relates a party to a legal entity in which it holds a significant proportion of the controlling voting rights</skos:definition>
+		<skos:definition>relates a party to a legal entity in which it holds a significant proportion of the voting rights</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsSomeControllingVotingRightsIn">
@@ -308,7 +300,7 @@
 		<rdfs:label>holds some controlling voting rights in</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-oac-ctl;ControllingParty"/>
 		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<skos:definition>relates a party to a legal entity in which it holds some controlling voting rights</skos:definition>
+		<skos:definition>relates a party to a legal entity in which it holds voting rights</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;isAffiliateOf">
@@ -316,7 +308,7 @@
 		<rdfs:label>is affiliate of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-cctl;Affiliate"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cctl;Affiliate"/>
-		<skos:definition>relates a party which directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control another party</skos:definition>
+		<skos:definition>relates a party which directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control by another party to that party</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;isWhollyOwnedBy">

--- a/BE/OwnershipAndControl/CorporateControl.rdf
+++ b/BE/OwnershipAndControl/CorporateControl.rdf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
 	<!ENTITY fibo-be-oac-cctl "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/">
 	<!ENTITY fibo-be-oac-cown "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/">
@@ -20,6 +21,7 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
 	xmlns:fibo-be-oac-cctl="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateControl/"
 	xmlns:fibo-be-oac-cown="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"
@@ -44,6 +46,7 @@
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/</sm:dependsOn>
@@ -51,6 +54,7 @@
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-be-oac-cctl</sm:fileAbbreviation>
 		<sm:filename>CorporateControl.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/ControlParties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/CorporateOwnership/"/>
@@ -64,7 +68,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified per the FIBO 2.0 RFC to add missing definitions and labels, eliminate references to BusinessFacingTypes, replace min 1 QCRs with someValuesFrom, address other hygiene issues, and limit the burden of certain restrictions, such as those on stock corporation, for typical applications.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/CorporateControl.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to correct reasoning anomalies.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190101/OwnershipAndControl/CorporateControl.rdf version of this ontology was revised to allow any legal entity to participate in control relations rather than limiting control to a stock corporation.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190101/OwnershipAndControl/CorporateControl.rdf version of this ontology was revised to allow any legal entity to participate in control relations rather than limiting control to a stock corporation, and simplifying others such that any party can be a significant shareholder, for example, rather than limiting this role to a legal entity.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -72,21 +76,21 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-oac-cctl;hasMajorityControllingInterestParty"/>
-				<owl:onClass rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestCompany"/>
+				<owl:onClass rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestParty"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-oac-cpty;hasSignificantControllingInterestParty"/>
-				<owl:onClass rdf:resource="&fibo-be-oac-cctl;SignificantShareholdingCompany"/>
+				<owl:onClass rdf:resource="&fibo-be-oac-cctl;SignificantShareholder"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-be-oac-cctl;isWhollyOwnedBy"/>
-				<owl:onClass rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
+				<owl:onClass rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestParty"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -97,10 +101,16 @@
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<fibo-fnd-utl-av:explanatoryNote>The restrictions defined herein extend the definition of stock corporation to link it to external entities that hold shares in it.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;Affiliate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-oac-cctl;isAffiliateOf"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-oac-cctl;Affiliate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>affiliate</rdfs:label>
 		<owl:equivalentClass>
 			<owl:Class>
@@ -112,7 +122,7 @@
 				</owl:unionOf>
 			</owl:Class>
 		</owl:equivalentClass>
-		<skos:definition>an affiliate of, or a person affiliated with, a specific person is a person that directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with, the person specified</skos:definition>
+		<skos:definition>legal person that directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control with, another legal person</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;ControlledCompany">
@@ -124,59 +134,65 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>controlled company</rdfs:label>
-		<skos:definition>a controlled party that is a legal entity over which a controlling party has some degree of control, typically by way of ownership of voting shares</skos:definition>
+		<skos:definition>controlled party that is a legal entity over which a controlling party has some degree of control, typically by way of ownership of voting shares</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;DomesticUltimateParent">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestParty"/>
 		<rdfs:label>domestic ultimate parent</rdfs:label>
-		<skos:definition>an organization that is recognized as the ultimate parent of a given company within the country or jurisdiction of incorporation; this relationship may or may not be present, i.e. in the case of a company that has no parent</skos:definition>
+		<skos:definition>party that is recognized as the ultimate parent of a given organization within the country or jurisdiction of incorporation or organization</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;GlobalUltimateParent">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestParty"/>
 		<rdfs:label>global ultimate parent</rdfs:label>
-		<skos:definition>an organization that is recognized as the ultimate parent of the company; this relationship may or may not be present, i.e. in the case of a company that has no parent</skos:definition>
+		<skos:definition>party that is recognized as the ultimate parent of a given organization world-wide</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;JointVenturePartner">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;EntityControllingParty"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;controls"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-le-fbo;JointVenture"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>joint venture partner</rdfs:label>
-		<skos:definition>a party in the role of joint venture partner to some venture</skos:definition>
-		<skos:editorialNote>This is part of ongoing work - legal definitions sought.</skos:editorialNote>
+		<skos:definition>party that shares capital, technology, human resources, risks, and benefits of an entity under shared control</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;NonWhollyOwnedSubsidiary">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;Subsidiary"/>
 		<rdfs:label>non-wholly owned subsidiary</rdfs:label>
-		<skos:definition>a subsidiary which is not a wholly owned subsidiary</skos:definition>
+		<skos:definition>subsidiary that is not 100 percent owned by its parent</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestCompany">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;VotingShareholdingCompany"/>
-		<rdfs:label>over fifty percent controlling interest company</rdfs:label>
-		<skos:definition>a voting shareholding company that owns more than fifty (50) percent of the voting shares in another company</skos:definition>
+	<owl:Class rdf:about="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestParty">
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
+		<rdfs:label>over fifty percent controlling interest party</rdfs:label>
+		<skos:definition>voting shareholder that owns more than fifty (50) percent of the voting shares in some legal entity</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-be-oac-cctl;SignificantShareholdingCompany">
+	<owl:Class rdf:about="&fibo-be-oac-cctl;SignificantShareholder">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;SignificantControllingInterestParty"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;VotingShareholdingCompany"/>
-		<rdfs:label>significant shareholding company</rdfs:label>
-		<skos:definition>a company that owns a significant voting stake in another company</skos:definition>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;VotingShareholder"/>
+		<rdfs:label>significant shareholder</rdfs:label>
+		<skos:definition>person or legal entity that owns a significant voting stake in another company</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Note that the concept of significance varies depending on the jurisdiction, and particularly with respect to reporting requirements.  For example, in some cases, three (3) percent ownership of any class or series of shares is considered significant, and in others it means more than five or ten percent of the total combined voting power across all classes of securities.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;Subsidiary">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;ControlledCompany"/>
 		<rdfs:label>subsidiary</rdfs:label>
-		<skos:definition>a company that is entirely or partially owned and entirely or partially controlled by another company</skos:definition>
+		<skos:definition>legal entity that is entirely or partially owned and entirely or partially controlled by another legal entity</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>A subsidiary is a separate, distinct legal entity from its parent company(ies) for the purposes of taxation, regulatory compliance, and with respect to liability.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-be-oac-cctl;TotalControllingInterestCompany">
+	<owl:Class rdf:about="&fibo-be-oac-cctl;TotalControllingInterestParty">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cpty;TotalOwner"/>
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestCompany"/>
-		<rdfs:label>total controlling interest company</rdfs:label>
-		<skos:definition>an organization having 100 percent ownership one or more organizations it holds voting shares in</skos:definition>
+		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestParty"/>
+		<rdfs:label>total controlling interest party</rdfs:label>
+		<skos:definition>voting shareholder that owns 100 percent of the voting shares in some legal entity</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>By virtue of holding 100 percent of the share ownership, the total controlling interest company also holds 100 percent of the controlling equity, if there is a difference.  Therefore, it is both a total owner and a total controlling party.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>parent company</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -191,7 +207,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>voting shareholder</rdfs:label>
-		<skos:definition>a party owning voting shares in some company limited by the issue of shares</skos:definition>
+		<skos:definition>shareholder whose shares confer the right to vote in corporate elections, including the right to elect directors at annual or special meetings, and to express their views to corporate management and directors on significant issues that may affect the value of those shares</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;VotingShareholding">
@@ -203,7 +219,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>voting shareholding</rdfs:label>
-		<skos:definition>a holding of some voting share</skos:definition>
+		<skos:definition>holding of some voting share</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;VotingShareholdingCompany">
@@ -215,13 +231,13 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>voting shareholding company</rdfs:label>
-		<skos:definition>a formal business organization that holds voting shares in some incorporated company</skos:definition>
+		<skos:definition>legal entity that holds voting shares in some other legal entity</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cctl;WhollyOwnedSubsidiary">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cctl;Subsidiary"/>
 		<rdfs:label>wholly owned subsidiary</rdfs:label>
-		<skos:definition>a subsidiary that is entirely owned and controlled by another company</skos:definition>
+		<skos:definition>subsidiary that is entirely owned and controlled by another organization</skos:definition>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasAffiliate">
@@ -254,9 +270,8 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cpty;hasSignificantControllingInterestParty"/>
 		<rdfs:label>has majority controlling interest party</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestCompany"/>
-		<skos:definition>relates a company to an organization that has a majority ownership and control over it, i.e., its parent organization, if there is one</skos:definition>
-		<skos:editorialNote>This is defined as company or other Formal Organization which owns a controlling stake of greater than 50 percent (50 percent plus one voting share or above) in this company.</skos:editorialNote>
+		<rdfs:range rdf:resource="&fibo-be-oac-cctl;OverFiftyPercentControllingInterestParty"/>
+		<skos:definition>relates a legal entity to a party that owns a controlling stake of greater than 50 percent (50 percent plus one voting share or above)</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;hasMajorityOwnedSubsidiary">
@@ -271,21 +286,21 @@
 		<rdfs:label>has subsidiary</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-cctl;Subsidiary"/>
-		<skos:definition>relates a company to one of its subsidiaries, that is an affiliae controlled by the company directly, or indirectly through one or more intermediaries</skos:definition>
+		<skos:definition>relates a legal entity to another organization that it controls directly, or indirectly, through one or more intermediaries</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsMajorityControllingVotingRightsIn">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsSignificantControllingVotingRightsIn"/>
 		<rdfs:label>holds majority controlling voting rights in</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<skos:definition>relates a legal person to a company in which the party holds fifty percent or more of the controlling voting rights</skos:definition>
+		<skos:definition>relates a party to a legal entity in which it holds fifty percent or more of the controlling voting rights</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsSignificantControllingVotingRightsIn">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;holdsSomeControllingVotingRightsIn"/>
 		<rdfs:label>holds significant controlling voting rights in</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<skos:definition>relates a legal person to a company in which the party holds a significant proportion of the controlling voting rights</skos:definition>
+		<skos:definition>relates a party to a legal entity in which it holds a significant proportion of the controlling voting rights</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;holdsSomeControllingVotingRightsIn">
@@ -293,15 +308,23 @@
 		<rdfs:label>holds some controlling voting rights in</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-oac-ctl;ControllingParty"/>
 		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<skos:definition>relates a legal person to a company in which that party holds some controlling voting rights</skos:definition>
+		<skos:definition>relates a party to a legal entity in which it holds some controlling voting rights</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;isAffiliateOf">
+		<rdf:type rdf:resource="&owl;SymmetricProperty"/>
+		<rdfs:label>is affiliate of</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-oac-cctl;Affiliate"/>
+		<rdfs:range rdf:resource="&fibo-be-oac-cctl;Affiliate"/>
+		<skos:definition>relates a party which directly, or indirectly through one or more intermediaries, controls, or is controlled by, or is under common control another party</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cctl;isWhollyOwnedBy">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-cctl;hasMajorityControllingInterestParty"/>
 		<rdfs:label>is wholly owned by</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestCompany"/>
-		<skos:definition>relates a company to an organization that has 100 percent ownership and control over it</skos:definition>
+		<rdfs:range rdf:resource="&fibo-be-oac-cctl;TotalControllingInterestParty"/>
+		<skos:definition>relates a legal entity to a party that has 100 percent ownership and control over it</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revises the domain of a number of properties related to control to be LegalEntity rather than StockCorporation, as well as the definition of LegalEntity to add restrictions on those properties, as they are applicable to many different organizational structures and not limited to stock corporations

Fixes: #1027 / BE-211


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


