### PR TITLE
FBC-257 - Redemption provisions should apply at the instrument level, and may not necessarily involve 'principal repayment'

### DIFF
--- a/BP/SecuritiesIssuance/IssuanceDocuments.rdf
+++ b/BP/SecuritiesIssuance/IssuanceDocuments.rdf
@@ -65,12 +65,6 @@
 	
 	<owl:Class rdf:about="&fibo-bp-iss-doc;ProspectusTerms">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesOnIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-iss;SecuritiesContractTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">prospectus terms set</rdfs:label>
 		<skos:definition xml:lang="en">A set of terms in a Prospectus which on issue will become the binding Contractual Terms of the Security. For example, Call Terms, Interest Payment Terms.</skos:definition>
 		<skos:editorialNote xml:lang="en">becomes: The terms in the Prospectus become legally binding contractual terms of the Security, at issue. (former property, now a restriction)</skos:editorialNote>
@@ -127,12 +121,6 @@
 	
 	<owl:Class rdf:about="&fibo-bp-iss-doc;TermsSheetTermsSet">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-bp-iss-doc;becomesOnIssue"/>
-				<owl:someValuesFrom rdf:resource="&fibo-sec-sec-iss;SecuritiesContractTerms"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">terms sheet terms set</rdfs:label>
 	</owl:Class>
 	
@@ -140,13 +128,6 @@
 		<rdfs:label xml:lang="en">becomes final</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-bp-iss-doc;SecurityDraftProspectus"/>
 		<rdfs:range rdf:resource="&fibo-bp-iss-doc;SecurityFinalProspectus"/>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-bp-iss-doc;becomesOnIssue">
-		<rdfs:label xml:lang="en">becomes on issue</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:range rdf:resource="&fibo-sec-sec-iss;SecuritiesContractTerms"/>
-		<skos:definition xml:lang="en">An individual set of terms in a Terms Sheet may become a corresponding set of Terms in an Security. This would happen as part of the Issuance process.</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;OfferingDocument">

--- a/FBC/DebtAndEquities/Debt.rdf
+++ b/FBC/DebtAndEquities/Debt.rdf
@@ -89,10 +89,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/DebtAndEquities/Debt/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200701/DebtAndEquities/Debt/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was added to the FBC domain via the FIBO 2.0 RFC in support of several FIBO debt-oriented initiatives.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/DebtAndEquities/Debt/ version of this ontology was modified to use the generic statistical measures and measurements now in FND.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190501/DebtAndEquities/Debt/ version of this ontology was modified to add several common day count conventions used to calculate the amount of accrued interest or the present value when the next coupon payment is less than a full coupon period away, to support collateral agreements such as deeds of trust, UCC filings and the like, to add the concept of a rate reset time of day, to eliminate duplication of concepts in LCC, to simplify addresses, and to merge countries with locations.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200301/DebtAndEquities/Debt/ version of this ontology was modified to make redemption provision a child of contractual commitment, as such provisions apply to preferred shares and other instruments in addition to debt.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -722,10 +723,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-dae-dbt;RedemptionProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PrincipalRepaymentTerms"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
 		<rdfs:label>redemption provision</rdfs:label>
 		<rdfs:isDefinedBy rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
-		<skos:definition>a contract provision enabling the issuer (writer) to regain possession through repayment of some stipulated price</skos:definition>
+		<skos:definition>contract provision enabling the issuer (writer) to regain possession through repayment of some stipulated price</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Econonmics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>In general, redemption is synonymous with &apos;buy back&apos; or &apos;cash in&apos;, depending on the kind of instrument. Redemption provisions are commonly applicable to the process of annulling a defeasible title, such as for a mortgage or tax sale, by paying the debt or fulfilling an obligation.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>

--- a/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities.rdf
+++ b/SEC/Debt/AssetBackedSecurities/AssetBackedSecurities.rdf
@@ -320,7 +320,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-ab-abs;IndexLinkedPrincipalDeterminationTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;PrincipalRepaymentTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-utl-alx;hasExpression"/>

--- a/SEC/Debt/Bonds.rdf
+++ b/SEC/Debt/Bonds.rdf
@@ -143,7 +143,7 @@
 		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Debt/Bonds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/Debt/Bonds.rdf version of this ontology was revised to reflect the refactored definition of a listing and improve the definition of corporate bond.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and eliminate a redundant superclass from RegularCouponSchedule.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate a duplicate &apos;isBasedOn&apos; property and replace it with the property of the same name in the debt ontology.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate a duplicate &apos;isBasedOn&apos; property and replace it with the property of the same name in the debt ontology, and to revise the inheritance hierarchy for bond conversion terms to reflect changes in the representation of redemption more generally.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -192,7 +192,6 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;BondConversionTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;ConversionTerms"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
