### PR TITLE
FND-306 - The domain of of several properties should not be 'Reference', which is too narrow

### DIFF
--- a/BE/GovernmentEntities/GovernmentEntities.rdf
+++ b/BE/GovernmentEntities/GovernmentEntities.rdf
@@ -78,13 +78,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200301/GovernmentEntities/GovernmentEntities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200701/GovernmentEntities/GovernmentEntities/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was added to Business Entities, per the issue resolutions identified in the FIBO BE 1.1 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20160801/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.2 RTF report.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20170201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified per the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20180201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to to rationalize natural person and legally capable person in a new concept, competent natural person, simplify / merge the legal person and formal organization class hierarchies, and revise certain definitions, such as for supranational entity, to correspond to ISO definitions.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20181201/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to reflect the move of hasObjective to FND to enable higher level reuse and eliminate a reasoning error.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20190501/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to eliminate duplication of concepts in LCC and merge the countries ontology with locations.</skos:changeNote>
+		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/BE/20200301/GovernmentEntities/GovernmentEntities.rdf version of this ontology was modified to replace isAppointedBy with isDesignatedBy due to a name change in Relations.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -223,7 +224,7 @@
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isAppointedBy"/>
+						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDesignatedBy"/>
 						<owl:someValuesFrom rdf:resource="&fibo-be-ge-ge;GovernmentBody"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>

--- a/BE/OwnershipAndControl/Executives.rdf
+++ b/BE/OwnershipAndControl/Executives.rdf
@@ -517,15 +517,16 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;delegatesControlTo">
+		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-exec;authorizes"/>
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;designates"/>
 		<rdfs:label>delegates control to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalPerson"/>
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
 		<skos:definition>indicates a party to which this legal person has delegated some authority or control</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;designatesSignatory">
 		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-exec;authorizes"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;designates"/>
 		<rdfs:label>designates signatory</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-be-oac-exec;Signatory"/>
 		<skos:definition>authorizes to sign agreements, access accounts and/or perform other similar tasks</skos:definition>
@@ -567,20 +568,9 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasDelegatedControlOf">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-ctl;isInControlOfThing"/>
 		<rdfs:label>has delegated control of</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-		<skos:definition>indicates a legal person that has delegated some authority or control to this party</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasDelegatedControlOfItself">
-		<rdfs:subPropertyOf rdf:resource="&fibo-be-oac-exec;hasDelegatedControlOf"/>
-		<rdfs:label>has delegated control of itself</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-oac-exec;LegallyDelegatedAuthority"/>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
-		<owl:inverseOf rdf:resource="&fibo-be-oac-exec;delegatesControlTo"/>
-		<skos:definition>indicates a legal person that has delegated some authority or control to this party, and as a result this party therefore has control over itself</skos:definition>
+		<skos:definition>indicates something or some party that is controlled via delegation</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-exec;hasDirector">

--- a/BP/SecuritiesIssuance/EquitiesIPOIssuance.rdf
+++ b/BP/SecuritiesIssuance/EquitiesIPOIssuance.rdf
@@ -114,23 +114,18 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;designates"/>
 				<owl:someValuesFrom>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;playsRole"/>
-						<owl:someValuesFrom>
-							<owl:Class>
-								<owl:unionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-bp-iss-ipo;CorporateBroker">
-									</rdf:Description>
-									<rdf:Description rdf:about="&fibo-bp-iss-ipo;Sponsor">
-									</rdf:Description>
-									<rdf:Description rdf:about="&fibo-bp-iss-ipo;ReportingAccountant">
-									</rdf:Description>
-									<rdf:Description rdf:about="&fibo-fbc-fct-ra;RegistrationAuthority">
-									</rdf:Description>
-								</owl:unionOf>
-							</owl:Class>
-						</owl:someValuesFrom>
-					</owl:Restriction>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-bp-iss-ipo;CorporateBroker">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-bp-iss-ipo;Sponsor">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-bp-iss-ipo;ReportingAccountant">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-fct-ra;RegistrationAuthority">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/BP/SecuritiesIssuance/EquitiesIPOIssuance.rdf
+++ b/BP/SecuritiesIssuance/EquitiesIPOIssuance.rdf
@@ -112,7 +112,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appoints"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;designates"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
 						<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;playsRole"/>

