### PR TITLE
FBC-261 - Need better and complete alignment of account and account-related properties with the situation pattern

### DIFF
--- a/BE/OwnershipAndControl/CorporateOwnership.rdf
+++ b/BE/OwnershipAndControl/CorporateOwnership.rdf
@@ -101,8 +101,8 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;ConstitutionalOwner"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
 		<rdfs:label xml:lang="en">shareholder</rdfs:label>
-		<skos:definition>The shares represent an ownership interest in a corporation, mutual fund, or partnership, or a unit of ownership in a structured product, such as a real estate investment trust.</skos:definition>
 		<skos:definition>party that owns shares in and has rights and responsibilities with respect to some asset, provided in exchange for investment</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>The shares represent an ownership interest in a corporation, mutual fund, or partnership, or a unit of ownership in a structured product, such as a real estate investment trust.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym xml:lang="en-US">stockholder</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	

--- a/BE/OwnershipAndControl/CorporateOwnership.rdf
+++ b/BE/OwnershipAndControl/CorporateOwnership.rdf
@@ -61,11 +61,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Parties/Roles/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/CorporateOwnership/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200901/OwnershipAndControl/CorporateOwnership/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified per the FIBO 2.0 RFC to reference shareholders&apos; equity in the definition of a shareholder.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to generalize the definition of beneficial owner rather than limiting it to shareholding and eliminate a duplicate restriction on shareholder.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190201/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to modify the inheritance hierarchy for beneficial owner to replace owner with controlling party as one of its parent classes.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/CorporateOwnership.rdf version of this ontology was modified to replace isEquityHeldBy with its parent, isHeldBy, eliminate redundant classes that were not used anywhere, and clean up a few definitions to be less ambiguous, not circular, and to conform with ISO 704.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -90,29 +91,18 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>beneficial owner</rdfs:label>
-		<skos:definition>party that enjoys the possession and/or benefits of ownership (such as receipt of income) of something even though its ownership (title) may be in the name of another party (called a nominee or registered owner)</skos:definition>
+		<skos:definition>party that enjoys the benefits of ownership (such as receipt of income) of something even though its ownership (title) may be in the name of another party (called a nominee or registered owner)</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/beneficial-owner.html</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:explanatoryNote>This covers entities which have any kind of control. From World Bank Report: In identifying the beneficial owner, the focus should be on two factors: the control exercised and the benefit derived. Control of a corporate vehicle will always depend on context, as control can be exercised in many different ways, including through ownership, contractually or informally.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Use of a nominee (who may be an agent, custodian, or a trustee) does not change the position regarding tax reporting and tax liability, and the beneficial owner remains responsible.</fibo-fnd-utl-av:explanatoryNote>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-oac-cown;PublicShareholder">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cown;Shareholder"/>
-		<rdfs:label>public shareholder</rdfs:label>
-		<skos:definition>a shareholder that holds publicly issued shares in a listed company</skos:definition>
-	</owl:Class>
-	
-	<owl:Class rdf:about="&fibo-be-oac-cown;RegisteredShareholder">
-		<rdfs:subClassOf rdf:resource="&fibo-be-oac-cown;Shareholder"/>
-		<rdfs:label>registered shareholder</rdfs:label>
-		<skos:definition>a shareholder that is registered on the shareholder registry for a company</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-be-oac-cown;Shareholder">
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;ConstitutionalOwner"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-agr-ctr;TransferableContractHolder"/>
 		<rdfs:label xml:lang="en">shareholder</rdfs:label>
-		<skos:definition>an individual, group, or organization that owns one or more shares in a corporation or mutual fund, or an interest in a general or limited partnership, or a unit of ownership in a structured product, such as a real estate investment trust, and in whose name the share is issued</skos:definition>
+		<skos:definition>The shares represent an ownership interest in a corporation, mutual fund, or partnership, or a unit of ownership in a structured product, such as a real estate investment trust.</skos:definition>
+		<skos:definition>party that owns shares in and has rights and responsibilities with respect to some asset, provided in exchange for investment</skos:definition>
 		<fibo-fnd-utl-av:synonym xml:lang="en-US">stockholder</fibo-fnd-utl-av:synonym>
 	</owl:Class>
 	
