### PR TITLE
FND-308 Eliminate unnecessary unions and max 1 restrictions in the addresses ontologies

### DIFF
--- a/FND/Places/Addresses.rdf
+++ b/FND/Places/Addresses.rdf
@@ -66,6 +66,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Places/Addresses.rdf version of this ontology was modified replace hasDefinition with isDefinedIn to clarify intent, and the address hierarchy was simplified to enable extensions for international and national delivery address specification, and to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Places/Addresses.rdf version of this ontology was modified to eliminate duplication of concepts in LCC, simplify address representation and merge countries with locations.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/Addresses.rdf version of this ontology was modified to correct a missing imports statement.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200601/Places/Addresses.rdf version of this ontology was modified to eliminate unnecessary unions and max 1 restrictions.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/Foundations/20130601/Organizations/Addresses.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
    (1) to use slash style URI/IRIss (also called 303 URIs, vs. hash style) as required to support server side processing 
    (2) to use version-independent IRIs for all definitions internally as opposed to version-specific IRIs
@@ -138,30 +139,32 @@
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;ConventionalStreetAddress">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;PhysicalAddress"/>
 		<rdfs:subClassOf>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine1"/>
-						<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-						<owl:onDataRange rdf:resource="&rdfs;Literal"/>
-					</owl:Restriction>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine2"/>
-						<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-						<owl:onDataRange rdf:resource="&rdfs;Literal"/>
-					</owl:Restriction>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine3"/>
-						<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-						<owl:onDataRange rdf:resource="&rdfs;Literal"/>
-					</owl:Restriction>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasStreetAddress"/>
-						<owl:onClass rdf:resource="&fibo-fnd-plc-adr;StreetAddress"/>
-						<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
-					</owl:Restriction>
-				</owl:unionOf>
-			</owl:Class>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasStreetAddress"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;StreetAddress"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine1"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&rdfs;Literal"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine2"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&rdfs;Literal"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasAddressLine3"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&rdfs;Literal"/>
+			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>conventional street address</rdfs:label>
 		<skos:definition>physical address that identifies a location on a street to which communications may be delivered</skos:definition>
@@ -255,36 +258,18 @@
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;PhysicalAddress">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;Address"/>
 		<rdfs:subClassOf>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasPostalCode"/>
-						<owl:onDataRange rdf:resource="&rdfs;Literal"/>
-						<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-					</owl:Restriction>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasIndividualPostcode"/>
-						<owl:onClass rdf:resource="&fibo-fnd-plc-adr;Postcode"/>
-						<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-					</owl:Restriction>
-				</owl:unionOf>
-			</owl:Class>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasIndividualPostcode"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;Postcode"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasCityName"/>
-						<owl:onDataRange rdf:resource="&rdfs;Literal"/>
-						<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-					</owl:Restriction>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasMunicipality"/>
-						<owl:onClass rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
-						<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-					</owl:Restriction>
-				</owl:unionOf>
-			</owl:Class>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasMunicipality"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-loc;Municipality"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -302,6 +287,20 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-adr;hasPostalCode"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&rdfs;Literal"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasCityName"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&rdfs;Literal"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasSubdivision"/>
 				<owl:someValuesFrom rdf:resource="&lcc-cr;CountrySubdivision"/>
 			</owl:Restriction>
@@ -309,6 +308,7 @@
 		<rdfs:label xml:lang="en">physical address</rdfs:label>
 		<skos:definition>physical address where communications can be addressed, papers served or representatives located for any kind of organization or person</skos:definition>
 		<skos:scopeNote>An address may be used as an index to the location of a building, apartment, office within an office block, or other structure or parcel of land, often using political boundaries and street names as references, along with other information such as house or building numbers or names.  Some addresses also contain secondary elements such as apartment or building numbers, or special codes to aid routing of mail and packages.</skos:scopeNote>
+		<fibo-fnd-utl-av:usageNote>Typically, addresses will have only one postcode expressed either as a string value or individual, and only a municipality (individual) or city (string value).</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;PhysicalAddressIdentifier">
@@ -484,7 +484,7 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
 				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;SecondaryUnitIndicator"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -645,20 +645,18 @@
 	<owl:Class rdf:about="&fibo-fnd-plc-adr;SupplementalAddressComponent">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-plc-adr;AddressComponent"/>
 		<rdfs:subClassOf>
-			<owl:Class>
-				<owl:unionOf rdf:parseType="Collection">
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
-						<owl:onDataRange rdf:resource="&rdfs;Literal"/>
-						<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-					</owl:Restriction>
-					<owl:Restriction>
-						<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-						<owl:onClass rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressIndicatorOrUnit"/>
-						<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-					</owl:Restriction>
-				</owl:unionOf>
-			</owl:Class>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+				<owl:onClass rdf:resource="&fibo-fnd-plc-adr;SupplementalAddressIndicatorOrUnit"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&rdfs;Literal"/>
+			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>

