### PR TITLE
FBC-260 - Need the ability to represent credit card accounts

### DIFF
--- a/AboutFIBODev.rdf
+++ b/AboutFIBODev.rdf
@@ -211,6 +211,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/"/>
 		
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 

--- a/BE/FunctionalEntities/FunctionalEntities.rdf
+++ b/BE/FunctionalEntities/FunctionalEntities.rdf
@@ -4,14 +4,14 @@
 	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-le-lp "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/">
-	<!ENTITY fibo-be-sps-sps "https://spec.edmcouncil.org/fibo/ontology/BE/SoleProprietorships/SoleProprietorships/">
 	<!ENTITY fibo-fnd-org-fm "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/">
-	<!ENTITY fibo-fnd-org-org "https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
 	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
 	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
 	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
 	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
 	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
@@ -24,14 +24,14 @@
 	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-le-lp="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"
-	xmlns:fibo-be-sps-sps="https://spec.edmcouncil.org/fibo/ontology/BE/SoleProprietorships/SoleProprietorships/"
 	xmlns:fibo-fnd-org-fm="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"
-	xmlns:fibo-fnd-org-org="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
 	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
 	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
 	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
 	xmlns:owl="http://www.w3.org/2002/07/owl#"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
@@ -46,66 +46,46 @@
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
 		<sm:copyright>Copyright (c) 2013-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2013-2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/</sm:dependsOn>
-		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/BE/SoleProprietorships/SoleProprietorships/</sm:dependsOn>
 		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://spec.edmcouncil.org/fibo/ontology/FND/</sm:dependsOn>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
 		<sm:fileAbbreviation>fibo-be-fct-fct</sm:fileAbbreviation>
 		<sm:filename>FunctionalEntities.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/LegalPersons/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/SoleProprietorships/SoleProprietorships/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/FormalOrganizations/"/>
-		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Organizations/Organizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20190901/FunctionalEntities/FunctionalEntities/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200901/FunctionalEntities/FunctionalEntities/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20150201/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.1 RTF report. Changes include deprecation of the SoleProprietorship class and making it equivalent to the class with the same name in the Sole Proprietorships ontology. This version also introduces a new FunctionalEntity class, as the parent of FunctionalBusinessEntity in this ontology and as the parent of Government in the GovernmentEntities ontology.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160801/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified by the FIBO 2.0 revision to address missing labels and definitions on the deprecated sole proprietorship class to match those in the equivalent class.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to generalize certain unions where they were no longer required and eliminate an unused import.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190201/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200301/FunctionalEntities/FunctionalEntities.rdf version of this ontology was modified to revise and extend the definition of merchant, to support merchant category codes as needed for representation of credit card transactions, merge business and functional business entity and eliminate commerce and commercial activity (which are not used anywhere in FIBO), and to clean up definitions and make them ISO 704 compliant.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-be-fct-fct;Business">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;CommercialActivity"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>business</rdfs:label>
-		<skos:definition>An organization or economic system where goods and services are exchanged for one another or for money. Every business requires some form of investment and enough customers to whom its output can be sold on a consistent basis in order to make a profit. Businesses can be privately owned, not-for-profit or state-owned. An example of a corporate business is PepsiCo, while a mom-and-pop catering business is a private enterprise.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/business.html</fibo-fnd-utl-av:definitionOrigin>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fct-fct;Commerce">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;CommercialActivity"/>
-		<rdfs:label>commerce</rdfs:label>
-		<skos:definition>the commercial activity of buying and selling goods</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-fct-fct;CommercialActivity">
-		<rdfs:label>commercial activity</rdfs:label>
-		<skos:definition>the context of carrying out trade and other commercial, i.e., for-profit activities</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>This is the context which distinguishes businesses or commercial organizations from organizations in general, the latter including government, trans-national and non profit organizations. Note that these distinctions are usually made with reference to these kinds of context and are not necessarily reflected in the structure of those organizations.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;CooperativeSociety">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
 		<rdfs:label>cooperative society</rdfs:label>
-		<skos:definition>a commercial enterprise owned and managed by and for the benefit of customers or workers</skos:definition>
+		<skos:definition>organization owned by and operated for the benefit of those using its services</skos:definition>
+		<skos:example>In agriculture, there are broadly three types of cooperatives: a machinery pool, a manufacturing/marketing cooperative, and a credit union</skos:example>
+		<fibo-fnd-utl-av:synonym>cooperative</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;FamilyOffice">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
 		<rdfs:label>family office</rdfs:label>
-		<skos:definition>a family office as defined in the relevant legislation</skos:definition>
+		<skos:definition>organization that assumes the day-to-day administration and management of a family’s affairs</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Family offices are often privately held companies set up to handle investment and wealth management for wealthy families.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;FunctionalBusinessEntity">
@@ -118,8 +98,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>functional business entity</rdfs:label>
-		<skos:definition>a business entity defined in terms of its function</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The key distinguishing feature of a functional business entity is that it may itself be constituted as some kind of business or legal entity, but the definition of this entity does not depend on it always having one specific legal structure (for example, always being a limited company). This would define for example a bank, a special purpose vehicle, most government bodies and so on.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>functional entity defined in terms of the nature of the commercial activity it conducts</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;FunctionalEntity">
@@ -132,20 +111,112 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>functional entity</rdfs:label>
-		<skos:definition>any independent party (i.e., person, business entity, governmental entity, or other organization) defined in terms of its function</skos:definition>
+		<skos:definition>independent party defined in terms of its function</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-fct-fct;Merchant">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;Business"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isCharacterizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;Commerce"/>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;MerchantCategoryCode"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;MerchantIdentifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>merchant</rdfs:label>
-		<skos:definition>a business entity engaged in a trading activity</skos:definition>
+		<skos:definition>party engaged in the purchase and sales of goods for profit</skos:definition>
 	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-fct-fct;MerchantCategoryCode">
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/IndustrySectorClassifier"/>
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDefinedIn"/>
+				<owl:onClass rdf:resource="&fibo-be-fct-fct;MerchantCategoryCodeScheme"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-fct-fct;hasGeneralMerchantCategoryDescription"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-be-fct-fct;hasSpecificMerchantCategoryDescription"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;Merchant"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>merchant category code</rdfs:label>
+		<skos:definition>code used internationally to classify a merchant</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>MCC</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 18245:2003 Retail financial services - Merchant category codes</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>Merchant categories are organized by the type of business, trade or services supplied.  Certain category codes including those for very large businesses, such as airlines and some hotel chains, may be delineated to the point of identifying the business.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Merchant category codes and/or the descriptions of the service categories are frequently used in credit card and other banking transactions for analysis and sometimes tax-related purposes.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-fct-fct;MerchantCategoryCodeScheme">
+		<rdfs:subClassOf rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/IndustrySectorClassificationScheme"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;defines"/>
+				<owl:someValuesFrom rdf:resource="&fibo-be-fct-fct;MerchantCategoryCode"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>merchant category code scheme</rdfs:label>
+		<skos:definition>scheme defining a set of codes for classifying merchant services</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>ISO 18245:2003 Retail financial services - Merchant category codes</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>ISO 18245 provides a set of merchant category codes that are used internationally.  Some countries, regional governments, banks, and other large organizations extend the basic codes with custom additions to fit business needs.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-be-fct-fct;MerchantIdentifier">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;Identifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
+				<owl:onClass rdf:resource="&fibo-be-fct-fct;Merchant"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>merchant identifier</rdfs:label>
+		<skos:definition>unique identifier for a merchant that is used, for example, for transaction interchange purposes</skos:definition>
+	</owl:Class>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-be-fct-fct;hasGeneralMerchantCategoryDescription">
+		<rdfs:label>has general merchant category description</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-fct-fct;MerchantCategoryCode"/>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>provides a text description of the industry sector to which the code applies</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-be-fct-fct;hasSpecificMerchantCategoryDescription">
+		<rdfs:label>has specific merchant category description</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-be-fct-fct;MerchantCategoryCode"/>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>provides a detailed, sector-specific text description to which the code applies</skos:definition>
+	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-be-le-fbo;OrganizationIdentifier">
 		<rdfs:subClassOf>

--- a/FBC/FunctionalEntities/FinancialServicesEntities.rdf
+++ b/FBC/FunctionalEntities/FinancialServicesEntities.rdf
@@ -100,6 +100,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181201/FunctionalEntities/FinancialServicesEntities/ version of this ontology was modified to generalize certain unions where they were no longer required and incorporate a new financial service provider identifier that is assigned functionally rather than to a legal entity.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190101/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to leverage the new party identifier and replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/FunctionalEntities/FinancialServicesEntities.rdf version of this ontology was revised to enable merging business and functional business entity in BE.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -564,7 +565,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;InvestmentBank">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;Business"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:subClassOf>
 			<owl:Class>