@@ -120,13 +110,14 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oac-opty;isEquityHeldBy"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
 				<owl:allValuesFrom rdf:resource="&fibo-be-oac-cown;Shareholder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>shareholding</rdfs:label>
-		<skos:definition>Legal power of stockholders (shareholders) varies in proportion to their shareholdings. Typically, ten percent and below stockholding provides no protection. Fifteen percent stockholding may give the power to petition courts against changing the shares class rights. Up to 49.9 percent stockholding normally gives power to demand calling of an extraordinary general meeting. Fifty percent and over stockholding gives power to fire a director and force out minority stockholders by acquiring their shares as per the rules of the firm. Holder of 75 percent of the stock has the power to change the articles and memorandum of association and the firms name, reduce the share capital, allow the firm to buy its own shares from other stockholders, and to shut down the business. One hundred percent stockholding of course gives total power under the corporate legislation.</skos:definition>
-		<fibo-fnd-utl-av:definitionOrigin rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/company-shareholdings.html</fibo-fnd-utl-av:definitionOrigin>
+		<skos:definition>financial asset that takes the form of shares considered as a unit</skos:definition>
+		<fibo-fnd-utl-av:adaptedFrom rdf:datatype="&xsd;anyURI">http://www.businessdictionary.com/definition/company-shareholdings.html</fibo-fnd-utl-av:adaptedFrom>
+		<fibo-fnd-utl-av:explanatoryNote>The legal power of a shareholder varies in proportion to their shareholding. Typically, ten percent and below stockholding provides no protection. Fifteen percent stockholding may give the power to petition courts against changing the shares class rights. Up to 49.9 percent stockholding normally gives power to demand calling of an extraordinary general meeting. Fifty percent and over stockholding gives power to fire a director and force out minority stockholders by acquiring their shares as per the rules of the firm. Holder of 75 percent of the stock has the power to change the articles and memorandum of association and the firms name, reduce the share capital, allow the firm to buy its own shares from other stockholders, and to shut down the business. One hundred percent stockholding of course gives total power under the corporate legislation.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 
 </rdf:RDF>

--- a/BE/OwnershipAndControl/OwnershipParties.rdf
+++ b/BE/OwnershipAndControl/OwnershipParties.rdf
@@ -86,7 +86,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200701/OwnershipAndControl/OwnershipParties/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/BE/20200901/OwnershipAndControl/OwnershipParties/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20131101/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified per the issue resolutions identified in the FIBO BE 1.0 FTF report.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20160201/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified per the FIBO 2.0 RFC to address missing labels and comments, and revise terminology related to shareholders&apos; equity due to requirements for SEC/Equities.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20180801/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified as a part of a simplification strategy for the organizational class hierarchy and to support GLEIF LEI Level 2 ownership relationships.</skos:changeNote>
@@ -94,6 +94,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20190901/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to eliminate duplication of concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200201/OwnershipAndControl/OwnershipParties.rdf version of this ontology was modified to integrate the concept of a situation, situational roles, and corresponding relations with the definition of entity ownership, and eliminate unused and logically inconsistent properties.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200601/OwnershipAndControl/OwnershipParties.rdf version of this ontology was revised to reflect the name change in FND from &apos;hasPrimaryParty&apos; to &apos;hasActiveParty&apos; to be more consistent with other role related properties.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/BE/20200701/OwnershipAndControl/OwnershipParties.rdf version of this ontology was revised to align isEquityHeldBy and hasInvestor with the situational pattern.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -111,7 +112,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;EntityOwner"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oac-opty;holdsEquityIn"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;ShareholdersEquity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -142,7 +143,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Owner"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oac-opty;holdsEquityIn"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-acc-aeq;OwnersEquity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -245,7 +246,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;OwnersEquity"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oac-opty;isEquityHeldBy"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-oac-opty;Investor"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -258,7 +259,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-be-oac-opty;EntityOwner"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-be-oac-opty;holdsEquityIn"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
 				<owl:someValuesFrom rdf:resource="&fibo-be-oac-opty;InvestmentEquity"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -342,15 +343,6 @@
 		<skos:definition>relates a legal person to the context in which it owns a formal organization</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-opty;hasInvestor">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;hasPartyInRole"/>
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
-		<rdfs:label>has investor</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<rdfs:range rdf:resource="&fibo-be-oac-opty;Investor"/>
-		<skos:definition>links an investment interest in something (e.g., a legal entity) to the party that holds or owns it, in whole or in part</skos:definition>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-be-oac-opty;hasOwnedEntity">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;isExperiencedBy"/>
 		<rdfs:label>has owned entity</rdfs:label>
