### PR TITLE
New minimal compliance hygiene test - annotation convention for rdfs:…

### DIFF
--- a/etc/testing/hygiene/testHygiene1079.sparql
+++ b/etc/testing/hygiene/testHygiene1079.sparql
@@ -1,0 +1,9 @@
+prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?error
+WHERE 
+{
+  ?s rdfs:comment ?o 
+  FILTER (CONTAINS(str(?s), "edmcouncil"))
+  BIND (concat ("WARN: ", str(?s), " has an rdfs:comment annotation: ", str(?o)) AS ?error)
+}


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This implements the minimal compliance hygiene test that finds usage of rdfs:comment in annotations.

Fixes: #1079


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


