### PR TITLE
Extending the set of hygiene test by implementing a test candidate T1

### DIFF
--- a/etc/testing/hygiene/testHygiene1067.sparql
+++ b/etc/testing/hygiene/testHygiene1067.sparql
@@ -1,0 +1,11 @@
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT (CONCAT("Warn:'", ?label, "' labels multiple objects.") as ?error)
+WHERE 
+{
+    ?s rdfs:label ?label
+    FILTER (REGEX (xsd:string(?s), "edmcouncil"))
+}
+GROUP BY ?label 
+HAVING (COUNT(?label) > 1)

--- a/etc/testing/hygiene/testHygiene1067.sparql
+++ b/etc/testing/hygiene/testHygiene1067.sparql
@@ -1,11 +1,15 @@
-prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> 
-prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
+PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT DISTINCT (CONCAT("Warn:'", ?label, "' labels multiple objects.") as ?error)
-WHERE 
-{
-    ?s rdfs:label ?label
-    FILTER (REGEX (xsd:string(?s), "edmcouncil"))
-}
-GROUP BY ?label 
-HAVING (COUNT(?label) > 1)
+SELECT  (concat("Warn: '", ?label, "' labels multiple objects.") AS ?error) ?object
+WHERE
+  { { SELECT DISTINCT  ?label
+      WHERE
+        { ?s  rdfs:label  ?label
+          FILTER regex(xsd:string(?s), "edmcouncil")
+        }
+      GROUP BY ?label
+      HAVING ( COUNT(?label) > 1 )
+    }
+    ?object  rdfs:label  ?label
+  }


### PR DESCRIPTION
See:  https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md#t1-polysemous-elements

Signed-off-by: Robert Trypuz <robert.trypuz@makolab.com>

## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes: #1067


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


