### PR TITLE
DER-73 - Eliminate duplicate hasPaymentSchedule property in Swaps

### DIFF
--- a/DER/DerivativesContracts/Swaps.rdf
+++ b/DER/DerivativesContracts/Swaps.rdf
@@ -82,9 +82,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200201/DerivativesContracts/Swaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200701/DerivativesContracts/Swaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/DerivativesContracts/Swaps/ version of this ontology was modified to refine the concept of a unique swap identifier (USI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20190201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20200201/DerivativesContracts/Swaps/ version of this ontology was modified to eliminate the property &apos;hasPaymentSchedule&apos; from this ontology in favor of the equivalent property with the same name from FND.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -99,13 +100,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLeg"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasPaymentSchedule"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-psch;hasPaymentSchedule"/>
 				<owl:allValuesFrom rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>fixed payment leg</rdfs:label>
-		<skos:definition>the terms for the fixed payment leg of a swap such as a dividend swap, or for any swap that has a fixed leg, including, for example, a single stock swap</skos:definition>
+		<skos:definition>swap leg that specifies contractual terms associated with a schedule of payments, such as those associated with a dividend swap, or for any swap that has a fixed leg, including, for example, a single stock swap</skos:definition>
 		<fibo-fnd-utl-av:synonym>fixed payment stream terms</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>funding leg</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:usageNote>Payments may be fixed or variable. These are now defined separately for each type of cashflow stream (swap stream) and independently of the function of the leg (payments, return etc.). The schedule may be expressed in one of two ways: as an explicit schedule of dates or as a formula for determining payment dates in advance (taking into account for example roll rules for non working days).</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-drc-swp;MajorSwapParticipant">
@@ -378,14 +381,6 @@
 		<rdfs:label>has paying party</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-der-drc-swp;SwapPayingParty"/>
 		<skos:definition>defines the payer party for a funding leg of a swap</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-drc-swp;hasPaymentSchedule">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasSchedule"/>
-		<rdfs:label>has payment schedule</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-pas-psch;PaymentSchedule"/>
-		<skos:definition>defines a schedule of payments for a funding leg of a swap</skos:definition>
-		<skos:editorialNote>Payments may be fixed or variable. These are now defined separately for each type of cashflow stream (swap stream) and independently of the function of the leg (payments, return etc.). The schedule may be expressed in one of two ways: as an explicit schedule of dates or as a formula for determining payment dates in advance (taking into account for example roll rules for non working days).</skos:editorialNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-drc-swp;hasReceivingParty">

--- a/DER/RateDerivatives/IRSwaps.rdf
+++ b/DER/RateDerivatives/IRSwaps.rdf
@@ -60,8 +60,8 @@
 		<dct:abstract>This ontology defines concepts specific to interest rate swap contracts, including but not limited to fixed and floating rate combinations, single and cross-currency contracts, etc.</dct:abstract>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:resource="http://www.w3.org/standards/techs/owl#w3c_all"/>
-		<sm:copyright>Copyright (c) 2016-2019 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2016-2019 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2016-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Swaps/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/RateDerivatives/"/>
@@ -89,8 +89,9 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/ParametricSchedules/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20190501/RateDerivatives/IRSwaps/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/20200701/RateDerivatives/IRSwaps/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20180801/RateDerivatives/IRSwaps.rdf version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/DER/20190501/RateDerivatives/IRSwaps/ version of this ontology was modified to eliminate the property &apos;hasPaymentSchedule&apos; from the Swaps ontology in favor of the equivalent property with the same name from FND.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -376,12 +377,6 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasPaymentSchedule"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestPaymentSchedule"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;specifies"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;InterestRateStreamEvent"/>
 			</owl:Restriction>
@@ -402,6 +397,12 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-bd;hasBusinessRecurrenceIntervalConvention"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-dae-dbt;DayCountConvention"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pas-psch;hasPaymentSchedule"/>
+				<owl:someValuesFrom rdf:resource="&fibo-der-rtd-irswp;SwapStreamInterestPaymentSchedule"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>interest rate swap leg</rdfs:label>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Replaced the duplicate hasPaymentSchedule property ……in Swaps and IRSwaps with the corresponding property from FND; moved notes from the property definition to the class where it is used in a restriction, namely FixedPaymentLeg, as they provide additional context that should have been associated with the class, rather than with the property, from the outset and massaged the definition of that class accordingly and so that it is no longer circular.

Fixes: #1092 / DER-73


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