@@ -632,7 +633,7 @@ A number of insurance companies operate brokerage arms that trade securities on 
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-fct-fse;NonDepositoryInstitution">
-		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;Business"/>
+		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label>non-depository institution</rdfs:label>
 		<skos:definition>any financial institution that acts as the middleman between two parties in a financial transaction, and that does not provide traditional depository services, such as brokerage firms, insurance companies, investment companies, etc.</skos:definition>

--- a/FBC/ProductsAndServices/CardAccounts.rdf
+++ b/FBC/ProductsAndServices/CardAccounts.rdf
@@ -1,0 +1,590 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
+	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
+	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
+	<!ENTITY fibo-fbc-pas-crd "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/">
+	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
+	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
+	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
+	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
+	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
+	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
+	<!ENTITY fibo-fnd-plc-loc "https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/">
+	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
+	<!ENTITY fibo-fnd-pty-rl "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/">
+	<!ENTITY fibo-fnd-rel-rel "https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/">
+	<!ENTITY fibo-fnd-utl-av "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+	<!ENTITY lcc-cr "https://www.omg.org/spec/LCC/Countries/CountryRepresentation/">
+	<!ENTITY lcc-lr "https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/">
+	<!ENTITY owl "http://www.w3.org/2002/07/owl#">
+	<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+	<!ENTITY skos "http://www.w3.org/2004/02/skos/core#">
+	<!ENTITY sm "http://www.omg.org/techprocess/ab/SpecificationMetadata/">
+	<!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+]>
+<rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"
+	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
+	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
+	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
+	xmlns:fibo-fbc-pas-crd="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"
+	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
+	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
+	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
+	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
+	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
+	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
+	xmlns:fibo-fnd-plc-loc="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"
+	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
+	xmlns:fibo-fnd-pty-rl="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"
+	xmlns:fibo-fnd-rel-rel="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"
+	xmlns:fibo-fnd-utl-av="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"
+	xmlns:lcc-cr="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"
+	xmlns:lcc-lr="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+	xmlns:sm="http://www.omg.org/techprocess/ab/SpecificationMetadata/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+	
+	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/">
+		<rdfs:label>Card Accounts Ontology</rdfs:label>
+		<dct:abstract>This ontology defines account-related concepts that are specific to credit and debit cards.</dct:abstract>
+		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
+		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
+		<sm:copyright>Copyright (c) 2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2020 Object Management Group, Inc.</sm:copyright>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
+		<sm:dependsOn rdf:datatype="&xsd;anyURI">https://www.omg.org/spec/LCC/</sm:dependsOn>
+		<sm:fileAbbreviation>fibo-fbc-pas-crd</sm:fileAbbreviation>
+		<sm:filename>CardAccounts.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Places/Locations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
+		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"/>
+		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
+	</owl:Ontology>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardAccount">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isLinkedToAccount"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasPrimaryAccountHolder"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;Cardholder"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasRepresentation"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;PrimaryCardAccountNumber"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>card account</rdfs:label>
+		<skos:definition>account associated with a payment card</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardAuthenticationValue">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
+		<rdfs:label>card authentication value</rdfs:label>
+		<skos:definition>card verification value specifically for JCB payment cards</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>CAV</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardAuthenticationValue2">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
+		<rdfs:label>card authentication value 2</rdfs:label>
+		<skos:definition>card verification value specifically for JCB payment cards</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:synonym>CAV2</fibo-fnd-utl-av:synonym>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardExpirationDate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>card expiration date</rdfs:label>
+		<skos:definition>date on which a given payment card expires</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardIdentificationNumber">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
+		<rdfs:label>card identification number</rdfs:label>
+		<skos:definition>card verification value specifically for American Express and Discover payment cards</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>CID</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardProduct">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialProduct"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCreditCardType"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasSubdivision"/>
+				<owl:onClass rdf:resource="&lcc-cr;CountrySubdivision"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;usesCurrency"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-plc-loc;hasCountry"/>
+				<owl:onClass rdf:resource="&lcc-cr;Country"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>card product</rdfs:label>
+		<skos:definition>financial product involving the issuance of credit and debit cards</skos:definition>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardSecurityCode">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
+		<rdfs:label>card security code</rdfs:label>
+		<skos:definition>card verification value specifically for American Express payment cards</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>CSC</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardValidationCode">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
+		<rdfs:label>card validation code</rdfs:label>
+		<skos:definition>card verification code specifically for MasterCard payment cards</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>PAN CVC</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardValidationCode2">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
+		<rdfs:label>card validation code 2</rdfs:label>
+		<skos:definition>card verification value specifically for MasterCard payment cards</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>PAN CVC2</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardVerificationCodeOrValue">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCard"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>card verification code or value</rdfs:label>
+		<skos:definition>code that specifies either (1) magnetic-stripe data, or (2) printed security features that are used to protect data integrity and limit alteration, counterfeiting and fraud generally</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardVerificationValue">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
+		<rdfs:label>card verification value</rdfs:label>
+		<skos:definition>card verification value specifically for Visa and Discover payment cards</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>CVV</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardVerificationValue2">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
+		<rdfs:label>card verification value 2</rdfs:label>
+		<skos:definition>card verification value specifically for Visa payment cards</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:synonym>CVV2</fibo-fnd-utl-av:synonym>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;Cardholder">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;holdsAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-oac-own;owns"/>
+						<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+					</owl:Restriction>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
+				<owl:someValuesFrom>
+					<owl:Restriction>
+						<owl:onProperty rdf:resource="&fibo-fnd-pty-pty;isAPartyTo"/>
+						<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+					</owl:Restriction>
+				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>cardholder</rdfs:label>
+		<skos:definition>account holder to whom a payment card is issued or other individual authorized to use the payment card</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCard">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;represents"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardAccount"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardProduct"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasLender"/>
+				<owl:onClass>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fbc-fi-fi;Issuer">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:onClass>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasBorrower"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;Cardholder"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>credit card</rdfs:label>
+		<skos:definition>card issued by a financial service provider that enables the cardholder to borrow funds</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Issuance of credit cards has the condition that the cardholder will pay back the original, borrowed amount plus any additional agreed-upon charges. The credit company provider may also grant a line of credit (LOC) to the cardholder which allows the holder to borrow money in the form of a cash advance.  The issuer pre-sets borrowing limits which have a basis on the individual&apos;s credit rating.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardAccount">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;LoanOrCreditAccount"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardProduct"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasPaymentDueDate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;PaymentDueDate"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasRepresentation"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCard"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>credit card account</rdfs:label>
+		<skos:definition>card account that is represented by a one or more credit cards</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardProduct">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCreditCardType"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCardAccount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCard"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>credit card product</rdfs:label>
+		<skos:definition>card product allowing the holder to purchase goods or services on credit</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardType">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>credit card type</rdfs:label>
+		<skos:definition>classifier that classifies a card product by network (i.e., Mastercard, Visa, American Express, etc.)</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;DebitCard">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;represents"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;DebitCardAccount"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;DebitCardProduct"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>debit card</rdfs:label>
+		<skos:definition>payment card issued by a financial service provider that enables the cardholder to access funds in a demand deposit account</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;DebitCardAccount">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;DebitCardProduct"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;hasRepresentation"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCard"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>debit card account</rdfs:label>
+		<skos:definition>card account that is represented by a one or more debit cards</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;DebitCardProduct">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCardAccount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCard"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>debit card product</rdfs:label>
+		<skos:definition>card product card typically provided by a depository institution allowing the holder to transfer money electronically to another account when making a purchase</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
+		<rdfs:label>magnetic stripe verification code or value</rdfs:label>
+		<skos:definition>card verification code on a card&apos;s magnetic stripe that uses secure cryptographic processes to protect data integrity on the stripe, and reveals any alteration or counterfeiting</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;Mastercard">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
+		<rdfs:label>Mastercard</rdfs:label>
+		<skos:definition>card product or individual card that is supported by the Mastercard Incorporated network</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;PaymentCard">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;DebtInstrument"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fi-fi;isNegotiable"/>
+				<owl:hasValue rdf:datatype="&xsd;boolean">false</owl:hasValue>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;isAssignable"/>
+				<owl:hasValue rdf:datatype="&xsd;boolean">false</owl:hasValue>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-doc;hasExpirationDate"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CardExpirationDate"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCardVerificationCode"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasPrimaryAccountNumber"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;PrimaryCardAccountNumber"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
+				<owl:onClass>
+					<owl:Class>
+						<owl:unionOf rdf:parseType="Collection">
+							<rdf:Description rdf:about="&fibo-fbc-fi-fi;Issuer">
+							</rdf:Description>
+							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialServiceProvider">
+							</rdf:Description>
+						</owl:unionOf>
+					</owl:Class>
+				</owl:onClass>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>payment card</rdfs:label>
+		<skos:definition>debt instrument in the form of a rectangular piece of plastic or metal issued by a financial services that enables the cardholder to withdraw or borrow funds</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Some debit cards may also be used as credit cards.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;PrimaryCardAccountNumber">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;AccountIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>primary card account number</rdfs:label>
+		<skos:definition>composite identifier of 14 or 16 digits embossed on a bank or payment card and encoded in the card&apos;s magnetic strip</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>PAN</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>The PAN identifies the issuer of the card and the account including part of the account number, and contains a check digit that verifies the authenticity of the embossed account number.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>primary account number</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
+		<rdfs:label>three-digit verification code or value</rdfs:label>
+		<skos:definition>card verification code that is the rightmost three-digit value printed in the signature panel area on the back of the card</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
+	</owl:Class>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;Visa">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
+		<rdfs:label>Visa</rdfs:label>
+		<skos:definition>card product or individual card that is supported by the Visa Inc. network</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasCardVerificationCode">
+		<rdfs:label>has card verification code</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
+		<skos:definition>links a credit card to either: (1) magnetic-stripe data, or (2) printed security features that are used to protect data integrity and limit alteration, counterfeiting and fraud generally</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasCreditCardType">
+		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
+		<rdfs:label>has credit card type</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
+		<skos:definition>indicates the underlying credit card classification for credit card program</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasPrimaryAccountNumber">
+		<rdfs:label>has primary account number</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-crd;PrimaryCardAccountNumber"/>
+		<skos:definition>specifies the account number displayed on the face of the card</skos:definition>
+		<skos:editorialNote>modeled independently of &apos;identifies&apos; in order to circumvent circular reasoning challenges</skos:editorialNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;usesCurrency">
+		<rdfs:subPropertyOf rdf:resource="&lcc-cr;uses"/>
+		<rdfs:label>uses currency</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;Currency"/>
+		<skos:definition>indicates the currency defined for the credit card product</skos:definition>
+	</owl:ObjectProperty>
+
+</rdf:RDF>

