### PR TITLE
Fix to bad characters check

### DIFF
--- a/etc/testing/hygiene/testHygiene0114.sparql
+++ b/etc/testing/hygiene/testHygiene0114.sparql
@@ -32,6 +32,6 @@ WHERE {
   BIND (REPLACE (xsd:string (?o), ?reg, "")  AS ?bads)
 #  FILTER (!REGEX (?o, (CONCAT ("^", ?reg, "*$"))))
   FILTER (?bads != "")
-  BIND (concat ("PRODERROR:", xsd:string(?o), " has a bad character |", ?bads, "|")
+  BIND (concat ("WARN:", xsd:string(?o), " has a bad character |", ?bads, "|")
 	  AS ?error)
  } 

--- a/etc/testing/hygiene/testHygiene0114.sparql
+++ b/etc/testing/hygiene/testHygiene0114.sparql
@@ -1,28 +1,13 @@
-prefix ex:    <http://www.example.org/time#>
-prefix sp:    <http://spinrdf.org/sp#>
-prefix sm:    <http://www.omg.org/techprocess/ab/SpecificationMetadata/>
 prefix afn:   <http://jena.apache.org/ARQ/function#>
-prefix dct:   <http://purl.org/dc/terms/>
 prefix owl:   <http://www.w3.org/2002/07/owl#>
 prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix xsd:   <http://www.w3.org/2001/XMLSchema#>
-prefix spin:  <http://spinrdf.org/spin#>
 prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
-prefix fibo-ind-ir-ir: <https://spec.edmcouncil.org/fibo/IND/InterestRates/InterestRates/>
-prefix fibo-fnd-utl-av: <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/>
-prefix fibo-fnd-pty-rl: <https://spec.edmcouncil.org/fibo/FND/Parties/Roles/>
-prefix fibo-fnd-aap-agt: <https://spec.edmcouncil.org/fibo/FND/AgentsAndPeople/Agents/>
-prefix fibo-der-drc-swp: <https://spec.edmcouncil.org/fibo/DER/DerivativesContracts/Swaps/>
-prefix fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/>
-prefix fibo-test-lattice: <http://www.omg.org/spec/fibo/etc/testing/patterns/lattice#>
-prefix fibo-der-rtd-irswp: <https://spec.edmcouncil.org/fibo/DER/RateDerivatives/IRSwaps/>
 
 ##
 # banner Text should not use special characters
 
-SELECT #?error
-# COUNT ( DISTINCT ?error)
-?s ?o ?error
+SELECT ?error
 WHERE {
   ?s ?p ?o
   FILTER (DATATYPE(?o)=xsd:string)


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz pawel.garbacz@makolab.com

## Description

This pr downgrades the level of the bad character check to warnings and refactors the warning messages so that the first word in them is 'WARN'.

Fixes: #1119

## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