@@ -376,29 +368,6 @@
 		<rdfs:domain rdf:resource="&fibo-be-oac-opty;EntityOwnership"/>
 		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalPerson"/>
 		<skos:definition>indicates a party that owns a formal organization</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-opty;holdsAnOwnershipInterestIn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-oac-own;owns"/>
-		<rdfs:label>holds an ownership interest in</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-le-lp;LegalEntity"/>
-		<skos:definition>links a party to some organization it holds an ownership interest in</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-opty;holdsEquityIn">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;holds"/>
-		<rdfs:label>holds equity in</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-fnd-acc-aeq;Equity"/>
-		<skos:definition>links a party to some equity it holds</skos:definition>
-	</owl:ObjectProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-be-oac-opty;isEquityHeldBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;hasPartyInRole"/>
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
-		<rdfs:label>is equity held by</rdfs:label>
-		<rdfs:range rdf:resource="&fibo-be-oac-opty;EntityOwner"/>
-		<owl:inverseOf rdf:resource="&fibo-be-oac-opty;holdsEquityIn"/>
-		<skos:definition>links some equity to the party that holds it</skos:definition>
 	</owl:ObjectProperty>
 
 </rdf:RDF>

--- a/FBC/ProductsAndServices/CardAccounts.rdf
+++ b/FBC/ProductsAndServices/CardAccounts.rdf
@@ -259,12 +259,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;holdsAccount"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
 				<owl:someValuesFrom>
 					<owl:Restriction>
@@ -283,6 +277,12 @@
 						<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
 					</owl:Restriction>
 				</owl:someValuesFrom>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-crd;CardAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>cardholder</rdfs:label>

--- a/FBC/ProductsAndServices/ClientsAndAccounts.rdf
+++ b/FBC/ProductsAndServices/ClientsAndAccounts.rdf
@@ -10,6 +10,7 @@
 	<!ENTITY fibo-fbc-fi-fi "https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/">
 	<!ENTITY fibo-fbc-pas-caa "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/">
 	<!ENTITY fibo-fbc-pas-fpas "https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/">
+	<!ENTITY fibo-fnd-acc-aeq "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/">
 	<!ENTITY fibo-fnd-acc-cur "https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/">
 	<!ENTITY fibo-fnd-agr-ctr "https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/">
 	<!ENTITY fibo-fnd-arr-arr "https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/">
@@ -44,6 +45,7 @@
 	xmlns:fibo-fbc-fi-fi="https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/"
 	xmlns:fibo-fbc-pas-caa="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/ClientsAndAccounts/"
 	xmlns:fibo-fbc-pas-fpas="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"
+	xmlns:fibo-fnd-acc-aeq="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"
 	xmlns:fibo-fnd-acc-cur="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"
 	xmlns:fibo-fnd-agr-ctr="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"
 	xmlns:fibo-fnd-arr-arr="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"
@@ -91,6 +93,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/FinancialServicesEntities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/"/>
+		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/AccountingEquity/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Arrangements/"/>
@@ -121,7 +124,7 @@
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;Account">
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
 				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
 				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
 			</owl:Restriction>