--- a/FBC/ProductsAndServices/CardAccounts.rdf
+++ b/FBC/ProductsAndServices/CardAccounts.rdf
@@ -89,6 +89,12 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;AmericanExpressNetwork">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+		<rdfs:label>American Express network</rdfs:label>
+		<skos:definition>credit card network and card issuer that both issues credit cards and processes payments for cards bearing its logo, as well as offering cardholder benefits like travel insurance</skos:definition>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CardAccount">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
 		<rdfs:subClassOf>
@@ -200,7 +206,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardValidationCode">
 		<rdf:type rdf:resource="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue"/>
 		<rdfs:label>card validation code</rdfs:label>
-		<skos:definition>card verification code specifically for MasterCard payment cards</skos:definition>
+		<skos:definition>card verification code specifically for Mastercard payment cards</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>PAN CVC</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
 	</owl:NamedIndividual>
@@ -208,7 +214,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;CardValidationCode2">
 		<rdf:type rdf:resource="&fibo-fbc-pas-crd;ThreeDigitVerificationCodeOrValue"/>
 		<rdfs:label>card validation code 2</rdfs:label>
-		<skos:definition>card verification value specifically for MasterCard payment cards</skos:definition>
+		<skos:definition>card verification value specifically for Mastercard payment cards</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>PAN CVC2</fibo-fnd-utl-av:abbreviation>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
 	</owl:NamedIndividual>
@@ -449,6 +455,18 @@
 		<skos:definition>card product card typically provided by a depository institution allowing the holder to transfer money electronically to another account when making a purchase</skos:definition>
 	</owl:Class>
 	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;DiscoverNetwork">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+		<rdfs:label>Discover network</rdfs:label>
+		<skos:definition>credit card network and card issuer offering benefits like secondary rental car collision insurance</skos:definition>
+	</owl:NamedIndividual>
+	
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;JBCNetwork">
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+		<rdfs:label>JBC network</rdfs:label>
+		<skos:definition>credit card network based in Japan, with coverage throughout Asia, with strategic partners worldwide</skos:definition>
+	</owl:NamedIndividual>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;MagneticStripeVerificationCodeOrValue">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardVerificationCodeOrValue"/>
 		<rdfs:label>magnetic stripe verification code or value</rdfs:label>
@@ -456,9 +474,9 @@
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;Mastercard">
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;MastercardNetwork">
 		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
-		<rdfs:label>Mastercard</rdfs:label>
+		<rdfs:label>Mastercard network</rdfs:label>
 		<skos:definition>credit card network that has its own suite of card protections and benefits, such as identity theft protection and extended warranties</skos:definition>
 	</owl:NamedIndividual>
 	
@@ -546,9 +564,9 @@
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.pcisecuritystandards.org/pci_security/glossary</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;Visa">
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;VisaNetwork">
 		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
-		<rdfs:label>Visa</rdfs:label>
+		<rdfs:label>Visa network</rdfs:label>
 		<skos:definition>credit card network that oversees the Visa Signature benefits associated with certain credit cards, such as premium rental car privileges and hotel perks</skos:definition>
 	</owl:NamedIndividual>
 	

--- a/FBC/ProductsAndServices/CardAccounts.rdf
+++ b/FBC/ProductsAndServices/CardAccounts.rdf
@@ -93,15 +93,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isLinkedToAccount"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
-				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasPrimaryAccountHolder"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;Cardholder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasPrimaryAccountHolder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;Cardholder"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isLinkedToAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -160,8 +159,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;FinancialProduct"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCreditCardType"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCreditCardNetwork"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -225,8 +224,8 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;denotes"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCard"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>card verification code or value</rdfs:label>
@@ -296,15 +295,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardProduct"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasBorrower"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;Cardholder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasLender"/>
-				<owl:onClass>
+				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&fibo-fbc-fi-fi;Issuer">
@@ -313,14 +311,13 @@
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
-				</owl:onClass>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-dae-dbt;hasBorrower"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;Cardholder"/>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>credit card</rdfs:label>
@@ -333,15 +330,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;LoanOrCreditAccount"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardProduct"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasPaymentDueDate"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;PaymentDueDate"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasPaymentDueDate"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;PaymentDueDate"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CreditCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -354,12 +350,31 @@
 		<skos:definition>card account that is represented by a one or more credit cards</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardNetwork">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:someValuesFrom rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>credit card network</rdfs:label>
+		<skos:definition>classifier for the network that authorizes, processes, and sets the terms of credit card transactions, as well as transfers payments between shoppers, merchants, and their banks</skos:definition>
+		<skos:example>Mastercard, Visa, American Express, Discover</skos:example>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardProduct">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCreditCardType"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-crd;hasCreditCardNetwork"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -379,24 +394,6 @@
 		<skos:definition>card product allowing the holder to purchase goods or services on credit</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-crd;CreditCardType">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardProduct"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
-				<owl:someValuesFrom rdf:resource="&xsd;string"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>credit card type</rdfs:label>
-		<skos:definition>classifier that classifies a card product by network (i.e., Mastercard, Visa, American Express, etc.)</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;DebitCard">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-crd;PaymentCard"/>
 		<rdfs:subClassOf>
@@ -409,8 +406,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;DebitCardProduct"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>debit card</rdfs:label>
@@ -422,8 +418,7 @@
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-crd;DebitCardProduct"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;DebitCardProduct"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -462,9 +457,9 @@
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;Mastercard">
-		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
 		<rdfs:label>Mastercard</rdfs:label>
-		<skos:definition>card product or individual card that is supported by the Mastercard Incorporated network</skos:definition>
+		<skos:definition>credit card network that has its own suite of card protections and benefits, such as identity theft protection and extended warranties</skos:definition>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-crd;PaymentCard">
@@ -504,8 +499,14 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isIssuedBy"/>
-				<owl:onClass>
+				<owl:someValuesFrom>
 					<owl:Class>
 						<owl:unionOf rdf:parseType="Collection">
 							<rdf:Description rdf:about="&fibo-fbc-fi-fi;Issuer">
