### PR TITLE
SEC-133 - Eliminate circular and ambiguous definitions in Bonds

### DIFF
--- a/SEC/Debt/Bonds.rdf
+++ b/SEC/Debt/Bonds.rdf
@@ -140,10 +140,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/"/>
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Debt/Bonds/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200901/Debt/Bonds/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Securities/Debt/Bonds.rdf version of this ontology was revised to reflect the refactored definition of a listing and improve the definition of corporate bond.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate duplication of concepts in LCC and eliminate a redundant superclass from RegularCouponSchedule.</skos:changeNote>
-		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate a duplicate &apos;isBasedOn&apos; property and replace it with the property of the same name in the debt ontology, to revise the inheritance hierarchy for bond conversion terms to reflect changes in the representation of redemption more generally, and to reflect the move of redemption provision from debt to financial instruments.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200401/Securities/Debt/Bonds.rdf version of this ontology was revised to eliminate a duplicate &apos;isBasedOn&apos; property and replace it with the property of the same name in the debt ontology, to revise the inheritance hierarchy for bond conversion terms to reflect changes in the representation of redemption more generally, to reflect the move of redemption provision from debt to financial instruments, and eliminate circular and ambiguous definitions.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -175,7 +175,8 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>bond</rdfs:label>
-		<skos:definition>fixed-income instrument in which the issuer owes the holders a debt and, depending on the terms of the bond, is obliged to pay interest (the coupon) and/or to repay the principal at maturity</skos:definition>
+		<skos:definition>fixed-income security representing a loan in which the issuer owes the holder(s) a debt</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Depending on the terms of the contract, the issuer is obliged to pay interest (the coupon) and/or to repay the principal at maturity.  The most common bonds are corporate or governmental, typically used to finance specific projects or operations.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;BondAmortizationPaymentTerms">
@@ -200,7 +201,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>bond conversion terms</rdfs:label>
-		<skos:definition>terms indicating when a convertible bond can be converted to another security (usually a publicly traded share issued by of the same issuer).</skos:definition>
+		<skos:definition>terms indicating when a convertible bond can be converted to another security (usually a publicly traded share issued by of the same issuer)</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;BondCoupon">
@@ -241,7 +242,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>bond registrar</rdfs:label>
-		<skos:definition>person or entity responsible for maintaining records on behalf of the issuer that identify the owners of a registered bond issue</skos:definition>
+		<skos:definition>party responsible for maintaining records on behalf of the issuer that identify the owners of a registered bond issue</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The trustee under a bond contract often also acts as registrar.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -381,8 +382,8 @@
 		<rdfs:label>corporate bond</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;GovernmentBond"/>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
-		<skos:definition>bond issued by a company in order to raise financing for purposes such as mergers and acquisitions, business expansion, or to cover ongoing operational needs</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Corporate bonds are typically longer-term debt instruments that have a maturity of at least one year. Corporate debt instruments with maturity shorter than one year are referred to as commercial paper.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>bond issued by a company in order to raise financing</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Corporate bonds are issued for purposes such as mergers and acquisitions, business expansion, or to cover ongoing operational needs, and are typically longer-term debt instruments that have a maturity of at least one year. Corporate debt instruments with maturity shorter than one year are referred to as commercial paper.</fibo-fnd-utl-av:explanatoryNote>
 		<fibo-fnd-utl-av:explanatoryNote>Note that some classification schemes consider any bond except those issued by a government in its own currency to be a corporate bond, for example, a bond issued by Canada in US dollars might be classified as a corporate bond. Bonds issued by multinational / supranational organizations such as the European Bank for Reconstruction and Development (EBRD) may also be considered corporate bonds rather than government bonds.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -587,7 +588,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-sec-lst;ListedSecurity"/>
 		<rdfs:label>listed bond</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;UnlistedBond"/>
-		<skos:definition>bond that may be traded on one or more exchanges</skos:definition>
+		<skos:definition>bond that may be traded on an exchange</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Most exchange traded bonds are corporate bonds (but most corporate bonds are not exchange traded bonds).</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -630,8 +631,9 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;GovernmentBond"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalSecurity"/>
 		<rdfs:label>municipal bond</rdfs:label>
-		<skos:definition>government bond that may be issued by states, cities, counties, special tax districts or special agencies or authorities of state or local governments</skos:definition>
+		<skos:definition>government bond that may be issued by a regional, rather than national, authority</skos:definition>
 		<fibo-fnd-utl-av:abbreviation>muni</fibo-fnd-utl-av:abbreviation>