@@ -171,14 +174,26 @@
 		<fibo-fnd-utl-av:explanatoryNote>In general, an account is associated with a contractual relationship between a buyer and seller under which payment may be made at a later time. General ledger accounts are an exception to this, however, and typically do not have account holders, including internal account holders. They may, on the other hand, have responsible parties.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
-	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountHolder">
-		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Owner"/>
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountAsAnAsset">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-acc-aeq;FinancialAsset"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;holdsAccount"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;isOwnedBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;Account"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:label>account as an asset</rdfs:label>
+		<skos:definition>financial asset in the form of an account</skos:definition>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountHolder">
+		<rdfs:subClassOf rdf:resource="&fibo-fnd-oac-own;Owner"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-pty-rl;isPlayedBy"/>
@@ -201,6 +216,12 @@
 				</owl:someValuesFrom>
 			</owl:Restriction>
 		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;Account"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
 		<rdfs:label>account holder</rdfs:label>
 		<skos:definition>party that owns the account</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>An account holder is named on the account and is authorized to conduct transactions associated with the account. Authorization is typically evidenced by signatures maintained on file by the account provider.</fibo-fnd-utl-av:explanatoryNote>
@@ -220,6 +241,25 @@
 		<skos:definition>identifier that denotes an account</skos:definition>
 		<fibo-fnd-utl-av:adaptedFrom>ISO 13616-1:2007 Financial services - International bank account number (IBAN)</fibo-fnd-utl-av:adaptedFrom>
 		<fibo-fnd-utl-av:synonym>account number</fibo-fnd-utl-av:synonym>
+	</owl:Class>
+	
+	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountOwnership">
+		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-fpas;Holding"/>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwnedThing"/>
+				<owl:onClass rdf:resource="&fibo-fbc-pas-caa;AccountAsAnAsset"/>
+				<owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-oac-own;hasOwningParty"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:label>account ownership</rdfs:label>
+		<skos:definition>holding of an account</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-fbc-pas-caa;AccountProvider">
@@ -436,12 +476,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-pas-caa;Account"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
-				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;CustomerAccountHolder"/>
-			</owl:Restriction>
-		</rdfs:subClassOf>
-		<rdfs:subClassOf>
-			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;realizes"/>
 				<owl:someValuesFrom>
 					<owl:Class>
@@ -459,6 +493,12 @@
 			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isDefinedIn"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fnd-pas-pas;ServiceAgreement"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
+				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;CustomerAccountHolder"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
@@ -501,7 +541,7 @@
 		</rdfs:subClassOf>
 		<rdfs:subClassOf>
 			<owl:Restriction>
-				<owl:onProperty rdf:resource="&fibo-fbc-pas-caa;holdsAccount"/>
+				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;holds"/>
 				<owl:someValuesFrom rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
 			</owl:Restriction>
 		</rdfs:subClassOf>
@@ -923,15 +963,6 @@
 		<skos:definition>indicates the account to which the transaction record or individual transaction applies</skos:definition>
 	</owl:ObjectProperty>
 	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasAccountHolder">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
-		<rdfs:label>has account holder</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;Account"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
-		<skos:definition>relates an account to a client or customer that owns the account</skos:definition>
-		<fibo-fnd-utl-av:synonym>has account owner</fibo-fnd-utl-av:synonym>
-	</owl:ObjectProperty>
-	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasBalance">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-acc-cur;hasMonetaryAmount"/>
 		<rdfs:label>has balance</rdfs:label>
@@ -979,20 +1010,20 @@
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasPrimaryAccountHolder">
 		<rdf:type rdf:resource="&owl;FunctionalProperty"/>
-		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
 		<rdfs:label>has primary account holder</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;CustomerAccountHolder"/>
 		<skos:definition>relates an account to a client or customer that is considered the primary owner of the account</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Note that for many financial institutions, there must be a client or customer designated as the primary owner. In cases where there is a tax identifier associated with the account, it is that of the primary owner.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:synonym>has primary account owner</fibo-fnd-utl-av:synonym>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;hasSecondaryAccountHolder">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;isHeldBy"/>
 		<rdfs:label>has secondary account holder</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;CustomerAccount"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
