### PR TITLE
FND-305 - Eliminate reasoning complexity due to the union in hasTag in the relations ontology

### DIFF
--- a/BE/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf
+++ b/BE/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf
@@ -58,7 +58,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200201/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200701/LegalEntities/NorthAmericanEntities/USExampleEntities/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/LegalEntities/NorthAmericanEntities/USExampleEntities.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -77,7 +78,7 @@
 		<rdf:type rdf:resource="&fibo-be-corp-corp;RegistrationIdentifier"/>
 		<rdfs:label>Alphabet Inc. business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Alphabet Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5786925</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5786925</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;AlphabetInc-US-CA"/>
 	</owl:NamedIndividual>
 	
@@ -104,7 +105,7 @@
 		<rdfs:label>Apple Inc. business entity identifier</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://businessfilings.sos.ca.gov/frmDetail.asp?CorpID=00806592"/>
 		<skos:definition>registration identifier assigned by the California Department of Corporations for Apple Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>C0806592</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>C0806592</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;AppleInc-US-CA"/>
 	</owl:NamedIndividual>
 	
@@ -130,7 +131,7 @@
 		<rdf:type rdf:resource="&fibo-be-corp-corp;RegistrationIdentifier"/>
 		<rdfs:label>International Business Machines Corporation business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the New York Division of Corporations for International Business Machines Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>30059</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>30059</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;InternationalBusinessMachinesCorporation-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -156,7 +157,7 @@
 		<rdf:type rdf:resource="&fibo-be-corp-corp;RegistrationIdentifier"/>
 		<rdfs:label>The Coca-Cola Company business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Division of Corporations for The Coca-Cola Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>88529</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>88529</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;TheCoca-ColaCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -171,7 +172,7 @@
 		<rdf:type rdf:resource="&fibo-be-corp-corp;RegistrationIdentifier"/>
 		<rdfs:label>The Home Depot, Inc. business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Division of Corporations for The Home Depot, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>856429</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>856429</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;TheHomeDepotInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -208,7 +209,7 @@
 		<rdf:type rdf:resource="&fibo-be-corp-corp;RegistrationIdentifier"/>
 		<rdfs:label>The Proctor &amp; Gamble Company business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Ohio Department of Corporations for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>20677</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>20677</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;TheProctorAndGambleCompany-US-OH"/>
 	</owl:NamedIndividual>
 	
@@ -223,7 +224,7 @@
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>The Proctor &amp; Gamble Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>2572IBTT8CCZW6AU4141</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>2572IBTT8CCZW6AU4141</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;TheProctorAndGambleCompany-US-OH"/>
 	</owl:NamedIndividual>
 	
@@ -231,7 +232,7 @@
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Alphabet Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Alphabet Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5493006MHB84DD0ZWV18</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5493006MHB84DD0ZWV18</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;AlphabetInc-US-CA"/>
 	</owl:NamedIndividual>
 	
@@ -239,7 +240,7 @@
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>Apple Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Apple Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HWUPKR0MPOU8FGXBT394</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>HWUPKR0MPOU8FGXBT394</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;AppleInc-US-CA"/>
 	</owl:NamedIndividual>
 	
@@ -247,7 +248,7 @@
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>The Home Depot, Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Home Depot, Inc.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>QEKMOTMBBKA8I816DO57</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>QEKMOTMBBKA8I816DO57</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;TheHomeDepotInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -255,7 +256,7 @@
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>The Coca-Cola Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Coca-Cola Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>UWJKFUJFZ02DKWI3RY53</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>UWJKFUJFZ02DKWI3RY53</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;TheCoca-ColaCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -263,7 +264,7 @@
 		<rdf:type rdf:resource="&fibo-be-le-lei;LegalEntityIdentifier"/>
 		<rdfs:label>International Business Machines Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for International Business Machines Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>VGRQXHF3J8VDLUA7XE92</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>VGRQXHF3J8VDLUA7XE92</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;InternationalBusinessMachinesCorporation-US-NY"/>
 	</owl:NamedIndividual>
 

--- a/DER/DerivativesContracts/SwapsIndividuals.rdf
+++ b/DER/DerivativesContracts/SwapsIndividuals.rdf
@@ -104,7 +104,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200301/DerivativesContracts/SwapsIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200701/DerivativesContracts/SwapsIndividuals/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200301/DerivativesContracts/SwapsIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -115,7 +116,7 @@
 		<skos:definition>individual representing the Delaware Division of Corporations business entity identifier for BSDR LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>5202500</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5202500</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-drc-swpind;BSDRLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -181,7 +182,7 @@
 		<skos:definition>individual representing the Delaware Division of Corporations business entity identifier for Chicago Mercantile Exchange, Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>3151025</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>3151025</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-drc-swpind;ChicagoMercantileExchangeInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -234,7 +235,7 @@
 		<skos:definition>individual representing the New York State Division of Corporations business entity identifier for DTCC Data Repository (U.S.) LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usjrga;NewYorkCorporationsRegulator"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4156912</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>4156912</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-drc-swpind;DTCCDataRepositoryLLC-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -300,7 +301,7 @@
 		<skos:definition>individual representing the Delaware Division of Corporations business entity identifier for ICE Trade Vault, LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usjrga;DelawareCorporationsRegulator"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4960384</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>4960384</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-drc-swpind;ICETradeVaultLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -329,7 +330,7 @@
 		<rdfs:label>BSDR LLC legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for BSDR LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>5493006SPIZKPPCPBB70</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5493006SPIZKPPCPBB70</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-drc-swpind;BSDRLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -338,7 +339,7 @@
 		<rdfs:label>DTCC Data Repository (U.S) LLC legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for DTCC Data Repository (U.S) LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300H9ZM7RDBM87W85</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300H9ZM7RDBM87W85</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-drc-swpind;DTCCDataRepositoryLLC-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -347,7 +348,7 @@
 		<rdfs:label>ICE Trade Vault, LLC legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for ICE Trade Vault, LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300KE78SX8RVDNO58</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300KE78SX8RVDNO58</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-drc-swpind;ICETradeVaultLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -356,7 +357,7 @@
 		<rdfs:label>Chicago Mercantile Exchange, Inc. legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for Chicago Mercantile Exchange, Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>SNZ2OJLFK8MNNCLQOF39</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>SNZ2OJLFK8MNNCLQOF39</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-drc-swpind;ChicagoMercantileExchangeInc-US-DE"/>
 	</owl:NamedIndividual>
 

--- a/DER/RateDerivatives/IRSwapExampleIndividuals.rdf
+++ b/DER/RateDerivatives/IRSwapExampleIndividuals.rdf
@@ -100,7 +100,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecurityAssets/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200601/RateDerivatives/IRSwapExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200701/RateDerivatives/IRSwapExampleIndividuals/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200601/RateDerivatives/IRSwapExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -229,7 +230,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>ZZ216659451</rdfs:label>
 		<skos:definition>ISIN for sample swap contract IY7VKEUR45886</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ZZ216659451</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>ZZ216659451</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886"/>
 	</owl:NamedIndividual>
 	
@@ -237,7 +238,7 @@
 		<rdf:type rdf:resource="&fibo-der-drc-swp;UniqueSwapIdentifier"/>
 		<rdfs:label>IY7VKEUR45886</rdfs:label>
 		<skos:definition>unique swap identifier for sample swap contract IY7VKEUR45886</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IY7VKEUR45886</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>IY7VKEUR45886</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-der-rtd-irsind;Contract-IY7VKEUR45886"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/BusinessRegistries.rdf
+++ b/FBC/FunctionalEntities/BusinessRegistries.rdf
@@ -85,13 +85,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/BusinessRegistries/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/BusinessRegistries/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.1 RTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified per FIBO 2.0 RFC primarily to loosen the constraints on address properties and better support standards including ISO 9362 (BIC codes), ISO 13616 (IBAN and BBAN codes), and ISO 17442 (the GLIEF LEI standard).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/BusinessRegistries.rdf version of this ontology was modified to generalize certain unions where they were no longer required, use the composite date datatype where appropriate, add individuals for entity expiration reason and validation level to better align with the GLEIF LEI data, and move international registration authorities, such as SWIFT, to a separate ontology for better modularity.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/FunctionalEntities/BusinessRegistries.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190701/FunctionalEntities/BusinessRegistries.rdf version of this ontology was revised to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/BusinessRegistries.rdf version of this ontology was revised to eliminate duplication with concepts in LCC, simplify addresses, normalize definitions to be ISO 704 compliant, and rationalize address properties.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/BusinessRegistries.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -151,16 +152,16 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityStatus"/>
 		<rdfs:label>active status</rdfs:label>
 		<skos:definition>status indicating that as of the last report or update, the entity was legally registered and operating</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ACTIVE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>ACTIVE</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;AnnulledStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>annulled status</rdfs:label>
 		<skos:definition>status indicating that the registration was determined to be erroneous or invalid after issuance</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ANNULLED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>ANNULLED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;BusinessRegisterIdentifier">
