### PR TITLE
Extending hygiene tests set - no property may have more than one inverse

### DIFF
--- a/etc/testing/hygiene/testHygiene1078.sparql
+++ b/etc/testing/hygiene/testHygiene1078.sparql
@@ -1,0 +1,21 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#> 
+
+SELECT ?error ?p1 ?p2 
+WHERE
+{
+{
+?p owl:inverseOf ?p1. 
+?p owl:inverseOf ?p2. 
+FILTER (?p1 != ?p2) 
+} 
+UNION
+{
+?p1 owl:inverseOf ?p. 
+?p2 owl:inverseOf ?p. 
+FILTER (?p1 != ?p2) 
+}
+FILTER (CONTAINS(str(?p), "edmcouncil"))
+FILTER (CONTAINS(str(?p1), "edmcouncil"))
+FILTER (CONTAINS(str(?p2), "edmcouncil"))
+BIND (concat ("WARN: object property whose iri is ", str(?p), " has more than one inverse object property") AS ?error)
+} 


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This check is to warn that there are object properties with multiple inverses.

Fixes: #1078


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