+		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;CustomerAccountHolder"/>
 		<skos:definition>relates an account to a client or customer that is considered a secondary, co-owner of the account</skos:definition>
 		<fibo-fnd-utl-av:synonym>has account co-owner</fibo-fnd-utl-av:synonym>
 		<fibo-fnd-utl-av:synonym>has secondary account owner</fibo-fnd-utl-av:synonym>
@@ -1025,15 +1056,6 @@
 		<rdfs:range rdf:resource="&xsd;string"/>
 		<skos:definition>indicates the status of the transaction record</skos:definition>
 	</owl:DatatypeProperty>
-	
-	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;holdsAccount">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;holds"/>
-		<rdfs:label>holds account</rdfs:label>
-		<rdfs:domain rdf:resource="&fibo-fbc-pas-caa;AccountHolder"/>
-		<rdfs:range rdf:resource="&fibo-fbc-pas-caa;Account"/>
-		<owl:inverseOf rdf:resource="&fibo-fbc-pas-caa;hasAccountHolder"/>
-		<skos:definition>relates a client or customer to an account that they own</skos:definition>
-	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fbc-pas-caa;involvesMerchant">
 		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-rel-rel;involves"/>

--- a/FND/Parties/Parties.rdf
+++ b/FND/Parties/Parties.rdf
@@ -68,7 +68,7 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Parties/Parties/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/20200901/Parties/Parties/"/>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20130801/Parties/Parties.rdf version of the ontology was was modified per the issue resolutions identified in the FIBO FND 1.0 FTF report and in https://spec.edmcouncil.org/fibo/ontology/FND/1.0/AboutFND-1.0/.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20141101/Parties/Parties.rdf version of this ontology was revised as a part of the issue resolutions identified in the FIBO FND 1.1 RTF report to add a parent of hasDate to date properties.</skos:changeNote>
 		<skos:changeNote>The http://www.omg.org/spec/EDMC-FIBO/FND/20160201/Parties/Parties.rdf version of this ontology was revised as a part of the FIBO 2.0 RFC to introduce disjointness axioms to aid users in understanding.</skos:changeNote>
@@ -84,6 +84,7 @@
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20190701/Parties/Parties.rdf version of this ontology was revised to eliminate duplication with the concepts in LCC.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200201/Parties/Parties.rdf version of this ontology was extended to support more complex situations involving parties in various roles, loosen the restriction on party in role with respect to commencement date, and to eliminate the redundant union in the definition of independent party.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200601/Parties/Parties.rdf version of this ontology was extended to rename &apos;hasPrimaryParty&apos; to &apos;hasActiveParty&apos; to be more consistent.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/FND/20200701/Parties/Parties.rdf version of this ontology was extended to align the properties holds and isHeldBy with the lattice to improve ownership-related reasoning.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -277,7 +278,7 @@
 			<rdf:Description rdf:about="&fibo-fnd-pty-pty;hasActor">
 			</rdf:Description>
 		</owl:propertyChainAxiom>
-		<skos:definition>relates a person or organization to an actor that drives a situation involving them</skos:definition>
+		<skos:definition>relates something to an actor that drives a situation involving it</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-pty-pty;hasActiveParty">
@@ -424,12 +425,11 @@
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;holds">
-		<rdfs:domain rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;directlyAffects"/>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-fnd-rel-rel;isHeldBy">
-		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;hasPartyInRole"/>
-		<rdfs:range rdf:resource="&fibo-fnd-pty-pty;PartyInRole"/>
+		<rdfs:subPropertyOf rdf:resource="&fibo-fnd-pty-pty;experiencesWith"/>
 	</owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added top level AccountOwnership related classes to better integrate account holder relations with the situational patterns, cleaned up content that wasn't used and didn't align with the pattern, including cleaning up the corresponding pattern for shareholder/shareholding ownership related content.

Fixes: #1178 / FBC-261


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