+		<fibo-fnd-utl-av:explanatoryNote>Municipal bonds may be issued by states, cities, counties, special tax districts or special agencies or authorities of state or local governments.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;MunicipalDebtFundsUsage">
@@ -697,15 +699,15 @@
 		</rdfs:subClassOf>
 		<rdfs:label>municipal security</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;SovereignDebtInstrument"/>
-		<skos:definition>bond, note, warrant, certificate of participation or other obligation issued by a state or local government or their agencies or authorities (such as cities, towns, villages, counties or special districts or authorities)</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>A prime feature of most municipal securities is that interest or other investment earnings on them are generally excluded from gross income of the bondholder for federal income tax purposes. Some municipal securities are subject to federal income tax, although the issuers or bondholders may receive other federal tax advantages for certain types of taxable municipal securities. Some examples include Build America Bonds, municipal fund securities and direct pay subsidy bonds.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>debt obligation issued by a regional governmental entity</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A municipal security is typically a bond, note, warrant, certificate or other similar obligation issued by a state or local government or their agencies or authorities (such as cities, towns, villages, counties or special districts or authorities).  A prime feature of most municipal securities is that interest or other investment earnings on them are generally excluded from gross income of the bondholder for federal income tax purposes. Some municipal securities are subject to federal income tax, although the issuers or bondholders may receive other federal tax advantages for certain types of taxable municipal securities. Some examples include Build America Bonds, municipal fund securities and direct pay subsidy bonds.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;MunicipalTrustee">
 		<rdfs:subClassOf rdf:resource="&fibo-be-tr-tr;Trustee"/>
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fct-fse;FinancialInstitution"/>
 		<rdfs:label>municipal trustee</rdfs:label>
-		<skos:definition>financial institution with trust powers, designated by the issuer or borrower, that acts, pursuant to a bond contract, in a fiduciary capacity for the benefit of the bondholders in enforcing the terms of the bond contract</skos:definition>
+		<skos:definition>financial institution with trust powers, designated by the issuer, that acts, pursuant to a bond contract, in a fiduciary capacity for the benefit of the bondholders in enforcing the terms of the bond contract</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>In many cases, the trustee also acts as custodian, paying agent, registrar and/or transfer agent for the bonds.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -764,7 +766,7 @@
 	<owl:NamedIndividual rdf:about="&fibo-sec-dbt-bnd;ProRataConvention">
 		<rdf:type rdf:resource="&fibo-sec-dbt-bnd;PartialRedemptionAllocationConvention"/>
 		<rdfs:label>pro rata convention</rdfs:label>
-		<skos:definition>convention whereby securities that are subject to partial call or redemption are allocated proportionately</skos:definition>
+		<skos:definition>convention whereby securities that are subject to partial redemption are allocated proportionately</skos:definition>
 	</owl:NamedIndividual>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;RateBasisConvention">
@@ -802,13 +804,14 @@
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;RegularCouponSchedule">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;CouponSchedule"/>
 		<rdfs:label>regular coupon schedule</rdfs:label>
-		<skos:definition>schedule including an initial and/or final stub period and an interval of regular coupon payment dates</skos:definition>
+		<skos:definition>schedule including an interval of regular coupon payment dates</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>A regular schedule may include an initial and/or final stub period.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;RegulatoryCall">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;CallEvent"/>
 		<rdfs:label>regulatory call</rdfs:label>
-		<skos:definition>call that is triggered by some regulatory event or rule</skos:definition>
+		<skos:definition>call triggered by some regulation-specific rule</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;RemarketableBond">
@@ -816,15 +819,15 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;FloatingRateNote"/>
 		<rdfs:label>remarketable bond</rdfs:label>
 		<skos:definition>corporate bond program where the coupon rate on outstanding bonds is periodically reset through an auction process</skos:definition>