@@ -514,14 +515,7 @@
 							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
-				</owl:onClass>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;isRealizedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
+				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>payment card</rdfs:label>
@@ -553,9 +547,9 @@
 	</owl:Class>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;Visa">
-		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
+		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
 		<rdfs:label>Visa</rdfs:label>
-		<skos:definition>card product or individual card that is supported by the Visa Inc. network</skos:definition>
+		<skos:definition>credit card network that oversees the Visa Signature benefits associated with certain credit cards, such as premium rental car privileges and hotel perks</skos:definition>
 	</owl:NamedIndividual>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasCardVerificationCode">
@@ -565,11 +559,11 @@
 		<skos:definition>links a credit card to either: (1) magnetic-stripe data, or (2) printed security features that are used to protect data integrity and limit alteration, counterfeiting and fraud generally</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasCreditCardType">
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasCreditCardNetwork">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
-		<rdfs:label>has credit card type</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-crd;CreditCardType"/>
-		<skos:definition>indicates the underlying credit card classification for credit card program</skos:definition>
+		<rdfs:label>has credit card network</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
+		<skos:definition>indicates the underlying network for credit card product</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-crd;hasPrimaryAccountNumber">

--- a/FBC/ProductsAndServices/CardAccounts.rdf
+++ b/FBC/ProductsAndServices/CardAccounts.rdf
@@ -461,9 +461,9 @@
 		<skos:definition>credit card network and card issuer offering benefits like secondary rental car collision insurance</skos:definition>
 	</owl:NamedIndividual>
 	
-	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;JBCNetwork">
+	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-crd;JCBNetwork">
 		<rdf:type rdf:resource="&fibo-fbc-pas-crd;CreditCardNetwork"/>
-		<rdfs:label>JBC network</rdfs:label>
+		<rdfs:label>JCB network</rdfs:label>
 		<skos:definition>credit card network based in Japan, with coverage throughout Asia, with strategic partners worldwide</skos:definition>
 	</owl:NamedIndividual>
 	

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -709,6 +709,12 @@
 		<skos:definition>date on which something was created</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;PaymentDueDate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>payment due date</rdfs:label>
+		<skos:definition>date by which payment of the current outstanding balance, part thereof, or a minimum amount due must be made to the creditor</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;PostingDate">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
 		<rdfs:label>posting date</rdfs:label>
@@ -951,6 +957,13 @@
 		<skos:definition>relates something to the date that it was created</skos:definition>
 	</owl:ObjectProperty>
 	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasPaymentDueDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+		<rdfs:label>has payment due date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;PaymentDueDate"/>
+		<skos:definition>indicates the date by which payment of some amount must be made to the creditor</skos:definition>
+	</owl:ObjectProperty>
+	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasPostingDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
 		<rdfs:label>has posting date</rdfs:label>
@@ -1021,6 +1034,14 @@
 		<rdfs:label>involves merchant</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-be-fct-fct;Merchant"/>
 		<skos:definition>indicates the merchant (seller) involved in the transaction</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;isLinkedToAccount">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-fpas;relatesTo"/>
+		<rdfs:label>is linked to account</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
+		<skos:definition>connects a given customer account to another customer account</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;isRealizedBy">

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -167,7 +167,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>account</rdfs:label>
-		<skos:definition>container for records associated with a business arrangement for regular dealings or services (such as personal or professional services, banking)</skos:definition>
+		<skos:definition>container for records associated with a business arrangement for regular transactions or services (such as personal or professional services, banking)</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In general, an account is associated with a contractual relationship between a buyer and seller under which payment may be made at a later time. General ledger accounts are an exception to this, however, and typically do not have account holders, including internal account holders. They may, on the other hand, have responsible parties.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -755,7 +755,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;TimeDepositAccount"/>
 		<rdfs:label>time deposit open account</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-pas-caa;TimeCertificateOfDepositAccount"/>
-		<skos:definition>time deposit account that allows deposits (other than time certificates of deposit) for which there is in force a written contract with the depositor that neither the whole nor any part of such deposit may be withdrawn prior to (1) the date of maturity which shall be not less than seven days after the date of the deposit, or (2) the expiration of a specified period of written notice of not less than seven days.</skos:definition>
+		<skos:definition>time deposit account that allows deposits (other than time certificates of deposit) for which there is in force a written contract with the depositor that neither the whole nor any part of such deposit may be withdrawn prior to (1) the date of maturity, which shall be not less than seven days after the date of the deposit, or (2) the expiration of a specified period of written notice of not less than seven days</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>https://www.fdic.gov/regulations/resources/call/crinst/2010-09/910gloss_093010.pdf</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
@@ -789,7 +789,7 @@
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionDepositAccount">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;DepositAccount"/>
 		<rdfs:label>transaction deposit account</rdfs:label>
-		<skos:definition>deposit or account from which the depositor or account holder is permitted to make transfers or withdrawals by negotiable or transferable instruments, payment orders of withdrawal, telephone transfers, or other similar devices for the purpose of making payments or transfers to third persons or others or from which the depositor may make third party payments at an automated teller machine (ATM), a remote service unit (RSU), or another electronic device, including by debit card</skos:definition>
+		<skos:definition>deposit account from which the depositor / account holder is permitted to make transfers or withdrawals by negotiable / transferable instruments, payment orders of withdrawal, telephone transfers, and so forth, and that may be accessible via an electronic device such as an automated teller machine (ATM), remote service unit (RSU), mobile device, and by debit card</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>https://www.fdic.gov/regulations/resources/call/crinst/2010-09/910gloss_093010.pdf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Excluded from transaction accounts are savings deposits (both money market deposit accounts (MMDAs) and other savings deposits), even though such deposits permit some third-party transfers. However, an account that otherwise meets the definition of a savings deposit but that authorizes or permits the depositor to exceed the transfer limitations specified for that account shall be reported as a transaction account.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -499,6 +499,12 @@
 				</owl:unionOf>
 			</owl:Class>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;holdsAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>customer account holder</rdfs:label>
 		<skos:definition>party that is a client or customer and that owns an account</skos:definition>
 	</owl:Class>

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -114,11 +114,18 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190701/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to eliminate the disjointness between a deposit account and investment account to allow for certain portfolio management accounts that have characteristics of both.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for balance, fee, general ledger, ledger account, income and related properties, revise definitions to be ISO 704 compliant, and eliminate duplication with concepts in LCC.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for transaction records, which are needed to represent statements of various sorts.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for transaction records, which are needed to represent statements of various sorts, to add the concept of an account statement, and to clean up and augment definitions related to accounts, account holders, etc. as required for the purpose of representing credit card accounts.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;Account">
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
@@ -128,22 +135,22 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-				<owl:onClass rdf:resource="&fibo-fnd-arr-doc;Record"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasCloseDate"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;CloseDate"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasAccountCloseDate"/>
-				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-doc;hasRecord"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionRecord"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasAccountOpenDate"/>
-				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasOpenDate"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;OpenDate"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -161,11 +168,17 @@
 		</rdfs:subClassOf>
 		<rdfs:label>account</rdfs:label>
 		<skos:definition>container for records associated with a business arrangement for regular dealings or services (such as personal or professional services, banking)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In general, an account is associated with a contractual relationship between a buyer and seller under which payment may be made at a later time.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>In general, an account is associated with a contractual relationship between a buyer and seller under which payment may be made at a later time. General ledger accounts are an exception to this, however, and typically do not have account holders, including internal account holders. They may, on the other hand, have responsible parties.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountHolder">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Owner"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;holdsAccount"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;Account"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
@@ -189,7 +202,9 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>account holder</rdfs:label>
-		<skos:definition>party holding an account</skos:definition>
+		<skos:definition>party that owns the account</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>An account holder is named on the account and is authorized to conduct transactions associated with the account. Authorization is typically evidenced by signatures maintained on file by the account provider.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>Note that this concept of account holder applies to internal accounts that are non-general ledger accounts also have account holders, such as payroll accounts, internal checking accounts associated with cashier&apos;s checks, and so forth.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountIdentifier">
@@ -249,6 +264,48 @@
 		<fibo-fnd-utl-av:explanatoryNote>Customers of financial service providers frequently hold multiple accounts - brokerage accounts, checking and savings accounts, trust accounts, and so forth - which may have specific terms and conditions associated with them.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountStatement">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;LegalDocument"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Record"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasEndingBalance"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;Balance"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasStartingBalance"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;Balance"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-arr-doc;hasReportingPeriod"/>