--- a/FBC/FunctionalEntities/RegistrationAuthorities.rdf
+++ b/FBC/FunctionalEntities/RegistrationAuthorities.rdf
@@ -75,10 +75,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/RegistrationAuthorities/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/FunctionalEntities/RegistrationAuthorities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified per the FIBO 2.0 RFC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified as a part of organizational hierarchy simplification, to loosen the definition of registrar, and to leverage the composite date value datatype.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190201/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, make Registry a subclass of Record and StructuredCollection, make RegistryEntry a child of CollectionConstituent and correct a misspelled annotation.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/FunctionalEntities/RegistrationAuthorities.rdf version of this ontology was modified to replace isAppointedBy with isDesignatedBy due to a property name change in Relations.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -101,7 +102,7 @@
 								<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-ra;RegistrationCapacity"/>
 							</owl:Restriction>
 							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isAppointedBy"/>
+								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDesignatedBy"/>
 								<owl:someValuesFrom>
 									<owl:Restriction>
 										<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;playsRole"/>

--- a/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/FinancialProductsAndServices.rdf
@@ -113,7 +113,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/ProductsAndServices/FinancialProductsAndServices/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20150801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to reflect issue resolutions detailed in the FIBO FBC 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified by the FIBO 2.0 RFC, including, but not limited to, the addition of lifecycle events, concepts related to trade settlement, and the definition of a unique transaction identifier (UTI).</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified as a part of organizational hierarchy simplification and to correct a logical inconsistency with respect to the representation of baskets.</skos:changeNote>
@@ -121,6 +121,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190701/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to add the notion of a weighted basket, whose consituents are weighted.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191101/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to eliminate duplication with concepts in LCC and eliminated a redundant superclass on FinancialServiceProvider.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200401/ProductsAndServices/FinancialProductsAndServices/ version of this ontology was modified to replace the property &apos;characterizes&apos; with &apos;describes&apos; with respect to restrictions on catalogs.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -228,7 +229,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;characterizes"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;describes"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;Product"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -314,7 +315,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;Catalog"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;characterizes"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;describes"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-fpas;FinancialProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -63,7 +63,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Relations/Relations.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Relations/Relations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and remove the unused hasDispositionDate property, whose semantics were unclear at best.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name, and to loosen domain restrictions on some properties which were too narrowly specified.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name, to loosen domain restrictions on some properties which were too narrowly specified, and to add two new properties, describes and isDescribedBy, which are more appropriate for certain cases where we were using characterizes and isCharacterizedBy.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -100,10 +100,9 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;characterizes">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 		<rdfs:label>characterizes</rdfs:label>
-		<skos:definition>describes the nature, features or quality of</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.thefreedictionary.com/characterized</fibo-fnd-utl-av:adaptedFrom>
+		<skos:definition>specifies a discriminating feature or quality of</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;comprises">
@@ -133,11 +132,16 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:definition>determines or identifies the essential qualities or meaning of, discovers and sets forth the meaning of, fixes or marks the limits of, demarcates</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;describes">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+		<rdfs:label>describes</rdfs:label>
+		<skos:definition>conveys the nature of</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;designates">
 		<rdfs:label>designates</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<skos:definition>names something officially or appoints someone to a position officially</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.dictionarycentral.com/definition/designate.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>names something officially</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;embodies">
@@ -290,6 +294,12 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;defines"/>
 		<skos:definition>indicates something that specifies the meaning associated with the subject</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Typically, a concept, such as a classifier or identifier, will be defined in terms of a scheme, contract, specification, standard, or other reference.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isDescribedBy">
+		<rdfs:label>is described by</rdfs:label>
+		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;describes"/>
+		<skos:definition>has general nature or description</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isEvaluatedBy">

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -63,7 +63,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Relations/Relations.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Relations/Relations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and remove the unused hasDispositionDate property, whose semantics were unclear at best.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions and to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name, and to loosen domain restrictions on some properties which were too narrowly specified.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -81,8 +81,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;appliesTo">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
 		<rdfs:label>applies to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
-		<skos:definition>a relation indicating something that is pertinent or relevant to the concept</skos:definition>
+		<skos:definition>is pertinent, suitable, or relevant to</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;appoints">
@@ -103,8 +102,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;characterizes">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
 		<rdfs:label>characterizes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
-		<skos:definition>a feature or quality that distinguishes something from something else</skos:definition>
+		<skos:definition>describes the nature, features or quality of</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.thefreedictionary.com/characterized</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
@@ -132,14 +130,13 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;defines">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;represents"/>
 		<rdfs:label>defines</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
 		<skos:definition>determines or identifies the essential qualities or meaning of, discovers and sets forth the meaning of, fixes or marks the limits of, demarcates</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;designates">
 		<rdfs:label>designates</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<skos:definition>to name something officially or appoint someone to a position officially</skos:definition>
