### PR TITLE
DER-75 - Additional clean-up is needed in the SecurityBasedSwaps and EquitySwaps

### DIFF
--- a/DER/SecurityBasedDerivatives/EquityForwards.rdf
+++ b/DER/SecurityBasedDerivatives/EquityForwards.rdf
@@ -2,6 +2,7 @@
 <!DOCTYPE rdf:RDF [
 	<!ENTITY dct "http://purl.org/dc/terms/">
 	<!ENTITY fibo-der-der-fwd "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/">
+	<!ENTITY fibo-der-drc-bsc "https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/">
 	<!ENTITY fibo-der-sbd-eqf "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquityForwards/">
 	<!ENTITY fibo-der-sbd-eqs "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquitySwaps/">
 	<!ENTITY fibo-der-sbd-sbd "https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/">
@@ -21,6 +22,7 @@
 <rdf:RDF xml:base="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquityForwards/"
 	xmlns:dct="http://purl.org/dc/terms/"
 	xmlns:fibo-der-der-fwd="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/Forwards/"
+	xmlns:fibo-der-drc-bsc="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/"
 	xmlns:fibo-der-sbd-eqf="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquityForwards/"
 	xmlns:fibo-der-sbd-eqs="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/EquitySwaps/"
 	xmlns:fibo-der-sbd-sbd="https://spec.edmcouncil.org/fibo/ontology/DER/SecurityBasedDerivatives/SecurityBasedDerivatives/"
@@ -71,13 +73,6 @@
 		<skos:editorialNote xml:lang="en">Referred to in formal terms for OTC Equity Forwards and Options. REVIEW: It does not look as though we have completely pinned down the meaning on this one, only that it&apos;s a piece of data that&apos;s used for something. We really need to see and model details of those deviation claculations, along with who does them and when. Also they may not directly be facts about the contract as such. REVIEW FpML: &apos;A single Dividend Adjustment Period.&apos;</skos:editorialNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-sbd-eqf;EquityForwardBuyer">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContractBuyer"/>
-		<rdfs:label xml:lang="en">equity forward buyer</rdfs:label>
-		<skos:definition xml:lang="en">The party that buys this forwward contract, that is the party which pays for this instrument and receives the rights defined by it.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">See note in Seller. See 2000 ISDA definitions Article 11.1 (b). FpML: &apos;A reference to the party that buys this instrument, ie. pays for this instrument and receives the rights defined by it. See 2000 ISDA definitions Article 11.1 (b). In the case of FRAs this the fixed rate payer.&apos; Interpretation: this is the party which is the counterparty to the contract.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-sbd-eqf;EquityForwardCashSettlement">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardCashSettlementCommitment"/>
 		<rdfs:label xml:lang="en">equity forward cash settlement</rdfs:label>
@@ -88,32 +83,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;EquityDerivative"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="https://spec.edmcouncil.org/fibo/ontology/DER/DerivativesContracts/DerivativesBasics/hasUnderlier"/>
+				<owl:onProperty rdf:resource="&fibo-der-drc-bsc;hasUnderlier"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-sbd;EquityObservable"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasBuyer"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-eqf;EquityForwardBuyer"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-der-fwd;hasSeller"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-eqf;EquityForwardSeller"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-der-sbd-eqf;dividendAdjustment"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-eqf;DividendAdjustmentPeriod"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-sbd-eqf;hasConditions"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-eqs;DividendConditions"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -138,13 +115,6 @@
 		<rdfs:label xml:lang="en">equity forward delivery commitment</rdfs:label>
 		<skos:definition xml:lang="en">The commitment to deliver an equity underlying at the maturity of an OTC Equity Forward contract.</skos:definition>
 		<skos:editorialNote xml:lang="en">Or, presumably, some cash equivalent in the event that the undelying is non deliverable, or for a non deliverable forward generally.</skos:editorialNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-sbd-eqf;EquityForwardSeller">
-		<rdfs:subClassOf rdf:resource="&fibo-der-der-fwd;ForwardContractSeller"/>
-		<rdfs:label xml:lang="en">equity forward seller</rdfs:label>
-		<skos:definition xml:lang="en">The party that sells or writes this forward instrument, that is the party which grants the rights defined by this instrument and in return receives a payment for it.</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The forward is always written by the party that is committing to sell the underlying, and is always bought by the party that is committing to take delivery of the underlying on the settlement date. The forward contract is the same as a conventional secondary market sale transaction but with the difference that the settlement date is in the future. See 2000 ISDA definitions Article 11.1 (a). FpML: &apos;A reference to the party that sells (&quot;writes&quot;) this instrument, i.e. that grants the rights defined by this instrument and in return receives a payment for it. See 2000 ISDA definitions Article 11.1 (a). In the case of FRAs this is the floating rate payer.&apos; Interpretation: this is the party which is the principal or writing party to the contract.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqf;EquityForwardTransaction">
@@ -220,12 +190,6 @@
 		<rdfs:domain rdf:resource="&fibo-der-sbd-eqf;EquityForwardContract"/>
 		<rdfs:range rdf:resource="&fibo-der-sbd-eqf;DividendAdjustmentPeriod"/>
 		<skos:definition xml:lang="en">One or more Dividend Adjustment Periods, which are used to calculate the Deviation between Expected Dividend and Actual Dividend in that Period.&apos;</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-sbd-eqf;hasConditions">
-		<rdfs:label xml:lang="en">has conditions</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-sbd-eqf;EquityForwardContract"/>
-		<rdfs:range rdf:resource="&fibo-der-sbd-eqs;DividendConditions"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-der-sbd-eqf;hasMethodOfAdjustment">

--- a/DER/SecurityBasedDerivatives/EquitySwaps.rdf
+++ b/DER/SecurityBasedDerivatives/EquitySwaps.rdf
@@ -99,12 +99,6 @@
 		<skos:definition xml:lang="en">dispersion leg whose underlying is a particular index</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-sbd-eqs;DividendConditions">
-		<rdfs:label xml:lang="en">dividend conditions</rdfs:label>
-		<skos:definition xml:lang="en">Conditions governing the payment of dividends to the receiver of the equity forward.</skos:definition>
-		<skos:editorialNote xml:lang="en">FpML has a set of terms for Dividend Conditions which are usable across a range of derivatives, including Forward. Many of the definitions of individual terms refer specifically to equity return (swaps) and it is not clear whether each such term also applies to Equity forwards (i.e. the definition is more specific than it should be), or if these are terms unique to Equity Return Swaps, among which are terms applicable to Equity forwards. REVIEW: 19 May: If you have a forward contract with a dividend before you settle there must be some terms to determine how the dividend is resolved. Similar question would apply with Bond Interst? No becaues this is a known amount so it is taken into account in the price that&apos;s been agreed (discount premium). Whether it&apos;s cum or ex coupon therefore doesn&apos;t affect pricing; with Dividend this is not the case, there afore there are contractual trerms about how that is to be resolved. FpML: A type describing the conditions governing the payment of dividends to the receiver of the equity return. With the exception of the dividend payout ratio, which is defined for each of the underlying components.</skos:editorialNote>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;DividendLeg">
 		<rdfs:subClassOf rdf:resource="&fibo-der-der-rsw;SimpleReturnLeg"/>
 		<rdfs:subClassOf>
@@ -133,24 +127,13 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-agr-ctr;hasContractualElement"/>
-				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-eqs;DividendLegPeriodTerm"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dividend leg</rdfs:label>
-		<skos:definition xml:lang="en">The Floating Payment Leg of a Dividend Swap. Swap dividend payment rates. Earlier notes this behaves very like a variance swap but instead of betting in pure variance you take a bet on dividend. What practically in one of these: The difference between th ereal life dividend and the one you think it should be. so I say it should bte 2% over the next 10 years, so I swap 2% for the actual dividend amount So then there is one single payment at the end which nets these up. So in the above example ... they are usually 3 month or 6 month contracts, so if for instance th edividend if quarterly, there might be 2 dividends where the difference is netted up at the end.for example. (Us 1/4ly usually , Eur 6 months). Depends on the company&apos;s articles of association etc. e.g. Unilever is 6 mo)/ Structurally, Div Swap corr Swap and Var Swap are structured similarly, with one strike at the beginning. Strike may be expressed in terms of the (price) variance (the variance of the returns) , the correlation between typically 2 underlyers. or the dividend for each of these three types of swap respectively. 17 march Dividend is a flow based on a share, so is this not the same as a Return Swap in that the dividend is the return on the dividend? Also recall that with stocks themselves, there is no comitment by the issuer to pay the dividends. FpML: &apos;Dividend leg.&apos;; &apos;Floating Payment Leg of a Dividend Swap.&apos;</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-sbd-eqs;DividendLegPeriodTerm">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-dt-fd;hasDatePeriod"/>
 				<owl:someValuesFrom rdf:resource="&fibo-der-sbd-eqs;QualifyingDividendPeriod"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">dividend leg period term</rdfs:label>
