### PR TITLE
IND-98 - Missing concepts related to part-time employment and underemployment

### DIFF
--- a/IND/EconomicIndicators/EconomicIndicators.rdf
+++ b/IND/EconomicIndicators/EconomicIndicators.rdf
@@ -117,7 +117,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/Indicators/Indicators/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20200701/EconomicIndicators/EconomicIndicators/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/IND/20200901/EconomicIndicators/EconomicIndicators/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20140601/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 1 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20150501/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the issue resolutions identified in the FIBO IND 1.0 FTF 3 report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/IND/20160801/EconomicIndicators/EconomicIndicators.rdf version of this ontology was modified per the FIBO 2.0 RFC. Primary changes include the addition of a number of statistical measures (mean, total, etc.) and their use in existing and new indicators, and the addition of several more economic indicators.</skos:changeNote>
@@ -494,6 +494,44 @@
 		<skos:definition>a subset of the civilian labor force considered to be employed during the reporting period</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>There are a number of distinctions with respect to how individuals are counted from country to country, including whether or not they are considered employed if they are on unpaid leave for some reason, and whether or not they are counted multiple times if they have more than one paying job.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulationPartTime">
+		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
+		<rdfs:label>employed population part-time</rdfs:label>
+		<skos:definition>subset of the employed population that includes persons that are working fewer than 30 to 35 hours per week based on usual working hours</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>https://stats.oecd.org/Index.aspx?DatasetCode=STLABOUR</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>In the U.S., part-time workers are those who usually work fewer than 35 hours per week.  See https://www.bls.gov/cps/definitions.htm for additional details.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>The definition of part-time varies considerably from country to country according to the OECD.  Classification may be based on (1) employee perception, (2) usual working hours, which is the most reliable measure, or (3) actual working hours, which varies due to holidays, illness, etc.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>population employed part-time</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulationPartTimeForEconomicReasons">
+		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EmployedPopulationPartTime"/>
+		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;UnderemployedPopulation"/>
+		<rdfs:label>employed population part-time for economic reasons</rdfs:label>
+		<skos:definition>subset of the employed population that includes persons that are working fewer than 30 to 35 hours per week due to slack work, unfavorable business conditions, inability to find full-time work, and seasonal declines in demand</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>https://stats.oecd.org/Index.aspx?DatasetCode=STLABOUR</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/cps/definitions.htm</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:synonym>involuntary part-time population</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>population employed part-time for economic reasons</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulationPartTimeForNonEconomicReasons">
+		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EmployedPopulationPartTime"/>
+		<rdfs:label>employed population part-time for non-economic reasons</rdfs:label>
+		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;EmployedPopulationPartTimeForEconomicReasons"/>
+		<skos:definition>subset of the employed population that includes persons that are working fewer than 30 to 35 hours per week due to illness or other health or medical limitations, childcare problems, family or personal obligations, being in school or training, retirement or Social Security limits on earnings, and having a job where full-time work is less than 35 hours</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/cps/definitions.htm</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:synonym>population employed part-time for non-economic reasons</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-ind-ei-ei;EmployedPopulationTemporarilyNotAtWork">
+		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
+		<rdfs:label>employed population temporarily not at work</rdfs:label>
+		<skos:definition>subset of the employed population that includes persons that are temporarily absent from work for various reasons</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>This includes persons temporarily not at work because of illness or injury, holiday or vacation, strike or lockout, educational or training leave, maternity or parental leave, reduction in economic activity, temporary disorganisation or suspension of work due to such reasons as bad weather, mechanical or electrical breakdown, or shortage of raw materials or fuels, or other temporary absence with or without leave should be considered as in paid employment provided they had a formal job attachment.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;EmploymentPopulationRatio">
@@ -928,14 +966,6 @@ A household may be located in a housing unit or in a set of collective living qu
 		<fibo-fnd-utl-av:explanatoryNote>There are a number of distinctions with respect to how individuals are counted from country to country, including whether or not they are considered employed if they are on unpaid leave for some reason, and whether or not they are counted multiple times if they have more than one paying job.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-ind-ei-ei;PopulationTemporarilyNotAtWork">
-		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
-		<rdfs:label>population temporarily not at work</rdfs:label>
-		<skos:definition>subset of the employed population that includes persons that are temporarily absent from work for various reasons</skos:definition>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>This includes persons temporarily not at work because of illness or injury, holiday or vacation, strike or lockout, educational or training leave, maternity or parental leave, reduction in economic activity, temporary disorganisation or suspension of work due to such reasons as bad weather, mechanical or electrical breakdown, or shortage of raw materials or fuels, or other temporary absence with or without leave should be considered as in paid employment provided they had a formal job attachment.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;ProducerPriceIndex">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-utl-alx;Expression"/>
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;EconomicIndicator"/>
@@ -1032,6 +1062,12 @@ A household may be located in a housing unit or in a set of collective living qu
 		<fibo-fnd-utl-av:adaptedFrom>https://www.bls.gov/news.release/empsit.t15.htm</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-ind-ei-ei;UnderemployedPopulationWithRespectToOccupation">
+		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;UnderemployedPopulation"/>
+		<rdfs:label>underemployed population with respect to occupation</rdfs:label>
+		<skos:definition>subset of the underemployed population that includes persons employed in a role that does not reflect their training and experience, excluding those that change careers</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;UnderutilizedPopulation">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;CivilianNonInstitutionalPopulation"/>
 		<rdfs:label>underutilized population</rdfs:label>
@@ -1053,9 +1089,15 @@ A household may be located in a housing unit or in a set of collective living qu
 	
 	<owl:Class rdf:about="&fibo-ind-ei-ei;UnemployedPopulation">
 		<rdfs:subClassOf rdf:resource="&fibo-ind-ei-ei;CivilianLaborForce"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-ind-ei-ei;hasDurationOfUnemployment"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fnd-dt-fd;Duration"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>unemployed population</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-ind-ei-ei;EmployedPopulation"/>
-		<skos:definition>a subset of the civilian labor force that is considered to have had no employment but was available for work, except for temporary illness, and had made specific efforts to find employment sometime during a specified period, during the reporting period</skos:definition>
+		<skos:definition>subset of the civilian labor force that is considered to have had no employment but was available for work, except for temporary illness, and had made specific efforts to find employment sometime during a specified period, during the reporting period</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>U.S. Bureau of Labor Statistics and Statistics Canada reference definitions - https://wiki.edmcouncil.org/pages/viewpage.action?pageId=6358041</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Persons who were waiting to be recalled to a job from which they had been laid off need not have been looking for work to be classified as unemployed.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
@@ -1128,6 +1170,14 @@ A household may be located in a housing unit or in a set of collective living qu
 		<rdfs:range rdf:resource="&xsd;boolean"/>
 		<skos:definition>indicates whether the calculation of the index includes energy and food prices or not</skos:definition>
 	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-ind-ei-ei;hasDurationOfUnemployment">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasDuration"/>
+		<rdfs:label>has duration of unemployment</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Duration"/>
+		<skos:definition>specifies the length of time, typically in weeks, that people classified as unemployed have been continuously looking for work</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:resource="https://www.bls.gov/cps/definitions.htm"/>
+	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-ind-ei-ei;hasIndicatorValue">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Augmented economic indicators to include information regarding part-time employment and underemployment

Fixes: #1142 / IND-98


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