+		<skos:definition>names something officially or appoints someone to a position officially</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.dictionarycentral.com/definition/designate.html</fibo-fnd-utl-av:definitionOrigin>
 	</owl:ObjectProperty>
 	

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -84,16 +84,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:definition>is pertinent, suitable, or relevant to</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;appoints">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;designates"/>
-		<rdfs:label>appoints</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<skos:definition>assigns a job or role to someone, selects or designates to fill an office or a position, fixes or sets by authority or by mutual agreement</skos:definition>
-		<skos:scopeNote>typically requires having the capacity or authority to appoint</skos:scopeNote>
-		<fibo-fnd-utl-av:adaptedFrom>Free Online Dictionary</fibo-fnd-utl-av:adaptedFrom>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;causes">
 		<rdfs:label>causes</rdfs:label>
 		<skos:definition>relationship between an event or set of events or factors (the cause) and a second event, phenomenon, situation, or result (the effect), where the second event or outcome is understood as a consequence of the first</skos:definition>
@@ -141,7 +131,8 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;designates">
 		<rdfs:label>designates</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<skos:definition>names something officially</skos:definition>
+		<skos:definition>appoints someone officially</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>This property is intended to cover assigning a job or role to someone, selecting or designating someone to fill an office or a position, and fixing or setting by authority or by mutual agreement.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;embodies">
@@ -249,14 +240,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:definition>(of a situation or event) includes (something) as a necessary part or result</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isAppointedBy">
-		<rdfs:label>is appointed by</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;appoints"/>
-		<skos:definition>indicates the individual or group that has assigned or appointed someone to an office or position</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isCausedBy">
 		<rdfs:label>is caused by</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;causes"/>
@@ -300,6 +283,13 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<rdfs:label>is described by</rdfs:label>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;describes"/>
 		<skos:definition>has general nature or description</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isDesignatedBy">
+		<rdfs:label>is designated by</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
+		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;designates"/>
+		<skos:definition>indicates the individual or group that has assigned or appointed someone to an office or position</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isEvaluatedBy">

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -130,7 +130,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;designates">
 		<rdfs:label>designates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
 		<skos:definition>appoints someone officially</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>This property is intended to cover assigning a job or role to someone, selecting or designating someone to fill an office or a position, and fixing or setting by authority or by mutual agreement.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
@@ -287,9 +286,8 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isDesignatedBy">
 		<rdfs:label>is designated by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;designates"/>
-		<skos:definition>indicates the individual or group that has assigned or appointed someone to an office or position</skos:definition>
+		<skos:definition>indicates the party that has assigned or appointed someone to an office or position</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isEvaluatedBy">

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -84,7 +84,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/Analytics.rdf version of this ontology was modified to add the concept of a weighting algorithm.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191101/Utilities/Analytics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, merge countries with locations, and correct a restriction on qualified measure.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/Analytics.rdf version of this ontology was modified to revise numeric index to be called numeric index value, and revise its definition to include a reference date, change its parent to quantity value, and move base date and period to scoped measure.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, and eliminate a duplicate property that is not used anywhere.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -652,14 +652,6 @@ For certain indices, one of the most common weighting factor is by market capita
 		<fibo-fnd-utl-av:explanatoryNote>In cases where some expression can only be calculated in SPARQL or via rules, this property is useful for stating what that calculation should be using the input arguments to the expression.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:AnnotationProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;evaluates">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;represents"/>
-		<rdfs:label>evaluates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;Expression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-rel-rel;Reference"/>
-		<skos:definition>calculates a quantity value based on some mathematical formula</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasAnchorDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label>has anchor date</rdfs:label>
@@ -678,7 +670,6 @@ For certain indices, one of the most common weighting factor is by market capita
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasArgument">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
 		<rdfs:label>has argument</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
 		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Variable"/>
 		<skos:definition>indicates a specific input to a function, formula or expression, also known as an independent variable</skos:definition>
 		<fibo-fnd-utl-av:synonym>has independent variable</fibo-fnd-utl-av:synonym>

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -84,7 +84,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/Analytics.rdf version of this ontology was modified to add the concept of a weighting algorithm.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191101/Utilities/Analytics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, merge countries with locations, and correct a restriction on qualified measure.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/Analytics.rdf version of this ontology was modified to revise numeric index to be called numeric index value, and revise its definition to include a reference date, change its parent to quantity value, and move base date and period to scoped measure.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, and eliminate a duplicate property that is not used anywhere.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, and eliminate duplicate properties that were not used anywhere.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -820,13 +820,6 @@ For certain indices, one of the most common weighting factor is by market capita
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether the measure reflects an estimate (approximation) or not</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;isEvaluatedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasRepresentation"/>
-		<rdfs:label>is evaluated by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Expression"/>
-		<skos:definition>links a quantity value to the expression that generated it</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;isValueOf">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -84,7 +84,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/Analytics.rdf version of this ontology was modified to add the concept of a weighting algorithm.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191101/Utilities/Analytics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, merge countries with locations, and correct a restriction on qualified measure.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/Analytics.rdf version of this ontology was modified to revise numeric index to be called numeric index value, and revise its definition to include a reference date, change its parent to quantity value, and move base date and period to scoped measure.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, and eliminate duplicate properties that were not used anywhere.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, add a domain/range to characterizes/isCharacterizedBy, and eliminate duplicate properties that were not used anywhere.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -100,6 +100,14 @@
 	<owl:Class rdf:about="&fibo-fnd-qt-qtu;Rate">
 		<owl:equivalentClass rdf:resource="&fibo-fnd-utl-alx;Ratio"/>
 	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;characterizes">