-		<skos:definition xml:lang="en">A part of a Dividend Leg, which is the dividend period and the terms relating to this.</skos:definition>
+		<rdfs:label xml:lang="en">dividend leg</rdfs:label>
+		<skos:definition xml:lang="en">floating leg of a dividend swap</skos:definition>
+		<skos:editorialNote xml:lang="en">FpML has a set of terms for Dividend Conditions which are usable across a range of derivatives, including Forward. Many of the definitions of individual terms refer specifically to equity return (swaps) and it is not clear whether each such term also applies to Equity forwards (i.e. the definition is more specific than it should be), or if these are terms unique to Equity Return Swaps, among which are terms applicable to Equity forwards. REVIEW: 19 May: If you have a forward contract with a dividend before you settle there must be some terms to determine how the dividend is resolved. Similar question would apply with Bond Interst? No becaues this is a known amount so it is taken into account in the price that&apos;s been agreed (discount premium). Whether it&apos;s cum or ex coupon therefore doesn&apos;t affect pricing; with Dividend this is not the case, there afore there are contractual trerms about how that is to be resolved. FpML: A type describing the conditions governing the payment of dividends to the receiver of the equity return. With the exception of the dividend payout ratio, which is defined for each of the underlying components.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;EquityCorrelationSwap">
@@ -218,7 +201,7 @@
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-eqs;SpecialDividendLegTerm">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;ContractualElement"/>
+		<rdfs:subClassOf rdf:resource="&fibo-der-drc-bsc;CashflowTerms"/>
 		<rdfs:label xml:lang="en">special dividend leg term</rdfs:label>
 		<skos:definition xml:lang="en">Special dividends and memorial dividends which are applicable. FpML: &apos;If present and true, then special dividends and memorial dividends are applicable.&apos; Note that &quot;if true&quot; (a yes/no term) and &quot;if present&quot; (this term, which is the presence of the thing) are two separate meanings. FpML implies the truth of the Yes/No fact by the presence or absence of this term. However, although FpML definition says &quot;if present and true&quot;, the term is just a &quot;boolean&quot; ie a YTes/no applicability term. Not sure where the special dividends themselves are defined.</skos:definition>
 	</owl:Class>
