### PR TITLE
Extending hygiene tests set - no unused imports

### DIFF
--- a/etc/testing/hygiene/testHygiene1081.sparql
+++ b/etc/testing/hygiene/testHygiene1081.sparql
@@ -1,0 +1,17 @@
+PREFIX owl:   <http://www.w3.org/2002/07/owl#>
+PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?error
+WHERE
+{
+    ?importingOntology owl:imports ?importedOntology.
+    FILTER (CONTAINS(str(?importingOntology), "edmcouncil"))
+    FILTER NOT EXISTS 
+    {
+        ?s ?p ?o.
+        FILTER (?p NOT IN (owl:imports))
+        FILTER (REGEX(str(?s), CONCAT(str(?importedOntology),".+")) || REGEX(str(?p), CONCAT(str(?importedOntology),".+")) || REGEX(str(?o), CONCAT(str(?importedOntology),".+")))
+    }
+    BIND (concat ("WARN: ontology ", str(?importingOntology), " does not reference any resource from imported ontology ", str(?importedOntology)) AS ?error)
+}


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This test is to find unused imports in the whole (aggregated) FIBO ontology.
This pr reopens https://github.com/edmcouncil/fibo/pull/1116, which was inadvertently closed by @mereolog.

Fixes: #1081


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).
