### PR TITLE
BE-227 - Editorial correction to eliminate a smart quote in the definition of family office

### DIFF
--- a/BE/FunctionalEntities/FunctionalEntities.rdf
+++ b/BE/FunctionalEntities/FunctionalEntities.rdf
@@ -87,7 +87,7 @@
 	<owl:Class rdf:about="&fibo-be-fct-fct;FamilyOffice">
 		<rdfs:subClassOf rdf:resource="&fibo-be-fct-fct;FunctionalBusinessEntity"/>
 		<rdfs:label>family office</rdfs:label>
-		<skos:definition>organization that assumes the day-to-day administration and management of a family’s affairs</skos:definition>
+		<skos:definition>organization that assumes the day-to-day administration and management of a family&apos;s affairs</skos:definition>
 		<fibo-fnd-utl-av:explanatoryNote>Family offices are often privately held companies set up to handle investment and wealth management for wealthy families.</fibo-fnd-utl-av:explanatoryNote>
 	</owl:Class>
 	
@@ -205,7 +205,7 @@
 		<rdfs:label>has merchant category description</rdfs:label>
 		<rdfs:domain rdf:resource="&fibo-be-fct-fct;MerchantCategoryCode"/>
 		<rdfs:range rdf:resource="&xsd;string"/>
-		<skos:definition>provides a text description of the sector or merchant to which the code applies</skos:definition>
+		<skos:definition>provides a text description of the sector to which the code applies</skos:definition>
 	</owl:DatatypeProperty>
 	
 	<owl:Class rdf:about="&fibo-be-le-fbo;OrganizationIdentifier">


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Eliminated smart quote in the definition of family office and the ambiguity in the definition of has merchant category description


Fixes: #1184 / BE-227


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