@@ -259,23 +260,23 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>cancelled status</rdfs:label>
 		<skos:definition>status indicating that the registration was abandoned prior to issuance</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CANCELLED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>CANCELLED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;DuplicateStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>duplicate status</rdfs:label>
 		<skos:definition>status indicating that the registration was determined to be a duplicate registration of the same entity as another registration; duplicate status is assigned to the non-surviving registration (i.e. the identifier that should no longer be used)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DUPLICATE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>DUPLICATE</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;EntityExpirationReason">
 		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -289,24 +290,24 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<rdfs:label>entity expiration reason - corporate action</rdfs:label>
 		<skos:definition>expiration reason indicating that an entity was acquired or merged with another entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CORPORATE_ACTION</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>CORPORATE_ACTION</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityExpirationReasonDissolved">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<rdfs:label>entity expiration reason - disolved</rdfs:label>
 		<skos:definition>expiration reason indicating that an entity ceased to operate</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>DISSOLVED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>DISSOLVED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityExpirationReasonOther">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityExpirationReason"/>
 		<rdfs:label>entity expiration reason - other</rdfs:label>
 		<skos:definition>expiration reason indicating something that is neither due to disolution nor corporate action</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>OTHER</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>OTHER</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;EntityLegalFormRegistry">
@@ -349,7 +350,7 @@
 		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -363,48 +364,48 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevel"/>
 		<rdfs:label>entity validation level - entity-supplied only</rdfs:label>
 		<skos:definition>Based on the validation procedures in use by the LOU responsible for the record, the information associated with this record has significant reliance on the information that a submitter provided due to the unavailability of corroborating information.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ENTITY_SUPPLIED_ONLY</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>ENTITY_SUPPLIED_ONLY</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityValidationLevelFullyCorroborated">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevel"/>
 		<rdfs:label>entity validation level - fully corroborated</rdfs:label>
 		<skos:definition>Based on the validation procedures in use by the LOU responsible for the record, there is sufficient information contained in authoritative public sources to corroborate the information that the submitter has provided for the record.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>FULLY_CORROBORATED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>FULLY_CORROBORATED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;EntityValidationLevelPartiallyCorroborated">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityValidationLevel"/>
 		<rdfs:label>entity validation level - partially corroborated</rdfs:label>
 		<skos:definition>Based on the validation procedures in use by the LOU responsible for the record, the information supplied by the registrant can be partially corroborated by public authoritative sources, while some of the record is dependent upon the information that the registrant submitted, either due to conflicts with authoritative information, or due to data unavailability.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PARTIALLY_CORROBORATED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>PARTIALLY_CORROBORATED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;InactiveStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;EntityStatus"/>
 		<rdfs:label>inactive status</rdfs:label>
 		<skos:definition>status indicating that the entity is no longer legally registered and/or operating, whether as a result of business closure, acquisition by or merger with another (or new) entity, or determination of illegitimacy</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>INACTIVE</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>INACTIVE</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;IssuedStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>issued status</rdfs:label>
 		<skos:definition>status indicating that the registration has been validated and issued, and which identifies an entity that was operating legally as of the last update</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ISSUED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>ISSUED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;LapsedStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>lapsed status</rdfs:label>
 		<skos:definition>status indicating that the registration that has not been renewed by the specified renewal date and is not known by public sources to have ceased operation as of the last update</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>LAPSED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>LAPSED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;LegalEntityIdentifierRegistry">
@@ -507,8 +508,8 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>merged status</rdfs:label>
 		<skos:definition>status indicating that the registration is for an entity that has been merged into another legal entity, such that this legal entity no longer exists as an independently operating entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>MERGED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>MERGED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;NorthAmericanIndustryClassificationSystemCode">
@@ -523,7 +524,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -560,24 +561,24 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>pending archival status</rdfs:label>
 		<skos:definition>status indicating that the registration is about to be transferred to a different registration authority, after which its registration status will revert to a non-pending status</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PENDING_ARCHIVAL</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>PENDING_ARCHIVAL</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;PendingTransferStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>pending transfer status</rdfs:label>
 		<skos:definition>status indicating that the registration has requested transfer to a different registration authority, and for which transfer is in progress</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PENDING_TRANSFER</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>PENDING_TRANSFER</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-breg;PendingValidationStatus">
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>pending validation status</rdfs:label>
 		<skos:definition>status indicating that an application for registration has been submitted and is in process, pending validation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PENDING_VALIDATION</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>PENDING_VALIDATION</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;RegistrationAuthorityCode">
@@ -607,8 +608,8 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>retired status</rdfs:label>
 		<skos:definition>status indicating that the registration is for an entity that has ceased operation, without having been merged into another entity</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RETIRED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>RETIRED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-breg;StandardIndustrialClassificationCode">
