### PR TITLE
FND-258 - CurrencyCodes and CurrencyAmount ontologies have too many dependencies

### DIFF
--- a/FND/Accounting/CurrencyAmount.rdf
+++ b/FND/Accounting/CurrencyAmount.rdf
@@ -3,10 +3,8 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
-	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
 	<!ENTITY fibo-fnd-law-jur "https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/">
 	<!ENTITY fibo-fnd-qt-qtu "https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-alx "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
@@ -22,10 +20,8 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
-	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
 	xmlns:fibo-fnd-law-jur="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"
 	xmlns:fibo-fnd-qt-qtu="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-alx="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
@@ -47,10 +43,8 @@ The definition of currency provided herein is compliant with the definitions giv
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
@@ -60,15 +54,13 @@ The definition of currency provided herein is compliant with the definitions giv
 		<sm:fileAbbreviation>fibo-fnd-acc-cur</sm:fileAbbreviation>
 		<sm:filename>CurrencyAmount.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/AgentsAndPeople/Agents/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Law/Jurisdiction/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Quantities/QuantitiesAndUnits/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200501/Accounting/CurrencyAmount/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200601/Accounting/CurrencyAmount/"/>
 		<skos:changeNote>The FIBO FND 1.0 (https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Accounting/CurrencyAmount.rdf) version of this ontology was modified per the additions introduced in the FIBO FBC RFC and related issue resolutions identified in the FIBO FND 1.1 RTF report and https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.1/, including adding support for ISO 4217 currency codes.</skos:changeNote>
 		<skos:changeNote>The FIBO FND 1.1 (https://spec.edmcouncil.org/fibo/ontology/FND/20160201/Accounting/CurrencyAmount.rdf) version of this ontology was modified per FIBO 2.0 RFC, including the addition of a new hasMonetaryAmount property as a superproperty of others required by various FIBO domain teams and integration with LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Accounting/CurrencyAmount.rdf version of this ontology was modified to include several classes to support automated inclusion of all ISO 4217 codes published as of 2018-06-04, and to revise definitions per the eighth edition of the specification.</skos:changeNote>
@@ -76,7 +68,7 @@ The definition of currency provided herein is compliant with the definitions giv
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Accounting/CurrencyAmount/ version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Accounting/CurrencyAmount/ version of this ontology was modified to improve definitions for notional amount and currency identifier.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191201/Accounting/CurrencyAmount/ version of this ontology was modified to correct the explanatory note on currency identifier.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191201/Accounting/CurrencyAmount/ version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191201/Accounting/CurrencyAmount/ version of this ontology was modified to eliminate duplication with concepts in LCC and the dependencies on a couple of ontologies that were unnecessary.</skos:changeNote>
 		<skos:editorialNote>(1) The present version of the ontology covers the English sections of the ISO 4217 standard only, and (2) UTF-8 character encodings are employed in names in the currency codes ontology to support the broadest number of tools.</skos:editorialNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -160,7 +152,7 @@ The definition of currency provided herein is compliant with the definitions giv
 		<rdfs:subClassOf rdf:resource="&lcc-lr;Identifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -237,7 +229,7 @@ The definition of currency provided herein is compliant with the definitions giv
 		<rdfs:subClassOf rdf:resource="&lcc-lr;Identifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -360,7 +352,7 @@ The definition of currency provided herein is compliant with the definitions giv
 		<rdfs:subClassOf rdf:resource="&lcc-lr;Identifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -458,7 +450,7 @@ The definition of currency provided herein is compliant with the definitions giv
 	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fnd-acc-cur;hasNumericCode">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+		<rdfs:subPropertyOf rdf:resource="&lcc-lr;hasTag"/>
 		<rdfs:label>has numeric code</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition>relates a numeric code to the currency or fund</skos:definition>

--- a/FND/Accounting/ISO4217-CurrencyCodes.rdf
+++ b/FND/Accounting/ISO4217-CurrencyCodes.rdf
@@ -3,9 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-fnd-acc-4217 "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
-	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
-	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
 	<!ENTITY lcc-3166-1 "https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/">
 	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
@@ -21,9 +19,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-fnd-acc-4217="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/ISO4217-CurrencyCodes/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
-	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
-	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
 	xmlns:lcc-3166-1="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"
 	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
@@ -45,9 +41,7 @@
 		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:directSource>ISO 4217:2015 - Codes for the representation of currencies and funds</sm:directSource>
@@ -57,7 +51,6 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
@@ -65,6 +58,7 @@
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Accounting/ISO4217-CurrencyCodes/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to replace Swaziland with Eswatini, which was revised by the LCC 1.1 RTF to reflect the change to the country name per the U.N.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190401/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Accounting/ISO4217-CurrencyCodes/ version of this ontology was modified to eliminate unnecessary dependencies on the relations ontology, and to replace skos:definition with skos:definition per FIBO policy.</skos:changeNote>
 		<skos:changeNote>This version is now generated from the ISO XML file as published on 2018-08-29</skos:changeNote>
 		<fibo-fnd-utl-av:explanatoryNote>This release includes all codes included in the ISO 4217 published code set.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
@@ -73,7 +67,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ADBUnitofAccount">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccount"/>
 		<rdfs:label>ADB Unit of Account</rdfs:label>
-		<rdfs:comment>the ADB Unit of Account</rdfs:comment>
+		<skos:definition>the ADB Unit of Account</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>965</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>ADB Unit of Account</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -81,9 +75,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AED">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AED</rdfs:label>
-		<rdfs:comment>the currency identifier for UAE Dirham</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>AED</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for UAE Dirham</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;UAEDirham"/>
+		<lcc-lr:hasTag>AED</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;UAEDirham"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -91,9 +85,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AFN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AFN</rdfs:label>
-		<rdfs:comment>the currency identifier for Afghani</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>AFN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Afghani</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Afghani"/>
+		<lcc-lr:hasTag>AFN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Afghani"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -101,9 +95,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ALL">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ALL</rdfs:label>
-		<rdfs:comment>the currency identifier for Lek</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ALL</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Lek</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Lek"/>
+		<lcc-lr:hasTag>ALL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Lek"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -111,9 +105,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AMD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AMD</rdfs:label>
-		<rdfs:comment>the currency identifier for Armenian Dram</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>AMD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Armenian Dram</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ArmenianDram"/>
+		<lcc-lr:hasTag>AMD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ArmenianDram"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -121,9 +115,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ANG">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ANG</rdfs:label>
-		<rdfs:comment>the currency identifier for Netherlands Antillean Guilder</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ANG</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Netherlands Antillean Guilder</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;NetherlandsAntilleanGuilder"/>
+		<lcc-lr:hasTag>ANG</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;NetherlandsAntilleanGuilder"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -131,9 +125,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AOA">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AOA</rdfs:label>
-		<rdfs:comment>the currency identifier for Kwanza</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>AOA</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Kwanza</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Kwanza"/>
+		<lcc-lr:hasTag>AOA</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Kwanza"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -141,9 +135,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ARS">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ARS</rdfs:label>
-		<rdfs:comment>the currency identifier for Argentine Peso</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ARS</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Argentine Peso</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ArgentinePeso"/>
+		<lcc-lr:hasTag>ARS</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ArgentinePeso"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -151,9 +145,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AUD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AUD</rdfs:label>
-		<rdfs:comment>the currency identifier for Australian Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>AUD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Australian Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
+		<lcc-lr:hasTag>AUD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;AustralianDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -161,9 +155,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AWG">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AWG</rdfs:label>
-		<rdfs:comment>the currency identifier for Aruban Florin</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>AWG</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Aruban Florin</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ArubanFlorin"/>
+		<lcc-lr:hasTag>AWG</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ArubanFlorin"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -171,9 +165,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AZN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>AZN</rdfs:label>
-		<rdfs:comment>the currency identifier for Azerbaijan Manat</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>AZN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Azerbaijan Manat</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;AzerbaijanManat"/>
+		<lcc-lr:hasTag>AZN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;AzerbaijanManat"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -181,7 +175,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Afghani">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Afghani</rdfs:label>
-		<rdfs:comment>the currency Afghani</rdfs:comment>
+		<skos:definition>the currency Afghani</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>971</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Afghanistan"/>
@@ -191,7 +185,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AlgerianDinar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Algerian Dinar</rdfs:label>
-		<rdfs:comment>the currency Algerian Dinar</rdfs:comment>
+		<skos:definition>the currency Algerian Dinar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>012</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Algeria"/>
@@ -201,7 +195,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ArgentinePeso">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Argentine Peso</rdfs:label>
-		<rdfs:comment>the currency Argentine Peso</rdfs:comment>
+		<skos:definition>the currency Argentine Peso</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>032</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Argentina"/>
@@ -211,7 +205,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ArmenianDram">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Armenian Dram</rdfs:label>
-		<rdfs:comment>the currency Armenian Dram</rdfs:comment>
+		<skos:definition>the currency Armenian Dram</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>051</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Armenia"/>
@@ -221,7 +215,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ArubanFlorin">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Aruban Florin</rdfs:label>
-		<rdfs:comment>the currency Aruban Florin</rdfs:comment>
+		<skos:definition>the currency Aruban Florin</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>533</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Aruba"/>
@@ -231,7 +225,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AustralianDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Australian Dollar</rdfs:label>
-		<rdfs:comment>the currency Australian Dollar</rdfs:comment>
+		<skos:definition>the currency Australian Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>036</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Australia"/>
@@ -248,7 +242,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;AzerbaijanManat">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Azerbaijan Manat</rdfs:label>
-		<rdfs:comment>the currency Azerbaijan Manat</rdfs:comment>
+		<skos:definition>the currency Azerbaijan Manat</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>944</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Azerbaijan"/>
@@ -258,9 +252,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BAM">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BAM</rdfs:label>
-		<rdfs:comment>the currency identifier for Convertible Mark</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BAM</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Convertible Mark</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ConvertibleMark"/>
+		<lcc-lr:hasTag>BAM</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ConvertibleMark"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -268,9 +262,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BBD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BBD</rdfs:label>
-		<rdfs:comment>the currency identifier for Barbados Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BBD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Barbados Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BarbadosDollar"/>
+		<lcc-lr:hasTag>BBD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BarbadosDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -278,9 +272,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BDT">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BDT</rdfs:label>
-		<rdfs:comment>the currency identifier for Taka</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BDT</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Taka</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Taka"/>
+		<lcc-lr:hasTag>BDT</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Taka"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -288,9 +282,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BGN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BGN</rdfs:label>
-		<rdfs:comment>the currency identifier for Bulgarian Lev</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BGN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Bulgarian Lev</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BulgarianLev"/>
+		<lcc-lr:hasTag>BGN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BulgarianLev"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -298,9 +292,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BHD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BHD</rdfs:label>
-		<rdfs:comment>the currency identifier for Bahraini Dinar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BHD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Bahraini Dinar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BahrainiDinar"/>
+		<lcc-lr:hasTag>BHD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BahrainiDinar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -308,9 +302,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BIF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BIF</rdfs:label>
-		<rdfs:comment>the currency identifier for Burundi Franc</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BIF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Burundi Franc</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BurundiFranc"/>
+		<lcc-lr:hasTag>BIF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BurundiFranc"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -318,9 +312,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BMD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BMD</rdfs:label>
-		<rdfs:comment>the currency identifier for Bermudian Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BMD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Bermudian Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BermudianDollar"/>
+		<lcc-lr:hasTag>BMD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BermudianDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -328,9 +322,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BND">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BND</rdfs:label>
-		<rdfs:comment>the currency identifier for Brunei Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BND</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Brunei Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BruneiDollar"/>
+		<lcc-lr:hasTag>BND</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BruneiDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -338,9 +332,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BOB">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BOB</rdfs:label>
-		<rdfs:comment>the currency identifier for Boliviano</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BOB</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Boliviano</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Boliviano"/>
+		<lcc-lr:hasTag>BOB</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Boliviano"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -348,9 +342,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BOV">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>BOV</rdfs:label>
-		<rdfs:comment>the funds identifier for Mvdol</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BOV</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the funds identifier for Mvdol</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Mvdol"/>
+		<lcc-lr:hasTag>BOV</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Mvdol"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -358,9 +352,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BRL">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BRL</rdfs:label>
-		<rdfs:comment>the currency identifier for Brazilian Real</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BRL</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Brazilian Real</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BrazilianReal"/>
+		<lcc-lr:hasTag>BRL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BrazilianReal"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -368,9 +362,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BSD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BSD</rdfs:label>
-		<rdfs:comment>the currency identifier for Bahamian Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BSD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Bahamian Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BahamianDollar"/>
+		<lcc-lr:hasTag>BSD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BahamianDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -378,9 +372,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BTN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BTN</rdfs:label>
-		<rdfs:comment>the currency identifier for Ngultrum</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BTN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Ngultrum</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Ngultrum"/>
+		<lcc-lr:hasTag>BTN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Ngultrum"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -388,9 +382,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BWP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BWP</rdfs:label>
-		<rdfs:comment>the currency identifier for Pula</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BWP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Pula</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Pula"/>
+		<lcc-lr:hasTag>BWP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Pula"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -398,9 +392,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BYN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BYN</rdfs:label>
-		<rdfs:comment>the currency identifier for Belarusian Ruble</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BYN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Belarusian Ruble</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BelarusianRuble"/>
+		<lcc-lr:hasTag>BYN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BelarusianRuble"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -408,9 +402,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BZD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>BZD</rdfs:label>
-		<rdfs:comment>the currency identifier for Belize Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>BZD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Belize Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BelizeDollar"/>
+		<lcc-lr:hasTag>BZD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BelizeDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -418,7 +412,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BahamianDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Bahamian Dollar</rdfs:label>
-		<rdfs:comment>the currency Bahamian Dollar</rdfs:comment>
+		<skos:definition>the currency Bahamian Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>044</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bahamas"/>
@@ -428,7 +422,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BahrainiDinar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Bahraini Dinar</rdfs:label>
-		<rdfs:comment>the currency Bahraini Dinar</rdfs:comment>
+		<skos:definition>the currency Bahraini Dinar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>048</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bahrain"/>
@@ -438,7 +432,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Baht">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Baht</rdfs:label>
-		<rdfs:comment>the currency Baht</rdfs:comment>
+		<skos:definition>the currency Baht</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>764</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Thailand"/>
@@ -448,7 +442,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Balboa">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Balboa</rdfs:label>
-		<rdfs:comment>the currency Balboa</rdfs:comment>
+		<skos:definition>the currency Balboa</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>590</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Panama"/>
@@ -458,7 +452,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BarbadosDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Barbados Dollar</rdfs:label>
-		<rdfs:comment>the currency Barbados Dollar</rdfs:comment>
+		<skos:definition>the currency Barbados Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>052</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Barbados"/>
@@ -468,7 +462,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BelarusianRuble">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Belarusian Ruble</rdfs:label>
-		<rdfs:comment>the currency Belarusian Ruble</rdfs:comment>
+		<skos:definition>the currency Belarusian Ruble</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>933</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Belarus"/>
@@ -478,7 +472,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BelizeDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Belize Dollar</rdfs:label>
-		<rdfs:comment>the currency Belize Dollar</rdfs:comment>
+		<skos:definition>the currency Belize Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>084</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Belize"/>
@@ -488,7 +482,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BermudianDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Bermudian Dollar</rdfs:label>
-		<rdfs:comment>the currency Bermudian Dollar</rdfs:comment>
+		<skos:definition>the currency Bermudian Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>060</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bermuda"/>
@@ -498,7 +492,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Boliviano">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Boliviano</rdfs:label>
-		<rdfs:comment>the currency Boliviano</rdfs:comment>
+		<skos:definition>the currency Boliviano</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>068</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bolivia"/>
@@ -508,7 +502,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BolívarSoberano">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Bolívar Soberano</rdfs:label>
-		<rdfs:comment>the currency Bolívar Soberano</rdfs:comment>
+		<skos:definition>the currency Bolívar Soberano</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>928</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Venezuela"/>
@@ -518,7 +512,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanCompositeUnit_EURCO">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccount"/>
 		<rdfs:label>Bond Markets Unit European Composite Unit (EURCO)</rdfs:label>
-		<rdfs:comment>the Bond Markets Unit European Composite Unit (EURCO)</rdfs:comment>
+		<skos:definition>the Bond Markets Unit European Composite Unit (EURCO)</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>955</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>Bond Markets Unit European Composite Unit (EURCO)</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -526,7 +520,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanMonetaryUnit_EMU-6">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccount"/>
 		<rdfs:label>Bond Markets Unit European Monetary Unit (E.M.U.-6)</rdfs:label>
-		<rdfs:comment>the Bond Markets Unit European Monetary Unit (E.M.U.-6)</rdfs:comment>
+		<skos:definition>the Bond Markets Unit European Monetary Unit (E.M.U.-6)</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>956</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>Bond Markets Unit European Monetary Unit (E.M.U.-6)</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -534,7 +528,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount17_EUA-17">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccount"/>
 		<rdfs:label>Bond Markets Unit European Unit of Account 17 (E.U.A.-17)</rdfs:label>
-		<rdfs:comment>the Bond Markets Unit European Unit of Account 17 (E.U.A.-17)</rdfs:comment>
+		<skos:definition>the Bond Markets Unit European Unit of Account 17 (E.U.A.-17)</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>958</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>Bond Markets Unit European Unit of Account 17 (E.U.A.-17)</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -542,7 +536,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount9_EUA-9">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccount"/>
 		<rdfs:label>Bond Markets Unit European Unit of Account 9 (E.U.A.-9)</rdfs:label>
-		<rdfs:comment>the Bond Markets Unit European Unit of Account 9 (E.U.A.-9)</rdfs:comment>
+		<skos:definition>the Bond Markets Unit European Unit of Account 9 (E.U.A.-9)</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>957</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>Bond Markets Unit European Unit of Account 9 (E.U.A.-9)</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -550,7 +544,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BrazilianReal">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Brazilian Real</rdfs:label>
-		<rdfs:comment>the currency Brazilian Real</rdfs:comment>
+		<skos:definition>the currency Brazilian Real</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>986</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Brazil"/>
@@ -560,7 +554,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BruneiDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Brunei Dollar</rdfs:label>
-		<rdfs:comment>the currency Brunei Dollar</rdfs:comment>
+		<skos:definition>the currency Brunei Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>096</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;BruneiDarussalam"/>
@@ -570,7 +564,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BulgarianLev">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Bulgarian Lev</rdfs:label>
-		<rdfs:comment>the currency Bulgarian Lev</rdfs:comment>
+		<skos:definition>the currency Bulgarian Lev</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>975</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bulgaria"/>
@@ -580,7 +574,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;BurundiFranc">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Burundi Franc</rdfs:label>
-		<rdfs:comment>the currency Burundi Franc</rdfs:comment>
+		<skos:definition>the currency Burundi Franc</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>108</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Burundi"/>
@@ -590,9 +584,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CAD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CAD</rdfs:label>
-		<rdfs:comment>the currency identifier for Canadian Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CAD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Canadian Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
+		<lcc-lr:hasTag>CAD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CanadianDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -600,9 +594,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CDF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CDF</rdfs:label>
-		<rdfs:comment>the currency identifier for Congolese Franc</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CDF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Congolese Franc</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CongoleseFranc"/>
+		<lcc-lr:hasTag>CDF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CongoleseFranc"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -610,7 +604,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CFAFrancBCEAO">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>CFA Franc BCEAO</rdfs:label>
-		<rdfs:comment>the currency CFA Franc BCEAO</rdfs:comment>
+		<skos:definition>the currency CFA Franc BCEAO</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>952</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Benin"/>
@@ -627,7 +621,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CFAFrancBEAC">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>CFA Franc BEAC</rdfs:label>
-		<rdfs:comment>the currency CFA Franc BEAC</rdfs:comment>
+		<skos:definition>the currency CFA Franc BEAC</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>950</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Cameroon"/>
@@ -642,7 +636,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CFPFranc">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>CFP Franc</rdfs:label>
-		<rdfs:comment>the currency CFP Franc</rdfs:comment>
+		<skos:definition>the currency CFP Franc</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>953</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;FrenchPolynesia"/>
@@ -654,9 +648,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CHE">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>CHE</rdfs:label>
-		<rdfs:comment>the funds identifier for WIR Euro</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CHE</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the funds identifier for WIR Euro</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;WIREuro"/>
+		<lcc-lr:hasTag>CHE</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;WIREuro"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -664,9 +658,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CHF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CHF</rdfs:label>
-		<rdfs:comment>the currency identifier for Swiss Franc</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CHF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Swiss Franc</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
+		<lcc-lr:hasTag>CHF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -674,9 +668,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CHW">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>CHW</rdfs:label>
-		<rdfs:comment>the funds identifier for WIR Franc</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CHW</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the funds identifier for WIR Franc</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;WIRFranc"/>
+		<lcc-lr:hasTag>CHW</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;WIRFranc"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -684,9 +678,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CLF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>CLF</rdfs:label>
-		<rdfs:comment>the funds identifier for Unidad de Fomento</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CLF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the funds identifier for Unidad de Fomento</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;UnidaddeFomento"/>
+		<lcc-lr:hasTag>CLF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;UnidaddeFomento"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -694,9 +688,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CLP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CLP</rdfs:label>
-		<rdfs:comment>the currency identifier for Chilean Peso</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CLP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Chilean Peso</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ChileanPeso"/>
+		<lcc-lr:hasTag>CLP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ChileanPeso"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -704,9 +698,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CNY">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CNY</rdfs:label>
-		<rdfs:comment>the currency identifier for Yuan Renminbi</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CNY</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Yuan Renminbi</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
+		<lcc-lr:hasTag>CNY</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;YuanRenminbi"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -714,9 +708,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;COP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>COP</rdfs:label>
-		<rdfs:comment>the currency identifier for Colombian Peso</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>COP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Colombian Peso</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ColombianPeso"/>
+		<lcc-lr:hasTag>COP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ColombianPeso"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -724,9 +718,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;COU">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>COU</rdfs:label>
-		<rdfs:comment>the funds identifier for Unidad de Valor Real</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>COU</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the funds identifier for Unidad de Valor Real</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;UnidaddeValorReal"/>
+		<lcc-lr:hasTag>COU</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;UnidaddeValorReal"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -734,9 +728,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CRC">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CRC</rdfs:label>
-		<rdfs:comment>the currency identifier for Costa Rican Colon</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CRC</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Costa Rican Colon</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CostaRicanColon"/>
+		<lcc-lr:hasTag>CRC</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CostaRicanColon"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -744,9 +738,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CUC">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CUC</rdfs:label>
-		<rdfs:comment>the currency identifier for Peso Convertible</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CUC</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Peso Convertible</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;PesoConvertible"/>
+		<lcc-lr:hasTag>CUC</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;PesoConvertible"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -754,9 +748,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CUP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CUP</rdfs:label>
-		<rdfs:comment>the currency identifier for Cuban Peso</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CUP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Cuban Peso</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CubanPeso"/>
+		<lcc-lr:hasTag>CUP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CubanPeso"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -764,9 +758,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CVE">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CVE</rdfs:label>
-		<rdfs:comment>the currency identifier for Cabo Verde Escudo</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CVE</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Cabo Verde Escudo</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CaboVerdeEscudo"/>
+		<lcc-lr:hasTag>CVE</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CaboVerdeEscudo"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -774,9 +768,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CZK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>CZK</rdfs:label>
-		<rdfs:comment>the currency identifier for Czech Koruna</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>CZK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Czech Koruna</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
+		<lcc-lr:hasTag>CZK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CzechKoruna"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -784,7 +778,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CaboVerdeEscudo">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Cabo Verde Escudo</rdfs:label>
-		<rdfs:comment>the currency Cabo Verde Escudo</rdfs:comment>
+		<skos:definition>the currency Cabo Verde Escudo</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>132</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CaboVerde"/>
@@ -794,7 +788,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CanadianDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Canadian Dollar</rdfs:label>
-		<rdfs:comment>the currency Canadian Dollar</rdfs:comment>
+		<skos:definition>the currency Canadian Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>124</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Canada"/>
@@ -804,7 +798,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CaymanIslandsDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Cayman Islands Dollar</rdfs:label>
-		<rdfs:comment>the currency Cayman Islands Dollar</rdfs:comment>
+		<skos:definition>the currency Cayman Islands Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>136</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CaymanIslands"/>
@@ -814,7 +808,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ChileanPeso">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Chilean Peso</rdfs:label>
-		<rdfs:comment>the currency Chilean Peso</rdfs:comment>
+		<skos:definition>the currency Chilean Peso</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>152</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Chile"/>
@@ -824,7 +818,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ColombianPeso">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Colombian Peso</rdfs:label>
-		<rdfs:comment>the currency Colombian Peso</rdfs:comment>
+		<skos:definition>the currency Colombian Peso</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>170</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Colombia"/>
@@ -834,7 +828,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ComorianFranc">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Comorian Franc</rdfs:label>
-		<rdfs:comment>the currency Comorian Franc</rdfs:comment>
+		<skos:definition>the currency Comorian Franc</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>174</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Comoros"/>
@@ -844,7 +838,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CongoleseFranc">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Congolese Franc</rdfs:label>
-		<rdfs:comment>the currency Congolese Franc</rdfs:comment>
+		<skos:definition>the currency Congolese Franc</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>976</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CongoDemocraticRepublicOf"/>
@@ -854,7 +848,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ConvertibleMark">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Convertible Mark</rdfs:label>
-		<rdfs:comment>the currency Convertible Mark</rdfs:comment>
+		<skos:definition>the currency Convertible Mark</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>977</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;BosniaAndHerzegovina"/>
@@ -864,7 +858,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CordobaOro">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Cordoba Oro</rdfs:label>
-		<rdfs:comment>the currency Cordoba Oro</rdfs:comment>
+		<skos:definition>the currency Cordoba Oro</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>558</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Nicaragua"/>
@@ -874,7 +868,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CostaRicanColon">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Costa Rican Colon</rdfs:label>
-		<rdfs:comment>the currency Costa Rican Colon</rdfs:comment>
+		<skos:definition>the currency Costa Rican Colon</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>188</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CostaRica"/>
@@ -884,7 +878,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CubanPeso">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Cuban Peso</rdfs:label>
-		<rdfs:comment>the currency Cuban Peso</rdfs:comment>
+		<skos:definition>the currency Cuban Peso</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>192</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Cuba"/>
@@ -894,7 +888,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;CzechKoruna">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Czech Koruna</rdfs:label>
-		<rdfs:comment>the currency Czech Koruna</rdfs:comment>
+		<skos:definition>the currency Czech Koruna</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>203</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Czechia"/>
@@ -904,9 +898,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DJF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>DJF</rdfs:label>
-		<rdfs:comment>the currency identifier for Djibouti Franc</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>DJF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Djibouti Franc</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;DjiboutiFranc"/>
+		<lcc-lr:hasTag>DJF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;DjiboutiFranc"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -914,9 +908,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DKK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>DKK</rdfs:label>
-		<rdfs:comment>the currency identifier for Danish Krone</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>DKK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Danish Krone</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
+		<lcc-lr:hasTag>DKK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;DanishKrone"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -924,9 +918,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DOP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>DOP</rdfs:label>
-		<rdfs:comment>the currency identifier for Dominican Peso</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>DOP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Dominican Peso</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;DominicanPeso"/>
+		<lcc-lr:hasTag>DOP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;DominicanPeso"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -934,9 +928,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DZD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>DZD</rdfs:label>
-		<rdfs:comment>the currency identifier for Algerian Dinar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>DZD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Algerian Dinar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;AlgerianDinar"/>
+		<lcc-lr:hasTag>DZD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;AlgerianDinar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -944,7 +938,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Dalasi">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Dalasi</rdfs:label>
-		<rdfs:comment>the currency Dalasi</rdfs:comment>
+		<skos:definition>the currency Dalasi</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>270</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Gambia"/>
@@ -954,7 +948,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DanishKrone">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Danish Krone</rdfs:label>
-		<rdfs:comment>the currency Danish Krone</rdfs:comment>
+		<skos:definition>the currency Danish Krone</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>208</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Denmark"/>
@@ -966,7 +960,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Denar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Denar</rdfs:label>
-		<rdfs:comment>the currency Denar</rdfs:comment>
+		<skos:definition>the currency Denar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>807</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Macedonia"/>
@@ -976,7 +970,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DjiboutiFranc">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Djibouti Franc</rdfs:label>
-		<rdfs:comment>the currency Djibouti Franc</rdfs:comment>
+		<skos:definition>the currency Djibouti Franc</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>262</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Djibouti"/>
@@ -986,7 +980,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Dobra">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Dobra</rdfs:label>
-		<rdfs:comment>the currency Dobra</rdfs:comment>
+		<skos:definition>the currency Dobra</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>930</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaoTomeAndPrincipe"/>
@@ -996,7 +990,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;DominicanPeso">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Dominican Peso</rdfs:label>
-		<rdfs:comment>the currency Dominican Peso</rdfs:comment>
+		<skos:definition>the currency Dominican Peso</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>214</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;DominicanRepublic"/>
@@ -1006,7 +1000,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Dong">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Dong</rdfs:label>
-		<rdfs:comment>the currency Dong</rdfs:comment>
+		<skos:definition>the currency Dong</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>704</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;VietNam"/>
@@ -1016,9 +1010,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;EGP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>EGP</rdfs:label>
-		<rdfs:comment>the currency identifier for Egyptian Pound</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>EGP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Egyptian Pound</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;EgyptianPound"/>
+		<lcc-lr:hasTag>EGP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;EgyptianPound"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1026,9 +1020,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ERN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ERN</rdfs:label>
-		<rdfs:comment>the currency identifier for Nakfa</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ERN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Nakfa</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Nakfa"/>
+		<lcc-lr:hasTag>ERN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Nakfa"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1036,9 +1030,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ETB">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ETB</rdfs:label>
-		<rdfs:comment>the currency identifier for Ethiopian Birr</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ETB</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Ethiopian Birr</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;EthiopianBirr"/>
+		<lcc-lr:hasTag>ETB</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;EthiopianBirr"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1046,9 +1040,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;EUR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>EUR</rdfs:label>
-		<rdfs:comment>the currency identifier for Euro</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>EUR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Euro</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Euro"/>
+		<lcc-lr:hasTag>EUR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1056,7 +1050,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;EastCaribbeanDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>East Caribbean Dollar</rdfs:label>
-		<rdfs:comment>the currency East Caribbean Dollar</rdfs:comment>
+		<skos:definition>the currency East Caribbean Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>951</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Anguilla"/>
@@ -1073,7 +1067,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;EgyptianPound">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Egyptian Pound</rdfs:label>
-		<rdfs:comment>the currency Egyptian Pound</rdfs:comment>
+		<skos:definition>the currency Egyptian Pound</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>818</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Egypt"/>
@@ -1083,7 +1077,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ElSalvadorColon">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>El Salvador Colon</rdfs:label>
-		<rdfs:comment>the currency El Salvador Colon</rdfs:comment>
+		<skos:definition>the currency El Salvador Colon</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>222</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;ElSalvador"/>
@@ -1093,7 +1087,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;EthiopianBirr">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Ethiopian Birr</rdfs:label>
-		<rdfs:comment>the currency Ethiopian Birr</rdfs:comment>
+		<skos:definition>the currency Ethiopian Birr</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>230</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Ethiopia"/>
@@ -1103,7 +1097,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Euro">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Euro</rdfs:label>
-		<rdfs:comment>the currency Euro</rdfs:comment>
+		<skos:definition>the currency Euro</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>978</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;AlandIslands"/>
@@ -1146,9 +1140,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;FJD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>FJD</rdfs:label>
-		<rdfs:comment>the currency identifier for Fiji Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>FJD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Fiji Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;FijiDollar"/>
+		<lcc-lr:hasTag>FJD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;FijiDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1156,9 +1150,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;FKP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>FKP</rdfs:label>
-		<rdfs:comment>the currency identifier for Falkland Islands Pound</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>FKP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Falkland Islands Pound</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;FalklandIslandsPound"/>
+		<lcc-lr:hasTag>FKP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;FalklandIslandsPound"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1166,7 +1160,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;FalklandIslandsPound">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Falkland Islands Pound</rdfs:label>
-		<rdfs:comment>the currency Falkland Islands Pound</rdfs:comment>
+		<skos:definition>the currency Falkland Islands Pound</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>238</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;FalklandIslands"/>
@@ -1176,7 +1170,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;FijiDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Fiji Dollar</rdfs:label>
-		<rdfs:comment>the currency Fiji Dollar</rdfs:comment>
+		<skos:definition>the currency Fiji Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>242</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Fiji"/>
@@ -1186,7 +1180,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Forint">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Forint</rdfs:label>
-		<rdfs:comment>the currency Forint</rdfs:comment>
+		<skos:definition>the currency Forint</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>348</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Hungary"/>
@@ -1196,9 +1190,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GBP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GBP</rdfs:label>
-		<rdfs:comment>the currency identifier for Pound Sterling</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>GBP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Pound Sterling</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
+		<lcc-lr:hasTag>GBP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;PoundSterling"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1206,9 +1200,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GEL">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GEL</rdfs:label>
-		<rdfs:comment>the currency identifier for Lari</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>GEL</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Lari</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Lari"/>
+		<lcc-lr:hasTag>GEL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Lari"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1216,9 +1210,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GHS">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GHS</rdfs:label>
-		<rdfs:comment>the currency identifier for Ghana Cedi</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>GHS</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Ghana Cedi</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;GhanaCedi"/>
+		<lcc-lr:hasTag>GHS</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;GhanaCedi"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1226,9 +1220,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GIP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GIP</rdfs:label>
-		<rdfs:comment>the currency identifier for Gibraltar Pound</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>GIP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Gibraltar Pound</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;GibraltarPound"/>
+		<lcc-lr:hasTag>GIP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;GibraltarPound"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1236,9 +1230,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GMD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GMD</rdfs:label>
-		<rdfs:comment>the currency identifier for Dalasi</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>GMD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Dalasi</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Dalasi"/>
+		<lcc-lr:hasTag>GMD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Dalasi"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1246,9 +1240,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GNF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GNF</rdfs:label>
-		<rdfs:comment>the currency identifier for Guinean Franc</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>GNF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Guinean Franc</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;GuineanFranc"/>
+		<lcc-lr:hasTag>GNF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;GuineanFranc"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1256,9 +1250,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GTQ">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GTQ</rdfs:label>
-		<rdfs:comment>the currency identifier for Quetzal</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>GTQ</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Quetzal</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Quetzal"/>
+		<lcc-lr:hasTag>GTQ</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Quetzal"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1266,9 +1260,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GYD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>GYD</rdfs:label>
-		<rdfs:comment>the currency identifier for Guyana Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>GYD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Guyana Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;GuyanaDollar"/>
+		<lcc-lr:hasTag>GYD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;GuyanaDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1276,7 +1270,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GhanaCedi">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Ghana Cedi</rdfs:label>
-		<rdfs:comment>the currency Ghana Cedi</rdfs:comment>
+		<skos:definition>the currency Ghana Cedi</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>936</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Ghana"/>
@@ -1286,7 +1280,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GibraltarPound">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Gibraltar Pound</rdfs:label>
-		<rdfs:comment>the currency Gibraltar Pound</rdfs:comment>
+		<skos:definition>the currency Gibraltar Pound</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>292</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Gibraltar"/>
@@ -1296,7 +1290,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Gold">
 		<rdf:type rdf:resource="&fibo-fnd-pas-pas;PreciousMetal"/>
 		<rdfs:label>Gold</rdfs:label>
-		<rdfs:comment>one troy ounce of the precious metal Gold</rdfs:comment>
+		<skos:definition>one troy ounce of the precious metal Gold</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>959</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>Gold</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -1304,7 +1298,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Gourde">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Gourde</rdfs:label>
-		<rdfs:comment>the currency Gourde</rdfs:comment>
+		<skos:definition>the currency Gourde</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>332</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Haiti"/>
@@ -1314,7 +1308,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Guarani">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Guarani</rdfs:label>
-		<rdfs:comment>the currency Guarani</rdfs:comment>
+		<skos:definition>the currency Guarani</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>600</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Paraguay"/>
@@ -1324,7 +1318,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GuineanFranc">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Guinean Franc</rdfs:label>
-		<rdfs:comment>the currency Guinean Franc</rdfs:comment>
+		<skos:definition>the currency Guinean Franc</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>324</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guinea"/>
@@ -1334,7 +1328,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;GuyanaDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Guyana Dollar</rdfs:label>
-		<rdfs:comment>the currency Guyana Dollar</rdfs:comment>
+		<skos:definition>the currency Guyana Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>328</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guyana"/>
@@ -1344,9 +1338,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;HKD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>HKD</rdfs:label>
-		<rdfs:comment>the currency identifier for Hong Kong Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>HKD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Hong Kong Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
+		<lcc-lr:hasTag>HKD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;HongKongDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1354,9 +1348,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;HNL">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>HNL</rdfs:label>
-		<rdfs:comment>the currency identifier for Lempira</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>HNL</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Lempira</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Lempira"/>
+		<lcc-lr:hasTag>HNL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Lempira"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1364,9 +1358,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;HRK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>HRK</rdfs:label>
-		<rdfs:comment>the currency identifier for Kuna</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>HRK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Kuna</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Kuna"/>
+		<lcc-lr:hasTag>HRK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Kuna"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1374,9 +1368,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;HTG">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>HTG</rdfs:label>
-		<rdfs:comment>the currency identifier for Gourde</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>HTG</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Gourde</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Gourde"/>
+		<lcc-lr:hasTag>HTG</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Gourde"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1384,9 +1378,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;HUF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>HUF</rdfs:label>
-		<rdfs:comment>the currency identifier for Forint</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>HUF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Forint</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Forint"/>
+		<lcc-lr:hasTag>HUF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Forint"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1394,7 +1388,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;HongKongDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Hong Kong Dollar</rdfs:label>
-		<rdfs:comment>the currency Hong Kong Dollar</rdfs:comment>
+		<skos:definition>the currency Hong Kong Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>344</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;HongKong"/>
@@ -1404,7 +1398,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Hryvnia">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Hryvnia</rdfs:label>
-		<rdfs:comment>the currency Hryvnia</rdfs:comment>
+		<skos:definition>the currency Hryvnia</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>980</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Ukraine"/>
@@ -1414,9 +1408,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IDR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>IDR</rdfs:label>
-		<rdfs:comment>the currency identifier for Rupiah</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>IDR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Rupiah</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
+		<lcc-lr:hasTag>IDR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Rupiah"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1424,9 +1418,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ILS">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ILS</rdfs:label>
-		<rdfs:comment>the currency identifier for New Israeli Sheqel</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ILS</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for New Israeli Sheqel</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;NewIsraeliSheqel"/>
+		<lcc-lr:hasTag>ILS</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;NewIsraeliSheqel"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1434,9 +1428,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;INR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>INR</rdfs:label>
-		<rdfs:comment>the currency identifier for Indian Rupee</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>INR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Indian Rupee</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
+		<lcc-lr:hasTag>INR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;IndianRupee"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1444,9 +1438,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IQD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>IQD</rdfs:label>
-		<rdfs:comment>the currency identifier for Iraqi Dinar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>IQD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Iraqi Dinar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;IraqiDinar"/>
+		<lcc-lr:hasTag>IQD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;IraqiDinar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1454,9 +1448,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IRR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>IRR</rdfs:label>
-		<rdfs:comment>the currency identifier for Iranian Rial</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>IRR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Iranian Rial</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;IranianRial"/>
+		<lcc-lr:hasTag>IRR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;IranianRial"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1464,9 +1458,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ISK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ISK</rdfs:label>
-		<rdfs:comment>the currency identifier for Iceland Krona</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ISK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Iceland Krona</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;IcelandKrona"/>
+		<lcc-lr:hasTag>ISK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;IcelandKrona"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1481,7 +1475,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IcelandKrona">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Iceland Krona</rdfs:label>
-		<rdfs:comment>the currency Iceland Krona</rdfs:comment>
+		<skos:definition>the currency Iceland Krona</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>352</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Iceland"/>
@@ -1491,7 +1485,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IndianRupee">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Indian Rupee</rdfs:label>
-		<rdfs:comment>the currency Indian Rupee</rdfs:comment>
+		<skos:definition>the currency Indian Rupee</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>356</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bhutan"/>
@@ -1502,7 +1496,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IranianRial">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Iranian Rial</rdfs:label>
-		<rdfs:comment>the currency Iranian Rial</rdfs:comment>
+		<skos:definition>the currency Iranian Rial</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>364</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Iran"/>
@@ -1512,7 +1506,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;IraqiDinar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Iraqi Dinar</rdfs:label>
-		<rdfs:comment>the currency Iraqi Dinar</rdfs:comment>
+		<skos:definition>the currency Iraqi Dinar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>368</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Iraq"/>
@@ -1522,9 +1516,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;JMD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>JMD</rdfs:label>
-		<rdfs:comment>the currency identifier for Jamaican Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>JMD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Jamaican Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;JamaicanDollar"/>
+		<lcc-lr:hasTag>JMD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;JamaicanDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1532,9 +1526,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;JOD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>JOD</rdfs:label>
-		<rdfs:comment>the currency identifier for Jordanian Dinar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>JOD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Jordanian Dinar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;JordanianDinar"/>
+		<lcc-lr:hasTag>JOD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;JordanianDinar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1542,9 +1536,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;JPY">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>JPY</rdfs:label>
-		<rdfs:comment>the currency identifier for Yen</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>JPY</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Yen</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Yen"/>
+		<lcc-lr:hasTag>JPY</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Yen"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1552,7 +1546,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;JamaicanDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Jamaican Dollar</rdfs:label>
-		<rdfs:comment>the currency Jamaican Dollar</rdfs:comment>
+		<skos:definition>the currency Jamaican Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>388</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Jamaica"/>
@@ -1562,7 +1556,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;JordanianDinar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Jordanian Dinar</rdfs:label>
-		<rdfs:comment>the currency Jordanian Dinar</rdfs:comment>
+		<skos:definition>the currency Jordanian Dinar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>400</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Jordan"/>
@@ -1572,9 +1566,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KES">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KES</rdfs:label>
-		<rdfs:comment>the currency identifier for Kenyan Shilling</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>KES</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Kenyan Shilling</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;KenyanShilling"/>
+		<lcc-lr:hasTag>KES</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;KenyanShilling"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1582,9 +1576,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KGS">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KGS</rdfs:label>
-		<rdfs:comment>the currency identifier for Som</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>KGS</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Som</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Som"/>
+		<lcc-lr:hasTag>KGS</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Som"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1592,9 +1586,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KHR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KHR</rdfs:label>
-		<rdfs:comment>the currency identifier for Riel</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>KHR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Riel</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Riel"/>
+		<lcc-lr:hasTag>KHR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Riel"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1602,9 +1596,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KMF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KMF</rdfs:label>
-		<rdfs:comment>the currency identifier for Comorian Franc</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>KMF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Comorian Franc</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ComorianFranc"/>
+		<lcc-lr:hasTag>KMF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ComorianFranc"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1612,9 +1606,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KPW">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KPW</rdfs:label>
-		<rdfs:comment>the currency identifier for North Korean Won</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>KPW</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for North Korean Won</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;NorthKoreanWon"/>
+		<lcc-lr:hasTag>KPW</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;NorthKoreanWon"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1622,9 +1616,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KRW">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KRW</rdfs:label>
-		<rdfs:comment>the currency identifier for Won</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>KRW</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Won</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Won"/>
+		<lcc-lr:hasTag>KRW</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Won"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1632,9 +1626,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KWD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KWD</rdfs:label>
-		<rdfs:comment>the currency identifier for Kuwaiti Dinar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>KWD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Kuwaiti Dinar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;KuwaitiDinar"/>
+		<lcc-lr:hasTag>KWD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;KuwaitiDinar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1642,9 +1636,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KYD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KYD</rdfs:label>
-		<rdfs:comment>the currency identifier for Cayman Islands Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>KYD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Cayman Islands Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CaymanIslandsDollar"/>
+		<lcc-lr:hasTag>KYD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CaymanIslandsDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1652,9 +1646,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KZT">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>KZT</rdfs:label>
-		<rdfs:comment>the currency identifier for Tenge</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>KZT</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Tenge</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Tenge"/>
+		<lcc-lr:hasTag>KZT</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Tenge"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1662,7 +1656,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KenyanShilling">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Kenyan Shilling</rdfs:label>
-		<rdfs:comment>the currency Kenyan Shilling</rdfs:comment>
+		<skos:definition>the currency Kenyan Shilling</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>404</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Kenya"/>
@@ -1672,7 +1666,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Kina">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Kina</rdfs:label>
-		<rdfs:comment>the currency Kina</rdfs:comment>
+		<skos:definition>the currency Kina</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>598</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;PapuaNewGuinea"/>
@@ -1682,7 +1676,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Kuna">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Kuna</rdfs:label>
-		<rdfs:comment>the currency Kuna</rdfs:comment>
+		<skos:definition>the currency Kuna</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>191</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Croatia"/>
@@ -1692,7 +1686,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;KuwaitiDinar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Kuwaiti Dinar</rdfs:label>
-		<rdfs:comment>the currency Kuwaiti Dinar</rdfs:comment>
+		<skos:definition>the currency Kuwaiti Dinar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>414</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Kuwait"/>
@@ -1702,7 +1696,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Kwanza">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Kwanza</rdfs:label>
-		<rdfs:comment>the currency Kwanza</rdfs:comment>
+		<skos:definition>the currency Kwanza</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>973</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Angola"/>
@@ -1712,7 +1706,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Kyat">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Kyat</rdfs:label>
-		<rdfs:comment>the currency Kyat</rdfs:comment>
+		<skos:definition>the currency Kyat</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>104</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Myanmar"/>
@@ -1722,9 +1716,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LAK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LAK</rdfs:label>
-		<rdfs:comment>the currency identifier for Lao Kip</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>LAK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Lao Kip</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;LaoKip"/>
+		<lcc-lr:hasTag>LAK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;LaoKip"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1732,9 +1726,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LBP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LBP</rdfs:label>
-		<rdfs:comment>the currency identifier for Lebanese Pound</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>LBP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Lebanese Pound</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;LebanesePound"/>
+		<lcc-lr:hasTag>LBP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;LebanesePound"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1742,9 +1736,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LKR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LKR</rdfs:label>
-		<rdfs:comment>the currency identifier for Sri Lanka Rupee</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>LKR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Sri Lanka Rupee</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SriLankaRupee"/>
+		<lcc-lr:hasTag>LKR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SriLankaRupee"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1752,9 +1746,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LRD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LRD</rdfs:label>
-		<rdfs:comment>the currency identifier for Liberian Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>LRD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Liberian Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;LiberianDollar"/>
+		<lcc-lr:hasTag>LRD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;LiberianDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1762,9 +1756,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LSL">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LSL</rdfs:label>
-		<rdfs:comment>the currency identifier for Loti</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>LSL</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Loti</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Loti"/>
+		<lcc-lr:hasTag>LSL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Loti"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1772,9 +1766,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LYD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>LYD</rdfs:label>
-		<rdfs:comment>the currency identifier for Libyan Dinar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>LYD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Libyan Dinar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;LibyanDinar"/>
+		<lcc-lr:hasTag>LYD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;LibyanDinar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1782,7 +1776,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LaoKip">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Lao Kip</rdfs:label>
-		<rdfs:comment>the currency Lao Kip</rdfs:comment>
+		<skos:definition>the currency Lao Kip</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>418</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;LaoPeoplesDemocraticRepublic"/>
@@ -1792,7 +1786,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Lari">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Lari</rdfs:label>
-		<rdfs:comment>the currency Lari</rdfs:comment>
+		<skos:definition>the currency Lari</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>981</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Georgia"/>
@@ -1802,7 +1796,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LebanesePound">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Lebanese Pound</rdfs:label>
-		<rdfs:comment>the currency Lebanese Pound</rdfs:comment>
+		<skos:definition>the currency Lebanese Pound</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>422</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Lebanon"/>
@@ -1812,7 +1806,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Lek">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Lek</rdfs:label>
-		<rdfs:comment>the currency Lek</rdfs:comment>
+		<skos:definition>the currency Lek</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>008</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Albania"/>
@@ -1822,7 +1816,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Lempira">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Lempira</rdfs:label>
-		<rdfs:comment>the currency Lempira</rdfs:comment>
+		<skos:definition>the currency Lempira</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>340</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Honduras"/>
@@ -1832,7 +1826,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Leone">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Leone</rdfs:label>
-		<rdfs:comment>the currency Leone</rdfs:comment>
+		<skos:definition>the currency Leone</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>694</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SierraLeone"/>
@@ -1842,7 +1836,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LiberianDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Liberian Dollar</rdfs:label>
-		<rdfs:comment>the currency Liberian Dollar</rdfs:comment>
+		<skos:definition>the currency Liberian Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>430</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Liberia"/>
@@ -1852,7 +1846,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;LibyanDinar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Libyan Dinar</rdfs:label>
-		<rdfs:comment>the currency Libyan Dinar</rdfs:comment>
+		<skos:definition>the currency Libyan Dinar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>434</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Libya"/>
@@ -1862,7 +1856,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Lilangeni">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Lilangeni</rdfs:label>
-		<rdfs:comment>the currency Lilangeni</rdfs:comment>
+		<skos:definition>the currency Lilangeni</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>748</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Eswatini"/>
@@ -1872,7 +1866,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Loti">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Loti</rdfs:label>
-		<rdfs:comment>the currency Loti</rdfs:comment>
+		<skos:definition>the currency Loti</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>426</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Lesotho"/>
@@ -1882,9 +1876,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MAD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MAD</rdfs:label>
-		<rdfs:comment>the currency identifier for Moroccan Dirham</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MAD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Moroccan Dirham</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;MoroccanDirham"/>
+		<lcc-lr:hasTag>MAD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;MoroccanDirham"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1892,9 +1886,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MDL">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MDL</rdfs:label>
-		<rdfs:comment>the currency identifier for Moldovan Leu</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MDL</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Moldovan Leu</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;MoldovanLeu"/>
+		<lcc-lr:hasTag>MDL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;MoldovanLeu"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1902,9 +1896,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MGA">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MGA</rdfs:label>
-		<rdfs:comment>the currency identifier for Malagasy Ariary</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MGA</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Malagasy Ariary</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;MalagasyAriary"/>
+		<lcc-lr:hasTag>MGA</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;MalagasyAriary"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1912,9 +1906,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MKD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MKD</rdfs:label>
-		<rdfs:comment>the currency identifier for Denar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MKD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Denar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Denar"/>
+		<lcc-lr:hasTag>MKD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Denar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1922,9 +1916,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MMK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MMK</rdfs:label>
-		<rdfs:comment>the currency identifier for Kyat</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MMK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Kyat</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Kyat"/>
+		<lcc-lr:hasTag>MMK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Kyat"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1932,9 +1926,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MNT">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MNT</rdfs:label>
-		<rdfs:comment>the currency identifier for Tugrik</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MNT</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Tugrik</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Tugrik"/>
+		<lcc-lr:hasTag>MNT</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Tugrik"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1942,9 +1936,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MOP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MOP</rdfs:label>
-		<rdfs:comment>the currency identifier for Pataca</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MOP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Pataca</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Pataca"/>
+		<lcc-lr:hasTag>MOP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Pataca"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1952,9 +1946,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MRU">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MRU</rdfs:label>
-		<rdfs:comment>the currency identifier for Ouguiya</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MRU</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Ouguiya</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Ouguiya"/>
+		<lcc-lr:hasTag>MRU</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Ouguiya"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1962,9 +1956,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MUR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MUR</rdfs:label>
-		<rdfs:comment>the currency identifier for Mauritius Rupee</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MUR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Mauritius Rupee</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;MauritiusRupee"/>
+		<lcc-lr:hasTag>MUR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;MauritiusRupee"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1972,9 +1966,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MVR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MVR</rdfs:label>
-		<rdfs:comment>the currency identifier for Rufiyaa</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MVR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Rufiyaa</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Rufiyaa"/>
+		<lcc-lr:hasTag>MVR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Rufiyaa"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1982,9 +1976,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MWK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MWK</rdfs:label>
-		<rdfs:comment>the currency identifier for Malawi Kwacha</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MWK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Malawi Kwacha</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;MalawiKwacha"/>
+		<lcc-lr:hasTag>MWK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;MalawiKwacha"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -1992,9 +1986,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MXN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MXN</rdfs:label>
-		<rdfs:comment>the currency identifier for Mexican Peso</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MXN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Mexican Peso</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
+		<lcc-lr:hasTag>MXN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2002,9 +1996,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MXV">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>MXV</rdfs:label>
-		<rdfs:comment>the funds identifier for Mexican Unidad de Inversion (UDI)</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MXV</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the funds identifier for Mexican Unidad de Inversion (UDI)</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;MexicanUnidaddeInversion_UDI"/>
+		<lcc-lr:hasTag>MXV</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;MexicanUnidaddeInversion_UDI"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2012,9 +2006,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MYR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MYR</rdfs:label>
-		<rdfs:comment>the currency identifier for Malaysian Ringgit</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MYR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Malaysian Ringgit</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
+		<lcc-lr:hasTag>MYR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;MalaysianRinggit"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2022,9 +2016,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MZN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>MZN</rdfs:label>
-		<rdfs:comment>the currency identifier for Mozambique Metical</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>MZN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Mozambique Metical</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;MozambiqueMetical"/>
+		<lcc-lr:hasTag>MZN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;MozambiqueMetical"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2032,7 +2026,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MalagasyAriary">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Malagasy Ariary</rdfs:label>
-		<rdfs:comment>the currency Malagasy Ariary</rdfs:comment>
+		<skos:definition>the currency Malagasy Ariary</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>969</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Madagascar"/>
@@ -2042,7 +2036,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MalawiKwacha">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Malawi Kwacha</rdfs:label>
-		<rdfs:comment>the currency Malawi Kwacha</rdfs:comment>
+		<skos:definition>the currency Malawi Kwacha</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>454</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Malawi"/>
@@ -2052,7 +2046,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MalaysianRinggit">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Malaysian Ringgit</rdfs:label>
-		<rdfs:comment>the currency Malaysian Ringgit</rdfs:comment>
+		<skos:definition>the currency Malaysian Ringgit</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>458</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Malaysia"/>
@@ -2062,7 +2056,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MauritiusRupee">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Mauritius Rupee</rdfs:label>
-		<rdfs:comment>the currency Mauritius Rupee</rdfs:comment>
+		<skos:definition>the currency Mauritius Rupee</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>480</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mauritius"/>
@@ -2072,7 +2066,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MexicanPeso">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Mexican Peso</rdfs:label>
-		<rdfs:comment>the currency Mexican Peso</rdfs:comment>
+		<skos:definition>the currency Mexican Peso</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>484</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mexico"/>
@@ -2082,7 +2076,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MexicanUnidaddeInversion_UDI">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
 		<rdfs:label>Mexican Unidad de Inversion (UDI)</rdfs:label>
-		<rdfs:comment>the funds Mexican Unidad de Inversion (UDI)</rdfs:comment>
+		<skos:definition>the funds Mexican Unidad de Inversion (UDI)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;MexicanPeso"/>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>979</fibo-fnd-acc-cur:hasNumericCode>
@@ -2094,7 +2088,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MoldovanLeu">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Moldovan Leu</rdfs:label>
-		<rdfs:comment>the currency Moldovan Leu</rdfs:comment>
+		<skos:definition>the currency Moldovan Leu</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>498</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Moldova"/>
@@ -2104,7 +2098,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MoroccanDirham">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Moroccan Dirham</rdfs:label>
-		<rdfs:comment>the currency Moroccan Dirham</rdfs:comment>
+		<skos:definition>the currency Moroccan Dirham</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>504</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Morocco"/>
@@ -2115,7 +2109,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;MozambiqueMetical">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Mozambique Metical</rdfs:label>
-		<rdfs:comment>the currency Mozambique Metical</rdfs:comment>
+		<skos:definition>the currency Mozambique Metical</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>943</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mozambique"/>
@@ -2125,7 +2119,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Mvdol">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
 		<rdfs:label>Mvdol</rdfs:label>
-		<rdfs:comment>the funds Mvdol</rdfs:comment>
+		<skos:definition>the funds Mvdol</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;Boliviano"/>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>984</fibo-fnd-acc-cur:hasNumericCode>
@@ -2137,9 +2131,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NAD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NAD</rdfs:label>
-		<rdfs:comment>the currency identifier for Namibia Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>NAD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Namibia Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;NamibiaDollar"/>
+		<lcc-lr:hasTag>NAD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;NamibiaDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2147,9 +2141,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NGN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NGN</rdfs:label>
-		<rdfs:comment>the currency identifier for Naira</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>NGN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Naira</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Naira"/>
+		<lcc-lr:hasTag>NGN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Naira"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2157,9 +2151,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NIO">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NIO</rdfs:label>
-		<rdfs:comment>the currency identifier for Cordoba Oro</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>NIO</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Cordoba Oro</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CordobaOro"/>
+		<lcc-lr:hasTag>NIO</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CordobaOro"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2167,9 +2161,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NOK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NOK</rdfs:label>
-		<rdfs:comment>the currency identifier for Norwegian Krone</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>NOK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Norwegian Krone</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
+		<lcc-lr:hasTag>NOK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;NorwegianKrone"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2177,9 +2171,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NPR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NPR</rdfs:label>
-		<rdfs:comment>the currency identifier for Nepalese Rupee</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>NPR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Nepalese Rupee</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;NepaleseRupee"/>
+		<lcc-lr:hasTag>NPR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;NepaleseRupee"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2187,9 +2181,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NZD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>NZD</rdfs:label>
-		<rdfs:comment>the currency identifier for New Zealand Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>NZD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for New Zealand Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
+		<lcc-lr:hasTag>NZD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;NewZealandDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2197,7 +2191,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Naira">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Naira</rdfs:label>
-		<rdfs:comment>the currency Naira</rdfs:comment>
+		<skos:definition>the currency Naira</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>566</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Nigeria"/>
@@ -2207,7 +2201,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Nakfa">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Nakfa</rdfs:label>
-		<rdfs:comment>the currency Nakfa</rdfs:comment>
+		<skos:definition>the currency Nakfa</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>232</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Eritrea"/>
@@ -2217,7 +2211,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NamibiaDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Namibia Dollar</rdfs:label>
-		<rdfs:comment>the currency Namibia Dollar</rdfs:comment>
+		<skos:definition>the currency Namibia Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>516</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Namibia"/>
@@ -2227,7 +2221,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NepaleseRupee">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Nepalese Rupee</rdfs:label>
-		<rdfs:comment>the currency Nepalese Rupee</rdfs:comment>
+		<skos:definition>the currency Nepalese Rupee</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>524</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Nepal"/>
@@ -2237,7 +2231,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NetherlandsAntilleanGuilder">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Netherlands Antillean Guilder</rdfs:label>
-		<rdfs:comment>the currency Netherlands Antillean Guilder</rdfs:comment>
+		<skos:definition>the currency Netherlands Antillean Guilder</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>532</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Curacao"/>
@@ -2248,7 +2242,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NewIsraeliSheqel">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>New Israeli Sheqel</rdfs:label>
-		<rdfs:comment>the currency New Israeli Sheqel</rdfs:comment>
+		<skos:definition>the currency New Israeli Sheqel</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>376</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Israel"/>
@@ -2258,7 +2252,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NewTaiwanDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>New Taiwan Dollar</rdfs:label>
-		<rdfs:comment>the currency New Taiwan Dollar</rdfs:comment>
+		<skos:definition>the currency New Taiwan Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>901</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Taiwan"/>
@@ -2268,7 +2262,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NewZealandDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>New Zealand Dollar</rdfs:label>
-		<rdfs:comment>the currency New Zealand Dollar</rdfs:comment>
+		<skos:definition>the currency New Zealand Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>554</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;CookIslands"/>
@@ -2282,7 +2276,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Ngultrum">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Ngultrum</rdfs:label>
-		<rdfs:comment>the currency Ngultrum</rdfs:comment>
+		<skos:definition>the currency Ngultrum</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>064</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bhutan"/>
@@ -2292,7 +2286,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NorthKoreanWon">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>North Korean Won</rdfs:label>
-		<rdfs:comment>the currency North Korean Won</rdfs:comment>
+		<skos:definition>the currency North Korean Won</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>408</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;KoreaDemocraticPeoplesRepublicOf"/>
@@ -2302,7 +2296,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;NorwegianKrone">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Norwegian Krone</rdfs:label>
-		<rdfs:comment>the currency Norwegian Krone</rdfs:comment>
+		<skos:definition>the currency Norwegian Krone</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>578</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;BouvetIsland"/>
@@ -2314,9 +2308,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;OMR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>OMR</rdfs:label>
-		<rdfs:comment>the currency identifier for Rial Omani</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>OMR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Rial Omani</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;RialOmani"/>
+		<lcc-lr:hasTag>OMR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;RialOmani"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2324,7 +2318,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Ouguiya">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Ouguiya</rdfs:label>
-		<rdfs:comment>the currency Ouguiya</rdfs:comment>
+		<skos:definition>the currency Ouguiya</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>929</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mauritania"/>
@@ -2334,9 +2328,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PAB">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PAB</rdfs:label>
-		<rdfs:comment>the currency identifier for Balboa</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>PAB</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Balboa</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Balboa"/>
+		<lcc-lr:hasTag>PAB</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Balboa"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2344,9 +2338,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PEN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PEN</rdfs:label>
-		<rdfs:comment>the currency identifier for Sol</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>PEN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Sol</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Sol"/>
+		<lcc-lr:hasTag>PEN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Sol"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2354,9 +2348,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PGK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PGK</rdfs:label>
-		<rdfs:comment>the currency identifier for Kina</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>PGK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Kina</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Kina"/>
+		<lcc-lr:hasTag>PGK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Kina"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2364,9 +2358,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PHP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PHP</rdfs:label>
-		<rdfs:comment>the currency identifier for Philippine Peso</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>PHP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Philippine Peso</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
+		<lcc-lr:hasTag>PHP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;PhilippinePeso"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2374,9 +2368,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PKR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PKR</rdfs:label>
-		<rdfs:comment>the currency identifier for Pakistan Rupee</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>PKR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Pakistan Rupee</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;PakistanRupee"/>
+		<lcc-lr:hasTag>PKR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;PakistanRupee"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2384,9 +2378,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PLN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PLN</rdfs:label>
-		<rdfs:comment>the currency identifier for Zloty</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>PLN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Zloty</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
+		<lcc-lr:hasTag>PLN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Zloty"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2394,9 +2388,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PYG">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>PYG</rdfs:label>
-		<rdfs:comment>the currency identifier for Guarani</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>PYG</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Guarani</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Guarani"/>
+		<lcc-lr:hasTag>PYG</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Guarani"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2404,7 +2398,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Paanga">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Pa&apos;anga</rdfs:label>
-		<rdfs:comment>the currency Pa&apos;anga</rdfs:comment>
+		<skos:definition>the currency Pa&apos;anga</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>776</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tonga"/>
@@ -2414,7 +2408,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PakistanRupee">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Pakistan Rupee</rdfs:label>
-		<rdfs:comment>the currency Pakistan Rupee</rdfs:comment>
+		<skos:definition>the currency Pakistan Rupee</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>586</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Pakistan"/>
@@ -2424,7 +2418,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Palladium">
 		<rdf:type rdf:resource="&fibo-fnd-pas-pas;PreciousMetal"/>
 		<rdfs:label>Palladium</rdfs:label>
-		<rdfs:comment>one troy ounce of the precious metal Palladium</rdfs:comment>
+		<skos:definition>one troy ounce of the precious metal Palladium</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>964</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>Palladium</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -2432,7 +2426,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Pataca">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Pataca</rdfs:label>
-		<rdfs:comment>the currency Pataca</rdfs:comment>
+		<skos:definition>the currency Pataca</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>446</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Macao"/>
@@ -2442,7 +2436,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PesoConvertible">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Peso Convertible</rdfs:label>
-		<rdfs:comment>the currency Peso Convertible</rdfs:comment>
+		<skos:definition>the currency Peso Convertible</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>931</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Cuba"/>
@@ -2452,7 +2446,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PesoUruguayo">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Peso Uruguayo</rdfs:label>
-		<rdfs:comment>the currency Peso Uruguayo</rdfs:comment>
+		<skos:definition>the currency Peso Uruguayo</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>858</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uruguay"/>
@@ -2462,7 +2456,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PhilippinePeso">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Philippine Peso</rdfs:label>
-		<rdfs:comment>the currency Philippine Peso</rdfs:comment>
+		<skos:definition>the currency Philippine Peso</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>608</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Philippines"/>
@@ -2472,7 +2466,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Platinum">
 		<rdf:type rdf:resource="&fibo-fnd-pas-pas;PreciousMetal"/>
 		<rdfs:label>Platinum</rdfs:label>
-		<rdfs:comment>one troy ounce of the precious metal Platinum</rdfs:comment>
+		<skos:definition>one troy ounce of the precious metal Platinum</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>962</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>Platinum</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -2480,7 +2474,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;PoundSterling">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Pound Sterling</rdfs:label>
-		<rdfs:comment>the currency Pound Sterling</rdfs:comment>
+		<skos:definition>the currency Pound Sterling</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>826</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guernsey"/>
@@ -2493,7 +2487,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Pula">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Pula</rdfs:label>
-		<rdfs:comment>the currency Pula</rdfs:comment>
+		<skos:definition>the currency Pula</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>072</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Botswana"/>
@@ -2503,9 +2497,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;QAR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>QAR</rdfs:label>
-		<rdfs:comment>the currency identifier for Qatari Rial</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>QAR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Qatari Rial</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;QatariRial"/>
+		<lcc-lr:hasTag>QAR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;QatariRial"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2513,7 +2507,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;QatariRial">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Qatari Rial</rdfs:label>
-		<rdfs:comment>the currency Qatari Rial</rdfs:comment>
+		<skos:definition>the currency Qatari Rial</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>634</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Qatar"/>
@@ -2523,7 +2517,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Quetzal">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Quetzal</rdfs:label>
-		<rdfs:comment>the currency Quetzal</rdfs:comment>
+		<skos:definition>the currency Quetzal</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>320</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Guatemala"/>
@@ -2533,9 +2527,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RON">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>RON</rdfs:label>
-		<rdfs:comment>the currency identifier for Romanian Leu</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>RON</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Romanian Leu</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
+		<lcc-lr:hasTag>RON</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;RomanianLeu"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2543,9 +2537,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RSD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>RSD</rdfs:label>
-		<rdfs:comment>the currency identifier for Serbian Dinar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>RSD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Serbian Dinar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SerbianDinar"/>
+		<lcc-lr:hasTag>RSD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SerbianDinar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2553,9 +2547,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RUB">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>RUB</rdfs:label>
-		<rdfs:comment>the currency identifier for Russian Ruble</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>RUB</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Russian Ruble</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
+		<lcc-lr:hasTag>RUB</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;RussianRuble"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2563,9 +2557,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RWF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>RWF</rdfs:label>
-		<rdfs:comment>the currency identifier for Rwanda Franc</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>RWF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Rwanda Franc</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;RwandaFranc"/>
+		<lcc-lr:hasTag>RWF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;RwandaFranc"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2573,7 +2567,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Rand">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Rand</rdfs:label>
-		<rdfs:comment>the currency Rand</rdfs:comment>
+		<skos:definition>the currency Rand</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>710</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Lesotho"/>
@@ -2585,7 +2579,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RialOmani">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Rial Omani</rdfs:label>
-		<rdfs:comment>the currency Rial Omani</rdfs:comment>
+		<skos:definition>the currency Rial Omani</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>512</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Oman"/>
@@ -2595,7 +2589,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Riel">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Riel</rdfs:label>
-		<rdfs:comment>the currency Riel</rdfs:comment>
+		<skos:definition>the currency Riel</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>116</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Cambodia"/>
@@ -2605,7 +2599,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RomanianLeu">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Romanian Leu</rdfs:label>
-		<rdfs:comment>the currency Romanian Leu</rdfs:comment>
+		<skos:definition>the currency Romanian Leu</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>946</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Romania"/>
@@ -2615,7 +2609,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Rufiyaa">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Rufiyaa</rdfs:label>
-		<rdfs:comment>the currency Rufiyaa</rdfs:comment>
+		<skos:definition>the currency Rufiyaa</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>462</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Maldives"/>
@@ -2625,7 +2619,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Rupiah">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Rupiah</rdfs:label>
-		<rdfs:comment>the currency Rupiah</rdfs:comment>
+		<skos:definition>the currency Rupiah</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>360</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Indonesia"/>
@@ -2635,7 +2629,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RussianRuble">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Russian Ruble</rdfs:label>
-		<rdfs:comment>the currency Russian Ruble</rdfs:comment>
+		<skos:definition>the currency Russian Ruble</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>643</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;RussianFederation"/>
@@ -2645,7 +2639,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;RwandaFranc">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Rwanda Franc</rdfs:label>
-		<rdfs:comment>the currency Rwanda Franc</rdfs:comment>
+		<skos:definition>the currency Rwanda Franc</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>646</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Rwanda"/>
@@ -2655,9 +2649,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SAR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SAR</rdfs:label>
-		<rdfs:comment>the currency identifier for Saudi Riyal</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SAR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Saudi Riyal</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SaudiRiyal"/>
+		<lcc-lr:hasTag>SAR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SaudiRiyal"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2665,9 +2659,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SBD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SBD</rdfs:label>
-		<rdfs:comment>the currency identifier for Solomon Islands Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SBD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Solomon Islands Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SolomonIslandsDollar"/>
+		<lcc-lr:hasTag>SBD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SolomonIslandsDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2675,9 +2669,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SCR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SCR</rdfs:label>
-		<rdfs:comment>the currency identifier for Seychelles Rupee</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SCR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Seychelles Rupee</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SeychellesRupee"/>
+		<lcc-lr:hasTag>SCR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SeychellesRupee"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2685,9 +2679,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SDG">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SDG</rdfs:label>
-		<rdfs:comment>the currency identifier for Sudanese Pound</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SDG</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Sudanese Pound</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SudanesePound"/>
+		<lcc-lr:hasTag>SDG</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SudanesePound"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2695,7 +2689,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SDR_SpecialDrawingRight">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccount"/>
 		<rdfs:label>SDR (Special Drawing Right)</rdfs:label>
-		<rdfs:comment>the IMF&apos;s SDR (Special Drawing Right)</rdfs:comment>
+		<skos:definition>the IMF&apos;s SDR (Special Drawing Right)</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>960</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>SDR (Special Drawing Right)</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -2703,9 +2697,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SEK">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SEK</rdfs:label>
-		<rdfs:comment>the currency identifier for Swedish Krona</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SEK</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Swedish Krona</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
+		<lcc-lr:hasTag>SEK</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SwedishKrona"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2713,9 +2707,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SGD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SGD</rdfs:label>
-		<rdfs:comment>the currency identifier for Singapore Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SGD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Singapore Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
+		<lcc-lr:hasTag>SGD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SingaporeDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2723,9 +2717,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SHP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SHP</rdfs:label>
-		<rdfs:comment>the currency identifier for Saint Helena Pound</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SHP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Saint Helena Pound</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SaintHelenaPound"/>
+		<lcc-lr:hasTag>SHP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SaintHelenaPound"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2733,9 +2727,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SLL">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SLL</rdfs:label>
-		<rdfs:comment>the currency identifier for Leone</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SLL</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Leone</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Leone"/>
+		<lcc-lr:hasTag>SLL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Leone"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2743,9 +2737,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SOS">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SOS</rdfs:label>
-		<rdfs:comment>the currency identifier for Somali Shilling</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SOS</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Somali Shilling</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SomaliShilling"/>
+		<lcc-lr:hasTag>SOS</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SomaliShilling"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2753,9 +2747,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SRD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SRD</rdfs:label>
-		<rdfs:comment>the currency identifier for Surinam Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SRD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Surinam Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SurinamDollar"/>
+		<lcc-lr:hasTag>SRD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SurinamDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2763,9 +2757,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SSP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SSP</rdfs:label>
-		<rdfs:comment>the currency identifier for South Sudanese Pound</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SSP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for South Sudanese Pound</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SouthSudanesePound"/>
+		<lcc-lr:hasTag>SSP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SouthSudanesePound"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2773,9 +2767,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;STN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>STN</rdfs:label>
-		<rdfs:comment>the currency identifier for Dobra</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>STN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Dobra</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Dobra"/>
+		<lcc-lr:hasTag>STN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Dobra"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2783,9 +2777,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SVC">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SVC</rdfs:label>
-		<rdfs:comment>the currency identifier for El Salvador Colon</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SVC</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for El Salvador Colon</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ElSalvadorColon"/>
+		<lcc-lr:hasTag>SVC</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ElSalvadorColon"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2793,9 +2787,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SYP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SYP</rdfs:label>
-		<rdfs:comment>the currency identifier for Syrian Pound</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SYP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Syrian Pound</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SyrianPound"/>
+		<lcc-lr:hasTag>SYP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SyrianPound"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2803,9 +2797,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SZL">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>SZL</rdfs:label>
-		<rdfs:comment>the currency identifier for Lilangeni</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>SZL</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Lilangeni</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Lilangeni"/>
+		<lcc-lr:hasTag>SZL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Lilangeni"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -2813,7 +2807,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SaintHelenaPound">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Saint Helena Pound</rdfs:label>
-		<rdfs:comment>the currency Saint Helena Pound</rdfs:comment>
+		<skos:definition>the currency Saint Helena Pound</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>654</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaintHelena"/>
@@ -2823,7 +2817,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SaudiRiyal">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Saudi Riyal</rdfs:label>
-		<rdfs:comment>the currency Saudi Riyal</rdfs:comment>
+		<skos:definition>the currency Saudi Riyal</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>682</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SaudiArabia"/>
@@ -2833,7 +2827,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SerbianDinar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Serbian Dinar</rdfs:label>
-		<rdfs:comment>the currency Serbian Dinar</rdfs:comment>
+		<skos:definition>the currency Serbian Dinar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>941</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Serbia"/>
@@ -2843,7 +2837,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SeychellesRupee">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Seychelles Rupee</rdfs:label>
-		<rdfs:comment>the currency Seychelles Rupee</rdfs:comment>
+		<skos:definition>the currency Seychelles Rupee</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>690</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Seychelles"/>
@@ -2853,7 +2847,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Silver">
 		<rdf:type rdf:resource="&fibo-fnd-pas-pas;PreciousMetal"/>
 		<rdfs:label>Silver</rdfs:label>
-		<rdfs:comment>one troy ounce of the precious metal Silver</rdfs:comment>
+		<skos:definition>one troy ounce of the precious metal Silver</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>961</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>Silver</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -2861,7 +2855,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SingaporeDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Singapore Dollar</rdfs:label>
-		<rdfs:comment>the currency Singapore Dollar</rdfs:comment>
+		<skos:definition>the currency Singapore Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>702</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Singapore"/>
@@ -2871,7 +2865,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Sol">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Sol</rdfs:label>
-		<rdfs:comment>the currency Sol</rdfs:comment>
+		<skos:definition>the currency Sol</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>604</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Peru"/>
@@ -2881,7 +2875,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SolomonIslandsDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Solomon Islands Dollar</rdfs:label>
-		<rdfs:comment>the currency Solomon Islands Dollar</rdfs:comment>
+		<skos:definition>the currency Solomon Islands Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>090</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SolomonIslands"/>
@@ -2891,7 +2885,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Som">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Som</rdfs:label>
-		<rdfs:comment>the currency Som</rdfs:comment>
+		<skos:definition>the currency Som</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>417</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Kyrgyzstan"/>
@@ -2901,7 +2895,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SomaliShilling">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Somali Shilling</rdfs:label>
-		<rdfs:comment>the currency Somali Shilling</rdfs:comment>
+		<skos:definition>the currency Somali Shilling</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>706</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Somalia"/>
@@ -2911,7 +2905,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Somoni">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Somoni</rdfs:label>
-		<rdfs:comment>the currency Somoni</rdfs:comment>
+		<skos:definition>the currency Somoni</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>972</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tajikistan"/>
@@ -2921,7 +2915,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SouthSudanesePound">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>South Sudanese Pound</rdfs:label>
-		<rdfs:comment>the currency South Sudanese Pound</rdfs:comment>
+		<skos:definition>the currency South Sudanese Pound</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>728</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SouthSudan"/>
@@ -2931,7 +2925,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SriLankaRupee">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Sri Lanka Rupee</rdfs:label>
-		<rdfs:comment>the currency Sri Lanka Rupee</rdfs:comment>
+		<skos:definition>the currency Sri Lanka Rupee</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>144</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SriLanka"/>
@@ -2941,7 +2935,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Sucre">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Sucre</rdfs:label>
-		<rdfs:comment>the currency Sucre</rdfs:comment>
+		<skos:definition>the currency Sucre</skos:definition>
 		<fibo-fnd-acc-cur:hasNumericCode>994</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-lr:hasName>Sucre</lcc-lr:hasName>
 	</owl:NamedIndividual>
@@ -2949,7 +2943,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SudanesePound">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Sudanese Pound</rdfs:label>
-		<rdfs:comment>the currency Sudanese Pound</rdfs:comment>
+		<skos:definition>the currency Sudanese Pound</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>938</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Sudan"/>
@@ -2959,7 +2953,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SurinamDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Surinam Dollar</rdfs:label>
-		<rdfs:comment>the currency Surinam Dollar</rdfs:comment>
+		<skos:definition>the currency Surinam Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>968</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Suriname"/>
@@ -2969,7 +2963,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SwedishKrona">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Swedish Krona</rdfs:label>
-		<rdfs:comment>the currency Swedish Krona</rdfs:comment>
+		<skos:definition>the currency Swedish Krona</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>752</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Sweden"/>
@@ -2979,7 +2973,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SwissFranc">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Swiss Franc</rdfs:label>
-		<rdfs:comment>the currency Swiss Franc</rdfs:comment>
+		<skos:definition>the currency Swiss Franc</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>756</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Liechtenstein"/>
@@ -2990,7 +2984,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;SyrianPound">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Syrian Pound</rdfs:label>
-		<rdfs:comment>the currency Syrian Pound</rdfs:comment>
+		<skos:definition>the currency Syrian Pound</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>760</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;SyrianArabRepublic"/>
@@ -3000,9 +2994,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;THB">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>THB</rdfs:label>
-		<rdfs:comment>the currency identifier for Baht</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>THB</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Baht</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Baht"/>
+		<lcc-lr:hasTag>THB</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Baht"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3010,9 +3004,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TJS">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TJS</rdfs:label>
-		<rdfs:comment>the currency identifier for Somoni</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>TJS</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Somoni</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Somoni"/>
+		<lcc-lr:hasTag>TJS</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Somoni"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3020,9 +3014,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TMT">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TMT</rdfs:label>
-		<rdfs:comment>the currency identifier for Turkmenistan New Manat</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>TMT</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Turkmenistan New Manat</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;TurkmenistanNewManat"/>
+		<lcc-lr:hasTag>TMT</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;TurkmenistanNewManat"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3030,9 +3024,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TND">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TND</rdfs:label>
-		<rdfs:comment>the currency identifier for Tunisian Dinar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>TND</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Tunisian Dinar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;TunisianDinar"/>
+		<lcc-lr:hasTag>TND</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;TunisianDinar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3040,9 +3034,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TOP">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TOP</rdfs:label>
-		<rdfs:comment>the currency identifier for Pa&apos;anga</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>TOP</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Pa&apos;anga</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Paanga"/>
+		<lcc-lr:hasTag>TOP</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Paanga"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3050,9 +3044,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TRY">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TRY</rdfs:label>
-		<rdfs:comment>the currency identifier for Turkish Lira</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>TRY</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Turkish Lira</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
+		<lcc-lr:hasTag>TRY</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;TurkishLira"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3060,9 +3054,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TTD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TTD</rdfs:label>
-		<rdfs:comment>the currency identifier for Trinidad and Tobago Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>TTD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Trinidad and Tobago Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;TrinidadandTobagoDollar"/>
+		<lcc-lr:hasTag>TTD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;TrinidadandTobagoDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3070,9 +3064,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TWD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TWD</rdfs:label>
-		<rdfs:comment>the currency identifier for New Taiwan Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>TWD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for New Taiwan Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
+		<lcc-lr:hasTag>TWD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;NewTaiwanDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3080,9 +3074,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TZS">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>TZS</rdfs:label>
-		<rdfs:comment>the currency identifier for Tanzanian Shilling</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>TZS</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Tanzanian Shilling</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;TanzanianShilling"/>
+		<lcc-lr:hasTag>TZS</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;TanzanianShilling"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3090,7 +3084,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Taka">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Taka</rdfs:label>
-		<rdfs:comment>the currency Taka</rdfs:comment>
+		<skos:definition>the currency Taka</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>050</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Bangladesh"/>
@@ -3100,7 +3094,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Tala">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Tala</rdfs:label>
-		<rdfs:comment>the currency Tala</rdfs:comment>
+		<skos:definition>the currency Tala</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>882</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Samoa"/>
@@ -3110,7 +3104,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TanzanianShilling">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Tanzanian Shilling</rdfs:label>
-		<rdfs:comment>the currency Tanzanian Shilling</rdfs:comment>
+		<skos:definition>the currency Tanzanian Shilling</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>834</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tanzania"/>
@@ -3120,7 +3114,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Tenge">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Tenge</rdfs:label>
-		<rdfs:comment>the currency Tenge</rdfs:comment>
+		<skos:definition>the currency Tenge</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>398</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Kazakhstan"/>
@@ -3130,7 +3124,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TrinidadandTobagoDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Trinidad and Tobago Dollar</rdfs:label>
-		<rdfs:comment>the currency Trinidad and Tobago Dollar</rdfs:comment>
+		<skos:definition>the currency Trinidad and Tobago Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>780</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;TrinidadAndTobago"/>
@@ -3140,7 +3134,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Tugrik">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Tugrik</rdfs:label>
-		<rdfs:comment>the currency Tugrik</rdfs:comment>
+		<skos:definition>the currency Tugrik</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>496</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Mongolia"/>
@@ -3150,7 +3144,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TunisianDinar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Tunisian Dinar</rdfs:label>
-		<rdfs:comment>the currency Tunisian Dinar</rdfs:comment>
+		<skos:definition>the currency Tunisian Dinar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>3</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>788</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Tunisia"/>
@@ -3160,7 +3154,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TurkishLira">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Turkish Lira</rdfs:label>
-		<rdfs:comment>the currency Turkish Lira</rdfs:comment>
+		<skos:definition>the currency Turkish Lira</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>949</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Turkey"/>
@@ -3170,7 +3164,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;TurkmenistanNewManat">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Turkmenistan New Manat</rdfs:label>
-		<rdfs:comment>the currency Turkmenistan New Manat</rdfs:comment>
+		<skos:definition>the currency Turkmenistan New Manat</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>934</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Turkmenistan"/>
@@ -3180,7 +3174,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UAEDirham">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>UAE Dirham</rdfs:label>
-		<rdfs:comment>the currency UAE Dirham</rdfs:comment>
+		<skos:definition>the currency UAE Dirham</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>784</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;UnitedArabEmirates"/>
@@ -3190,9 +3184,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UAH">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UAH</rdfs:label>
-		<rdfs:comment>the currency identifier for Hryvnia</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>UAH</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Hryvnia</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Hryvnia"/>
+		<lcc-lr:hasTag>UAH</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Hryvnia"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3200,9 +3194,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UGX">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UGX</rdfs:label>
-		<rdfs:comment>the currency identifier for Uganda Shilling</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>UGX</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Uganda Shilling</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;UgandaShilling"/>
+		<lcc-lr:hasTag>UGX</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;UgandaShilling"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3210,9 +3204,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;USD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>USD</rdfs:label>
-		<rdfs:comment>the currency identifier for US Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>USD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for US Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
+		<lcc-lr:hasTag>USD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3220,7 +3214,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;USDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>US Dollar</rdfs:label>
-		<rdfs:comment>the currency US Dollar</rdfs:comment>
+		<skos:definition>the currency US Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>840</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;AmericanSamoa"/>
@@ -3247,7 +3241,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;USDollar_Nextday">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
 		<rdfs:label>US Dollar (Next day)</rdfs:label>
-		<rdfs:comment>the funds US Dollar (Next day)</rdfs:comment>
+		<skos:definition>the funds US Dollar (Next day)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;USDollar"/>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>997</fibo-fnd-acc-cur:hasNumericCode>
@@ -3259,9 +3253,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;USN">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>USN</rdfs:label>
-		<rdfs:comment>the funds identifier for US Dollar (Next day)</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>USN</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the funds identifier for US Dollar (Next day)</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;USDollar_Nextday"/>
+		<lcc-lr:hasTag>USN</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;USDollar_Nextday"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3269,9 +3263,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UYI">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>UYI</rdfs:label>
-		<rdfs:comment>the funds identifier for Uruguay Peso en Unidades Indexadas (UI)</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>UYI</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the funds identifier for Uruguay Peso en Unidades Indexadas (UI)</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;UruguayPesoenUnidadesIndexadas_UI"/>
+		<lcc-lr:hasTag>UYI</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;UruguayPesoenUnidadesIndexadas_UI"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3279,9 +3273,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UYU">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UYU</rdfs:label>
-		<rdfs:comment>the currency identifier for Peso Uruguayo</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>UYU</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Peso Uruguayo</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;PesoUruguayo"/>
+		<lcc-lr:hasTag>UYU</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;PesoUruguayo"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3289,9 +3283,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UYW">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;FundsIdentifier"/>
 		<rdfs:label>UYW</rdfs:label>
-		<rdfs:comment>the funds identifier for Unidad Previsional</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>UYW</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the funds identifier for Unidad Previsional</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;UnidadPrevisional"/>
+		<lcc-lr:hasTag>UYW</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;UnidadPrevisional"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3299,9 +3293,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UZS">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>UZS</rdfs:label>
-		<rdfs:comment>the currency identifier for Uzbekistan Sum</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>UZS</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Uzbekistan Sum</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;UzbekistanSum"/>
+		<lcc-lr:hasTag>UZS</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;UzbekistanSum"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3309,7 +3303,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UgandaShilling">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Uganda Shilling</rdfs:label>
-		<rdfs:comment>the currency Uganda Shilling</rdfs:comment>
+		<skos:definition>the currency Uganda Shilling</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>800</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uganda"/>
@@ -3319,7 +3313,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UnidadPrevisional">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
 		<rdfs:label>Unidad Previsional</rdfs:label>
-		<rdfs:comment>the funds Unidad Previsional</rdfs:comment>
+		<skos:definition>the funds Unidad Previsional</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;PesoUruguayo"/>
 		<fibo-fnd-acc-cur:hasMinorUnit>4</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>927</fibo-fnd-acc-cur:hasNumericCode>
@@ -3331,7 +3325,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UnidaddeFomento">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
 		<rdfs:label>Unidad de Fomento</rdfs:label>
-		<rdfs:comment>the funds Unidad de Fomento</rdfs:comment>
+		<skos:definition>the funds Unidad de Fomento</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;ChileanPeso"/>
 		<fibo-fnd-acc-cur:hasMinorUnit>4</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>990</fibo-fnd-acc-cur:hasNumericCode>
@@ -3343,7 +3337,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UnidaddeValorReal">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
 		<rdfs:label>Unidad de Valor Real</rdfs:label>
-		<rdfs:comment>the funds Unidad de Valor Real</rdfs:comment>
+		<skos:definition>the funds Unidad de Valor Real</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;ColombianPeso"/>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>970</fibo-fnd-acc-cur:hasNumericCode>
@@ -3355,7 +3349,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UruguayPesoenUnidadesIndexadas_UI">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
 		<rdfs:label>Uruguay Peso en Unidades Indexadas (UI)</rdfs:label>
-		<rdfs:comment>the funds Uruguay Peso en Unidades Indexadas (UI)</rdfs:comment>
+		<skos:definition>the funds Uruguay Peso en Unidades Indexadas (UI)</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;PesoUruguayo"/>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>940</fibo-fnd-acc-cur:hasNumericCode>
@@ -3367,7 +3361,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;UzbekistanSum">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Uzbekistan Sum</rdfs:label>
-		<rdfs:comment>the currency Uzbekistan Sum</rdfs:comment>
+		<skos:definition>the currency Uzbekistan Sum</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>860</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Uzbekistan"/>
@@ -3377,9 +3371,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;VES">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>VES</rdfs:label>
-		<rdfs:comment>the currency identifier for Bolívar Soberano</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>VES</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Bolívar Soberano</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>
+		<lcc-lr:hasTag>VES</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BolívarSoberano"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3387,9 +3381,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;VND">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>VND</rdfs:label>
-		<rdfs:comment>the currency identifier for Dong</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>VND</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Dong</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Dong"/>
+		<lcc-lr:hasTag>VND</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Dong"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3397,9 +3391,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;VUV">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>VUV</rdfs:label>
-		<rdfs:comment>the currency identifier for Vatu</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>VUV</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Vatu</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Vatu"/>
+		<lcc-lr:hasTag>VUV</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Vatu"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3407,7 +3401,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Vatu">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Vatu</rdfs:label>
-		<rdfs:comment>the currency Vatu</rdfs:comment>
+		<skos:definition>the currency Vatu</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>548</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Vanuatu"/>
@@ -3417,7 +3411,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;WIREuro">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
 		<rdfs:label>WIR Euro</rdfs:label>
-		<rdfs:comment>the funds WIR Euro</rdfs:comment>
+		<skos:definition>the funds WIR Euro</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;Euro"/>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>947</fibo-fnd-acc-cur:hasNumericCode>
@@ -3429,7 +3423,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;WIRFranc">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Funds"/>
 		<rdfs:label>WIR Franc</rdfs:label>
-		<rdfs:comment>the funds WIR Franc</rdfs:comment>
+		<skos:definition>the funds WIR Franc</skos:definition>
 		<fibo-fnd-acc-cur:hasCurrency rdf:resource="&fibo-fnd-acc-4217;SwissFranc"/>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>948</fibo-fnd-acc-cur:hasNumericCode>
@@ -3441,9 +3435,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;WST">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>WST</rdfs:label>
-		<rdfs:comment>the currency identifier for Tala</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>WST</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Tala</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Tala"/>
+		<lcc-lr:hasTag>WST</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Tala"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3451,7 +3445,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Won">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Won</rdfs:label>
-		<rdfs:comment>the currency Won</rdfs:comment>
+		<skos:definition>the currency Won</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>410</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;KoreaRepublicOf"/>
@@ -3461,9 +3455,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XAF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XAF</rdfs:label>
-		<rdfs:comment>the currency identifier for CFA Franc BEAC</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XAF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for CFA Franc BEAC</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CFAFrancBEAC"/>
+		<lcc-lr:hasTag>XAF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CFAFrancBEAC"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3471,9 +3465,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XAG">
 		<rdf:type rdf:resource="&fibo-fnd-pas-pas;PreciousMetalIdentifier"/>
 		<rdfs:label>XAG</rdfs:label>
-		<rdfs:comment>one troy ounce of the precious metal identifier for Silver</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XAG</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>one troy ounce of the precious metal identifier for Silver</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Silver"/>
+		<lcc-lr:hasTag>XAG</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Silver"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3481,9 +3475,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XAU">
 		<rdf:type rdf:resource="&fibo-fnd-pas-pas;PreciousMetalIdentifier"/>
 		<rdfs:label>XAU</rdfs:label>
-		<rdfs:comment>one troy ounce of the precious metal identifier for Gold</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XAU</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>one troy ounce of the precious metal identifier for Gold</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Gold"/>
+		<lcc-lr:hasTag>XAU</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Gold"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3491,9 +3485,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XBA">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XBA</rdfs:label>
-		<rdfs:comment>the identifier for Bond Markets Unit European Composite Unit (EURCO)</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XBA</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the identifier for Bond Markets Unit European Composite Unit (EURCO)</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanCompositeUnit_EURCO"/>
+		<lcc-lr:hasTag>XBA</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanCompositeUnit_EURCO"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3501,9 +3495,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XBB">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XBB</rdfs:label>
-		<rdfs:comment>the identifier for Bond Markets Unit European Monetary Unit (E.M.U.-6)</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XBB</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the identifier for Bond Markets Unit European Monetary Unit (E.M.U.-6)</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanMonetaryUnit_EMU-6"/>
+		<lcc-lr:hasTag>XBB</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanMonetaryUnit_EMU-6"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3511,9 +3505,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XBC">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XBC</rdfs:label>
-		<rdfs:comment>the identifier for Bond Markets Unit European Unit of Account 9 (E.U.A.-9)</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XBC</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the identifier for Bond Markets Unit European Unit of Account 9 (E.U.A.-9)</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount9_EUA-9"/>
+		<lcc-lr:hasTag>XBC</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount9_EUA-9"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3521,9 +3515,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XBD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XBD</rdfs:label>
-		<rdfs:comment>the identifier for Bond Markets Unit European Unit of Account 17 (E.U.A.-17)</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XBD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the identifier for Bond Markets Unit European Unit of Account 17 (E.U.A.-17)</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount17_EUA-17"/>
+		<lcc-lr:hasTag>XBD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;BondMarketsUnitEuropeanUnitofAccount17_EUA-17"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3531,9 +3525,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XCD">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XCD</rdfs:label>
-		<rdfs:comment>the currency identifier for East Caribbean Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XCD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for East Caribbean Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;EastCaribbeanDollar"/>
+		<lcc-lr:hasTag>XCD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;EastCaribbeanDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3541,9 +3535,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XDR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XDR</rdfs:label>
-		<rdfs:comment>the IMF&apos;s identifier for SDR (Special Drawing Right)</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XDR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the IMF&apos;s identifier for SDR (Special Drawing Right)</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;SDR_SpecialDrawingRight"/>
+		<lcc-lr:hasTag>XDR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;SDR_SpecialDrawingRight"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3551,9 +3545,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XOF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XOF</rdfs:label>
-		<rdfs:comment>the currency identifier for CFA Franc BCEAO</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XOF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for CFA Franc BCEAO</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CFAFrancBCEAO"/>
+		<lcc-lr:hasTag>XOF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CFAFrancBCEAO"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3561,9 +3555,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XPD">
 		<rdf:type rdf:resource="&fibo-fnd-pas-pas;PreciousMetalIdentifier"/>
 		<rdfs:label>XPD</rdfs:label>
-		<rdfs:comment>one troy ounce of the precious metal identifier for Palladium</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XPD</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>one troy ounce of the precious metal identifier for Palladium</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Palladium"/>
+		<lcc-lr:hasTag>XPD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Palladium"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3571,9 +3565,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XPF">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XPF</rdfs:label>
-		<rdfs:comment>the currency identifier for CFP Franc</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XPF</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for CFP Franc</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;CFPFranc"/>
+		<lcc-lr:hasTag>XPF</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;CFPFranc"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3581,9 +3575,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XPT">
 		<rdf:type rdf:resource="&fibo-fnd-pas-pas;PreciousMetalIdentifier"/>
 		<rdfs:label>XPT</rdfs:label>
-		<rdfs:comment>one troy ounce of the precious metal identifier for Platinum</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XPT</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>one troy ounce of the precious metal identifier for Platinum</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Platinum"/>
+		<lcc-lr:hasTag>XPT</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Platinum"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3591,9 +3585,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XSU">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XSU</rdfs:label>
-		<rdfs:comment>the currency identifier for Sucre</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XSU</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Sucre</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Sucre"/>
+		<lcc-lr:hasTag>XSU</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Sucre"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3601,17 +3595,17 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XTS">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XTS</rdfs:label>
-		<rdfs:comment>Codes specifically reserved for testing purposes</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XTS</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>Codes specifically reserved for testing purposes</skos:definition>
+		<lcc-lr:hasTag>XTS</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XUA">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;UnitOfAccountIdentifier"/>
 		<rdfs:label>XUA</rdfs:label>
-		<rdfs:comment>the identifier for ADB Unit of Account</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XUA</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the identifier for ADB Unit of Account</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ADBUnitofAccount"/>
+		<lcc-lr:hasTag>XUA</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ADBUnitofAccount"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3619,17 +3613,17 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;XXX">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>XXX</rdfs:label>
-		<rdfs:comment>The codes assigned for transactions where no currency is involved</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>XXX</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>The codes assigned for transactions where no currency is involved</skos:definition>
+		<lcc-lr:hasTag>XXX</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;YER">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>YER</rdfs:label>
-		<rdfs:comment>the currency identifier for Yemeni Rial</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>YER</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Yemeni Rial</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;YemeniRial"/>
+		<lcc-lr:hasTag>YER</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;YemeniRial"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3637,7 +3631,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;YemeniRial">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Yemeni Rial</rdfs:label>
-		<rdfs:comment>the currency Yemeni Rial</rdfs:comment>
+		<skos:definition>the currency Yemeni Rial</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>886</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Yemen"/>
@@ -3647,7 +3641,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Yen">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Yen</rdfs:label>
-		<rdfs:comment>the currency Yen</rdfs:comment>
+		<skos:definition>the currency Yen</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>0</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>392</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Japan"/>
@@ -3657,7 +3651,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;YuanRenminbi">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Yuan Renminbi</rdfs:label>
-		<rdfs:comment>the currency Yuan Renminbi</rdfs:comment>
+		<skos:definition>the currency Yuan Renminbi</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>156</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;China"/>
@@ -3667,9 +3661,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ZAR">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ZAR</rdfs:label>
-		<rdfs:comment>the currency identifier for Rand</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ZAR</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Rand</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;Rand"/>
+		<lcc-lr:hasTag>ZAR</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;Rand"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3677,9 +3671,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ZMW">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ZMW</rdfs:label>
-		<rdfs:comment>the currency identifier for Zambian Kwacha</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ZMW</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Zambian Kwacha</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ZambianKwacha"/>
+		<lcc-lr:hasTag>ZMW</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ZambianKwacha"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3687,9 +3681,9 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ZWL">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;CurrencyIdentifier"/>
 		<rdfs:label>ZWL</rdfs:label>
-		<rdfs:comment>the currency identifier for Zimbabwe Dollar</rdfs:comment>
-		<fibo-fnd-rel-rel:hasTag>ZWL</fibo-fnd-rel-rel:hasTag>
+		<skos:definition>the currency identifier for Zimbabwe Dollar</skos:definition>
 		<lcc-lr:denotes rdf:resource="&fibo-fnd-acc-4217;ZimbabweDollar"/>
+		<lcc-lr:hasTag>ZWL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fnd-acc-4217;ZimbabweDollar"/>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-fnd-acc-4217;ISO4217-CodeSet"/>
 	</owl:NamedIndividual>
@@ -3697,7 +3691,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ZambianKwacha">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Zambian Kwacha</rdfs:label>
-		<rdfs:comment>the currency Zambian Kwacha</rdfs:comment>
+		<skos:definition>the currency Zambian Kwacha</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>967</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Zambia"/>
@@ -3707,7 +3701,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;ZimbabweDollar">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Zimbabwe Dollar</rdfs:label>
-		<rdfs:comment>the currency Zimbabwe Dollar</rdfs:comment>
+		<skos:definition>the currency Zimbabwe Dollar</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>932</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Zimbabwe"/>
@@ -3717,7 +3711,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fnd-acc-4217;Zloty">
 		<rdf:type rdf:resource="&fibo-fnd-acc-cur;Currency"/>
 		<rdfs:label>Zloty</rdfs:label>
-		<rdfs:comment>the currency Zloty</rdfs:comment>
+		<skos:definition>the currency Zloty</skos:definition>
 		<fibo-fnd-acc-cur:hasMinorUnit>2</fibo-fnd-acc-cur:hasMinorUnit>
 		<fibo-fnd-acc-cur:hasNumericCode>985</fibo-fnd-acc-cur:hasNumericCode>
 		<lcc-cr:isUsedBy rdf:resource="&lcc-3166-1;Poland"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Limited certain dependencies in currency amount and currency codes; replaced use of rdfs:comment with skos:definition in currency codes per FIBO policy


Fixes: #1048 / FND-258


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