+		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;Aspect"/>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isCharacterizedBy">
+		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Aspect"/>
+	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-fnd-utl-alx;AnnualizedStandardDeviation">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;StandardDeviation"/>

--- a/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
+++ b/SEC/Securities/SecuritiesIdentificationIndividuals.rdf
@@ -89,11 +89,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesIdentificationIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/SecuritiesIdentificationIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIdentification/ version of this ontology was modified to correct several logic issues.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190601/Securities/SecuritiesIdentification/ version of this ontology was updated to represent identifiers as classes rather than individuals and rename (migrate) the hasDefinition property to isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190701/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to restructure the concept of a listing and augment it with a number of relevant characteristics.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to eliminate duplication of concepts with LCC and eliminate punning in individual definitions.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Securities/SecuritiesIdentificationIndividuals/ version of this ontology was modified to replace &apos;characterizes&apos; with &apos;describes&apos;, which more accurately expresses the intent.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -344,7 +345,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;ProprietarySecurityIdentificationScheme"/>
 		<rdfs:label>Euroclear Clearstream common code  scheme</rdfs:label>
 		<skos:definition>nine-digit security identification scheme, defined originally by Euroclear and CEDEL (now Clearstream) that is used to identify securities in Europe for the purposes of facilitating clearing and settlement of trades</skos:definition>
-		<fibo-fnd-rel-rel:characterizes rdf:resource="&fibo-sec-sec-idind;CommonCodeRepository"/>
+		<fibo-fnd-rel-rel:describes rdf:resource="&fibo-sec-sec-idind;CommonCodeRepository"/>
 		<fibo-fnd-utl-av:synonym>common code scheme</fibo-fnd-utl-av:synonym>
 	</owl:NamedIndividual>
 	
@@ -419,7 +420,7 @@
 		<rdf:type rdf:resource="&fibo-sec-sec-id;FinancialInstrumentIdentificationScheme"/>
 		<rdfs:label>financial instrument global identifier scheme</rdfs:label>
 		<skos:definition>standard identification scheme for financial instrument identifiers (not limited to securities) published by the Object Management Group (OMG)</skos:definition>
-		<fibo-fnd-rel-rel:characterizes rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry"/>
+		<fibo-fnd-rel-rel:describes rdf:resource="&fibo-sec-sec-idind;FinancialInstrumentGlobalIdentifierRegistry"/>
 		<fibo-fnd-utl-av:abbreviation>FIGI scheme</fibo-fnd-utl-av:abbreviation>
 	</owl:NamedIndividual>
 	
@@ -514,7 +515,7 @@
 		<rdfs:label>Stock Exchange Daily Official List (SEDOL) scheme</rdfs:label>
 		<rdfs:seeAlso rdf:resource="http://www.londonstockexchange.com/products-and-services/reference-data/sedol-master-file/sedolallocation.htm"/>
 		<skos:definition>national security identification scheme used to identify all stocks and registered bonds in the United Kingdom for the purposes of facilitating clearing and settlement of trades</skos:definition>
-		<fibo-fnd-rel-rel:characterizes rdf:resource="&fibo-sec-sec-idind;SEDOLMasterFile"/>
+		<fibo-fnd-rel-rel:describes rdf:resource="&fibo-sec-sec-idind;SEDOLMasterFile"/>
 		<fibo-fnd-utl-av:abbreviation>SEDOL scheme</fibo-fnd-utl-av:abbreviation>
 	</owl:NamedIndividual>
 	


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Removed 'Reference' as the domain of several properties; eliminated a redundant 'evaluates' property from Analytics that was not used anywhere; adjusted definitions for a few properties in Relations that were not ISO 704 compliant

Fixes: #1095 / [FND-306](https://jira.edmcouncil.org/browse/FND-306)


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