+				<owl:onClass rdf:resource="&fibo-fnd-dt-fd;ExplicitDatePeriod"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;appliesToAccount"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;Account"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;recordsTransaction"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;IndividualTransaction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>account statement</rdfs:label>
+		<skos:definition>periodic summary of account activity for a given period of time</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Common kinds of account statements include checking account statements, usually provided monthly, and brokerage account statements, which are provided monthly or quarterly, depending on the terms of the account agreement. Monthly credit card bills are also considered account statements.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountingTransaction">
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-pas-pas;TransactionEvent"/>
 		<rdfs:label>accounting transaction</rdfs:label>
@@ -262,35 +319,17 @@
 		<fibo-fnd-utl-av:explanatoryNote>The balance is the net amount after factoring in all debits and credits, including service charges and fees.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-caa;BankAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Account"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;Bank"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;BankAccountIdentifier"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>bank account</rdfs:label>
-		<skos:definition>account held or provided by, as a service, a bank</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;BankAccountIdentifier">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;AccountIdentifier"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;BankAccount"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;DemandDepositAccount"/>
 				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>bank account identifier</rdfs:label>
-		<skos:definition>identifier that identifies a bank account</skos:definition>
+		<skos:definition>identifier that identifies a demand deposit account provided by a bank</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>bank account number</fibo-fnd-utl-av:synonym>
 	</owl:Class>
@@ -386,38 +425,21 @@
 		<fibo-fnd-utl-av:explanatoryNote>When the term is over it can be withdrawn or it can be held for another term. The longer the term the better the yield on the money.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-caa;DemandDepositAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;TransactionDepositAccount"/>
-		<rdfs:label>demand deposit account</rdfs:label>
-		<skos:definition>non-interest-bearing deposit account in which deposits are payable immediately on demand, or that are issued with an original maturity or required notice period of less than seven days, or that represent funds for which the depository institution does not reserve the right to require at least seven days&apos; written notice of an intended withdrawal</skos:definition>
-		<fibo-fnd-utl-av:abbreviation>DDA</fibo-fnd-utl-av:abbreviation>
-		<fibo-fnd-utl-av:adaptedFrom>https://www.fdic.gov/regulations/resources/call/crinst/2010-09/910gloss_093010.pdf</fibo-fnd-utl-av:adaptedFrom>
-		<fibo-fnd-utl-av:explanatoryNote>Demand deposits include any matured time deposits without automatic renewal provisions, unless the deposit agreement provides for the funds to be transferred at maturity to another type of account. Demand deposits do not include: (i) money market deposit accounts (MMDAs) or (ii) NOW accounts.</fibo-fnd-utl-av:explanatoryNote>
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;CloseDate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>close date</rdfs:label>
+		<skos:definition>date on which something was closed</skos:definition>
+		<skos:example>account close date, transaction record close date, and so forth</skos:example>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-caa;DepositAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;BankingProduct"/>
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;InvestmentOrDepositAccount"/>
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;CustomerAccount">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Account"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;CustomerAccountHolder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>deposit account</rdfs:label>
-		<skos:definition>account that provides a record of money placed with a depository institution for safekeeping and management</skos:definition>
-		<skos:example>Deposit accounts include savings accounts, money market accounts, and transactional accounts, such as demand deposit accounts, among others.</skos:example>
-		<fibo-fnd-utl-av:explanatoryNote>The account holder has the right to withdraw deposited funds, as set forth in the terms and conditions governing the account agreement. Deposit accounts may be insured up to a certain amount, depending on the jurisdiction.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-pas-caa;Fee">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<rdfs:label>fee</rdfs:label>
-		<skos:definition>charge for services performed</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-pas-caa;FinancialServiceAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Account"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
@@ -429,27 +451,6 @@
 							<rdf:Description rdf:about="&fibo-fbc-pas-fpas;FinancialService">
 							</rdf:Description>
 						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-pty-pty;hasPartyInRole"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:intersectionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-fbc-pas-caa;AccountHolder">
-							</rdf:Description>
-							<owl:Class>
-								<owl:unionOf rdf:parseType="Collection">
-									<rdf:Description rdf:about="&fibo-fnd-pas-pas;Client">
-									</rdf:Description>
-									<rdf:Description rdf:about="&fibo-fnd-pas-pas;Customer">
-									</rdf:Description>
-								</owl:unionOf>
-							</owl:Class>
-						</owl:intersectionOf>
 					</owl:Class>
 				</owl:someValuesFrom>
 			</owl:Restriction>
@@ -481,8 +482,55 @@
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;AccountIdentifier"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label>financial service account</rdfs:label>
-		<skos:definition>account provided by a financial service provider associated with a specific financial product or service</skos:definition>
+		<rdfs:label>customer account</rdfs:label>
+		<skos:definition>account provided by a financial service provider to a customer or client that is associated with a specific financial product or service</skos:definition>
+		<fibo-fnd-utl-av:synonym>financial service account</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;CustomerAccountHolder">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+		<rdfs:subClassOf>
+			<owl:Class>
+				<owl:unionOf rdf:parseType="Collection">
+					<rdf:Description rdf:about="&fibo-fnd-pas-pas;Client">
+					</rdf:Description>
+					<rdf:Description rdf:about="&fibo-fnd-pas-pas;Customer">
+					</rdf:Description>
+				</owl:unionOf>
+			</owl:Class>
+		</rdfs:subClassOf>
+		<rdfs:label>customer account holder</rdfs:label>
+		<skos:definition>party that is a client or customer and that owns an account</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;DemandDepositAccount">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;TransactionDepositAccount"/>
+		<rdfs:label>demand deposit account</rdfs:label>
+		<skos:definition>non-interest-bearing deposit account in which deposits are payable immediately on demand, or that are issued with an original maturity or required notice period of less than seven days, or that represent funds for which the depository institution does not reserve the right to require at least seven days&apos; written notice of an intended withdrawal</skos:definition>
+		<fibo-fnd-utl-av:abbreviation>DDA</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:adaptedFrom>https://www.fdic.gov/regulations/resources/call/crinst/2010-09/910gloss_093010.pdf</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>Demand deposits include any matured time deposits without automatic renewal provisions, unless the deposit agreement provides for the funds to be transferred at maturity to another type of account. Demand deposits do not include: (i) money market deposit accounts (MMDAs) or (ii) NOW accounts.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;DepositAccount">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;BankingProduct"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;InvestmentOrDepositAccount"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isProvidedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-fct-fse;DepositoryInstitution"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>deposit account</rdfs:label>
+		<skos:definition>account that provides a record of money placed with a depository institution for safekeeping and management</skos:definition>
+		<skos:example>Deposit accounts include savings accounts, money market accounts, and transactional accounts, such as demand deposit accounts, among others.</skos:example>
+		<fibo-fnd-utl-av:explanatoryNote>The account holder has the right to withdraw deposited funds, as set forth in the terms and conditions governing the account agreement. Deposit accounts may be insured up to a certain amount, depending on the jurisdiction.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;Fee">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+		<rdfs:label>fee</rdfs:label>
+		<skos:definition>charge for services performed</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;GeneralLedger">
@@ -626,10 +674,10 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;InvestmentOrDepositAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;FinancialServiceAccount"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Account"/>
 		<rdfs:label>investment or deposit account</rdfs:label>
 		<skos:definition>account associated with a product or service that requires the account holder to provide funds for management by the account provider</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>The account holder may or may not be entitled to consideration in exchange for providing such funds, for example, interest, depending on the type of account and the terms and conditions associated with it.  Also, there may be fees associated with management services provided by the account provider.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:explanatoryNote>The account holder may or may not be entitled to consideration in exchange for providing such funds, for example, interest, depending on the type of account and the terms and conditions associated with it.  Also, there may be fees associated with management services provided by the account provider.  Note too that this may be an internal account held on behalf of an institution or a customer account.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;LedgerAccount">
@@ -639,10 +687,11 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;LoanOrCreditAccount">
-		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;FinancialServiceAccount"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Account"/>
 		<rdfs:label>loan or credit account</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-fbc-pas-caa;InvestmentOrDepositAccount"/>
 		<skos:definition>account associated with a service in which the account holder receives funds from the account provider under certain terms and conditions for repayment</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Note that this may be an internal account held on behalf of an institution or a customer account, such as a line of credit account associated with an internal line of business.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;NonTransactionDepositAccount">