-		<skos:editorialNote>A remarketing agent (dealer or underwriter) periodically surveys bond holders to identify those who want to sell bonds. The agent surveys market (or holds an auction) to determine interest rate at which the bonds can be resold. The rate on all outstanding bonds resets at the new rate. These programs are perpetual in the sense they often don&apos;t have a fixed maturity date, but the company can redeem them. If an auction fails, i.e., the agent can&apos;t place all the bonds then.</skos:editorialNote>
+		<fibo-fnd-utl-av:explanatoryNote>A remarketing agent (dealer or underwriter) periodically surveys bond holders to identify those who want to sell bonds. The agent surveys market (or holds an auction) to determine interest rate at which the bonds can be resold. The rate on all outstanding bonds resets at the new rate. These programs are perpetual in the sense they often don&apos;t have a fixed maturity date, but the company can redeem them. If an auction fails, i.e., the agent can&apos;t place all the bonds then.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;RevenueBond">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;SecuredBond"/>
 		<rdfs:label>revenue bond</rdfs:label>
-		<skos:definition>municipal bond supported by the revenue from a specific project, such as a toll bridge, highway or local stadium</skos:definition>
-		<fibo-fnd-utl-av:explanatoryNote>Revenue bonds are municipal bonds that finance income-producing projects and are secured by a specified revenue source. Typically, revenue bonds can be issued by any government agency or fund that is managed in the manner of a business, such as entities having both operating revenues and expenses.</fibo-fnd-utl-av:explanatoryNote>
+		<skos:definition>municipal bond supported by the revenue from a specific project</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote>Revenue bonds are municipal bonds that finance income-producing projects, such as toll bridges, highways, or local stadiums, and are secured by a specified revenue source. Typically, revenue bonds can be issued by any government agency or fund that is managed in the manner of a business, such as entities having both operating revenues and expenses.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SecuredBond">
@@ -854,7 +857,7 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;SovereignDebtInstrument"/>
 		<rdfs:label>sovereign bond</rdfs:label>
 		<owl:disjointWith rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
-		<skos:definition>bond issued by a national or sovereign government of a country</skos:definition>
+		<skos:definition>bond issued by the government of a country</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Sovereign bonds issued by G20 developed countries are generally full faith and credit obligations. Sovereign bonds issued by emerging and developing countries may be issued in local currency or a G7 currency, and may either be full faith and credit (unsecured) or secured.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -872,28 +875,28 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>sovereign debt instrument</rdfs:label>
-		<skos:definition>debt security issued by a national or sovereign government of a country</skos:definition>
+		<skos:definition>debt security issued by the government of a country</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SpecialAssessmentBond">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;SecuredBond"/>
 		<rdfs:label>special assessment bond</rdfs:label>
-		<skos:definition>an obligation payable from revenues of a special assessment</skos:definition>
+		<skos:definition>municipal bond used to fund a development project that is payable from the revenues of an assessment (tax) on the community that is intended to benefit from the project</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>A special assessment is a charge imposed against a property in a particular locality because that property receives a special benefit by virtue of some public improvement, separate and apart from the general benefit accruing to the public at large. Special assessments may be apportioned according to the value of the benefit received, rather than merely the cost of the improvement.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SpecialObligationBond">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:label>special obligation bond</rdfs:label>
-		<skos:definition>bond secured by a limited revenue source or promise to pay</skos:definition>
+		<skos:definition>bond secured by a limited revenue source, such as receipts derived from a designated project</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;SpecialTaxBond">
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-bnd;SecuredBond"/>
 		<rdfs:label>special tax bond</rdfs:label>
-		<skos:definition>bond secured by revenues derived from one or more designated taxes other than ad valorem taxes</skos:definition>
+		<skos:definition>bond secured by revenues derived from designated taxes other than ad valorem taxes</skos:definition>
 		<skos:example>For example, bonds for a particular purpose might be supported by sales, cigarette, fuel or business license taxes.</skos:example>
 	</owl:Class>
 	
@@ -1037,7 +1040,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>variable coupon bond</rdfs:label>
-		<skos:definition>bond that has a floating or variable interest rate, or coupon rate</skos:definition>
+		<skos:definition>bond that has a floating interest rate</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The rate adjusts according to a predetermined formula outlined in the bond&apos;s prospectus or official statement.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -1056,7 +1059,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>variable coupon terms</rdfs:label>
-		<skos:definition>contractual terms specifying the calculation of the floating or variable interest rate, or coupon rate for a variable coupon bond</skos:definition>
+		<skos:definition>contractual terms specifying the calculation of the interest rate for a variable coupon bond</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;VariableDebtPrincipal">
@@ -1082,7 +1085,6 @@
 		<rdfs:subClassOf rdf:resource="&fibo-sec-dbt-dbti;FullyIndexedInterestRate"/>
 		<rdfs:label>variable interest calculation formula</rdfs:label>
 		<skos:definition>formula for the calculation of variable interest</skos:definition>
