### PR TITLE
DER-72 - Incorporate the example interest rate swap contract corresponding to the standard reporting use case

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -24,7 +24,7 @@
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/">
   		<rdfs:label>About FIBO Development</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users.  It loads the very latest version of every FIBO ontology (released, provisional, and informative) based on the contents of GitHub, for use in particular while working on revisions.  Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-05-29T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-06-28T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
@@ -164,6 +164,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/ForwardRateAgreements/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/InflationSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IROptions/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/OTCIndexOptions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>	 
@@ -403,7 +404,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 	 
-	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20200501/AboutFIBODev/"/>
+	 	<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20200601/AboutFIBODev/"/>
   </owl:Ontology>
   
 </rdf:RDF>

--- a/AboutFIBOProd.rdf
+++ b/AboutFIBOProd.rdf
@@ -24,7 +24,7 @@
   <owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/AboutFIBOProd/">
   		<rdfs:label>About FIBO Production</rdfs:label>
 		<dct:abstract>This ontology is provided for the convenience of FIBO users.  It loads all of the very latest FIBO production ontologies based on the contents of GitHub, rather than those that comprise a specific version, such as a quarterly release.  Note that metadata files and other 'load' files, such as the various domain-specific 'all' files, are intentionally excluded.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2020-05-29T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-06-28T18:00:00</dct:issued>
 		<dct:license rdf:resource="http://opensource.org/licenses/MIT"/>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2014-2020 EDM Council, Inc.</sm:copyright>
@@ -85,6 +85,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/SwapsIndividuals/"/>
 		
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
 		
@@ -239,7 +240,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20200501/AboutFIBOProd/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/20200601/AboutFIBOProd/"/>
   </owl:Ontology>
 
 </rdf:RDF>

--- a/DER/AllDER-ExampleIndividuals.rdf
+++ b/DER/AllDER-ExampleIndividuals.rdf
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-derex-all "https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ExampleIndividuals/">
+	<!ENTITY fibo-derri-all "https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ReferenceIndividuals/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-secex-all "https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ExampleIndividuals/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ExampleIndividuals/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-derex-all="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ExampleIndividuals/"
+	xmlns:fibo-derri-all="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ReferenceIndividuals/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-secex-all="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ExampleIndividuals/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ExampleIndividuals/">
+		<rdfs:label>Derivatives Domain, with Reference Individuals</rdfs:label>
+		<dct:abstract>The Derivatives (DER) Domain covers many of the concepts that are common to derivative instruments, including but not limited to options, futures, forwards, swaps, and a wide range of other derivatives. This ontology provides metadata about the Derivatives Domain and its contents.</dct:abstract>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-06-28T18:00:00</dct:issued>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<dct:title>EDMC Financial Industry Business Ontology (FIBO) Derivatives (DER) Domain, with Reference Individuals</dct:title>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:contributor>Adaptive, Inc.</sm:contributor>
+		<sm:contributor>Bloomberg LP</sm:contributor>
+		<sm:contributor>Citigroup</sm:contributor>
+		<sm:contributor>Commodities Futures Trading Commission (CFTC)</sm:contributor>
+		<sm:contributor>Deutsche Bank</sm:contributor>
+		<sm:contributor>John F. Gemski</sm:contributor>
+		<sm:contributor>John F. Tierney</sm:contributor>
+		<sm:contributor>Mizuho</sm:contributor>
+		<sm:contributor>Nordea Bank AB</sm:contributor>
+		<sm:contributor>Office of Financial Research (US Dept of the Treasury)</sm:contributor>
+		<sm:contributor>Quarule</sm:contributor>
+		<sm:contributor>State Street Bank and Trust</sm:contributor>
+		<sm:contributor>Tahoe Blue Ltd</sm:contributor>
+		<sm:contributor>Thematix Partners LLC</sm:contributor>
+		<sm:contributor>Wells Fargo</sm:contributor>
+		<sm:contributor>Working Ontologist</sm:contributor>
+		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">http://www.omg.org/techprocess/ab/SpecificationMetadata/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-derri-all</sm:fileAbbreviation>
+		<sm:filename>AllDER-ReferenceIndividuals.rdf</sm:filename>
+		<sm:keyword>derivative instruments</sm:keyword>
+		<sm:keyword>options, futures, rights instruments, swaps</sm:keyword>
+		<sm:moduleAbbreviation>fibo-der</sm:moduleAbbreviation>
+		<rdfs:seeAlso rdf:resource="https://www.edmcouncil.org/fibo/"/>
+		<owl:imports rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/AllDER-ReferenceIndividuals/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/AllSEC-ExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200601/AllDER-ExampleIndividuals/"/>
+		<fibo-fnd-utl-av:explanatoryNote>The &apos;all&apos; ontology for SEC example individuals is provided for convenience for FIBO users.  This ontology does not add new assertions, but imports all of the Production (Released) ontologies that comprise the FIBO Foundations (FND), Business Entities (BE), Financial Business and Commerce (FBC), Indices and Indicators (IND), Securities (SEC) and Derivatives (DER) domains, including all individuals, with examples of how to encode information for a notional interest rate swap contract.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Ontology>
+
+</rdf:RDF>

