### PR TITLE
Hygiene check for disjunctive definitions

### DIFF
--- a/etc/testing/hygiene/testHygiene1127.sparql
+++ b/etc/testing/hygiene/testHygiene1127.sparql
@@ -1,0 +1,14 @@
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+
+
+##
+# banner Definitions should not contain the "or" connective.
+
+SELECT ?error ?o
+WHERE 
+{
+  ?s skos:definition ?o
+  FILTER (REGEX(str(?s), "edmcouncil"))
+  FILTER (REGEX (str(?o), "\\sor\\s"))
+  BIND (concat ("WARN: definition of ", str(?s), " is ambiguous because of the presence of disjunction. ") AS ?error) 
+} 


### PR DESCRIPTION
Signed-off-by: Pawel Garbacz <pawel.garbacz@makolab.com>

## Description

This is to warn about all definitions that contain the "or" connective.

Fixes: #1127 


## Checklist:

- [X] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [X] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [X] My changes have been reconciled with latest master and no merge conflicts remain.
- [X] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [X] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [X] The issue has been tested locally using a reasoner (for ontology changes).


