### PR TITLE
BE-214 - The semantics of isPartiallyOwnedBy and its subproperties and inverses are wrong

### DIFF
--- a/BE/OwnershipAndControl/ControlParties.rdf
+++ b/BE/OwnershipAndControl/ControlParties.rdf
@@ -73,7 +73,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/ControlParties.rdf version of this ontology was modified per the FIBO 2.0 RFC to add missing labels and definitions, eliminate references to BusinessFacingTypes, etc.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/ControlParties.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to correct reasoning anomalies.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190101/OwnershipAndControl/ControlParties.rdf version of this ontology was modified to eliminate duplication of concepts with LCC.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/ControlParties.rdf version of this ontology was modified to integrate the concept of a situation, situational roles, and corresponding relations with the definition of control.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/ControlParties.rdf version of this ontology was modified to integrate the concept of a situation, situational roles, and corresponding relations with the definition of control and eliminate an unused and logically inconsistent property.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -467,15 +467,6 @@
 		<rdfs:range rdf:resource="&fibo-be-oac-cpty;SignificantControllingInterestParty"/>
 		<skos:definition>identifies an entity that owns a significant percentage of the equity in this company, but less than 50 percent</skos:definition>
 		<skos:editorialNote>This is a relationship for any ownership between a lower threshold (defined in AML regulations locally) and 50 percent. It is the inverse of the Affiliate (AKA Associate) relationship.</skos:editorialNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;hasTotalOwner">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-opty;hasConstitutionalOwner"/>
-		<rdfs:label>has total owner</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-cpty;TotalOwner"/>
-		<skos:definition>indicates the party that wholly controls the organization, i.e., one that owns 100 percent interest</skos:definition>
-		<skos:editorialNote>This may be any entity which is capable of exercising ownership. Scope Note: By virtue of holding 100 percent of the equity ownership, the Total Owner also holds 100 percent of the controlling equity, if there is a difference. Therefore it is both a total owner and a total controlling party. For this reason it is included among the control relationships and is a specialization of the has majority controlling party relationships.</skos:editorialNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-cpty;holdsSomeMeansOf">

--- a/BE/OwnershipAndControl/OwnershipParties.rdf
+++ b/BE/OwnershipAndControl/OwnershipParties.rdf
@@ -92,7 +92,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to support GLEIF LEI Level 2 ownership relationships.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20181201/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to integrate the concept of a situation, situational roles, and corresponding relations with the definition of entity ownership.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to integrate the concept of a situation, situational roles, and corresponding relations with the definition of entity ownership, and eliminate unused and logically inconsistent properties.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -290,14 +290,6 @@
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.google.com/#q=guarantees</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-opty;hasConstitutionalOwner">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-opty;isPartiallyOwnedBy"/>
-		<rdfs:label>has constitutional owner</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-opty;ConstitutionalOwner"/>
-		<skos:definition>links a constitutional interest/position in something (e.g., a legal entity) to the party that holds or owns it, in whole or in part</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-opty;hasDirectOwnership">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;experiences"/>
 		<rdfs:label>has direct ownership</rdfs:label>
@@ -406,15 +398,6 @@
 		<rdfs:range rdf:resource="&fibo-be-oac-opty;EntityOwner"/>
 		<owl:inverseOf rdf:resource="&fibo-be-oac-opty;holdsEquityIn"/>
 		<skos:definition>links some equity to the party that holds it</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-opty;isPartiallyOwnedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-own;isOwnedBy"/>
-		<rdfs:label>is partially owned by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-opty;EntityOwner"/>
-		<owl:inverseOf rdf:resource="&fibo-be-oac-opty;holdsAnOwnershipInterestIn"/>
-		<skos:definition>links an interest or position in something (e.g, a formal business organization) to the party that holds or owns it, in whole or in part</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminated unused, redundant and logically inconsistent properties related to partial ownership

Fixes: #1034 / [BE-214](https://jira.edmcouncil.org/browse/BE-214)


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