@@ -623,7 +624,7 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
@@ -658,8 +659,8 @@ NAICS was developed under the auspices of the Office of Management and Budget (O
 		<rdf:type rdf:resource="&fibo-fbc-fct-breg;RegistrationStatus"/>
 		<rdfs:label>transferred status</rdfs:label>
 		<skos:definition>status indicating that the registration that has been transferred to a different registration authority</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TRANSFERRED</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.gleif.org/en/about-lei/common-data-file-format/lei-cdf-format/lei-cdf-format-version-2-1</fibo-fnd-utl-av:adaptedFrom>
+		<lcc-lr:hasTag>TRANSFERRED</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-fct-breg;hasAlternativeLanguageLegalName">

--- a/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf
@@ -92,10 +92,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI information for the European Central Bank, eliminate duplication with concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/EuropeanEntities/EURegulatoryAgencies.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -201,7 +202,7 @@
 		<rdfs:label>European Central Bank legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for the European Central Bank</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-eufseind;WMDatenserviceEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300DTUYXVMJXZNY75</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300DTUYXVMJXZNY75</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eurga;EuropeanCentralBank"/>
 	</owl:NamedIndividual>
 

--- a/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf
@@ -89,11 +89,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to eliminate usage of deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to eliminate duplication of concepts in LCC, simplify addresses and merge countries with locations in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/EuropeanEntities/EuropeanFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -459,7 +460,7 @@
 		<rdfs:label>London Stock Exchange plc. legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for London Stock Exchange plc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangeUnaVistaRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>213800D1EI4B9WTWWD28</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>213800D1EI4B9WTWWD28</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;LondonStockExchangePlc"/>
 	</owl:NamedIndividual>
 	
@@ -468,7 +469,7 @@
 		<rdfs:label>LuxCSD S.A. legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for LuxCSD S.A.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDLEIRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>222100T6ICDIY8V4VX70</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>222100T6ICDIY8V4VX70</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDSA"/>
 	</owl:NamedIndividual>
 	
@@ -477,7 +478,7 @@
 		<rdfs:label>Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann GmbH &amp; Co. KG legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for Herausgebergemeinschaft Wertpapier-Mitteilungen Keppler, Lehmann GmbH &amp; Co. KG</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-eufseind;WMDatenserviceEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>5299000J2N45DDNE4Y28</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5299000J2N45DDNE4Y28</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;HerausgebergemeinschaftWertpapier-MitteilungenKepplerLehmannGmbHAndCoKG-DE"/>
 	</owl:NamedIndividual>
 	
@@ -486,7 +487,7 @@
 		<rdfs:label>Euroclear SA/NV legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for Euroclear SA/NV</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300CBNW05DILT6870</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300CBNW05DILT6870</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;EuroclearSANV"/>
 	</owl:NamedIndividual>
 	
@@ -495,7 +496,7 @@
 		<rdfs:label>Clearstream Banking S.A. legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for Clearstream Banking S.A.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-eufseind;LuxCSDLEIRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300OL514RA0SXJJ44</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300OL514RA0SXJJ44</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;ClearstreamBankingSA"/>
 	</owl:NamedIndividual>
 	
@@ -504,7 +505,7 @@
 		<rdfs:label>Business Entity Data (BED) B.V. legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for Business Entity Data (BED) B.V.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>EVK05KS7XY1DEII3R011</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>EVK05KS7XY1DEII3R011</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-eufseind;BusinessEntityData-NL"/>
 	</owl:NamedIndividual>
 

--- a/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf
@@ -95,10 +95,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgenciess.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgenciess.rdf version of this ontology was revised to update the GLEIF LEI registration information for the Bank of Canada, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/CARegulatoryAgencies.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -161,7 +162,7 @@ The Bank provides liquidity to the financial system, gives policy advice to the 
 		<rdfs:label>Bank of Canada legal entity identifier</rdfs:label>
 		<skos:definition>individual representing the legal entity identifier for the Federal Reserve Bank of New York</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300PN6MKI0CLP4T28</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300PN6MKI0CLP4T28</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-cajrga;BankOfCanada"/>
 	</owl:NamedIndividual>
 

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf
@@ -140,11 +140,12 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level and entity ownership relations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/FunctionalEntities/USJurisdiction/USExampleIndividuals.rdf version of this ontology was modified to add information about the example corporations included in FIBO use cases for securities instrument data and various indices such as the DJIA, update LEI records generally, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -331,9 +332,9 @@
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-breg:hasInitialRegistrationDate>1997-06-05</fibo-fbc-fct-breg:hasInitialRegistrationDate>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessInformationRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>FK010222</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfSouthDakotaJurisdiction"/>
+		<lcc-lr:hasTag>FK010222</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociation-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -345,22 +346,22 @@
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociationBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociationBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
-		<fibo-fnd-rel-rel:hasTag>MELNUS3PXXX</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>MELNUS3PXXX</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociation-US-DE"/>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;BNYMellonNationalAssociationBusinessPartyPrefix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>BNY Mellon, National Association business party prefix</rdfs:label>
-		<fibo-fnd-rel-rel:hasTag>MELN</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociationBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>MELN</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;BNYMellonNationalAssociationBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>BNY Mellon, National Association business party suffix</rdfs:label>
-		<fibo-fnd-rel-rel:hasTag>3P</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociationBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>3P</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;BNYMellonNationalAssociationDateEstablished">
@@ -381,7 +382,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>BNY Mellon, National Association FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for BNY Mellon, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>7946</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>7946</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -403,7 +404,7 @@
 		<rdfs:label>BNY Mellon, National Association RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to BNY Mellon, National Association</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>934329</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>934329</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -411,7 +412,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>BNY Mellon, National Association RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for BNY Mellon, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>043019265</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>043019265</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -454,9 +455,9 @@
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for the Bank of New York Mellon Corporation</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4299124</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>4299124</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;BankOfNewYorkMellonCorporation-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -485,7 +486,7 @@
 		<rdfs:label>Bank of New York Mellon Corporation RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to The Bank of New York Mellon Corporation</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>3587146</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>3587146</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;BankOfNewYorkMellonCorporation"/>
 	</owl:NamedIndividual>
 	
@@ -526,9 +527,9 @@
 		<fibo-be-corp-corp:hasDateOfRegistration rdf:resource="&fibo-fbc-fct-usind;CitiCardsSouthDakotaAcceptanceCorpIncorporationDate"/>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>3686137</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>3686137</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitiCardsSouthDakotaAcceptanceCorp-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -565,7 +566,7 @@
 		<rdfs:label>Citi Cards South Dakota Acceptance Corp. RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Citi Cards South Dakota Acceptance Corp.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>3225130</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>3225130</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitiCardsSouthDakotaAcceptanceCorp"/>
 	</owl:NamedIndividual>
 	
@@ -601,9 +602,9 @@
 		<fibo-be-corp-corp:hasDateOfRegistration rdf:resource="&fibo-fbc-fct-usind;CitibankNAIncorporationDate"/>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>944169</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>944169</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitibankNA-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -625,8 +626,8 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>Citibank, N.A. FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for Citibank, N.A.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>7213</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:explanatoryNote>From the NIC and FDIC records, it appears that Citibank, National Association (with RSSD of 112855 and FDIC certificate of 16100) and Citibank, N.A. have been merged into a single national bank, with the surviving FDIC certificate and RSSD as defined herein.</fibo-fnd-utl-av:explanatoryNote>
+		<lcc-lr:hasTag>7213</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitibankNA"/>
 	</owl:NamedIndividual>
 	
@@ -687,8 +688,8 @@
 		<rdfs:label>Citibank, N.A. RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Citibank, N.A.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>476810</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-utl-av:explanatoryNote>From the NIC and FDIC records, it appears that Citibank, National Association (with RSSD of 112855 and FDIC certificate of 16100) and Citibank, N.A. have been merged into a single national bank, with the surviving FDIC certificate and RSSD as defined herein.</fibo-fnd-utl-av:explanatoryNote>
+		<lcc-lr:hasTag>476810</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitibankNA"/>
 	</owl:NamedIndividual>
 	
@@ -696,7 +697,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>Citibank, N.A. RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for Citibank, N.A.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>021000089</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>021000089</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitibankNA"/>
 	</owl:NamedIndividual>
 	
@@ -725,9 +726,9 @@
 		<rdfs:label>Citicorp LLC business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Citicorp LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>3911630</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>3911630</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CiticorpLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -759,7 +760,7 @@
 		<rdfs:label>Citicorp LLC RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Citicorp LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>3375370</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>3375370</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CiticorpLLC"/>
 	</owl:NamedIndividual>
 	
@@ -800,9 +801,9 @@
 		<rdfs:label>Citigroup Inc. business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Citigroup Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>2154254</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>2154254</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitigroupInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -842,7 +843,7 @@
 		<rdfs:label>Citigroup Inc. RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Citigroup Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>1951350</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>1951350</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitigroupInc"/>
 	</owl:NamedIndividual>
 	
@@ -870,9 +871,9 @@
 		<rdfs:label>FMR LLC business entity identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for FMR LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4403845</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>4403845</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;FMRLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -912,7 +913,7 @@
 		<rdfs:label>FMR LLC RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to FMR LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>1245983</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>1245983</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;FMRLLC"/>
 	</owl:NamedIndividual>
 	
@@ -935,7 +936,7 @@
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;InternationalBusinessMachinesCorporationBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;InternationalBusinessMachinesCorporationBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
-		<fibo-fnd-rel-rel:hasTag>IBMXUS33XXX</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>IBMXUS33XXX</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;InternationalBusinessMachinesCorporation-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -943,16 +944,16 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>International Business Machines Corporation business party prefix</rdfs:label>
 		<skos:definition>business party prefix for International Business Machines Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>IBMX</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;InternationalBusinessMachinesCorporationBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>IBMX</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;InternationalBusinessMachinesCorporationBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>International Business Machines Corporation business party suffix</rdfs:label>
 		<skos:definition>business party suffix for International Business Machines Corporation</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;InternationalBusinessMachinesCorporationBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>33</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;InternationalBusinessMachinesCorporationLegalEntityIdentifierRegistryEntry">
@@ -995,9 +996,9 @@
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for JPMorgan Chase &amp; Co.</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>691011</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>691011</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCo-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1009,7 +1010,7 @@
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCoBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCoBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
-		<fibo-fnd-rel-rel:hasTag>HAMQUS31XXX</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>HAMQUS31XXX</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCo-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1017,16 +1018,16 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. business party prefix</rdfs:label>
 		<skos:definition>business party prefix for JPMorgan Chase &amp; Co.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HAMQ</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCoBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>HAMQ</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseAndCoBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. business party suffix</rdfs:label>
 		<skos:definition>business party suffix for JPMorgan Chase &amp; Co.</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>31</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCoBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>31</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseAndCoHeadquartersAddress">
@@ -1065,7 +1066,7 @@
 		<rdfs:label>JPMorgan Chase &amp; Co. RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to JPMorgan Chase &amp; Co.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>1039502</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>1039502</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCo"/>
 	</owl:NamedIndividual>
 	
@@ -1111,9 +1112,9 @@
 		<skos:definition>registration identifier assigned by the Ohio Department of Corporations for JPMorgan Chase Bank, National Association</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal"/>
-		<fibo-fnd-rel-rel:hasTag>2118141</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfOhioJurisdiction"/>
+		<lcc-lr:hasTag>2118141</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociation-US-OH"/>
 	</owl:NamedIndividual>
 	
@@ -1125,7 +1126,7 @@
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
-		<fibo-fnd-rel-rel:hasTag>CHASUS33XXX</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>CHASUS33XXX</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociation-US-OH"/>
 	</owl:NamedIndividual>
 	
@@ -1133,16 +1134,16 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association business party prefix</rdfs:label>
 		<skos:definition>business party prefix for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CHAS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>CHAS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association business party suffix</rdfs:label>
 		<skos:definition>business party suffix for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>33</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociationDateEstablished">
@@ -1163,7 +1164,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>628</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>628</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -1185,7 +1186,7 @@
 		<rdfs:label>JPMorgan Chase Bank, National Association RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to JPMorgan Chase Bank, National Association</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>852218</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>852218</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -1193,7 +1194,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>JPMorgan Chase Bank, National Association RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for JPMorgan Chase Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>021000021</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>021000021</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -1232,9 +1233,9 @@
 		<skos:definition>registration identifier assigned by the California Division of Corporations for Pinnacle Bank</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>C2859719</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfCaliforniaJurisdiction"/>
+		<lcc-lr:hasTag>C2859719</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;PinnacleBank-US-CA"/>
 	</owl:NamedIndividual>
 	
@@ -1251,7 +1252,7 @@
 		<rdfs:label>Pinnacle Bank California Certificate of Authority identifier</rdfs:label>
 		<skos:definition>registration identifier assigned by the California Department of Business Oversight for the California Certificate of Authority (banking license) for Pinnacle Bank</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBankingRegulator"/>
-		<fibo-fnd-rel-rel:hasTag>2261</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>2261</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;PinnacleBankCaliforniaCertificateOfAuthority"/>
 	</owl:NamedIndividual>
 	
@@ -1267,7 +1268,7 @@
 		<rdfs:label>Pinnacle Bank FDIC Certificate</rdfs:label>
 		<skos:definition>FDIC Certificate number for Pinnacle Bank</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;FDICInstitutionDirectory"/>
-		<fibo-fnd-rel-rel:hasTag>58297</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>58297</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;PinnacleBank"/>
 	</owl:NamedIndividual>
 	
@@ -1299,7 +1300,7 @@
 		<rdfs:label>Pinnacle Bank RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Pinnacle Bank</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>3455227</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>3455227</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;PinnacleBank"/>
 	</owl:NamedIndividual>
 	
@@ -1307,7 +1308,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>Pinnacle Bank RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for Pinnacle Bank</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>121144340</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>121144340</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;PinnacleBank"/>
 	</owl:NamedIndividual>
 	
@@ -1341,9 +1342,9 @@
 		<skos:definition>registration identifier assigned by the Massachusetts Corporations Division for State Street Bank and Trust Company</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsCorporationRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>00011313</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfMassachusettsJurisdiction"/>
+		<lcc-lr:hasTag>00011313</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompany-US-MA"/>
 	</owl:NamedIndividual>
 	
@@ -1355,7 +1356,7 @@
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
-		<fibo-fnd-rel-rel:hasTag>SBOSUS33XXX</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>SBOSUS33XXX</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompany-US-MA"/>
 	</owl:NamedIndividual>
 	
@@ -1363,16 +1364,16 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>State Street Bank and Trust Company business party prefix</rdfs:label>
 		<skos:definition>business party prefix for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SBOS</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>SBOS</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>State Street Bank and Trust Company business party suffix</rdfs:label>
 		<skos:definition>business party suffix for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>33</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompanyDateEstablished">
@@ -1393,7 +1394,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>State Street Bank and Trust Company FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>14</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>14</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -1415,7 +1416,7 @@
 		<rdfs:label>State Street Bank and Trust Company RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to State Street Bank and Trust Company</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>35301</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>35301</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -1423,7 +1424,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>State Street Bank and Trust Company RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for State Street Bank and Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>011000028</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>011000028</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -1461,9 +1462,9 @@
 		<skos:definition>registration identifier assigned by the Massachusetts Corporations Division for State Street Corporation</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsCorporationRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>042456637</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfMassachusettsJurisdiction"/>
+		<lcc-lr:hasTag>042456637</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;StateStreetCorporation-US-MA"/>
 	</owl:NamedIndividual>
 	
@@ -1503,7 +1504,7 @@
 		<rdfs:label>State Street Corporation RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to State Street Corporation</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>1111435</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>1111435</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;StateStreetCorporation"/>
 	</owl:NamedIndividual>
 	
@@ -1515,7 +1516,7 @@
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;TheCoca-ColaCompanyBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;TheCoca-ColaCompanyBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
-		<fibo-fnd-rel-rel:hasTag>TCCCUS33XXX</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>TCCCUS33XXX</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;TheCoca-ColaCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1523,16 +1524,16 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>The Coca-Cola Company business party prefix</rdfs:label>
 		<skos:definition>business party prefix for The Coca-Cola Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>TCCC</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;TheCoca-ColaCompanyBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>TCCC</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;TheCoca-ColaCompanyBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>The Coca-Cola Company business party suffix</rdfs:label>
 		<skos:definition>business party suffix for The Coca-Cola Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;TheCoca-ColaCompanyBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>33</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;TheCoca-ColaCompanyCorporateAddress">
@@ -1591,7 +1592,7 @@
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
-		<fibo-fnd-rel-rel:hasTag>PGGTUS33XXX</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>PGGTUS33XXX</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-be-le-usee;TheProctorAndGambleCompany-US-OH"/>
 	</owl:NamedIndividual>
 	
@@ -1599,16 +1600,16 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>The Proctor &amp; Gamble Company business party prefix</rdfs:label>
 		<skos:definition>business party prefix for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PGGT</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>PGGT</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>The Proctor &amp; Gamble Company business party suffix</rdfs:label>
 		<skos:definition>business party suffix for The Proctor &amp; Gamble Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>33</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>33</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;TheProctorAndGambleCompanyCorporateAddress">
@@ -1670,9 +1671,9 @@
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for WFC Holdings, LLC</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>2939552</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>2939552</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WFCHoldingsLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1746,9 +1747,9 @@
 		<skos:definition>registration identifier assigned by the Delaware Department of Corporations for Wells Fargo &amp; Company</skos:definition>
 		<fibo-fbc-fct-breg:hasEntityStatus rdf:resource="&fibo-fbc-fct-breg;ActiveStatus"/>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>637901</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>637901</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WellsFargoAndCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1789,7 +1790,7 @@
 		<rdfs:label>Wells Fargo &amp; Company RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Wells Fargo &amp; Company</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>1120754</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>1120754</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WellsFargoAndCompany"/>
 	</owl:NamedIndividual>
 	
@@ -1824,7 +1825,7 @@
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationBusinessPartyPrefix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationBusinessPartySuffix"/>
 		<fibo-fnd-rel-rel:comprises rdf:resource="&lcc-3166-1;US"/>
-		<fibo-fnd-rel-rel:hasTag>WFBIUS6SXXX</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>WFBIUS6SXXX</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociation-US"/>
 	</owl:NamedIndividual>
 	
@@ -1832,16 +1833,16 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartyPrefix"/>
 		<rdfs:label>Wells Fargo Bank, National Association business party prefix</rdfs:label>
 		<skos:definition>business party prefix for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>WFBI</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>WFBI</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationBusinessPartySuffix">
 		<rdf:type rdf:resource="&fibo-fbc-fct-fse;BusinessPartySuffix"/>
 		<rdfs:label>Wells Fargo Bank, National Association business party suffix</rdfs:label>
 		<skos:definition>business party suffix for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>6S</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isIncludedIn rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationBusinessIdentifierCode"/>
+		<lcc-lr:hasTag>6S</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociationDateEstablished">
@@ -1862,7 +1863,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;FDICCertificateNumber"/>
 		<rdfs:label>Wells Fargo Bank, National Association FDIC Certificate number</rdfs:label>
 		<skos:definition>FDIC Certificate number for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3511</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>3511</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -1916,7 +1917,7 @@
 		<rdfs:label>Wells Fargo Bank, National Association RSSD identifier</rdfs:label>
 		<skos:definition>research statistics supervision discount identifier (RSSD ID), assigned by the Federal Reserve to Wells Fargo Bank, National Association</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>451965</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>451965</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -1924,7 +1925,7 @@
 		<rdf:type rdf:resource="&fibo-fbc-fct-usjrga;RoutingTransitNumber"/>
 		<rdfs:label>Wells Fargo Bank, National Association RTN</rdfs:label>
 		<skos:definition>routing transit number (RTN) for Wells Fargo Bank, National Association</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>121000248</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>121000248</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -1933,7 +1934,7 @@
 		<rdfs:label>BNY Mellon, National Association legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for BNY Mellon, National Association</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4EP6JBYBTPTQ47LZOB67</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>4EP6JBYBTPTQ47LZOB67</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;BNYMellonNationalAssociation-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1942,7 +1943,7 @@
 		<rdfs:label>Citicorp LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Citicorp LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300PSHWOM1D1JVL23</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300PSHWOM1D1JVL23</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CiticorpLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1951,7 +1952,7 @@
 		<rdfs:label>State Street Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for State Street Corporation</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300ZFEEJ2IP5VME73</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300ZFEEJ2IP5VME73</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;StateStreetCorporation-US-MA"/>
 	</owl:NamedIndividual>
 	
@@ -1960,7 +1961,7 @@
 		<rdfs:label>State Street Bank and Trust Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for State Street Bank and Trust Company</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>571474TGEMMWANRLN572</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>571474TGEMMWANRLN572</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;StateStreetBankAndTrustCompany-US-MA"/>
 	</owl:NamedIndividual>
 	
@@ -1969,7 +1970,7 @@
 		<rdfs:label>Citigroup Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Citigroup Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>6SHGI4ZSSLCXXQSBB395</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>6SHGI4ZSSLCXXQSBB395</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitigroupInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1978,7 +1979,7 @@
 		<rdfs:label>FMR LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for FMR LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>6X064LF7Y6B4DKF2GZ26</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>6X064LF7Y6B4DKF2GZ26</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;FMRLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -1987,7 +1988,7 @@
 		<rdfs:label>JPMorgan Chase Bank, National Association legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for JPMorgan Chase Bank, National Association</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>7H6GLXDRUGQFU57RNE97</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>7H6GLXDRUGQFU57RNE97</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseBankNationalAssociation-US-OH"/>
 	</owl:NamedIndividual>
 	
@@ -1996,7 +1997,7 @@
 		<rdfs:label>JPMorgan Chase &amp; Co. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for JPMorgan Chase &amp; Co.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>8I5DZWZKVSZI1NUHU748</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>8I5DZWZKVSZI1NUHU748</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;JPMorganChaseAndCo-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -2005,7 +2006,7 @@
 		<rdfs:label>Citibank, N.A. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Citibank N.A.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>E57ODZWZ7FF32TWEFA76</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>E57ODZWZ7FF32TWEFA76</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;CitibankNA-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -2014,7 +2015,7 @@
 		<rdfs:label>Wells Fargo Bank, National Association legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Wells Fargo Bank, National Association</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;BloombergLEIRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>KB1H1DSPRFMYMCUFXT09</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>KB1H1DSPRFMYMCUFXT09</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WellsFargoBankNationalAssociation-US"/>
 	</owl:NamedIndividual>
 	
@@ -2023,7 +2024,7 @@
 		<rdfs:label>WFC Holdings, LLC legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for WFC Holdings, LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;BloombergLEIRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>OT19FZZ6Z7A27CCLDY33</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>OT19FZZ6Z7A27CCLDY33</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WFCHoldingsLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -2032,7 +2033,7 @@
 		<rdfs:label>Wells Fargo &amp; Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Wells Fargo &amp; Company</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>PBLD0EJDB5FWOLXP3B76</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>PBLD0EJDB5FWOLXP3B76</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;WellsFargoAndCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -2041,7 +2042,7 @@
 		<rdfs:label>The Bank of New York Mellon Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Bank of New York Mellon Corporation</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>WFLLPEPC7FZXENRZV188</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>WFLLPEPC7FZXENRZV188</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usind;BankOfNewYorkMellonCorporation-US-DE"/>
 	</owl:NamedIndividual>
 

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf
@@ -131,10 +131,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-CA/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was added via the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to reflect revisions to the GLEIF LEI representation for validation level.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190101/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was modified to normalize a few labels and definitions, revise GLEIF LEI registration data, eliminate duplication of concepts in LCC, simplify addresses, and merge countries with locations in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -144,7 +145,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>Delaware Division of Corporations business entity identifier for Bloomberg L.P.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>2110234</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>2110234</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -162,7 +163,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>Delaware Division of Corporations business entity identifier for Bloomberg Finance L.P.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4348344</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>4348344</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;BloombergFinanceLP-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -284,7 +285,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>Federal Reserve RSSD identifier for Bloomberg L.P. as a data processing servicer</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NationalInformationCenterRepository"/>
-		<fibo-fnd-rel-rel:hasTag>2217129</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>2217129</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP"/>
 	</owl:NamedIndividual>
 	
@@ -343,7 +344,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for The Depository Trust &amp; Clearing Corporation</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>628925</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>628925</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;DTCC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -379,7 +380,7 @@
 		<rdfs:label>DTC FDIC certificate number</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>FDIC certificate number for The Depository Trust Company</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>90544</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>90544</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;DepositoryTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -413,7 +414,7 @@
 		<rdfs:label>RSSD identifier for The Depository Trust Company</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>Federal Reserve RSSD identifier for The Depository Trust Company (DTC)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>52719</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>52719</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;DepositoryTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -422,7 +423,7 @@
 		<rdfs:label>The Depository Trust Company RTN</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>Routing Transit Number (RTN) for the Depository Trust Company (DTC)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>026002066</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>026002066</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;DepositoryTrustCompany"/>
 	</owl:NamedIndividual>
 	
@@ -521,7 +522,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>Delaware Division of Corporations business entity identifier for Intercontinental Exchange, Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>5298907</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5298907</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchangeInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -593,7 +594,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USFinancialServicesEntitiesIndividuals/"/>
 		<skos:definition>New York Division of Corporations business entity identifier for S&amp;P Global Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>99979</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>99979</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;SPGlobalInc-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -733,7 +734,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>Federal Reserve Bank of New York legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for the Federal Reserve Bank of New York</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;BloombergLEIRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>254900Y8NKGV541U8Q32</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>254900Y8NKGV541U8Q32</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveBankOfNewYork-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -742,7 +743,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>Intercontinental Exchange legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Intercontinental Exchange</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>5493000F4ZO33MV32P92</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5493000F4ZO33MV32P92</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;IntercontinentalExchangeInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -751,7 +752,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>Bloomberg Finance L.P. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Bloomberg Finance L.P.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;BloombergLEIRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>5493001KJTIIGC8Y1R12</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5493001KJTIIGC8Y1R12</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;BloombergFinanceLP-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -760,7 +761,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>Thomson Reuters Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Thomson Reuters Corporation</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300561UZND4C7B569</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300561UZND4C7B569</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;ThomsonReutersCorporation"/>
 	</owl:NamedIndividual>
 	
@@ -769,7 +770,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>Bloomberg L.P. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for Bloomberg L.P.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;BloombergLEIRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300B56MD0ZC402L06</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300B56MD0ZC402L06</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;BloombergLP-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -778,7 +779,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>The Depository Trust Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Depository Trust Company</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>MLDY5N6PZ58ZE60QU102</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>MLDY5N6PZ58ZE60QU102</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;DTC-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -787,7 +788,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>Corporation Service Company legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for the Corporation Service Company</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>549300NOPSIMGJNT8J31</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>549300NOPSIMGJNT8J31</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -796,7 +797,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>The Depository Trust &amp; Clearing Corporation legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for The Depository Trust &amp; Clearing Corporation</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>MLDY5N6PZ58ZE60QU102</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>MLDY5N6PZ58ZE60QU102</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;DTCC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -805,7 +806,7 @@ DTC brings efficiency to the securities industry by retaining custody of more th
 		<rdfs:label>S&amp;P Global, Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for S&amp;P Global, Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>Y6X4K52KMJMZE7I7MY94</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>Y6X4K52KMJMZE7I7MY94</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usfsind;SPGlobalInc-US-NY"/>
 	</owl:NamedIndividual>
 

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf
@@ -112,9 +112,10 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180901/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/ version of this ontology was modified to support revisions of the MIC codes as of 11 January 2019, including the new URI strategy, and to move the registry definitions to a new international financial organizations ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals/ version of this ontology was modified to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/NorthAmericanEntities/USMarketsAndExchangesIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -133,7 +134,7 @@
 		<rdfs:label>CBOE Global Markets, Inc. business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for CBOE Global Markets, Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4205301</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>4205301</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usmkt;CBOEGlobalMarketsInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -232,7 +233,7 @@
 		<rdfs:label>NYSE American Options, LLC business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for NYSE American Options LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4982468</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>4982468</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usmkt;NYSEAmericanOptionsLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -287,7 +288,7 @@
 		<rdfs:label>NYSE Arca, Inc. business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for NYSE Arca, Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>787634</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>787634</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usmkt;NYSEArcaInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -312,7 +313,7 @@
 		<rdfs:label>NYSE Arca Holdings, Inc. business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for NYSE Arca Holdings, Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>3703898</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>3703898</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usmkt;NYSEArcaHoldingsInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -413,7 +414,7 @@
 		<rdfs:label>NYSE Group, Inc. business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for NYSE Group, Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4160866</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>4160866</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usmkt;NYSEGroupInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -449,7 +450,7 @@
 		<rdfs:label>NYSE Holdings LLC business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Division of Corporations business entity identifier for NYSE Holdings LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>5257784</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5257784</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usmkt;NYSEHoldingsLLC-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -522,7 +523,7 @@
 		<rdfs:label>New York Stock Exchange LLC business entity identifier</rdfs:label>
 		<skos:definition>the New York Department of State Division of Corporations business entity identifier for New York Stock Exchange LLC</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>3230916</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>3230916</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchangeLLC-US-NY"/>
 	</owl:NamedIndividual>
 	
@@ -574,7 +575,7 @@
 		<rdfs:label>United Agent Group Inc. US-DE business entity identifier</rdfs:label>
 		<skos:definition>the Delaware Department of Corporations business entity identifier for the United Agent Group Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>5991300</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>5991300</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usmkt;UnitedAgentGroupInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -604,7 +605,7 @@
 		<rdfs:label>United Agent Group Inc. US-NY business entity identifier</rdfs:label>
 		<skos:definition>the New York Department of State Division of Corporations business entity identifier for the United Agent Group Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4914572</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>4914572</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usmkt;UnitedAgentGroupInc-US-NY"/>
 	</owl:NamedIndividual>
 	

--- a/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
+++ b/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf
@@ -133,10 +133,11 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/USJurisdiction/USRegulatoryAgencies.rdf version of this ontology was modified to integrate a financial services provider identifier for certain banking identifiers, add a property for secondary federal regulator, add individual registration schemes for state-specific business registries, improve on some definitions, normalize some of the labels, eliminate duplication of concepts in LCC, to simplify addresses, merge countries with locations in FND, eliminte the redundant notion of an InstitutionType, which can be determined using a SPARQL query or classification and results in a very large disjunction, and correct a couple of improperly defined annotations.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -165,9 +166,9 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for the American Bankers Association (ABA)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>3409652</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>3409652</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;AmericanBankersAssociation"/>
 	</owl:NamedIndividual>
 	
@@ -269,9 +270,9 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for Accuity Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>4069925</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>4069925</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;AccuityInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -420,7 +421,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the California Business Entities Registry</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000598</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>RA000598</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;CaliforniaBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
 	
@@ -506,9 +507,9 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for the Corporation Service Company</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>101330</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>101330</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;CorporationServiceCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -540,9 +541,9 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for The Corporation Trust Company (CT Corporation)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>101330</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>101330</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;CorporationTrustCompany-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -613,7 +614,7 @@
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the Delaware Business Entities Registry</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000602</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>RA000602</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
 	
@@ -632,9 +633,9 @@
 		<rdfs:label>FDIC business entity identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>Delaware Department of Corporations business entity identifier for the FDIC</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>1003818</fibo-fnd-rel-rel:hasTag>
 		<fibo-fnd-rel-rel:isDefinedIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessRegistrationIdentifierScheme"/>
 		<fibo-fnd-rel-rel:isGovernedBy rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
+		<lcc-lr:hasTag>1003818</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalDepositInsuranceCorporation"/>
 	</owl:NamedIndividual>
 	
@@ -1036,8 +1037,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve eighth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the eighth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of St. Louis</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>8</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Eighth District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>8</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEighthDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1057,8 +1058,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve eleventh district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the eleventh district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Dallas</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>11</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Eleventh District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>11</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveEleventhDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1080,8 +1081,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve fifth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the fifth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Richmond</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>5</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Fifth District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>5</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFifthDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1101,8 +1102,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve first district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the first district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Boston</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>1</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>First District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>1</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFirstDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1123,8 +1124,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve fourth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the fourth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Cleveland</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>4</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Fourth District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>4</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveFourthDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1147,8 +1148,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve ninth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the ninth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Minneapolis</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>9</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Ninth District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>9</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveNinthDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1183,8 +1184,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve second district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the second district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of New York</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>2</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Second District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>2</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSecondDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1206,8 +1207,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve seventh district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the seventh district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Chicago</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>7</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Seventh District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>7</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSeventhDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1230,8 +1231,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve sixth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the sixth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Atlanta</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>6</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Sixth District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>6</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveSixthDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1269,8 +1270,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve tenth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the tenth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Kansas City</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>10</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Tenth District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>10</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTenthDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1290,8 +1291,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve third district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the third district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of Philadelphia</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>3</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Third District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>3</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveThirdDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1320,8 +1321,8 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:label>Federal Reserve twelfth district identifier</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<skos:definition>identifier for the twelfth district of the Federal Reserve, which represents the district governed by the Federal Reserve Bank of San Francisco</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>12</fibo-fnd-rel-rel:hasTag>
 		<lcc-lr:hasName>Twelfth District of the Federal Reserve System</lcc-lr:hasName>
+		<lcc-lr:hasTag>12</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;FederalReserveTwelfthDistrict"/>
 	</owl:NamedIndividual>
 	
@@ -1468,7 +1469,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the Massachusetts Corporation Registry</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000613</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>RA000613</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;MassachusettsCorporationRegistry"/>
 	</owl:NamedIndividual>
 	
@@ -1597,7 +1598,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the New York State (NYS) Department of State, Division of Corporations, State Records and Uniform Commercial Code (UCC) registry of business entities</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000628</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>RA000628</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;NewYorkBusinessEntitiesRegistry"/>
 	</owl:NamedIndividual>
 	
@@ -1679,7 +1680,7 @@ In addition to serving as members of the Board, the Chairman and Vice Chairman o
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the Ohio Business Filing Portal</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000629</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>RA000629</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;OhioBusinessFilingPortal"/>
 	</owl:NamedIndividual>
 	
@@ -1852,7 +1853,7 @@ The ABA RTN is necessary for the Federal Reserve Banks to process Fedwire funds 
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/"/>
 		<rdfs:seeAlso rdf:resource="https://www.gleif.org/en/about-lei/gleif-registration-authorities-list"/>
 		<skos:definition>GLEIF Registration Authority List identifier for the South Dakota Business Information Registry</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>RA000635</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>RA000635</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-fbc-fct-usjrga;SouthDakotaBusinessInformationRegistry"/>
 	</owl:NamedIndividual>
 	

--- a/FND/Arrangements/Ratings.rdf
+++ b/FND/Arrangements/Ratings.rdf
@@ -83,10 +83,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Ratings/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Arrangements/Ratings/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190601/Arrangements/Ratings.rdf version of this ontology was revised to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Arrangements/Ratings.rdf version of this ontology was revised to add properties indicating the &apos;best&apos; and &apos;worst&apos; scores on a given scale.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Ratings.rdf version of this ontology was revised to eliminate duplication with LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Ratings.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -95,7 +96,7 @@
 		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
@@ -54,7 +54,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/NorthAmerica/USPostalServiceAddresses/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Places/NorthAmerica/USPostalServiceAddresses/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/NorthAmerica/USPostalServiceAddresses.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -281,7 +282,7 @@
 		<rdfs:label xml:lang="en">East</rdfs:label>
 		<rdfs:label xml:lang="es">Este</rdfs:label>
 		<skos:definition>geographic directional symbol for East</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>E</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>E</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;GeneralDeliveryAddress">
@@ -375,7 +376,7 @@
 		<rdfs:label xml:lang="es">Norte</rdfs:label>
 		<rdfs:label xml:lang="en">North</rdfs:label>
 		<skos:definition>geographic directional symbol for North</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>N</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>N</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Northeast">
@@ -383,7 +384,7 @@
 		<rdfs:label xml:lang="es">Noreste</rdfs:label>
 		<rdfs:label xml:lang="en">Northeast</rdfs:label>
 		<skos:definition>geographic directional symbol for Northeast</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NE</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>NE</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Northwest">
@@ -391,8 +392,8 @@
 		<rdfs:label xml:lang="es">Noroeste</rdfs:label>
 		<rdfs:label xml:lang="en">Northwest</rdfs:label>
 		<skos:definition>geographic directional symbol for Northwest</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>NO</fibo-fnd-rel-rel:hasTag>
-		<fibo-fnd-rel-rel:hasTag>NW</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>NO</lcc-lr:hasTag>
+		<lcc-lr:hasTag>NW</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;OverseasMilitaryAddress">
@@ -492,7 +493,7 @@
 		<rdfs:label xml:lang="en">South</rdfs:label>
 		<rdfs:label xml:lang="es">Sur</rdfs:label>
 		<skos:definition>geographic directional symbol for South</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>S</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>S</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Southeast">
@@ -500,7 +501,7 @@
 		<rdfs:label xml:lang="en">Southeast</rdfs:label>
 		<rdfs:label xml:lang="es">Sureste</rdfs:label>
 		<skos:definition>geographic directional symbol for Southeast</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SE</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>SE</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fnd-plc-uspsa;Southwest">
@@ -508,8 +509,8 @@
 		<rdfs:label xml:lang="en">Southwest</rdfs:label>
 		<rdfs:label xml:lang="es">Suroeste</rdfs:label>
 		<skos:definition>geographic directional symbol for Southwest</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>SO</fibo-fnd-rel-rel:hasTag>
-		<fibo-fnd-rel-rel:hasTag>SW</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>SO</lcc-lr:hasTag>
+		<lcc-lr:hasTag>SW</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;StandardizedAddress">
@@ -558,8 +559,8 @@
 		<rdfs:label xml:lang="es">Oeste</rdfs:label>
 		<rdfs:label xml:lang="en">West</rdfs:label>
 		<skos:definition>geographic directional symbol for West</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>O</fibo-fnd-rel-rel:hasTag>
-		<fibo-fnd-rel-rel:hasTag>W</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>O</lcc-lr:hasTag>
+		<lcc-lr:hasTag>W</lcc-lr:hasTag>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-uspsa;ZIPCode">

--- a/FND/ProductsAndServices/ProductsAndServices.rdf
+++ b/FND/ProductsAndServices/ProductsAndServices.rdf
@@ -76,7 +76,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200201/ProductsAndServices/ProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/ProductsAndServices/ProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20150801/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified per the issue resolutions identified in the FIBO FND 1.1 RTF report to replace MoneyAmount with AmountOfMoney.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified for the FIBO 2.0 RFC to add NegotiableCommodity and Consumer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/ProductsAndServices/ProductsAndServices.rdf version of this ontology was modified to include classes to support automated inclusion of all ISO 4217 codes published as of 2018-06-04.</skos:changeNote>
@@ -84,6 +84,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/ProductsAndServices/ProductsAndServices.rdf version of this ontology was revised to leverage the new party identifier.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/ProductsAndServices/ProductsAndServices.rdf version of this ontology was revised to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/ProductsAndServices/ProductsAndServices.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/ProductsAndServices/ProductsAndServices.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -251,7 +252,7 @@
 		<rdfs:subClassOf rdf:resource="&lcc-lr;Identifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -63,7 +63,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Relations/Relations.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Relations/Relations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and remove the unused hasDispositionDate property, whose semantics were unclear at best.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, and to eliminate circular definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions, and eliminate the definition of hasTag in favor of the one in LCC (which had an overly complex range that is not needed for the FIBO use cases identified to date).</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -219,23 +219,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<rdfs:range rdf:resource="&fibo-fnd-rel-rel;Reference"/>
 		<skos:definition>relates a concept to some textual or other symbol which is intended to convey the sense of that concept or to some form of words which sets out the meaning of that concept</skos:definition>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasTag">
-		<rdfs:label>has tag</rdfs:label>
-		<rdfs:range>
-			<rdfs:Datatype>
-				<owl:unionOf rdf:parseType="Collection">
-					<rdf:Description rdf:about="&xsd;string">
-					</rdf:Description>
-					<rdf:Description rdf:about="&xsd;base64Binary">
-					</rdf:Description>
-					<rdf:Description rdf:about="&xsd;hexBinary">
-					</rdf:Description>
-				</owl:unionOf>
-			</rdfs:Datatype>
-		</rdfs:range>
-		<skos:definition>has a unique combination of alphanumeric characters or binary representation corresponding to the identifier, code, or other element to which it applies</skos:definition>
-	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;holds">
 		<rdfs:label>holds</rdfs:label>
@@ -422,9 +405,5 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&lcc-lr;hasDenotation">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasRepresentation"/>
 	</owl:ObjectProperty>
-	
-	<owl:DatatypeProperty rdf:about="&lcc-lr;hasTag">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
-	</owl:DatatypeProperty>
 
 </rdf:RDF>

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -63,7 +63,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Relations/Relations.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Relations/Relations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and remove the unused hasDispositionDate property, whose semantics were unclear at best.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions, and eliminate the definition of hasTag in favor of the one in LCC (which had an overly complex range that is not needed for the FIBO use cases identified to date).</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions and to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -219,6 +219,24 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<rdfs:range rdf:resource="&fibo-fnd-rel-rel;Reference"/>
 		<skos:definition>relates a concept to some textual or other symbol which is intended to convey the sense of that concept or to some form of words which sets out the meaning of that concept</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fnd-rel-rel;hasTag">
+		<rdfs:label>has tag</rdfs:label>
+		<rdfs:range>
+			<rdfs:Datatype>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&xsd;string">
+					</rdf:Description>
+					<rdf:Description rdf:about="&xsd;base64Binary">
+					</rdf:Description>
+					<rdf:Description rdf:about="&xsd;hexBinary">
+					</rdf:Description>
+				</owl:unionOf>
+			</rdfs:Datatype>
+		</rdfs:range>
+		<owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+		<skos:definition>has a unique combination of alphanumeric characters or binary representation corresponding to the identifier, code, or other element to which it applies</skos:definition>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;holds">
 		<rdfs:label>holds</rdfs:label>

--- a/IND/InterestRates/MarketDataProviders.rdf
+++ b/IND/InterestRates/MarketDataProviders.rdf
@@ -111,7 +111,8 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/Regions/ISO3166-2-SubdivisionCodes-US/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20200301/InterestRates/MarketDataProviders/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20200701/InterestRates/MarketDataProviders/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20200301/InterestRates/MarketDataProviders.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -151,7 +152,7 @@
 		<rdfs:label>BGC Partners, Inc. business entity identifier</rdfs:label>
 		<skos:definition>Delaware Division of Corporations business entity identifier for BGC Partners, Inc. b</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usjrga;DelawareBusinessEntitiesRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>3051512</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>3051512</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-ind-ir-mdp;BGCPartnersInc-US-DE"/>
 	</owl:NamedIndividual>
 	
@@ -253,7 +254,7 @@
 		<rdfs:label>BGC Partners, Inc. legal entity identifier</rdfs:label>
 		<skos:definition>legal entity identifier for BGC Partners, Inc.</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredIn rdf:resource="&fibo-fbc-fct-usfsind;GlobalMarketsEntityIdentifierRegistry"/>
-		<fibo-fnd-rel-rel:hasTag>TF1LXM1YNB81WKUH5G19</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>TF1LXM1YNB81WKUH5G19</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-ind-ir-mdp;BGCPartnersInc-US-DE"/>
 	</owl:NamedIndividual>
 

--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -95,8 +95,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquitiesExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquitiesExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was modified to add CFI codes to the example equity instruments.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -115,9 +116,9 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>Alphabet Inc. class A financial instrument short name</rdfs:label>
 		<skos:definition>Alphabet Inc. class A common share financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ALPHABET INC/SH CL A</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH CL A</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>ALPHABET INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<lcc-lr:hasTag>ALPHABET INC/SH CL A</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -136,9 +137,9 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>Alphabet Inc. class C financial instrument short name</rdfs:label>
 		<skos:definition>Alphabet Inc. class C capital stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ALPHABET INC/SH CAP SH NV</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH CAP SH NV</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>ALPHABET INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<lcc-lr:hasTag>ALPHABET INC/SH CAP SH NV</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -166,9 +167,9 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>Apple Inc. common stock financial instrument short name</rdfs:label>
 		<skos:definition>Apple Inc. common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>APPLE INC/SH SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>APPLE INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<lcc-lr:hasTag>APPLE INC/SH SH</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -184,7 +185,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000B9Y5X2</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Apple Inc. common shares listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000B9Y5X2</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG000B9Y5X2</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNASListedAppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -192,7 +193,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BKZDM1</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Home Depot common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BKZDM1</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG000BKZDM1</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -200,7 +201,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BLNQ16</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for IBM common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BLNQ16</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG000BLNQ16</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedInternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -208,7 +209,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BMX4N8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Coca-Cola Company common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BMX4N8</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG000BMX4N8</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -216,7 +217,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BR2WS4</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Proctor &amp; Gamble Company common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BR2WS4</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG000BR2WS4</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -224,7 +225,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000BWQFY7</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Wells Fargo &amp; Company common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000BWQFY7</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG000BWQFY7</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedWellsFargoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -232,7 +233,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000DMBZW1</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for JPMorgan Chase &amp; Co. common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000DMBZW1</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG000DMBZW1</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedJPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -240,7 +241,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG000FY4VG8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Citigroup Inc. common shares listed in the New York Stock Exchange (NYSE)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG000FY4VG8</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG000FY4VG8</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedCitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -248,7 +249,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5MQ8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Coca-Cola Company common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5MQ8</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG001S5MQ8</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -256,7 +257,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5N8V8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Apple Inc. common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5N8V8</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG001S5N8V8</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -264,7 +265,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5RTW7</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Home Depot, Inc. common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5RTW7</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG001S5RTW7</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -272,7 +273,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5S399</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for IBM common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5S399</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG001S5S399</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -280,7 +281,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5V4L9</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for The Proctor &amp; Gamble Company common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5V4L9</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG001S5V4L9</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -288,7 +289,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S5XF23</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Wells Fargo &amp; Company common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S5XF23</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG001S5XF23</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;WellsFargoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -296,7 +297,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S72ZG4</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Citigroup Inc. common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S72ZG4</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG001S72ZG4</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -304,7 +305,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG001S8CRC3</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for JPMorgan Chase &amp; Co. common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG001S8CRC3</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG001S8CRC3</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -312,7 +313,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG009S39JY5</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Alphabet Inc. class A common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG009S39JY5</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG009S39JY5</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -320,7 +321,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG009S3NB21</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Alphabet Inc. class C common shares</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG009S3NB21</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG009S3NB21</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -328,7 +329,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG009S4MT03</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Alphabet Inc. class A common shares listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG009S4MT03</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG009S4MT03</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNASListedAlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -336,7 +337,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG009S4MVF2</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Alphabet Inc. class C common shares listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG009S4MVF2</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG009S4MVF2</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNASListedAlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -344,7 +345,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifier"/>
 		<rdfs:label>BBG00JPR0LX8</rdfs:label>
 		<skos:definition>Financial Instrument Global Identifier (FIGI) for Apple Inc. common shares listed in the London Stock Exchange</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>BBG00JPR0LX8</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>BBG00JPR0LX8</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XLOMListedAppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -352,7 +353,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>02079K107</rdfs:label>
 		<skos:definition>Alphabet Inc. class C common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>02079K107</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>02079K107</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -360,7 +361,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>02079K305</rdfs:label>
 		<skos:definition>Alphabet Inc. class A common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>02079K305</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>02079K305</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -368,7 +369,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>037833100</rdfs:label>
 		<skos:definition>Apple Inc. common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>037833100</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>037833100</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -376,7 +377,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>172967424</rdfs:label>
 		<skos:definition>Citigroup Inc. common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>172967424</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>172967424</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -384,7 +385,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>191216100</rdfs:label>
 		<skos:definition>The Coca-Cola Company common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>191216100</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>191216100</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -392,7 +393,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>437076102</rdfs:label>
 		<skos:definition>The Home Depot, Inc. common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>437076102</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>437076102</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -400,7 +401,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>459200101</rdfs:label>
 		<skos:definition>IBM common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>459200101</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>459200101</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -408,7 +409,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>46625H100</rdfs:label>
 		<skos:definition>JPMorgan Chase &amp; Co. common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>46625H100</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>46625H100</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -416,7 +417,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>742718109</rdfs:label>
 		<skos:definition>The Proctor &amp; Gamble Company common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>742718109</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>742718109</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -424,7 +425,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;CommitteeOnUniformSecuritiesIdentificationProceduresNumber"/>
 		<rdfs:label>949746101</rdfs:label>
 		<skos:definition>Wells Fargo &amp; Company common share CUSIP</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>949746101</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>949746101</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;WellsFargoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -444,9 +445,9 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>Citigroup Inc. common stock financial instrument short name</rdfs:label>
 		<skos:definition>Citigroup Inc. common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>CITIGROUP INC/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>CITIGROUP INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<lcc-lr:hasTag>CITIGROUP INC/SH</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -462,7 +463,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US02079K1079</rdfs:label>
 		<skos:definition>Alphabet Inc. class C common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US02079K1079</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US02079K1079</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -470,7 +471,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US02079K3059</rdfs:label>
 		<skos:definition>Alphabet Inc. class A common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US02079K3059</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US02079K3059</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -478,7 +479,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US0378331005</rdfs:label>
 		<skos:definition>Apple Inc. common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US0378331005</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US0378331005</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;AppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -486,7 +487,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US1729674242</rdfs:label>
 		<skos:definition>Citigroup Inc. common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US1729674242</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US1729674242</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;CitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -494,7 +495,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US1912161007</rdfs:label>
 		<skos:definition>The Coca-Cola Company common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US1912161007</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US1912161007</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -502,7 +503,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US4370761029</rdfs:label>
 		<skos:definition>The Home Depot, Inc. common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US4370761029</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US4370761029</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -510,7 +511,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US4592001014</rdfs:label>
 		<skos:definition>IBM common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US4592001014</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US4592001014</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -518,7 +519,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US46625H1005</rdfs:label>
 		<skos:definition>JPMorgan Chase &amp; Co. common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US46625H1005</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US46625H1005</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -526,7 +527,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US7427181091</rdfs:label>
 		<skos:definition>The Proctor &amp; Gamble Company common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US7427181091</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US7427181091</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -534,7 +535,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;InternationalSecuritiesIdentificationNumber"/>
 		<rdfs:label>US9497461015</rdfs:label>
 		<skos:definition>Wells Fargo &amp; Company common share ISIN</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>US9497461015</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>US9497461015</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;WellsFargoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -554,9 +555,9 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>International Business Machines Corporation common stock financial instrument short name</rdfs:label>
 		<skos:definition>IBM common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>INTL BUS MACHIN/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>INTL BUS MACHIN</fibo-sec-sec-iss:hasIssuerShortName>
+		<lcc-lr:hasTag>INTL BUS MACHIN/SH</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;InternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -584,9 +585,9 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>JPMorgan Chase &amp; Co. common stock financial instrument short name</rdfs:label>
 		<skos:definition>JPMorgan Chase &amp; Co. common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>JPMORGAN CHASE/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>JPMORGAN CHASE</fibo-sec-sec-iss:hasIssuerShortName>
+		<lcc-lr:hasTag>JPMORGAN CHASE/SH</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;JPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -602,7 +603,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-idind;StockExchangeDailyOfficialListCode"/>
 		<rdfs:label>B0YQ5W0</rdfs:label>
 		<skos:definition>Apple Inc. common share SEDOL listed in the London Stock Exchange</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>B0YQ5W0</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>B0YQ5W0</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XLOMListedAppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -622,9 +623,9 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>The Coca-Cola Company common stock financial instrument short name</rdfs:label>
 		<skos:definition>The Coca-Cola Company common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>COCA COLA CO/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>COCA COLA CO</fibo-sec-sec-iss:hasIssuerShortName>
+		<lcc-lr:hasTag>COCA COLA CO/SH</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -652,9 +653,9 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>The Home Depot, Inc. common stock financial instrument short name</rdfs:label>
 		<skos:definition>Home Depot, Inc. common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>HOME DEPOT INC/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>HOME DEPOT INC</fibo-sec-sec-iss:hasIssuerShortName>
+		<lcc-lr:hasTag>HOME DEPOT INC/SH</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -682,9 +683,9 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-iss;FinancialInstrumentShortName"/>
 		<rdfs:label>The Proctor &amp; Gamble Company common stock financial instrument short name</rdfs:label>
 		<skos:definition>The Proctor &amp; Gamble Company common stock financial instrument short name (FISN)</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>PROCTER &amp; GAMBL/SH</fibo-fnd-rel-rel:hasTag>
 		<fibo-sec-sec-iss:hasInstrumentDescription>SH</fibo-sec-sec-iss:hasInstrumentDescription>
 		<fibo-sec-sec-iss:hasIssuerShortName>PROCTER &amp; GAMBL</fibo-sec-sec-iss:hasIssuerShortName>
+		<lcc-lr:hasTag>PROCTER &amp; GAMBL/SH</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;TheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -701,7 +702,7 @@
 		<rdfs:label>XLOM - 0R2V</rdfs:label>
 		<skos:definition>ticker symbol for Apple Inc. common stock listed in the London Stock Exchange</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-mkti;Exchange-XLOM"/>
-		<fibo-fnd-rel-rel:hasTag>0R2V</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>0R2V</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XLOMListedAppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -710,7 +711,7 @@
 		<rdfs:label>XNAS - AAPL</rdfs:label>
 		<skos:definition>ticker symbol for Apple Inc. common stock listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
-		<fibo-fnd-rel-rel:hasTag>AAPL</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>AAPL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNASListedAppleIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -719,7 +720,7 @@
 		<rdfs:label>XNAS - GOOG</rdfs:label>
 		<skos:definition>ticker symbol for Alphabet Inc. class C capital stock listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
-		<fibo-fnd-rel-rel:hasTag>GOOG</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>GOOG</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNASListedAlphabetIncClassCCapitalStock"/>
 	</owl:NamedIndividual>
 	
@@ -728,7 +729,7 @@
 		<rdfs:label>XNAS - GOOGL</rdfs:label>
 		<skos:definition>ticker symbol for Alphabet Inc. class A common stock listed in the Nasdaq (NASDAQ-NGS)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
-		<fibo-fnd-rel-rel:hasTag>GOOGL</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>GOOGL</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNASListedAlphabetIncClassACommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -737,7 +738,7 @@
 		<rdfs:label>XNYS - C</rdfs:label>
 		<skos:definition>ticker symbol for Citigroup Inc. common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
-		<fibo-fnd-rel-rel:hasTag>C</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>C</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedCitigroupIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -746,7 +747,7 @@
 		<rdfs:label>XNYS - HD</rdfs:label>
 		<skos:definition>ticker symbol for The Home Depot, Inc. common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
-		<fibo-fnd-rel-rel:hasTag>HD</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>HD</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheHomeDepotIncCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -755,7 +756,7 @@
 		<rdfs:label>XNYS - IBM</rdfs:label>
 		<skos:definition>ticker symbol for Wells Fargo &amp; Company common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
-		<fibo-fnd-rel-rel:hasTag>IBM</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>IBM</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedInternationalBusinessMachinesCorporationCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -764,7 +765,7 @@
 		<rdfs:label>XNYS - JPM</rdfs:label>
 		<skos:definition>ticker symbol for JPMorgan Chase &amp; Co. common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
-		<fibo-fnd-rel-rel:hasTag>JPM</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>JPM</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedJPMorganChaseAndCoCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -773,7 +774,7 @@
 		<rdfs:label>XNYS - KO</rdfs:label>
 		<skos:definition>ticker symbol for The Coca-Cola Company common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
-		<fibo-fnd-rel-rel:hasTag>KO</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>KO</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheCoca-ColaCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -782,7 +783,7 @@
 		<rdfs:label>XNYS - PG</rdfs:label>
 		<skos:definition>ticker symbol for The Proctor &amp; Gamble Company common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
-		<fibo-fnd-rel-rel:hasTag>PG</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>PG</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedTheProctorAndGambleCompanyCommonStock"/>
 	</owl:NamedIndividual>
 	
@@ -791,7 +792,7 @@
 		<rdfs:label>XNYS - WFC</rdfs:label>
 		<skos:definition>ticker symbol for Wells Fargo &amp; Company common stock listed on the New York Stock Exchange (NYSE)</skos:definition>
 		<fibo-fbc-fct-ra:isRegisteredBy rdf:resource="&fibo-fbc-fct-usmkt;NewYorkStockExchange"/>
-		<fibo-fnd-rel-rel:hasTag>WFC</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>WFC</lcc-lr:hasTag>
 		<lcc-lr:identifies rdf:resource="&fibo-sec-eq-eqind;XNYSListedWellsFargoCommonStock"/>
 	</owl:NamedIndividual>
 	

--- a/SEC/Equities/EquityCFIClassificationIndividuals.rdf
+++ b/SEC/Equities/EquityCFIClassificationIndividuals.rdf
@@ -58,7 +58,8 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquityCFIClassificationIndividuals/"/>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquityCFIClassificationIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -134,7 +135,7 @@
 		</rdf:type>
 		<rdfs:label>ESETFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, restricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESETFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>ESETFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
@@ -210,7 +211,7 @@
 		</rdf:type>
 		<rdfs:label>ESEUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, enhanced voting, unrestricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESEUFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>ESEUFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
@@ -286,7 +287,7 @@
 		</rdf:type>
 		<rdfs:label>ESNTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, restricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESNTFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>ESNTFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
@@ -328,7 +329,7 @@
 		</rdf:type>
 		<rdfs:label>ESNUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, non-voting, unrestricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESNUFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>ESNUFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
@@ -404,7 +405,7 @@
 		</rdf:type>
 		<rdfs:label>ESRTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, restricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESRTFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>ESRTFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
@@ -480,7 +481,7 @@
 		</rdf:type>
 		<rdfs:label>ESRUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, restricted voting, unrestricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESRUFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>ESRUFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
@@ -556,7 +557,7 @@
 		</rdf:type>
 		<rdfs:label>ESVTFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, restricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESVTFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>ESVTFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 	
@@ -598,7 +599,7 @@
 		</rdf:type>
 		<rdfs:label>ESVUFR CFI common/ordinary share classifier</rdfs:label>
 		<skos:definition>CFI code for a common, voting, unrestricted transfer, fully-paid, registered share</skos:definition>
-		<fibo-fnd-rel-rel:hasTag>ESVUFR</fibo-fnd-rel-rel:hasTag>
+		<lcc-lr:hasTag>ESVUFR</lcc-lr:hasTag>
 		<lcc-lr:isMemberOf rdf:resource="&fibo-sec-sec-cls;ISO10962-201910-CodeScheme"/>
 	</owl:NamedIndividual>
 

--- a/SEC/Securities/SecuritiesClassification.rdf
+++ b/SEC/Securities/SecuritiesClassification.rdf
@@ -49,10 +49,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Securities/SecuritiesClassification/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/SecuritiesClassification/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesClassification.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesClassification.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesClassification.rdf version of this ontology was modified to add an class representing the ISO 10962 CFI standard and an individual for the 2019 version of that standard.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Securities/SecuritiesClassification.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -117,7 +118,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasTag"/>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
 				<owl:onDataRange rdf:resource="&xsd;string"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminate remaining references to fibo-fnd-rel-rel:hasTag in favor of lcc-lr:hasTag, and remove the relations property.  This property was created to cover complex datatypes in addition to strings as the basis for any code or identifier, which in practice has been unnecessary.  If corner cases arise over time that require binary data tags, we should create separate properties to address them.  Eliminating this union in the range of hasTag reduces reasoning complexity as well as removing a duplicate property name more generally.


Fixes: #1082 / FND-305 - also relates to #1043 


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


