### PR TITLE
Tests for Quality Compliance - Synonyms as classes

### DIFF
--- a/etc/testing/hygiene/testHygiene1103.sparql
+++ b/etc/testing/hygiene/testHygiene1103.sparql
@@ -1,4 +1,5 @@
-prefix owl:   <http://www.w3.org/2002/07/owl#> 
+prefix owl:   <http://www.w3.org/2002/07/owl#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#> 
 
 ##
 # banner Equivalent classes may indicate polysemy spread accross multiple classes

--- a/etc/testing/hygiene/testHygiene1103.sparql
+++ b/etc/testing/hygiene/testHygiene1103.sparql
@@ -1,0 +1,16 @@
+prefix owl:   <http://www.w3.org/2002/07/owl#> 
+
+##
+# banner Equivalent classes may indicate polysemy spread accross multiple classes
+
+SELECT DISTINCT ?error
+WHERE {
+  FILTER (ISIRI(?class1))
+  FILTER (REGEX(str(?class1), "edmcouncil"))
+  FILTER NOT EXISTS {?class1 owl:deprecated "true"^^xsd:boolean}
+  FILTER (ISIRI (?class2))
+  FILTER (REGEX(str(?class2), "edmcouncil"))
+  FILTER NOT EXISTS {?class2 owl:deprecated "true"^^xsd:boolean}
+  ?class1 owl:equivalentClass ?class2 .
+  BIND (concat ("WARN: Class ", str(?class1), " is modeled as equivalent to ", str(?class2), " - this may indicate polysemy management that is not complient with FIBO.") AS ?error)
+}


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

https://github.com/edmcouncil/fibo/blob/master/ONTOLOGY_GUIDE.md#t2-synonyms-as-classes suggests a test to find all equivalent named classes as they may indicate that synonyms were modelled as separated classes, which is not consistent with FIBO conventions.
This pr is to implement this test.

Fixes: #1103


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