--- a/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
+++ b/FND/Places/NorthAmerica/USPostalServiceAddresses.rdf
@@ -55,7 +55,7 @@
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Places/NorthAmerica/USPostalServiceAddresses/"/>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/NorthAmerica/USPostalServiceAddresses.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Places/NorthAmerica/USPostalServiceAddresses.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here, and correct a duplicate label.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -198,7 +198,7 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-plc-uspsa;USPostalServiceAddressIdentifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>delivery point code set</rdfs:label>
+		<rdfs:label>delivery address code set</rdfs:label>
 		<rdfs:seeAlso rdf:resource="https://pe.usps.com/cpim/ftp/pubs/Pub28/pub28.pdf"/>
 		<skos:definition>system of numeric codes that substitute for specified delivery point details according to the U.S. Postal Service Publication 28</skos:definition>
 	</owl:Class>

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -63,7 +63,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Relations/Relations.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Relations/Relations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and remove the unused hasDispositionDate property, whose semantics were unclear at best.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions and to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name, and to loosen domain restrictions on some properties which were too narrowly specified.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -81,8 +81,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;appliesTo">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
 		<rdfs:label>applies to</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
-		<skos:definition>a relation indicating something that is pertinent or relevant to the concept</skos:definition>
+		<skos:definition>is pertinent, suitable, or relevant to</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;appoints">
@@ -103,8 +102,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;characterizes">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
 		<rdfs:label>characterizes</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
-		<skos:definition>a feature or quality that distinguishes something from something else</skos:definition>
+		<skos:definition>describes the nature, features or quality of</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.thefreedictionary.com/characterized</fibo-fnd-utl-av:adaptedFrom>
 	</owl:ObjectProperty>
 	
@@ -132,14 +130,13 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;defines">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;represents"/>
 		<rdfs:label>defines</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
 		<skos:definition>determines or identifies the essential qualities or meaning of, discovers and sets forth the meaning of, fixes or marks the limits of, demarcates</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;designates">
 		<rdfs:label>designates</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-aap-agt;AutonomousAgent"/>
-		<skos:definition>to name something officially or appoint someone to a position officially</skos:definition>
+		<skos:definition>names something officially or appoints someone to a position officially</skos:definition>
 		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.dictionarycentral.com/definition/designate.html</fibo-fnd-utl-av:definitionOrigin>
 	</owl:ObjectProperty>
 	

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -84,7 +84,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/Analytics.rdf version of this ontology was modified to add the concept of a weighting algorithm.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191101/Utilities/Analytics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, merge countries with locations, and correct a restriction on qualified measure.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/Analytics.rdf version of this ontology was modified to revise numeric index to be called numeric index value, and revise its definition to include a reference date, change its parent to quantity value, and move base date and period to scoped measure.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, and eliminate a duplicate property that is not used anywhere.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -652,14 +652,6 @@ For certain indices, one of the most common weighting factor is by market capita
 		<fibo-fnd-utl-av:explanatoryNote>In cases where some expression can only be calculated in SPARQL or via rules, this property is useful for stating what that calculation should be using the input arguments to the expression.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:AnnotationProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;evaluates">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;represents"/>
-		<rdfs:label>evaluates</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-utl-alx;Expression"/>
-		<rdfs:range rdf:resource="&fibo-fnd-rel-rel;Reference"/>
-		<skos:definition>calculates a quantity value based on some mathematical formula</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasAnchorDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label>has anchor date</rdfs:label>
@@ -678,7 +670,6 @@ For certain indices, one of the most common weighting factor is by market capita
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;hasArgument">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
 		<rdfs:label>has argument</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
 		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Variable"/>
 		<skos:definition>indicates a specific input to a function, formula or expression, also known as an independent variable</skos:definition>
 		<fibo-fnd-utl-av:synonym>has independent variable</fibo-fnd-utl-av:synonym>

--- a/FND/Utilities/Analytics.rdf
+++ b/FND/Utilities/Analytics.rdf
@@ -84,7 +84,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Utilities/Analytics.rdf version of this ontology was modified to add the concept of a weighting algorithm.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20191101/Utilities/Analytics.rdf version of this ontology was modified to eliminate duplication with concepts in LCC, merge countries with locations, and correct a restriction on qualified measure.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Utilities/Analytics.rdf version of this ontology was modified to revise numeric index to be called numeric index value, and revise its definition to include a reference date, change its parent to quantity value, and move base date and period to scoped measure.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, and eliminate a duplicate property that is not used anywhere.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200401/Utilities/Analytics.rdf version of this ontology was modified to change the parent class of Classifier to Aspect, loosen the domain on the hasArgument property, which was too narrow in some cases, and eliminate duplicate properties that were not used anywhere.</skos:changeNote>
 		<skos:changeNote>This ontology was added to Foundations in advance of the June 2014 Boston meeting in support of the IND RFC.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
@@ -820,13 +820,6 @@ For certain indices, one of the most common weighting factor is by market capita
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether the measure reflects an estimate (approximation) or not</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;isEvaluatedBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;hasRepresentation"/>
-		<rdfs:label>is evaluated by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-utl-alx;Expression"/>
-		<skos:definition>links a quantity value to the expression that generated it</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-utl-alx;isValueOf">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminated overly restrictive unions and some max 1 cardinality restrictions in addresses to allow for a broader range of options and improve reasoning efficiency; eliminated a duplicate label in the US jurisdiction version of addresses

Fixes: #1095 / FND-308


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