@@ -264,13 +247,6 @@ Further Notes:This is effectively an abstract leg - there are no streams of paym
 		<rdfs:domain rdf:resource="&fibo-der-drc-swp;CorrelationLeg"/>
 		<skos:definition xml:lang="en">The method according to which an amount or a date is determined.</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-der-sbd-eqs;fixedStrike">
-		<rdfs:label xml:lang="en">fixed strike</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-der-sbd-eqs;DividendLegPeriodTerm"/>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryAmount"/>
-		<skos:definition xml:lang="en">The strike amount.</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-der-sbd-eqs;materialDividendsApplicable">
 		<rdfs:label xml:lang="en">material dividends applicable</rdfs:label>

--- a/DER/SecurityBasedDerivatives/SecurityBasedDerivatives.rdf
+++ b/DER/SecurityBasedDerivatives/SecurityBasedDerivatives.rdf
@@ -63,29 +63,6 @@
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Provisional"/>
 	</owl:Ontology>
 	
-	<owl:Class rdf:about="&fibo-der-sbd-sbd;BasketOfCreditIndices">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-bsk;BasketOfIndices"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasConstituent"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-sec-bsk;BasketOfIndicesConstituent">
-							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-								<owl:allValuesFrom rdf:resource="&fibo-ind-mkt-bas;CreditIndex"/>
-							</owl:Restriction>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">basket of credit indices</rdfs:label>
-		<skos:definition xml:lang="en">basket of indices that are credit-specific benchmarks</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-sbd-sbd;BasketOfDebtInstruments">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-bsk;BasketOfSecurities"/>
 		<rdfs:subClassOf>
@@ -103,29 +80,6 @@
 		<skos:definition xml:lang="en">basket of securities whose constituents are debt instruments</skos:definition>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-der-sbd-sbd;BasketOfEquityIndices">
-		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-bsk;BasketOfIndices"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fnd-arr-arr;hasConstituent"/>
-				<owl:someValuesFrom>
-					<owl:Class>
-						<owl:unionOf rdf:parseType="Collection">
-							<rdf:Description rdf:about="&fibo-sec-sec-bsk;BasketOfIndicesConstituent">
-							</rdf:Description>
-							<owl:Restriction>
-								<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;comprises"/>
-								<owl:allValuesFrom rdf:resource="&fibo-ind-mkt-bas;EquityIndex"/>
-							</owl:Restriction>
-						</owl:unionOf>
-					</owl:Class>
-				</owl:someValuesFrom>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label xml:lang="en">basket of equity indices</rdfs:label>
-		<skos:definition xml:lang="en">basket of indices that are equity-specific benchmarks</skos:definition>
-	</owl:Class>
-	
 	<owl:Class rdf:about="&fibo-der-sbd-sbd;DebtInstrumentDerivative">
 		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;SecurityBasedDerivative"/>
 		<rdfs:subClassOf>