-		<skos:editorialNote>This inherits all the facts about Interest Calculation Formula without alteration.</skos:editorialNote>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;VariableInterestExpression">
@@ -1121,7 +1123,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>variable principal bond</rdfs:label>
-		<skos:definition>bond whose principal adjusts over time with changes in an index such as inflation or GDP</skos:definition>
+		<skos:definition>bond whose principal adjusts over time with changes in an index</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>The principal on variable principal bonds adjusts line with an index such as inflation or GDP. For example, for a bond linked to the CPI, if inflation rises two percent the principal increases by 2 percent. The coupon rate is typically fixed. The best-known example is TIPS or Treasury Inflation Protected Bonds, which are linked to the CPI. TIPs offer a real or inflation adjusted rate of return.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -1181,7 +1183,7 @@
 			</owl:Restriction>
 		</rdfs:subClassOf>
 		<rdfs:label>zero coupon bond call</rdfs:label>
-		<skos:definition>call event associated with a zero coupon or original issue discount bond</skos:definition>
+		<skos:definition>call event associated with a zero coupon bond</skos:definition>
 	</owl:Class>
 	
 	<owl:Class rdf:about="&fibo-sec-dbt-bnd;ZeroCouponTerms">
@@ -1268,7 +1270,7 @@
 		<rdfs:label>has final maturity date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-fbc-fi-fi;RedemptionProvision"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-		<skos:definition>indicates the final payment date of a loan or other financial instrument, at which point the principal (and all remaining interest) is due to be paid</skos:definition>
+		<skos:definition>indicates the final payment date of a financial instrument, at which point the principal (and all remaining interest) is due to be paid</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasFirstCallPrice">
@@ -1363,7 +1365,7 @@
 		<rdfs:label>has last coupon payment date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;CouponPaymentTerms"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-		<skos:definition>specifies the final date on which the issuer or its agent expects or commits to make a coupon payment</skos:definition>
+		<skos:definition>specifies the final date on which the issuer expects to make a final coupon payment</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">The last coupon date sometimes occurs at an irregular time; that is, if the bond pays coupons every six months, the last coupon period may be longer or shorter than six months.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:ObjectProperty>
 	
@@ -1381,7 +1383,7 @@
 		<rdfs:label>has municipal trustee</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-bnd;MunicipalBond"/>
 		<rdfs:range rdf:resource="&fibo-sec-dbt-bnd;MunicipalTrustee"/>
-		<skos:definition>specifies the financial institution with trust powers, designated by the issuer or borrower, that acts, pursuant to a bond contract, in a fiduciary capacity for the benefit of the bondholders in enforcing the terms of the bond contract.</skos:definition>
+		<skos:definition>specifies the financial institution with trust powers, designated by the issuer, that acts, pursuant to a bond contract, in a fiduciary capacity for the benefit of the bondholders in enforcing the terms of the bond contract</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasOriginalIssueDiscountAmount">
@@ -1421,7 +1423,7 @@
 		<rdfs:label>has put date</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;PutFeature"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;ExplicitDate"/>
-		<skos:definition>indicates the date on which a security is subject to optional or mandatory redemption by the bond holder</skos:definition>
+		<skos:definition>indicates the date on which a security is subject to redemption by the bond holder</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasPutFrequency">
@@ -1429,7 +1431,7 @@
 		<rdfs:label>has put frequency</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-sec-dbt-dbti;PutFeature"/>
 		<rdfs:range rdf:resource="&fibo-fnd-dt-fd;RecurrenceInterval"/>
-		<skos:definition>indicates the frequency of the tender or put period</skos:definition>
+		<skos:definition>indicates the recurring window of time in which the put feature can be exercised</skos:definition>
 	</owl:ObjectProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-dbt-bnd;hasRedemptionAmount">
@@ -1474,7 +1476,7 @@
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bnd;isMandatory">
 		<rdfs:label>is mandatory</rdfs:label>
 		<rdfs:range rdf:resource="&xsd;boolean"/>
-		<skos:definition>indicates whether something is mandatory</skos:definition>
+		<skos:definition>indicates whether something is required</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:DatatypeProperty rdf:about="&fibo-sec-dbt-bnd;isProRated">


### PR DESCRIPTION
Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

There were over 40 circular and/or ambiguous definitions in the bonds ontology.  This resolution eliminates most of them.

Fixes: #1182  / SEC-133


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