@@ -1259,7 +1258,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasExtraordinaryRedemptionProvision">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 		<rdfs:label>has extraordinary redemption provision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-bnd;ExtraordinaryRedemptionProvision"/>
 		<skos:definition>relates the redemption provision of a debt instrument to one-time provision that may be exercised by the issuer under certain circumstances</skos:definition>
 	</owl:ObjectProperty>
@@ -1267,7 +1266,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasFinalMaturityDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label>has final maturity date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<skos:definition>indicates the final payment date of a loan or other financial instrument, at which point the principal (and all remaining interest) is due to be paid</skos:definition>
 	</owl:ObjectProperty>

--- a/SEC/Debt/DebtInstruments.rdf
+++ b/SEC/Debt/DebtInstruments.rdf
@@ -83,11 +83,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/EconomicIndicators/EconomicIndicators/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/InterestRates/InterestRates/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Debt/DebtInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Debt/DebtInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Debt/DebtInstruments.rdf version of this ontology was modified to reflect use of actualExpression as an annotation rather than datatype property, to deprecate maturity-related properties which have been moved to financial instruments more generally, and to simplify restrictions on tradable debt instrument.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190501/Debt/DebtInstruments.rdf version of this ontology was modified to support integration of the bonds ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Debt/DebtInstruments.rdf version of this ontology was modified to correct the declaration of the property &apos;has estate or death put feature&apos; to remove an erroneous subproperty relationship and integrate the instrument pricing ontology.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Debt/DebtInstruments.rdf version of this ontology was modified to reflect a change to make redemption provision a child of contractual commitment, as such provisions apply to preferred shares and other instruments in addition to debt, and eliminate non-tradable and tradable debt instrument redemption provisions, which are synonymous, and adjust the hierarchy for call feature, notification provision, and put feature accordingly.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -165,7 +166,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;CallFeature">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasNotificationProvision"/>
@@ -180,7 +181,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>call feature</rdfs:label>
-		<skos:definition>a redemption provision defining the rights of the issuer to buy back a security at a call price after a call protection period</skos:definition>
+		<skos:definition>redemption provision defining the rights of the issuer to buy back a security at a call price after a call protection period</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>EDM Council / Quarule</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Most corporate and municipal bonds have ten-year call features (termed call protection by holders); government securities typically have none.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>call provision</fibo-fnd-utl-av:synonym>
@@ -195,7 +196,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>call notification provision</rdfs:label>
-		<skos:definition>a provision of a call feature defining notification requirements</skos:definition>
+		<skos:definition>provision of a call feature defining notification requirements</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;CallPremium">
@@ -337,7 +338,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasRedemptionProvision"/>
-				<owl:onClass rdf:resource="&fibo-sec-dbt-dbti;NonTradableDebtRedemptionProvision"/>
+				<owl:onClass rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -361,14 +362,8 @@
 		<fibo-fnd-utl-av:explanatoryNote>Generally, a nonnegotiable instrument may be redeemed by the issuer, but this is often subject to some limitations.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbti;NonTradableDebtRedemptionProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
-		<rdfs:label>non-tradable debt redemption terms</rdfs:label>
-		<skos:definition>terms for repayment of principal on debt instruments that are not traded securities, such as over the counter, bilateral paper</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;NotificationProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasDatePeriod"/>
@@ -376,7 +371,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>notification provision</rdfs:label>
-		<skos:definition>a provision of a redemption feature defining notification requirements</skos:definition>
+		<skos:definition>provision of a redemption feature defining notification requirements</skos:definition>
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-dbti;ParValue">
@@ -422,7 +417,8 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;PutFeature">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;DebtTerms"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-dbt-dbti;hasNotificationProvision"/>
@@ -437,7 +433,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>put feature</rdfs:label>
-		<skos:definition>a redemption provision giving the holder the right, but not the obligation, to sell a specified amount of the debt instrument (i.e., redeem it), prior to maturity</skos:definition>
+		<skos:definition>redemption provision giving the holder the right, but not the obligation, to sell a specified amount of the debt instrument (i.e., redeem it), prior to maturity</skos:definition>
 		<skos:editorialNote>FIBIM has term &quot;Putable Date&quot; which (by implication, and comparing with definition for &quot;Next Call Date&quot;) is presumably a single calendar date in the future, at a given point in time. That does not cover the definition of formal terms defining when and how the issue may be put, which is what is modeled here.</skos:editorialNote>
 		<fibo-fnd-utl-av:adaptedFrom>Barron&apos;s Dictionary of Business and Economics Terms, Fifth Edition, 2012</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>put provision</fibo-fnd-utl-av:synonym>