@@ -652,6 +701,12 @@
 		<skos:definition>any deposit account that is not explicitly considered a transaction account</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>https://www.fdic.gov/regulations/resources/call/crinst/2010-09/910gloss_093010.pdf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Non-transaction accounts include: (a) savings deposits ((i) money market deposit accounts (MMDAs) and (ii) other savings deposits) and (b) time deposits ((i) time certificates of deposit and (ii) time deposits, open account).</fibo-fnd-utl-av:explanatoryNote>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;OpenDate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>open date</rdfs:label>
+		<skos:definition>date on which something was created</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;PostingDate">
@@ -765,15 +820,15 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasTransactionRecordCloseDate"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionRecordCloseDate"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasCloseDate"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;CloseDate"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasTransactionRecordOpenDate"/>
-				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionRecordOpenDate"/>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasOpenDate"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;OpenDate"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -806,12 +861,7 @@
 		</rdfs:subClassOf>
 		<rdfs:label>transaction record</rdfs:label>
 		<skos:definition>record of transactions associated with an account</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionRecordCloseDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-		<rdfs:label>transaction record close date</rdfs:label>
-		<skos:definition>date on which a transaction record was closed</skos:definition>
+		<fibo-fnd-utl-av:usageNote>The date a particular transaction record is closed typically corresponds to (and may precede) the date the account is closed, though in the case of certain accounts, such as a credit card account, if a customer is issued a new account or card number due to loss, fraud, or for some other reason, it is possible that multiple transaction records would be associated with the account.  In that case, the close date might correspond to the date that a hold was placed on the original account.</fibo-fnd-utl-av:usageNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionRecordIdentifier">
@@ -832,12 +882,6 @@
 		</rdfs:subClassOf>
 		<rdfs:label>transaction record identifier</rdfs:label>
 		<skos:definition>unique identifier for record of transactions</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionRecordOpenDate">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-		<rdfs:label>transaction record open date</rdfs:label>
-		<skos:definition>date on which a transaction record was created</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionSubcategory">
@@ -867,28 +911,44 @@
 		<skos:definition>indicates the account to which the transaction record or individual transaction applies</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasAccountCloseDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasEndDate"/>
-		<rdfs:label>has account close date</rdfs:label>
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasAccountHolder">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
+		<rdfs:label>has account holder</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;Account"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-		<skos:definition>relates an account to the date that it was closed</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasAccountOpenDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasStartDate"/>
-		<rdfs:label>has account open date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;Account"/>
-		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-		<skos:definition>relates an account to the date that it was created or opened</skos:definition>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+		<skos:definition>relates an account to a client or customer that owns the account</skos:definition>
+		<fibo-fnd-utl-av:synonym>has account owner</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasBalance">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 		<rdfs:label>has balance</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;Account"/>
 		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;Balance"/>
 		<skos:definition>relates an account to the net amount of money available in that account</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasCloseDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasEndDate"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+		<rdfs:label>has close date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;CloseDate"/>
+		<skos:definition>relates something to the date that it was closed</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasEndingBalance">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-caa;hasBalance"/>
+		<rdfs:label>has ending balance</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;AccountStatement"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;Balance"/>
+		<skos:definition>relates an account statement to the amount of money available in that account at the end of the statement period</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasOpenDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasStartDate"/>
+		<rdfs:label>has open date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;OpenDate"/>
+		<skos:definition>relates something to the date that it was created</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasPostingDate">
@@ -898,11 +958,33 @@
 		<skos:definition>indicates the date that the transaction was posted to the account</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasRecord">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-		<rdfs:label>has record</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;TransactionRecord"/>
-		<skos:definition>indicates a record associated with an account</skos:definition>
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasPrimaryAccountHolder">
+		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
+		<rdfs:label>has primary account holder</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+		<skos:definition>relates an account to a client or customer that is considered the primary owner of the account</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Note that for many financial institutions, there must be a client or customer designated as the primary owner. In cases where there is a tax identifier associated with the account, it is that of the primary owner.</fibo-fnd-utl-av:explanatoryNote>
+		<fibo-fnd-utl-av:synonym>has primary account owner</fibo-fnd-utl-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasSecondaryAccountHolder">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
+		<rdfs:label>has secondary account holder</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+		<skos:definition>relates an account to a client or customer that is considered a secondary, co-owner of the account</skos:definition>
+		<fibo-fnd-utl-av:synonym>has account co-owner</fibo-fnd-utl-av:synonym>
+		<fibo-fnd-utl-av:synonym>has secondary account owner</fibo-fnd-utl-av:synonym>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasStartingBalance">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-caa;hasBalance"/>
+		<rdfs:label>has starting balance</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;AccountStatement"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;Balance"/>
+		<skos:definition>relates an account statement to the amount of money available in that account at the beginning of the statement period</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasTransactionDate">
@@ -919,30 +1001,20 @@
 		<skos:definition>provides a textual description of the transaction</skos:definition>
 	</owl:DatatypeProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasTransactionRecordCloseDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasEndDate"/>
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
-		<rdfs:label>has transaction record close date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;TransactionRecord"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;TransactionRecordCloseDate"/>
-		<skos:definition>relates a transaction record to the date on which it was closed</skos:definition>
-		<fibo-fnd-utl-av:usageNote>The date a particular transaction record is closed typically corresponds to (and may precede) the date the account is closed, though in the case of certain accounts, such as a credit card account, if a customer is issued a new account or card number due to loss, fraud, or for some other reason, it is possible that multiple transaction records would be associated with the account.  In that case, the close date might correspond to the date that a hold was placed on the original account.</fibo-fnd-utl-av:usageNote>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasTransactionRecordOpenDate">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasStartDate"/>
-		<rdfs:label>has transaction record open date</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;TransactionRecord"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;TransactionRecordOpenDate"/>
-		<skos:definition>relates a transaction record to the date the record was created</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:DatatypeProperty rdf:about="&fibo-fbc-pas-caa;hasTransactionRecordStatus">
 		<rdfs:label>has transaction record status</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition>indicates the status of the transaction record</skos:definition>
 	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;holdsAccount">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;holds"/>
+		<rdfs:label>holds account</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;Account"/>
+		<owl:inverseOf rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
+		<skos:definition>relates a client or customer to an account that they own</skos:definition>
+	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;involvesMerchant">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;involves"/>
@@ -961,6 +1033,19 @@
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
 		<rdfs:label>realizes</rdfs:label>
 		<skos:definition>makes concrete</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;recordsTransaction">
+		<rdfs:label>records transaction</rdfs:label>
+		<owl:propertyChainAxiom rdf:parseType="Collection">
+			<rdf:Description rdf:about="&fibo-fbc-pas-caa;appliesToAccount">
+			</rdf:Description>
+			<rdf:Description rdf:about="&fibo-fnd-arr-doc;hasRecord">
+			</rdf:Description>
+			<rdf:Description rdf:about="&fibo-fbc-fct-ra;hasRegistryEntry">
+			</rdf:Description>
+		</owl:propertyChainAxiom>
+		<skos:definition>links an account statement to the individual transactions it documents</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:Class rdf:about="&fibo-fnd-pas-pas;ContractualProduct">

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
+	<!ENTITY fibo-be-fct-fct "https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/">
 	<!ENTITY fibo-be-le-fbo "https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/">
 	<!ENTITY fibo-be-oac-exec "https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/">
 	<!ENTITY fibo-fbc-dae-dbt "https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/">
 	<!ENTITY fibo-fbc-fct-fse "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/">
+	<!ENTITY fibo-fbc-fct-ra "https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/">
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
+	<!ENTITY fibo-fnd-arr-cls "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/">
 	<!ENTITY fibo-fnd-arr-doc "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/">
 	<!ENTITY fibo-fnd-arr-id "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/">
 	<!ENTITY fibo-fnd-dt-fd "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/">
+	<!ENTITY fibo-fnd-dt-oc "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/">
 	<!ENTITY fibo-fnd-oac-own "https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/">
 	<!ENTITY fibo-fnd-pas-pas "https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/">
 	<!ENTITY fibo-fnd-pty-pty "https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/">
@@ -31,19 +35,23 @@
 ]>
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
 	xmlns:dct="http://purl.org/dc/terms/"
+	xmlns:fibo-be-fct-fct="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"
 	xmlns:fibo-be-le-fbo="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"
 	xmlns:fibo-be-oac-exec="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"
 	xmlns:fibo-fbc-dae-dbt="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"
 	xmlns:fibo-fbc-fct-fse="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"
+	xmlns:fibo-fbc-fct-ra="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
+	xmlns:fibo-fnd-arr-cls="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"
 	xmlns:fibo-fnd-arr-doc="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"
 	xmlns:fibo-fnd-arr-id="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"
 	xmlns:fibo-fnd-dt-fd="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"
