### PR TITLE
FND-314 - The restriction that links a jurisdiction to the legal system applied by the judiciary in that jurisdiction is overly constraining and not needed

### DIFF
--- a/FND/Law/Jurisdiction.rdf
+++ b/FND/Law/Jurisdiction.rdf
@@ -46,7 +46,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Law/Jurisdiction/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Law/Jurisdiction/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20130801/Law/Jurisdiction.rdf version of the ontology was was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in http://www.omg.org/spec/EDMC-FIBO/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Law/Jurisdiction.rdf version of the ontology was was modified per the FIBO 2.0 RFC to integrate LCC.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/FIBO/Foundations/20130601/Law/Jurisdiction.owl version of the ontology was revised in advance of the September 2013 New Brunswick, NJ meeting, as follows:
@@ -56,64 +56,9 @@
    (4) to use 4-level abbreviations and corresponding namespace prefixes for all FIBO ontologies, reflecting a family/specification/module/ontology structure
    (5) to incorporate changes to the specification metadata to support documentation at the family, specification, module, and ontology level, similar to the abbreviations
    (6) to revise definitions using more formal sources.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Law/Jurisdiction.rdf version of the ontology was was modified to eliminate an unused import.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20180801/Law/Jurisdiction.rdf version of the ontology was modified to remove the constraint on jurisdiction that it is governed by some legal system, eliminate the class legal system and its children, which were very general and not used anywhere in FIBO, clean up remaining definitions with better sources, and eliminate an unused import.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;CivilLawJurisdiction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;CivilLawSystem"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">civil law jurisdiction</rdfs:label>
-		<skos:definition>a civil law jurisdiction</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;CivilLawSystem">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;LegalSystem"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-law-jur;appliesIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;CivilLawJurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>civil law system</rdfs:label>
-		<skos:definition>a legal system originating in Europe, intellectualized within the framework of late Roman law, and whose most prevalent feature is that its core principles are codified into a referable system which serves as the primary source of law</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://en.wikipedia.org/wiki/Civil_law_(legal_system)</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>This can be contrasted with common law systems whose intellectual framework comes from judge-made decisional law which gives precedential authority to prior court decisions on the principle that it is unfair to treat similar facts differently on different occasions (doctrine of judicial precedent).</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;CommonLawJurisdiction">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;CommonLawSystem"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>common law jurisdiction</rdfs:label>
-		<skos:definition>a jurisdiction based on common law</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;CommonLawSystem">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-law-jur;LegalSystem"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-law-jur;appliesIn"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;CommonLawJurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>common law system</rdfs:label>
-		<skos:definition>common law, also known as case law or precedent, is law developed by judges through decisions of courts and similar tribunals</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://en.wikipedia.org/wiki/Common_law</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>A jurisdiction which is based in Common Law will also have alongside a legislature that passes statutes.</fibo-fnd-utl-av:explanatoryNote>
-		<fibo-fnd-utl-av:explanatoryNote>By contrast, civil law (codified/continental law) is set on statutes adopted through the legislative/parliamentary process and/or regulations issued by the executive branch on base of the parliamentary statutes.
-
-A common law system is a legal system that gives great potential precedential weight to common law, on the principle that it is unfair to treat similar facts differently on different occasions. The body of precedent is called common law and it binds future decisions. In cases where the parties disagree on what the law is, a common law court looks to past precedential decisions of relevant courts. If a similar dispute has been resolved in the past, the court is bound to follow the reasoning used in the prior decision (this principle is known as stare decisis). If, however, the court finds that the current dispute is fundamentally distinct from all previous cases (called a matter of first impression), judges have the authority and duty to make law by creating precedent. Thereafter, the new decision becomes precedent, and will bind future courts.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-jur;Jurisdiction">
 		<rdfs:subClassOf>
@@ -122,35 +67,9 @@ A common law system is a legal system that gives great potential precedential we
 				<owl:someValuesFrom rdf:resource="&lcc-cr;GeographicRegion"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-jur;LegalSystem"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">jurisdiction</rdfs:label>
-		<skos:definition>the limits or territory within which authority may be exercised; the power, right, or authority to interpret and apply the law</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin>Merriam-Webster Online Dictionary</fibo-fnd-utl-av:definitionOrigin>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-fnd-law-jur;LegalSystem">
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-law-jur;appliesIn"/>
-				<owl:allValuesFrom rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isGovernedBy"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fnd-law-cor;GovernmentalConstitution"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">legal system</rdfs:label>
-		<skos:definition>Legal regimen of a country consisting of (1) a written or oral constitution, (2) primary legislation (statutes) enacted by the legislative body established by the constitution, (3) subsidiary legislation (bylaws) made by person or bodies authorized by the primary legislation to do so, (4) customs applied by the courts on the basis of traditional practices, and (5) principles or practices of civil, common, Roman, or other code of law.</skos:definition>
-		<skos:editorialNote>This is a Mediating Thing, that is some context in which things have their meaning and existence - in this case, laws and the interpretation thereof by courts.</skos:editorialNote>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/legal-system.html</fibo-fnd-utl-av:definitionOrigin>
-		<fibo-fnd-utl-av:explanatoryNote>The contemporary legal systems of the world are generally based on one of three basic systems: civil law, common law, and religious law, or combinations of these. However, the legal system of each country is shaped by its unique history and so incorporates individual variations.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>power of a court to adjudicate cases, issue orders, and interpret and apply the law with respect to some specific geographic area</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom>https://www.law.cornell.edu/wex/jurisdiction</fibo-fnd-utl-av:adaptedFrom>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fnd-law-jur;StatuteLaw">
@@ -163,22 +82,23 @@ A common law system is a legal system that gives great potential precedential we
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">statute law</rdfs:label>
 		<skos:altLabel>statutory law</skos:altLabel>
-		<skos:definition>written law (as opposed to oral or customary law) set down by a legislature or by a legislator (in the case of an absolute monarchy)</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://en.wikipedia.org/wiki/Statute_law</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>law enacted by a legislature</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">https://www.law.cornell.edu/wex/statute</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>In the United States, statutes may also be called acts, such as the Civil Rights Act of 1964 or the Sarbanes-Oxley Act.  Federal laws must be passed by both houses of Congress, the House of Representative and the Senate, and then usually require approval from the president before they can take effect.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Statutes may originate with national, state legislatures or local municipalities. Statutory laws are subordinate to the higher constitutional laws of the land.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-law-jur;appliesIn">
 		<rdfs:label>applies in</rdfs:label>
 		<rdfs:range rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
-		<skos:definition>indicates the jurisdiction in which a law, regulation, or legal system applies</skos:definition>
+		<skos:definition>indicates the jurisdiction in which a law applies</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-law-jur;hasReach">
 		<rdfs:label>has reach</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fnd-law-jur;Jurisdiction"/>
 		<rdfs:range rdf:resource="&lcc-cr;GeographicRegion"/>
-		<skos:definition>indicates the geopolitical unit (country, federal province or municipality) or geophysical extent in which the jurisdiction has effect</skos:definition>
+		<skos:definition>indicates the geopolitical area covered by the jurisdiction</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Revised the Jurisdictions ontology to (1) remove the constraint on jurisdiction that it is governed by some legal system, (2) eliminate the class legal system and its children, which were very general and not used anywhere in FIBO, and (3) clean up remaining definitions with better sources

Fixes: #ISSUE_NUMBER


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


