### PR TITLE
Add banner keyword to new hygiene tests

### DIFF
--- a/etc/testing/hygiene/testHygiene1067.sparql
+++ b/etc/testing/hygiene/testHygiene1067.sparql
@@ -1,15 +1,21 @@
 PREFIX  xsd:  <http://www.w3.org/2001/XMLSchema#>
 PREFIX  rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
+##
+# banner Labels should be unique across FIBO.
+
 SELECT  (concat("Warn: '", ?label, "' labels multiple objects.") AS ?error) ?object
 WHERE
-  { { SELECT DISTINCT  ?label
-      WHERE
-        { ?s  rdfs:label  ?label
-          FILTER regex(xsd:string(?s), "edmcouncil")
+{ 
+	{ 
+		SELECT DISTINCT  ?label
+		WHERE
+        { 
+			?s  rdfs:label  ?label
+			FILTER regex(xsd:string(?s), "edmcouncil")
         }
-      GROUP BY ?label
-      HAVING ( COUNT(?label) > 1 )
+		GROUP BY ?label
+		HAVING ( COUNT(?label) > 1 )
     }
     ?object  rdfs:label  ?label
-  }
+}

--- a/etc/testing/hygiene/testHygiene1068.sparql
+++ b/etc/testing/hygiene/testHygiene1068.sparql
@@ -3,6 +3,9 @@ prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
 
+##
+# banner Definitions shouldn't be circular.
+
 SELECT DISTINCT ?error ?definition ?label
 WHERE {
   ?s rdfs:label ?label .

--- a/etc/testing/hygiene/testHygiene1078.sparql
+++ b/etc/testing/hygiene/testHygiene1078.sparql
@@ -1,5 +1,8 @@
 prefix owl:   <http://www.w3.org/2002/07/owl#> 
 
+##
+# banner Object properties shouldn't have more than one inverse.
+
 SELECT ?error ?p1 ?p2 
 WHERE
 {

--- a/etc/testing/hygiene/testHygiene1079.sparql
+++ b/etc/testing/hygiene/testHygiene1079.sparql
@@ -1,5 +1,8 @@
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 
+##
+# banner rdfs:comment shouldn't be used for FIBO annotation.
+
 SELECT DISTINCT ?error
 WHERE 
 {


### PR DESCRIPTION
 Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

banner keyword was added to new hygiene SPARQL tests to facilitate interpretation of tests' results in Jenkins.

Fixes: #1112


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