+	xmlns:fibo-fnd-dt-oc="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/"
 	xmlns:fibo-fnd-oac-own="https://spec.edmcouncil.org/fibo/ontology/FND/OwnershipAndControl/Ownership/"
 	xmlns:fibo-fnd-pas-pas="https://spec.edmcouncil.org/fibo/ontology/FND/ProductsAndServices/ProductsAndServices/"
 	xmlns:fibo-fnd-pty-pty="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Parties/"
@@ -67,19 +75,26 @@
 		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
 		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
+		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<sm:dependsOn rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/"/>
 		<sm:fileAbbreviation>fibo-fbc-pas-caa</sm:fileAbbreviation>
 		<sm:filename>ClientsAndAccounts.rdf</sm:filename>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/FunctionalEntities/FunctionalEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/LegalEntities/FormalBusinessOrganizations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/OwnershipAndControl/Executives/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/DebtAndEquities/Debt/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/ClassificationSchemes/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Documents/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/"/>
@@ -92,13 +107,14 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200201/ProductsAndServices/ClientsAndAccounts/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/ProductsAndServices/ClientsAndAccounts/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20160801/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised per the FIBO 2.0 RFC with respect to the definitions for accounts and account identifiers, such as BBAN and IBAN identifiers, including but not limited to bank accounts.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to support the addition of maturity-related properties to financial instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20181101/ProductsAndServices/ClientsAndAccounts/ version of this ontology was modified to replace hasDefinition with isDefinedIn to clarify intent.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190701/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20190901/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to eliminate the disjointness between a deposit account and investment account to allow for certain portfolio management accounts that have characteristics of both.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20191201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for balance, fee, general ledger, ledger account, income and related properties, revise definitions to be ISO 704 compliant, and eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FBC/20200201/ProductsAndServices/ClientsAndAccounts.rdf version of this ontology was revised to add definitions for transaction records, which are needed to represent statements of various sorts.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -481,6 +497,90 @@
 		<skos:definition>accounting record summarizing changes in position as transactions are posted during an accounting period</skos:definition>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;IndividualTransaction">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;RegistryEntry"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;DatedCollectionConstituent"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-oc;Occurrence"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;isRegisteredIn"/>
+				<owl:allValuesFrom rdf:resource="&fibo-fbc-pas-caa;TransactionRecord"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionIdentifier"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;involvesMerchant"/>
+				<owl:onClass rdf:resource="&fibo-be-fct-fct;Merchant"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionSubcategory"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasTransactionDescription"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;appliesToAccount"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;Account"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasPostingDate"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;PostingDate"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;isClassifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionCategory"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasTransactionDate"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionDate"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
+				<owl:onClass rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-dt-oc;exemplifies"/>
+				<owl:onClass rdf:resource="&fibo-fnd-pas-pas;TransactionEvent"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>individual transaction</rdfs:label>
+		<skos:definition>event that has a monetary impact and is documented in the records associated with an account</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;InternationalBankAccountIdentifier">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;BankAccountIdentifier"/>
 		<rdfs:subClassOf>
@@ -554,6 +654,12 @@
 		<fibo-fnd-utl-av:explanatoryNote>Non-transaction accounts include: (a) savings deposits ((i) money market deposit accounts (MMDAs) and (ii) other savings deposits) and (b) time deposits ((i) time certificates of deposit and (ii) time deposits, open account).</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;PostingDate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>posting date</rdfs:label>
+		<skos:definition>date that determines in which posting period a document or journal entry is added to an account record</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;RelationshipManager">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-exec;ResponsibleParty"/>
 		<rdfs:subClassOf>
@@ -598,6 +704,33 @@
 		<fibo-fnd-utl-av:adaptedFrom>https://www.fdic.gov/regulations/resources/call/crinst/2010-09/910gloss_093010.pdf</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionCategory">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;IndividualTransaction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>transaction category</rdfs:label>
+		<skos:definition>high-level classifier for an individual transaction</skos:definition>
+		<skos:example>credit, debit, fee</skos:example>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionDate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>transaction date</rdfs:label>
+		<skos:definition>date on which a specific transaction was initiated</skos:definition>
+	</owl:Class>
+	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionDepositAccount">
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;DepositAccount"/>
 		<rdfs:label>transaction deposit account</rdfs:label>
@@ -605,6 +738,134 @@
 		<fibo-fnd-utl-av:adaptedFrom>https://www.fdic.gov/regulations/resources/call/crinst/2010-09/910gloss_093010.pdf</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>Excluded from transaction accounts are savings deposits (both money market deposit accounts (MMDAs) and other savings deposits), even though such deposits permit some third-party transfers. However, an account that otherwise meets the definition of a savings deposit but that authorizes or permits the depositor to exceed the transfer limitations specified for that account shall be reported as a transaction account.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionIdentifier">
+		<rdfs:subClassOf rdf:resource="&lcc-lr;Identifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;IndividualTransaction"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>transaction identifier</rdfs:label>
+		<skos:definition>identifier for an individual transaction associated with an account</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionRecord">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;Registry"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-doc;Record"/>
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;DatedStructuredCollection"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;isIdentifiedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionRecordIdentifier"/>
+				<owl:maxQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasTransactionRecordCloseDate"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionRecordCloseDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasTransactionRecordOpenDate"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionRecordOpenDate"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasTransactionRecordStatus"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;appliesToAccount"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;Account"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isManagedBy"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;AccountProvider"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fbc-fct-ra;hasRegistryEntry"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;IndividualTransaction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>transaction record</rdfs:label>
+		<skos:definition>record of transactions associated with an account</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionRecordCloseDate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>transaction record close date</rdfs:label>
+		<skos:definition>date on which a transaction record was closed</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionRecordIdentifier">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-ra;RegistryIdentifier"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;identifies"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;TransactionRecord"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>transaction record identifier</rdfs:label>
+		<skos:definition>unique identifier for record of transactions</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionRecordOpenDate">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
+		<rdfs:label>transaction record open date</rdfs:label>
+		<skos:definition>date on which a transaction record was created</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;TransactionSubcategory">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-arr-cls;Classifier"/>
+		<rdfs:subClassOf rdf:resource="&lcc-lr;CodeElement"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-lr;hasTag"/>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&lcc-cr;classifies"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;IndividualTransaction"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>transaction subcategory</rdfs:label>
+		<skos:definition>second-level classifier for a transaction, e.g., direct deposit, check, cash advance, withdrawl, payment, purchase, and so forth</skos:definition>
+	</owl:Class>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;appliesToAccount">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;appliesTo"/>
+		<rdfs:label>applies to account</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;Account"/>
+		<skos:definition>indicates the account to which the transaction record or individual transaction applies</skos:definition>
+	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasAccountCloseDate">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasEndDate"/>
@@ -628,6 +889,66 @@
 		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;Account"/>
 		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;Balance"/>
 		<skos:definition>relates an account to the net amount of money available in that account</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasPostingDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+		<rdfs:label>has posting date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;PostingDate"/>
+		<skos:definition>indicates the date that the transaction was posted to the account</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasRecord">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+		<rdfs:label>has record</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;TransactionRecord"/>
+		<skos:definition>indicates a record associated with an account</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasTransactionDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+		<rdfs:label>has transaction date</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;TransactionDate"/>
+		<skos:definition>indicates the date on which the transaction actually occurred</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-pas-caa;hasTransactionDescription">
+		<rdfs:label>has transaction description</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;IndividualTransaction"/>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>provides a textual description of the transaction</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasTransactionRecordCloseDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasEndDate"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+		<rdfs:label>has transaction record close date</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;TransactionRecord"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;TransactionRecordCloseDate"/>
+		<skos:definition>relates a transaction record to the date on which it was closed</skos:definition>
+		<fibo-fnd-utl-av:usageNote>The date a particular transaction record is closed typically corresponds to (and may precede) the date the account is closed, though in the case of certain accounts, such as a credit card account, if a customer is issued a new account or card number due to loss, fraud, or for some other reason, it is possible that multiple transaction records would be associated with the account.  In that case, the close date might correspond to the date that a hold was placed on the original account.</fibo-fnd-utl-av:usageNote>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasTransactionRecordOpenDate">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasExplicitDate"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-dt-fd;hasStartDate"/>
+		<rdfs:label>has transaction record open date</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;TransactionRecord"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;TransactionRecordOpenDate"/>
+		<skos:definition>relates a transaction record to the date the record was created</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-fbc-pas-caa;hasTransactionRecordStatus">
+		<rdfs:label>has transaction record status</rdfs:label>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition>indicates the status of the transaction record</skos:definition>
+	</owl:DatatypeProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;involvesMerchant">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;involves"/>
+		<rdfs:label>involves merchant</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-be-fct-fct;Merchant"/>
+		<skos:definition>indicates the merchant (seller) involved in the transaction</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;isRealizedBy">

