### PR TITLE
SEC-139 - FIBO is lacking a specific property to represent share class

### DIFF
--- a/SEC/Equities/EquitiesExampleIndividuals.rdf
+++ b/SEC/Equities/EquitiesExampleIndividuals.rdf
@@ -95,9 +95,10 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquitiesExampleIndividuals/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201001/Equities/EquitiesExampleIndividuals/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquitiesExampleIndividuals.rdf version of this ontology was modified to add CFI codes to the example equity instruments.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200501/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to replace uses of hasTag in Relations with hasTag from LCC, as the more complex union of datatypes in the Relations concept is not needed here.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200701/Equities/EquitiesExampleIndividuals.rdf version of this ontology was revised to add the share class to some of the examples.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -108,6 +109,7 @@
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
+		<fibo-sec-eq-eq:hasShareClass>A</fibo-sec-eq-eq:hasShareClass>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<lcc-cr:isClassifiedBy rdf:resource="&fibo-sec-eq-10962;ESVUFR"/>
 	</owl:NamedIndividual>
@@ -129,6 +131,7 @@
 		<fibo-fbc-fi-fi:isLegallyRecordedIn rdf:resource="&fibo-be-ge-usj;StateOfDelawareJurisdiction"/>
 		<fibo-fbc-fi-fi:isNegotiable rdf:datatype="&xsd;boolean">true</fibo-fbc-fi-fi:isNegotiable>
 		<fibo-fnd-rel-rel:isIssuedBy rdf:resource="&fibo-sec-eq-eqind;AlphabetIncEquityIssuer"/>
+		<fibo-sec-eq-eq:hasShareClass>C</fibo-sec-eq-eq:hasShareClass>
 		<fibo-sec-sec-iss:isIssuedInForm rdf:resource="&fibo-sec-sec-iss;RegisteredForm"/>
 		<fibo-sec-sec-lst:hasHomeExchange rdf:resource="&fibo-fbc-fct-mkti;Exchange-XNAS"/>
 	</owl:NamedIndividual>

--- a/SEC/Equities/EquityInstruments.rdf
+++ b/SEC/Equities/EquityInstruments.rdf
@@ -124,11 +124,12 @@
 		<owl:imports rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesRestrictions/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Countries/CountryRepresentation/"/>
 		<owl:imports rdf:resource="https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/"/>
-		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments/"/>
+		<owl:versionIRI rdf:resource="https://spec.edmcouncil.org/fibo/ontology/SEC/20201001/Equities/EquityInstruments/"/>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20180801/Equities/EquityInstruments.rdf version of this ontology was revised to replace &apos;publicly-traded share&apos; with &apos;exchange-specific share&apos;, which is the more commonly used designation and corresponds better with the intended semantics of this concept, to merge in concepts that were formerly in a separate ShareTerms ontology, and eliminate deprecated elements.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20190901/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of listed share, update definitions to remove leading articles, add missing properties and restrictions, revise the definition of dividend.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20191201/Equities/EquityInstruments.rdf version of this ontology was revised to refine the definition of share to include a restriction for hasSharesOutstanding, eliminate duplication of concepts in LCC, and add the concept of an equity issuer.</skos:changeNote>
 		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200301/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate additional features required to map the CFI classification scheme to equity instruments, including features specific to preferred shares.</skos:changeNote>
+		<skos:changeNote>The https://spec.edmcouncil.org/fibo/ontology/SEC/20200801/Equities/EquityInstruments.rdf version of this ontology was revised to incorporate a property allowing representation of the share class.</skos:changeNote>
 		<fibo-fnd-utl-av:hasMaturityLevel rdf:resource="&fibo-fnd-utl-av;Release"/>
 	</owl:Ontology>
 	
@@ -742,6 +743,13 @@
 		<rdfs:subClassOf rdf:resource="&fibo-fbc-fi-fi;EquityInstrument"/>
 		<rdfs:subClassOf>
 			<owl:Restriction>
+				<owl:onProperty rdf:resource="&fibo-sec-eq-eq;hasShareClass"/>
+				<owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">0</owl:minQualifiedCardinality>
+				<owl:onDataRange rdf:resource="&xsd;string"/>
+			</owl:Restriction>
+		</rdfs:subClassOf>
+		<rdfs:subClassOf>
+			<owl:Restriction>
 				<owl:onProperty rdf:resource="&fibo-fnd-rel-rel;confers"/>
 				<owl:someValuesFrom rdf:resource="&fibo-sec-eq-eq;VotingRight"/>
 			</owl:Restriction>
@@ -981,6 +989,14 @@
 		<rdfs:range rdf:resource="&fibo-fnd-acc-cur;MonetaryPrice"/>
 		<skos:definition>indicates the premium price per share over the market price, if any, that must be paid in order to redeem the stock</skos:definition>
 	</owl:ObjectProperty>
+	
+	<owl:DatatypeProperty rdf:about="&fibo-sec-eq-eq;hasShareClass">
+		<rdfs:label xml:lang="en">has share class</rdfs:label>
+		<rdfs:domain rdf:resource="&fibo-sec-eq-eq;Share"/>
+		<rdfs:range rdf:resource="&xsd;string"/>
+		<skos:definition xml:lang="en">indicates the class to which the share belongs, typically differentiated by privileges, such as voting rights</skos:definition>
+		<fibo-fnd-utl-av:explanatoryNote xml:lang="en">Classes of shares, including shares in a mutual fund, are designated by name or a character (letter), such as A, B, C, etc.  In the case of a mutual fund, different classes of shares may incur different fees and expenses.</fibo-fnd-utl-av:explanatoryNote>
+	</owl:DatatypeProperty>
 	
 	<owl:ObjectProperty rdf:about="&fibo-sec-eq-eq;hasSharePaymentStatus">
 		<rdfs:subPropertyOf rdf:resource="&lcc-cr;isClassifiedBy"/>


### PR DESCRIPTION

Signed-off-by: Elisa Kendall <ekendall@thematix.com>

## Description

Added a property to represent the share class and used it in individuals for Alphabet shares to provide an example of how to use it

Fixes: #1145 / SEC-139


## Checklist:

- [x] I'm familiar with the [FIBO developer quide](../CONTRIBUTING.md#contributing-to-the-fibo-code). My contribution meets all the requirements described there.
- [x] My contribution follows the [principles of best practices for FIBO](../ONTOLOGY_GUIDE.md).
- [x] My changes have been reconciled with latest master and no merge conflicts remain.
- [x] This PR is related to exactly one issue. The issue is referenced by using a GitHub keyword such as "fixes", "closes", or "resolves".
- [x] Hygiene tests have been applied by a PR with "(WIP)" in title.
- [x] The issue has been tested locally using a reasoner (for ontology changes).