--- a/DER/RateDerivatives/IRSwapExampleIndividuals.rdf
+++ b/DER/RateDerivatives/IRSwapExampleIndividuals.rdf
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-der-drc-swp "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/">
+	<!ENTITY fibo-der-rtd-irsind "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/">
+	<!ENTITY fibo-der-rtd-irswp "https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/">
+	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
+	<!ENTITY fibo-fbc-fct-bci "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/">
+	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
+	<!ENTITY fibo-fnd-acc-4217 "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/">
+	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
+	<!ENTITY fibo-fnd-dt-bd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/">
+	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY fibo-ind-ir-cm "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/">
+	<!ENTITY fibo-ind-ir-ir "https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/">
+	<!ENTITY fibo-sec-dbt-dbti "https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/">
+	<!ENTITY fibo-sec-sec-ast "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/">
+	<!ENTITY fibo-sec-sec-id "https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-der-drc-swp="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"
+	xmlns:fibo-der-rtd-irsind="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/"
+	xmlns:fibo-der-rtd-irswp="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"
+	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
+	xmlns:fibo-fbc-fct-bci="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"
+	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
+	xmlns:fibo-fnd-acc-4217="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"
+	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
+	xmlns:fibo-fnd-dt-bd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"
+	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:fibo-ind-ir-cm="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"
+	xmlns:fibo-ind-ir-ir="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"
+	xmlns:fibo-sec-dbt-dbti="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"
+	xmlns:fibo-sec-sec-ast="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"
+	xmlns:fibo-sec-sec-id="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwapExampleIndividuals/">
+		<rdfs:label>Interest Rate Swap Example Individuals Ontology</rdfs:label>
+		<dct:abstract>This ontology provides examples of how to represent individuals for interest rate swaps and swap legs based on the Mizuho mocked-up sample data provided in the FIBO wiki.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2018-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2018-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FBC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/IND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/SEC/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-der-rtd-irsind</sm:fileAbbreviation>
+		<sm:filename>IRSwapExampleIndividuals.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/BusinessCentersIndividuals/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/BusinessDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/CommonInterestRates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Debt/DebtInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200601/RateDerivatives/IRSwapExampleIndividuals/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
+	</owl:Ontology>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886">
+		<rdf:type rdf:resource="&fibo-der-rtd-irswp;FixedFloatSingleCurrencyInterestRateSwap"/>
+		<rdfs:label>contract IY7VKEUR45886</rdfs:label>
+		<skos:definition>contract IY7VKEUR45886 that is a fixed/float, single currency interest rate swap</skos:definition>
+		<fibo-der-drc-swp:exchanges rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886"/>
+		<fibo-der-drc-swp:exchanges rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886"/>
+		<fibo-fnd-agr-ctr:hasContractParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-A"/>
+		<fibo-fnd-agr-ctr:hasContractParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-ZZZWWK96TRQY0F2IY7VK"/>
+		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-der-rtd-irsind;PortfolioAlpha"/>
+		<lcc-lr:isIdentifiedBy rdf:resource="&fibo-der-rtd-irsind;ISIN-ZZ216659451"/>
+		<lcc-lr:isIdentifiedBy rdf:resource="&fibo-der-rtd-irsind;IY7VKEUR45886"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886">
+		<rdf:type rdf:resource="&fibo-der-rtd-irswp;FixedInterestRateLeg"/>
+		<rdfs:label>contract leg 1 IY7VKEUR45886</rdfs:label>
+		<skos:definition>contract IY7VKEUR45886 swap leg 1 that is a fixed interest rate leg</skos:definition>
+		<fibo-der-drc-swp:hasPayingParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-ZZZWWK96TRQY0F2IY7VK"/>
+		<fibo-der-drc-swp:hasReceivingParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-A"/>
+		<fibo-fbc-dae-dbt:hasInterestRate rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-InterestRate"/>
+		<fibo-fnd-acc-cur:hasNotionalAmount rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-NotionalAmount"/>
+		<fibo-fnd-agr-ctr:hasEffectiveDate rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-EffectiveDate"/>
+		<fibo-fnd-arr-doc:hasTerminationDate rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-TerminationDate"/>
+		<fibo-fnd-rel-rel:isMandatedBy rdf:resource="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886"/>
+		<fibo-fnd-utl-av:explanatoryNote>Need to create the 1st period fixing date, payment days offset, discount notional amount, average remaining notional currency, net present value currency (pair, of type monetary amount)</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-sec-dbt-dbti:hasInterestPaymentTerms rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-InterestPaymentTerms"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-EffectiveDate">
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>contract leg 1 IY7VKEUR45886 effective date</rdfs:label>
+		<fibo-fnd-dt-fd:hasDateValue>2015-12-12</fibo-fnd-dt-fd:hasDateValue>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-InterestPaymentTerms">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentTerms"/>
+		<rdfs:label>contract leg 1 interest payment terms IY7VKEUR45886</rdfs:label>
+		<skos:definition>interest payment terms for contract IY7VKEUR45886 swap leg 1 that is a fixed interest rate leg</skos:definition>
+		<fibo-fbc-dae-dbt:hasAccrualBasis rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention-30E360"/>
+		<fibo-fbc-dae-dbt:hasInterestPaymentFrequency rdf:resource="&fibo-ind-ir-ir;OneYear"/>
+		<fibo-fbc-dae-dbt:hasInterestRate rdf:resource="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-InterestRate"/>
+		<fibo-fnd-dt-bd:hasBusinessDayAdjustment rdf:resource="&fibo-der-rtd-irsind;EuropeanCentralBankBBusinessDayAdjustment"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-InterestRate">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;FixedInterestRate"/>
+		<rdfs:label>contract leg 1 IY7VKEUR45886 fixed interest rate</rdfs:label>
+		<fibo-fnd-acc-cur:hasRateValue rdf:datatype="&xsd;decimal">1.0579</fibo-fnd-acc-cur:hasRateValue>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-NotionalAmount">
+		<rdf:type rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+		<rdfs:label>contract leg 1 IY7VKEUR45886 notional amount</rdfs:label>
+		<fibo-fnd-acc-cur:hasAmount rdf:datatype="&xsd;decimal">1286805</fibo-fnd-acc-cur:hasAmount>
+		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg1-IY7VKEUR45886-TerminationDate">
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>contract leg 1 IY7VKEUR45886 termination date</rdfs:label>
+		<fibo-fnd-dt-fd:hasDateValue>2025-08-17</fibo-fnd-dt-fd:hasDateValue>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886">
+		<rdf:type rdf:resource="&fibo-der-rtd-irswp;FloatingInterestRateLeg"/>
+		<rdfs:label>contract leg 2 IY7VKEUR45886</rdfs:label>
+		<skos:definition>contract IY7VKEUR45886 swap leg 2 that is a floating interest rate leg</skos:definition>
+		<fibo-der-drc-swp:hasPayingParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-A"/>
+		<fibo-der-drc-swp:hasReceivingParty rdf:resource="&fibo-der-rtd-irsind;SwapContractParty-ZZZWWK96TRQY0F2IY7VK"/>
+		<fibo-fbc-dae-dbt:hasInterestRate rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-InterestRate"/>
+		<fibo-fnd-acc-cur:hasNotionalAmount rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-NotionalAmount"/>
+		<fibo-fnd-agr-ctr:hasEffectiveDate rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-EffectiveDate"/>
+		<fibo-fnd-arr-doc:hasTerminationDate rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-TerminationDate"/>
+		<fibo-fnd-rel-rel:isMandatedBy rdf:resource="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886"/>
+		<fibo-fnd-utl-av:explanatoryNote>Need to create the interest rate reset schedule or add a simple payment frequency, need a separate property for reference interest rate, need rate tenor</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-sec-dbt-dbti:hasInterestPaymentTerms rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-InterestPaymentTerms"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-EffectiveDate">
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>contract leg 2 IY7VKEUR45886 effective date</rdfs:label>
+		<fibo-fnd-dt-fd:hasDateValue>2015-12-12</fibo-fnd-dt-fd:hasDateValue>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-InterestPaymentTerms">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;InterestPaymentTerms"/>
+		<rdfs:label>contract leg 2 interest payment terms IY7VKEUR45886</rdfs:label>
+		<skos:definition>interest payment terms for contract IY7VKEUR45886 swap leg 2 that is a floating interest rate leg</skos:definition>
+		<fibo-fbc-dae-dbt:hasAccrualBasis rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention-30E360"/>
+		<fibo-fbc-dae-dbt:hasInterestPaymentFrequency rdf:resource="&fibo-ind-ir-ir;SixMonths"/>
+		<fibo-fbc-dae-dbt:hasInterestRate rdf:resource="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-InterestRate"/>
+		<fibo-fnd-dt-bd:hasBusinessDayAdjustment rdf:resource="&fibo-der-rtd-irsind;EuropeanCentralBankBBusinessDayAdjustment"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-InterestRate">
+		<rdf:type rdf:resource="&fibo-fbc-dae-dbt;FloatingInterestRate"/>
+		<rdfs:label>contract leg 2 IY7VKEUR45886 floating interest rate</rdfs:label>
+		<fibo-fnd-acc-cur:hasRateValue rdf:datatype="&xsd;decimal">0.309</fibo-fnd-acc-cur:hasRateValue>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-NotionalAmount">
+		<rdf:type rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+		<rdfs:label>contract leg 2 IY7VKEUR45886 notional amount</rdfs:label>
+		<fibo-fnd-acc-cur:hasAmount rdf:datatype="&xsd;decimal">1286805</fibo-fnd-acc-cur:hasAmount>
+		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ContractLeg2-IY7VKEUR45886-TerminationDate">
+		<rdf:type rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>contract leg 2 IY7VKEUR45886 termination date</rdfs:label>
+		<fibo-fnd-dt-fd:hasDateValue>2025-08-17</fibo-fnd-dt-fd:hasDateValue>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;EuropeanCentralBankBBusinessDayAdjustment">
+		<rdf:type rdf:resource="&fibo-fnd-dt-bd;BusinessDayAdjustment"/>
+		<rdfs:label>European Central Bank business day adjustment</rdfs:label>
+		<skos:definition>business day adjustment for the ECB</skos:definition>
+		<fibo-fnd-dt-bd:hasBusinessDayConvention rdf:resource="&fibo-fnd-dt-bd;BusinessDayModifiedFollowing"/>
+		<fibo-fnd-plc-loc:hasBusinessCenter rdf:resource="&fibo-fbc-fct-bci;Frankfurt"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;ISIN-ZZ216659451">
+		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
+		<rdfs:label>ZZ216659451</rdfs:label>
+		<skos:definition>ISIN for sample swap contract IY7VKEUR45886</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>ZZ216659451</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;IY7VKEUR45886">
+		<rdf:type rdf:resource="&fibo-der-drc-swp;UniqueSwapIdentifier"/>
+		<rdfs:label>IY7VKEUR45886</rdfs:label>
+		<skos:definition>unique swap identifier for sample swap contract IY7VKEUR45886</skos:definition>
+		<fibo-fnd-rel-rel:hasTag>IY7VKEUR45886</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:identifies rdf:resource="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886"/>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;PortfolioAlpha">
+		<rdf:type rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
+		<rdfs:label>portfolio Alpha</rdfs:label>
+		<skos:definition>sample contract portfolio Alpha</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;PortfolioBeta">
+		<rdf:type rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
+		<rdfs:label>portfolio Beta</rdfs:label>
+		<skos:definition>sample contract portfolio Beta</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;PortfolioDelta">
+		<rdf:type rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
+		<rdfs:label>portfolio Delta</rdfs:label>
+		<skos:definition>sample contract portfolio Delta</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;PortfolioGamma">
+		<rdf:type rdf:resource="&fibo-sec-sec-ast;Portfolio"/>
+		<rdfs:label>portfolio Gamma</rdfs:label>
+		<skos:definition>sample contract portfolio Gamma</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;SecuritiesTransaction-IY7VKEUR45886">
+		<rdf:type rdf:resource="&fibo-fbc-fi-fi;SecuritiesTransaction"/>
+		<rdfs:label>securities transaction IY7VKEUR45886</rdfs:label>
+		<skos:definition>securities transaction for contract IY7VKEUR45886</skos:definition>
+		<fibo-fbc-pas-fpas:isFacilitatedBy rdf:resource="&fibo-der-rtd-irsind;Trader-J_Adams"/>
+		<fibo-fnd-rel-rel:appliesTo rdf:resource="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886"/>
+		<fibo-fnd-utl-av:explanatoryNote>Need to create the trade event - this is the activity (maybe we should rename these now? in FND to activity and event?) and add lifecycle elements - date and time, status of the trade and settlement status</fibo-fnd-utl-av:explanatoryNote>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;SwapContractParty-A">
+		<rdf:type rdf:resource="&fibo-der-drc-swp;SwapParty"/>
+		<rdfs:label>swap contract party A</rdfs:label>
+		<skos:definition>swap contract party A for all of the sample contracts in the sample swap data</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;SwapContractParty-ZZZWWK96TRQY0F2IY7VK">
+		<rdf:type rdf:resource="&fibo-der-drc-swp;SwapParty"/>
+		<rdf:type rdf:resource="&fibo-fnd-agr-ctr;Counterparty"/>
+		<rdfs:label>swap contract party ZZZWWK96TRQY0F2IY7VK</rdfs:label>
+		<skos:definition>swap contract party ZZZWWK96TRQY0F2IY7VK</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-der-rtd-irsind;Trader-J_Adams">
+		<rdf:type rdf:resource="&fibo-fbc-pas-fpas;Trader"/>
+		<rdfs:label>trader J. Adams</rdfs:label>
+	</owl:NamedIndividual>
+
+</rdf:RDF>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Adds a new example individuals ontology for interest rate swaps, representing a single, notional contract that is a fixed-float, single currency interest rate swap based on the example data the DER working group has been using, from Mizuho, to vet the IR Swap ontology and all of its dependencies, as well as a new load file that loads this new ontology as well as all of the other examples, reference data, and core FIBO ontologies in production

Fixes: #1046 / DER-72


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