--- a/FBC/ProductsAndServices/MetadataFBCProductsAndServices.rdf
+++ b/FBC/ProductsAndServices/MetadataFBCProductsAndServices.rdf
@@ -24,26 +24,27 @@
 	<owl:Ontology rdf:about="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/">
 		<rdfs:label>Metadata about the EDMC-FIBO Financial Business and Commerce(FBC) Products and Services Module</rdfs:label>
 		<dct:abstract>The FBC Products and Services module extends the FND Products and Services module via ontologies defining financial products, financial services, financial service providers, and product catalogs as well as customer/client accounts.</dct:abstract>
-		<dct:issued rdf:datatype="&xsd;dateTime">2018-08-27T18:00:00</dct:issued>
+		<dct:issued rdf:datatype="&xsd;dateTime">2020-09-28T18:00:00</dct:issued>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
 		<sm:contentLanguage rdf:datatype="&xsd;anyURI">http://www.w3.org/standards/techs/owl#w3c_all</sm:contentLanguage>
-		<sm:copyright>Copyright (c) 2015-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:fileAbbreviation>fibo-fbc-pas-mod</sm:fileAbbreviation>
 		<sm:filename>MetadataFBCProductsAndServices.rdf</sm:filename>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20180801/ProductsAndServices/MetadataFBCProductsAndServices/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/20200901/ProductsAndServices/MetadataFBCProductsAndServices/"/>
 	</owl:Ontology>
 	
 	<owl:NamedIndividual rdf:about="&fibo-fbc-pas-mod;FBCProductsAndServicesModule">
 		<rdf:type rdf:resource="&sm;Module"/>
 		<rdfs:label>FIBO FBC Products and Services Module</rdfs:label>
 		<dct:abstract>The products and services module extends the FND Products and Services module via ontologies defining financial products, financial services, financial service providers, and product catalogs as well as customer/client accounts.</dct:abstract>
+		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"/>
 		<dct:hasPart rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
 		<dct:license rdf:datatype="&xsd;anyURI">http://opensource.org/licenses/MIT</dct:license>
-		<sm:copyright>Copyright (c) 2015-2018 EDM Council, Inc.</sm:copyright>
-		<sm:copyright>Copyright (c) 2015-2018 Object Management Group, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2020 EDM Council, Inc.</sm:copyright>
+		<sm:copyright>Copyright (c) 2015-2020 Object Management Group, Inc.</sm:copyright>
 		<sm:moduleAbbreviation>FIBO-FBC-PAS</sm:moduleAbbreviation>
 		<rdfs:seeAlso rdf:resource="https://spec.edmcouncil.org/fibo/"/>
 	</owl:NamedIndividual>

--- a/FND/Arrangements/Documents.rdf
+++ b/FND/Arrangements/Documents.rdf
@@ -44,7 +44,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Documents/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Arrangements/Documents/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Arrangements/Documents.rdf version of this ontology was introduced as a part of the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/ in advance of the Long Beach meeting in December 2014.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20141101/Arrangements/Documents.rdf version of this ontology was revised as a part of the issue resolutions identified in the FIBO FND 1.1 RTF report to add a parent of hasDate to date properties.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20160201/Arrangements/Documents.rdf version of this ontology was revised as a part of the issue resolutions identified in the FIBO FND 1.2 RTF report to add a definition for a record.</skos:changeNote>
@@ -52,6 +52,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Arrangements/Documents.rdf version of this ontology was revised to add a new records property.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20181201/Arrangements/Documents.rdf version of this ontology was revised to eliminate deprecated properties.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Arrangements/Documents.rdf version of this ontology was revised to integrate additional document concepts, including certificate, draft, and notice and eliminate duplication with concepts in LCC.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Arrangements/Documents.rdf version of this ontology was revised to add a hasRecord property.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -122,6 +123,13 @@
 		<rdfs:label>has expiration date</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;Date"/>
 		<skos:definition>links something, typically an agreement, contract, document, or perishable item, with an expiration date</skos:definition>
+	</owl:ObjectProperty>
+	
+	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-doc;hasRecord">
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;comprises"/>
+		<rdfs:label>has record</rdfs:label>
+		<rdfs:range rdf:resource="&fibo-fnd-arr-doc;Record"/>
+		<skos:definition>links something to a record that pertains to it</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-arr-doc;hasReportingPeriod">

--- a/FND/Relations/Relations.rdf
+++ b/FND/Relations/Relations.rdf
@@ -43,7 +43,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Relations/Relations/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Relations/Relations/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20170201/Relations/Relations.rdf version of this ontology was modified per the FIBO 2.0 RFC to include additional properties and the linkage to LCC.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Relations/Relations.owl version of the ontology submitted with 
 the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
@@ -63,7 +63,7 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190501/Relations/Relations.rdf version of this ontology was modified to rename (migrate) the hasDefinition property to isDefinedIn.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Relations/Relations.rdf version of this ontology was modified to eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190901/Relations/Relations.rdf version of this ontology was modified to eliminate duplication with concepts in LCC and remove the unused hasDispositionDate property, whose semantics were unclear at best.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name, to loosen domain restrictions on some properties which were too narrowly specified, and to add two new properties, describes and isDescribedBy, which are more appropriate for certain cases where we were using characterizes and isCharacterizedBy.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200301/Relations/Relations.rdf version of this ontology was modified to move hasAcquisitionDate to Financial Dates to improve usability and simplify reasoning, to eliminate circular definitions, to deprecate fibo-fnd-rel-rel;hasTag in favor of the simpler LCC property of the same name, to loosen domain restrictions on some properties which were too narrowly specified, and to add two new properties, describes and isDescribedBy, which are more appropriate for certain cases where we were using characterizes and isCharacterizedBy.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -207,7 +207,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;hasRepresentation">
 		<rdfs:subPropertyOf rdf:resource="&lcc-lr;has"/>
 		<rdfs:label>has representation</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-rel-rel;Reference"/>
 		<skos:definition>relates a concept to some textual or other symbol which is intended to convey the sense of that concept or to some form of words which sets out the meaning of that concept</skos:definition>
 	</owl:ObjectProperty>
 	
@@ -396,7 +395,6 @@ the FIBO FND RFC, was revised in advance of the September 2013 New Brunswick, NJ
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;represents">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;refersTo"/>
 		<rdfs:label>represents</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fnd-rel-rel;Reference"/>
 		<owl:inverseOf rdf:resource="&fibo-fnd-rel-rel;hasRepresentation"/>
 		<skos:definition>illustrates, symbolizes, exemplifies, stands for, or means</skos:definition>
 	</owl:ObjectProperty>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -153,6 +153,7 @@
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies/" uri="./FBC/FunctionalEntities/NorthAmericanEntities/USRegulatoryAgencies.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/" uri="./FBC/FunctionalEntities/RegistrationAuthorities.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegulatoryAgencies/" uri="./FBC/FunctionalEntities/RegulatoryAgencies.rdf"/>
+	<uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/CardAccounts/" uri="./FBC/ProductsAndServices/CardAccounts.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/" uri="./FBC/ProductsAndServices/ClientsAndAccounts.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/" uri="./FBC/ProductsAndServices/FinancialProductsAndServices.rdf"/>
     <uri id="User Entered Import Resolution" name="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/MetadataFBCProductsAndServices/" uri="./FBC/ProductsAndServices/MetadataFBCProductsAndServices.rdf"/>


### PR DESCRIPTION
## Description

This resolution refines concepts related to accounts, including new concepts covering account statements, transaction records, individual transactions, and cleans up a number of definitions related to accounts based on user experiences.  It renames FinancialServiceAccount to CustomerAccount to improve user understanding, and extends the concept of a customer account to include card accounts (credit card account and debit card account).  It relates a card account to a card product, including classifying card products by network.  It relates a card account to the payment card (debit or credit), and supports common features of such cards, including the primary card account number (PAN), expiration date, and security code based on the international standard (see https://www.pcisecuritystandards.org/pci_security/glossary) for representing such codes.

Note that the card accounts ontology is provisional at this time, in order to solicit additional review prior to release.

Fixes: #1158 / FBC-260


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