@@ -550,13 +546,6 @@
 		<fibo-fnd-utl-av:explanatoryNote>Details from Ecofin: A [debt] instrument can be traded, if its features depend only on one borrower. If the instrument has no bilateral or multilateral obligations, the investor can easily transfer it to another investor without asking the borrower (except the terms prohibit this explicitly). This is simplified with securitised instruments, where the debt is already split into handy denominations which trade easily (e.g. in round thousands or millions as with bonds, commercial paper, etc.). But in principle it works also with interbank loans and similar instruments. FIBIM Definition: Financial instruments evidencing moneys owed by the issuer to the holder on terms as specified.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
-		<rdfs:label>tradable debt instrument redemption provision</rdfs:label>
-		<skos:definition>terms for the redemption of the debt represented by a debt security</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Debt represented by a tradable debt security may be paid as a one off payment at maturity, by paying down principal amounts periodically, or by a call of the issue by the issuer. Debt that is defined by a convertible bond are redeemed by conversion into an equity security issued by the same company. More notes from the EDMC SME Review: Distinction between call and amortizing is whether you pay off everybody at the same time or via a lottery. SF can be either. either amortize the payment of a SF or pay it off by a lottery. The terms of the instrument determine that. Mandatory - all in the schedule. Mandatory to the bond issuer. Issuer has to pay off a certain amount at a certain time - this is in the Schedule. Callable - nothing mandatory.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-sec-dbt-dbti;VariableIncomeSecurity">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrument"/>
 		<rdfs:label>variable income security</rdfs:label>
@@ -656,7 +645,7 @@
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-dbti;hasNotificationProvision">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
 		<rdfs:label>has notification provision</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-dbti;NotificationProvision"/>
 		<skos:definition>relates the redemption provision of a debt instrument to a notification provision (e.g., call or put notification)</skos:definition>
 	</owl:ObjectProperty>
@@ -769,14 +758,14 @@
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-dbti;isExtendableByHolder">
 		<rdfs:label>is extendable by holder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether the expiration date or maturity date can be extended by the holder</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-dbti;isExtendableByIssuer">
 		<rdfs:label>is extendable by issuer</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;TradableDebtInstrumentRedemptionProvision"/>
+		<rdfs:domain rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether the issuer has the option to extend the debt rather than refinancing</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>If not, the issuer may only refinance the debt by calling the issue and creating a new issue.</fibo-fnd-utl-av:explanatoryNote>

--- a/SEC/Securities/SecuritiesIssuance.rdf
+++ b/SEC/Securities/SecuritiesIssuance.rdf
@@ -3,6 +3,7 @@
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-be-fct-pub "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
+	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
 	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
@@ -33,6 +34,7 @@
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-be-fct-pub="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
+	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
 	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
@@ -75,6 +77,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/Publishers/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
@@ -96,10 +99,11 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesIssuance/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Securities/SecuritiesIssuance/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Securities/SecuritiesIssuance/ version of this ontology was modified to refine the concept of a securities underwriter.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20181201/Securities/SecuritiesIssuance/ version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200201/Securities/SecuritiesIssuance/ version of this ontology was modified to add the concept of the form the security is issued in, namely bearer or registered.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/SecuritiesIssuance/ version of this ontology was modified to refactor conversion terms as a child of redemption provision and eliminate the unnecessary securities contract terms class.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -164,7 +168,13 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;ConversionTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-iss;SecuritiesContractTerms"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-dae-dbt;RedemptionProvision"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-sec-sec-iss;specifiesConversionInto"/>
@@ -173,7 +183,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>conversion terms</rdfs:label>
 		<skos:definition>contract terms specifying when and how a security may be converted to another security (usually of the same issuer)</skos:definition>
-		<skos:editorialNote>Not to be confused with the underlying indicators of a derivative, i.e., convertible bonds to common stock.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;ConvertibleSecurity">
@@ -365,18 +374,6 @@
 		<skos:definition>form of a security whereby ownership is recorded in the name of the owner on the books of the issuer or the issuer&apos;s registrar and can only be transferred to another owner when endorsed by the registered owner</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>With registered securities, a ledger is kept by the issuing company or agent which records the owners of all the securities. Transfer of ownership can only occur when names are changed in the ledger.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:NamedIndividual>
-	
-	<owl:Class rdf:about="&fibo-sec-sec-iss;SecuritiesContractTerms">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualCommitment"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fi-fi;Security"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>securities contract terms</rdfs:label>
-		<skos:definition>one or more contractual commitments that are specific to financial instruments that can be bought or sold and may or may not be negotiable</skos:definition>
-	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-sec-iss;SecuritiesOffering">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;Offering"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised the debt terms / redemption terms hierarch……y to make redemption provision a direct subclass of contractual commitment rather than of principal repayment terms, given that it applies to preferred shares; refactored the conversion and redemption provisions more generally and eliminated a couple of unneeded intervening classes that were not widely used and that didn't have restrictions that we need.

Fixes: #1110 / FBC-257


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