@@ -140,7 +94,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>debt instrument derivative</rdfs:label>
-		<skos:definition>security-based derivative whose underlier is an individual tradable debt instrument, a credit index, or a custom basket of debt-related assets</skos:definition>
+		<skos:definition>security-based derivative whose underlier is an individual tradable debt instrument, credit index, or custom basket of debt-related assets</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-sbd;DebtObservable">
@@ -155,8 +109,6 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-dbt-dbti;TradableDebtInstrument">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-sbd-sbd;BasketOfCreditIndices">
-							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-ind-mkt-bas;CreditIndex">
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-ind-mkt-bas;BasketOfCreditRisks">
@@ -167,7 +119,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>debt observable</rdfs:label>
-		<skos:definition>security underlier that is an individual debt instrument, a credit index, or a custom basket of debt assets</skos:definition>
+		<skos:definition>security underlier that is an individual debt instrument, credit index, or custom basket of debt assets</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-sbd;EquityDerivative">
@@ -179,7 +131,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>equity derivative</rdfs:label>
-		<skos:definition>security-based derivative whose underlier is an individual share, an equity index, or a custom basket of equity assets</skos:definition>
+		<skos:definition>security-based derivative whose underlier is an individual share, equity index, or custom basket of equity assets</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-sbd;EquityObservable">
@@ -194,8 +146,6 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-sec-eq-eq;ListedShare">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-der-sbd-sbd;BasketOfEquityIndices">
-							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-ind-mkt-bas;EquityIndex">
 							</rdf:Description>
 						</owl:unionOf>
@@ -204,20 +154,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>equity observable</rdfs:label>
-		<skos:definition>security underlier that is an individual share, an equity index, or a custom basket of equity assets</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-sbd-sbd;PerformanceBasedVariableLeg">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;SwapLeg"/>
-		<rdfs:label>performance-based variable leg</rdfs:label>
-		<skos:definition>floating leg of a security-based swap that depends on some statistical measure of the performance of the underlier</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-sbd-sbd;RealizedVariableLeg">
-		<rdfs:subClassOf rdf:resource="&fibo-der-sbd-sbd;PerformanceBasedVariableLeg"/>
-		<rdfs:label>realized variable leg</rdfs:label>
-		<skos:definition>performance-based leg wherein the payment is netted at maturity rather than periodically</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>In this case there is a single payment at maturity/settlement and so there is no stream of cashflows either way.  The other leg of these swaps is implied, and is simply the strike price.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>security underlier that is an individual share, equity index, or custom basket of equity assets</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-sbd;SecurityBasedDerivative">
@@ -229,7 +166,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label xml:lang="en">security-based derivative</rdfs:label>
-		<skos:definition>derivative instrument whose underlier consists of one or more of a basket of securities, individual securities, or security indices</skos:definition>
+		<skos:definition>derivative instrument whose underlier consists of a basket of securities, individual securities, or security indices</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-der-sbd-sbd;SecurityUnderlier">
@@ -246,8 +183,6 @@
 							</rdf:Description>
 							<rdf:Description rdf:about="&fibo-ind-mkt-bas;ReferenceIndex">
 							</rdf:Description>
-							<rdf:Description rdf:about="&fibo-sec-sec-bsk;BasketOfIndices">
-							</rdf:Description>
 						</owl:unionOf>
 					</owl:Class>
 				</owl:onClass>
@@ -255,20 +190,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>security underlier</rdfs:label>
-		<skos:definition>underlier consisting of one or more of a basket of securities, individual securities, security indices, or some combination thereof</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-der-sbd-sbd;StatisticalSwap">
-		<rdfs:subClassOf rdf:resource="&fibo-der-drc-swp;Swap"/>
-		<rdfs:subClassOf>
-			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-der-drc-swp;hasLeg"/>
-				<owl:onClass rdf:resource="&fibo-der-sbd-sbd;PerformanceBasedVariableLeg"/>
-				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:label>statistical swap contract</rdfs:label>
-		<skos:definition>security-based swap that depends on some statistical measure of the performance of the underlier</skos:definition>
+		<skos:definition>underlier consisting of a basket of securities, an individual security, reference index, or some combination thereof</skos:definition>
 	</owl:Class>
 
 </rdf:RDF>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminated additional unused and duplicate classes in security-based and equity swaps as well as in equity forwards, cleaned up more of the terminology based on FCT discussion


Fixes: #1173 / DER-75


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


